### PR TITLE
Fix terminal Ctrl+A/D tab cycling

### DIFF
--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -117,6 +117,10 @@ function normalizeHotkeyString(keys: string): string {
 let listenerAttached = false;
 let lookupIndex: Map<string, string> = new Map(); // normalized keys → hotkey id
 
+function isXtermHelperTarget(target: HTMLElement): boolean {
+  return target.classList.contains('xterm-helper-textarea') || target.closest('.xterm') !== null;
+}
+
 function handleKeyDown(e: KeyboardEvent) {
   const target = e.target as HTMLElement;
   const isInput =
@@ -139,7 +143,7 @@ function handleKeyDown(e: KeyboardEvent) {
   // Let native text editing win for shortcuts users expect in focused inputs.
   // In particular, tab cycling uses mod+a/mod+d, but inputs need mod+a
   // for select-all and mod+d for normal browser/text-field behavior.
-  if (isInput && (pressed === 'mod+a' || pressed === 'mod+d')) return;
+  if (isInput && !isXtermHelperTarget(target) && (pressed === 'mod+a' || pressed === 'mod+d')) return;
 
   // Skip if typing in input and shortcut doesn't use mod key
   if (isInput && !pressed.includes('mod')) return;


### PR DESCRIPTION
## Summary
- Preserve native Ctrl+A/Ctrl+D behavior for real focused text inputs.
- Exempt xterm.js helper textarea from that input guard so terminal focus can still use Pane tab cycling.

## Visual Overview
Before:
```mermaid
flowchart LR
  Key[Ctrl+A / Ctrl+D in terminal] --> Xterm[xterm helper textarea]
  Xterm --> InputGuard[Hotkey input guard]
  InputGuard --> Blocked[Pane tab cycling blocked]
```

After:
```mermaid
flowchart LR
  Key[Ctrl+A / Ctrl+D in terminal] --> Xterm[xterm helper textarea]
  Xterm --> Exempt[xterm target exemption]
  Exempt --> Hotkey[Pane hotkey store]
  Hotkey --> Switch[Switch panel tabs]
```

## Testing
- pnpm run --filter frontend typecheck
- pnpm run --filter frontend lint
- git diff --check
- Pre-commit hook: full workspace typecheck and lint passed

Note: local commands report the existing Node engine warning because this shell uses Node v20.19.3 while the repo requires >=22.14.0.