### PR TITLE
Improve analytics setup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ import { AddProjectDialog } from './components/AddProjectDialog';
 import { useNavigationStore } from './stores/navigationStore';
 import { initPostHog, capture, posthog } from './services/posthog';
 import type { VersionUpdateInfo, PermissionInput } from './types/session';
-import type { TerminalShortcut } from './types/config';
+import type { AnalyticsIdentity, TerminalShortcut } from './types/config';
 import type { ResumableSession } from '../../shared/types/panels';
 import type { Project } from './types/project';
 import { isMac } from './utils/platformUtils';
@@ -265,23 +265,54 @@ function App() {
   // Both must live in the same effect so buffered events aren't replayed before init.
   useEffect(() => {
     if (!appConfig) return;
-    initPostHog({
-      enabled: appConfig.analytics?.enabled ?? false,
-      posthogApiKey: appConfig.analytics?.posthogApiKey,
-      posthogHost: appConfig.analytics?.posthogHost,
-    });
-    // Sync distinct ID to main process so shutdown analytics use the same identity
-    const distinctId = posthog.get_distinct_id();
-    if (distinctId) {
-      window.electronAPI?.analytics?.syncDistinctId(distinctId);
-    }
-    // Now that PostHog is initialized, register the IPC listener.
-    // The preload buffers any events that arrived before this point and replays them.
-    if (!window.electronAPI?.analytics?.onMainEvent) return;
-    const cleanup = window.electronAPI.analytics.onMainEvent((event) => {
-      capture(event.eventName, event.properties);
-    });
-    return cleanup;
+
+    let cleanup: (() => void) | undefined;
+    let cancelled = false;
+
+    const initializeAnalytics = async () => {
+      let identity: AnalyticsIdentity | undefined;
+      const analyticsEnabled = appConfig.analytics?.enabled ?? false;
+
+      if (analyticsEnabled) {
+        try {
+          const identityResult = await window.electronAPI?.analytics?.getIdentity?.();
+          if (identityResult?.success) {
+            identity = identityResult.data;
+          }
+        } catch (error) {
+          console.error('[App] Error resolving analytics identity:', error);
+        }
+      }
+
+      if (cancelled) return;
+
+      initPostHog({
+        enabled: analyticsEnabled,
+        posthogApiKey: appConfig.analytics?.posthogApiKey,
+        posthogHost: appConfig.analytics?.posthogHost,
+        identity,
+      });
+
+      // Sync distinct ID to main process so shutdown analytics use the same identity
+      const distinctId = identity?.distinctId || posthog.get_distinct_id();
+      if (distinctId) {
+        window.electronAPI?.analytics?.syncDistinctId(distinctId);
+      }
+
+      // Now that PostHog is initialized, register the IPC listener.
+      // The preload buffers any events that arrived before this point and replays them.
+      if (!window.electronAPI?.analytics?.onMainEvent) return;
+      cleanup = window.electronAPI.analytics.onMainEvent((event) => {
+        capture(event.eventName, event.properties);
+      });
+    };
+
+    void initializeAnalytics();
+
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
   }, [appConfig]);
 
   // CRITICAL PERFORMANCE FIX: Cleanup to prevent V8 array iteration issues

--- a/frontend/src/components/AnalyticsConsentDialog.tsx
+++ b/frontend/src/components/AnalyticsConsentDialog.tsx
@@ -90,7 +90,7 @@ export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsCon
             <BarChart3 className="h-6 w-6 text-interactive flex-shrink-0 mt-0.5" />
             <div className="space-y-3">
               <p className="text-text-primary">
-                We do not collect any code, prompts, or identifying information.
+                We do not collect any code, prompts, or file paths.
               </p>
               <p className="text-text-secondary">
                 Your data helps us make Pane better. You can change this anytime in Settings.

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1208,16 +1208,16 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
 
               <SettingsSection
                 title="Analytics"
-                description="Help improve Pane by sharing anonymous usage data"
+                description="Help improve Pane by sharing usage data"
                 icon={<BarChart3 className="w-4 h-4" />}
               >
                 <Checkbox
-                  label="Enable anonymous analytics tracking"
+                  label="Enable analytics tracking"
                   checked={analyticsEnabled}
                   onChange={(e) => setAnalyticsEnabled(e.target.checked)}
                 />
                 <p className="text-xs text-text-tertiary mt-1">
-                  Pane collects anonymous usage analytics (feature usage, performance metrics) to improve the product. No prompts, code, file paths, or personal data is ever collected. You can opt-out at any time.
+                  Pane collects usage analytics to improve the product. No prompts, code, or file paths are collected. You can opt out at any time.
                 </p>
               </SettingsSection>
             </CollapsibleCard>

--- a/frontend/src/services/posthog.ts
+++ b/frontend/src/services/posthog.ts
@@ -11,6 +11,32 @@ export interface PostHogConfig {
   enabled: boolean;
   posthogApiKey?: string;
   posthogHost?: string;
+  identity?: {
+    distinctId: string;
+    identitySource: string;
+    githubUsername?: string;
+    githubEmail?: string;
+    gitEmail?: string;
+    gitEmailHash?: string;
+    gitUserName?: string;
+  };
+}
+
+function identifyUser(config: PostHogConfig): void {
+  if (!config.enabled || !config.identity) return;
+
+  const properties = {
+    identity_source: config.identity.identitySource,
+    github_username: config.identity.githubUsername,
+    github_email: config.identity.githubEmail,
+    git_email: config.identity.gitEmail,
+    git_email_sha256: config.identity.gitEmailHash,
+    git_user_name: config.identity.gitUserName,
+  };
+
+  posthog.identify(config.identity.distinctId, Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined)
+  ));
 }
 
 export function initPostHog(config: PostHogConfig): void {
@@ -39,20 +65,13 @@ export function initPostHog(config: PostHogConfig): void {
       capture_pageview: true,
       persistence: 'localStorage',
       opt_out_capturing_by_default: true,
-      loaded: (ph) => {
-        if (config.enabled) {
-          ph.opt_in_capturing();
-        }
-      },
     });
 
     currentApiKey = apiKey;
     currentHost = host;
-    currentEnabled = config.enabled;
-    return;
   }
 
-  // SDK already initialized with same key/host — just sync opt-in state
+  // SDK already initialized with same key/host — just sync opt-in state.
   if (currentEnabled !== config.enabled) {
     if (config.enabled) {
       posthog.opt_in_capturing();
@@ -61,6 +80,8 @@ export function initPostHog(config: PostHogConfig): void {
     }
     currentEnabled = config.enabled;
   }
+
+  identifyUser(config);
 }
 
 export function optIn(): void {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -14,6 +14,16 @@ export interface CustomCommand {
   command: string;
 }
 
+export interface AnalyticsIdentity {
+  distinctId: string;
+  identitySource: 'email' | 'github' | 'git_name' | 'posthog' | 'anonymous';
+  githubUsername?: string;
+  githubEmail?: string;
+  gitEmail?: string;
+  gitEmailHash?: string;
+  gitUserName?: string;
+}
+
 export interface AppConfig {
   gitRepoPath: string;
   verbose?: boolean;
@@ -54,6 +64,13 @@ export interface AppConfig {
     enabled: boolean;
     posthogApiKey?: string;
     posthogHost?: string;
+    distinctId?: string;
+    identitySource?: AnalyticsIdentity['identitySource'];
+    githubUsername?: string;
+    githubEmail?: string;
+    gitEmail?: string;
+    gitEmailHash?: string;
+    gitUserName?: string;
   };
   // User-defined custom commands for the Add Tool picker
   customCommands?: CustomCommand[];

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -369,6 +369,7 @@ interface ElectronAPI {
 
   // Analytics tracking
   analytics: {
+    getIdentity: () => Promise<IPCResponse<import('./config').AnalyticsIdentity>>;
     onMainEvent: (callback: (event: { eventName: string; properties: Record<string, unknown> }) => void) => () => void;
     syncDistinctId: (distinctId: string) => void;
   };

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -36,6 +36,7 @@ import { VersionChecker } from './services/versionChecker';
 import { Logger } from './utils/logger';
 import { ArchiveProgressManager } from './services/archiveProgressManager';
 import { AnalyticsManager } from './services/analyticsManager';
+import { resolveAnalyticsIdentity } from './services/analyticsIdentity';
 import { SpotlightManager } from './services/spotlightManager';
 import { startupRetentionResult } from './services/database';
 import { resourceMonitorService } from './services/resourceMonitorService';
@@ -919,7 +920,18 @@ async function initializeServices() {
   // Initialize analytics manager early so it can be used by SessionManager
   analyticsManager = new AnalyticsManager(configManager);
 
-  // Receive the renderer's posthog-js distinct ID so shutdown analytics use the same identity
+  ipcMain.handle('analytics:get-identity', async () => {
+    try {
+      const identity = resolveAnalyticsIdentity(configManager.getAnalyticsDistinctId());
+      await configManager.setAnalyticsIdentity(identity);
+      return { success: true, data: identity };
+    } catch (error) {
+      console.error('[Analytics] Failed to resolve identity:', error);
+      return { success: false, error: 'Failed to resolve analytics identity' };
+    }
+  });
+
+  // Receive the renderer's PostHog distinct ID so shutdown analytics use the same identity
   ipcMain.on('analytics:sync-distinct-id', async (_event: Electron.IpcMainEvent, distinctId: string) => {
     try {
       await configManager.setAnalyticsDistinctId(distinctId);
@@ -1476,6 +1488,12 @@ app.on('before-quit', async (event) => {
               session_duration_seconds: sessionDurationSeconds,
               app_version: app.getVersion(),
               platform: os.platform(),
+              identity_source: settings.identitySource,
+              github_username: settings.githubUsername,
+              github_email: settings.githubEmail,
+              git_email: settings.gitEmail,
+              git_email_sha256: settings.gitEmailHash,
+              git_user_name: settings.gitUserName,
               $lib: 'posthog-node',
             },
             timestamp: new Date().toISOString(),

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -829,6 +829,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Analytics tracking
   analytics: {
+    getIdentity: () => ipcRenderer.invoke('analytics:get-identity'),
     onMainEvent: (callback: (event: { eventName: string; properties: Record<string, unknown> }) => void) => {
       // Replay any events that arrived before this callback was registered
       for (const buffered of analyticsEventBuffer) {

--- a/main/src/services/analyticsIdentity.ts
+++ b/main/src/services/analyticsIdentity.ts
@@ -1,0 +1,61 @@
+import { execFileSync } from 'child_process';
+import * as crypto from 'crypto';
+import * as os from 'os';
+import { getShellPath } from '../utils/shellPath';
+import type { AnalyticsIdentity } from '../types/config';
+
+function commandEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, PATH: getShellPath() };
+}
+
+function runCommand(command: string, args: string[]): string | undefined {
+  try {
+    const output = execFileSync(command, args, {
+      cwd: os.homedir(),
+      encoding: 'utf8',
+      env: commandEnv(),
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+    return output.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value.trim().toLowerCase()).digest('hex');
+}
+
+export function resolveAnalyticsIdentity(existingDistinctId?: string): AnalyticsIdentity {
+  const githubUsername = runCommand('gh', ['api', 'user', '--jq', '.login']);
+  const githubEmail = runCommand('gh', ['api', 'user', '--jq', '.email // empty']);
+  const gitEmail = runCommand('git', ['config', '--global', 'user.email']);
+  const gitUserName = runCommand('git', ['config', '--global', 'user.name']);
+  const email = githubEmail || gitEmail;
+  const gitEmailHash = email ? sha256(email) : undefined;
+
+  let distinctId = existingDistinctId || `anon-${Date.now().toString(36)}`;
+  let identitySource: AnalyticsIdentity['identitySource'] = existingDistinctId ? 'posthog' : 'anonymous';
+
+  if (email) {
+    distinctId = `email:${email.trim().toLowerCase()}`;
+    identitySource = 'email';
+  } else if (githubUsername) {
+    distinctId = `github:${githubUsername}`;
+    identitySource = 'github';
+  } else if (gitUserName) {
+    distinctId = `git_name:${gitUserName.trim().toLowerCase()}`;
+    identitySource = 'git_name';
+  }
+
+  return {
+    distinctId,
+    identitySource,
+    githubUsername,
+    githubEmail,
+    gitEmail,
+    gitEmailHash,
+    gitUserName,
+  };
+}

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import type { AppConfig } from '../types/config';
+import type { AnalyticsIdentity, AppConfig } from '../types/config';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
 import { DEFAULT_WORKTREE_FILE_SYNC_ENTRIES } from '../../../shared/types/worktreeFileSync';
 import fs from 'fs/promises';
@@ -335,12 +335,30 @@ export class ConfigManager extends EventEmitter {
   async setAnalyticsDistinctId(distinctId: string): Promise<void> {
     if (!this.config.analytics) {
       this.config.analytics = {
-        enabled: true,
+        enabled: false,
         posthogApiKey: 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1',
         posthogHost: 'https://us.i.posthog.com'
       };
     }
     this.config.analytics.distinctId = distinctId;
+    await this.saveConfig();
+  }
+
+  async setAnalyticsIdentity(identity: AnalyticsIdentity): Promise<void> {
+    if (!this.config.analytics) {
+      this.config.analytics = {
+        enabled: false,
+        posthogApiKey: 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1',
+        posthogHost: 'https://us.i.posthog.com'
+      };
+    }
+    this.config.analytics.distinctId = identity.distinctId;
+    this.config.analytics.identitySource = identity.identitySource;
+    this.config.analytics.githubUsername = identity.githubUsername;
+    this.config.analytics.githubEmail = identity.githubEmail;
+    this.config.analytics.gitEmail = identity.gitEmail;
+    this.config.analytics.gitEmailHash = identity.gitEmailHash;
+    this.config.analytics.gitUserName = identity.gitUserName;
     await this.saveConfig();
   }
 

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -11,6 +11,29 @@ export interface CustomCommand {
   command: string;
 }
 
+export interface AnalyticsIdentity {
+  distinctId: string;
+  identitySource: 'email' | 'github' | 'git_name' | 'posthog' | 'anonymous';
+  githubUsername?: string;
+  githubEmail?: string;
+  gitEmail?: string;
+  gitEmailHash?: string;
+  gitUserName?: string;
+}
+
+export interface AnalyticsConfig {
+  enabled: boolean;
+  posthogApiKey?: string;
+  posthogHost?: string;
+  distinctId?: string;
+  identitySource?: AnalyticsIdentity['identitySource'];
+  githubUsername?: string;
+  githubEmail?: string;
+  gitEmail?: string;
+  gitEmailHash?: string;
+  gitUserName?: string;
+}
+
 import type { CloudVmConfig } from '../../../shared/types/cloud';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
 
@@ -69,12 +92,7 @@ export interface AppConfig {
   // Off by default. Requires app restart; the supervisor is forked once at `app.whenReady`.
   usePtyHost?: boolean;
   // PostHog analytics settings
-  analytics?: {
-    enabled: boolean;
-    posthogApiKey?: string;
-    posthogHost?: string;
-    distinctId?: string; // Random UUID for anonymous user identification
-  };
+  analytics?: AnalyticsConfig;
   // User-defined custom commands for the Add Tool picker
   customCommands?: CustomCommand[];
   // Terminal shortcuts — hotkey-triggered clipboard paste snippets
@@ -129,12 +147,7 @@ export interface UpdateConfigRequest {
   // Off by default. Requires app restart to take effect.
   usePtyHost?: boolean;
   // PostHog analytics settings
-  analytics?: {
-    enabled: boolean;
-    posthogApiKey?: string;
-    posthogHost?: string;
-    distinctId?: string; // Random UUID for anonymous user identification
-  };
+  analytics?: AnalyticsConfig;
   // User-defined custom commands for the Add Tool picker
   customCommands?: CustomCommand[];
   // Terminal shortcuts — hotkey-triggered clipboard paste snippets


### PR DESCRIPTION
## Summary
- Improve analytics initialization and identity handling
- Keep analytics startup resilient when local tooling is unavailable
- Simplify analytics settings and consent copy

## Testing
- pnpm typecheck
- pnpm lint
- pnpm build:frontend
- pnpm build:main

Note: full pnpm build reached build:electron and failed in this WSL toolchain while rebuilding msgpackr-extract for x64; frontend and main builds passed.