### PR TITLE
Fix collapsed sidebar session cycling shortcuts

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -10,7 +10,6 @@ import { Dropdown } from './ui/Dropdown';
 import { Tooltip } from './ui/Tooltip';
 import type { DropdownItem } from './ui/Dropdown';
 import { API } from '../utils/api';
-import { cycleIndex } from '../utils/arrayUtils';
 import { cn } from '../utils/cn';
 import type { Session, GitStatus } from '../types/session';
 import type { Project } from '../types/project';
@@ -125,33 +124,13 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
     return result;
   }, [projects, expandedProjects, sessionsByProject]);
 
-  // Flat list of ALL active sessions (for cycling - includes collapsed projects)
-  const allActiveSessions = useMemo(() => {
-    const result: Session[] = [];
-    projects.forEach(p => {
-      const list = sessionsByProject.get(p.id) || [];
-      result.push(...list);
-    });
-    return result;
-  }, [projects, sessionsByProject]);
-
   // Register ⌘1-⌘9 hotkeys with dynamic session name labels
   const allVisibleSessionsRef = useRef(allVisibleSessions);
   allVisibleSessionsRef.current = allVisibleSessions;
-  const allActiveSessionsRef = useRef(allActiveSessions);
-  allActiveSessionsRef.current = allActiveSessions;
-  const pinnedSessionsRef = useRef(pinnedSessions);
-  pinnedSessionsRef.current = pinnedSessions;
-  const activeSessionIdRef = useRef(activeSessionId);
-  activeSessionIdRef.current = activeSessionId;
   const setActiveSessionRef = useRef(setActiveSession);
   setActiveSessionRef.current = setActiveSession;
   const navigateToSessionsRef = useRef(navigateToSessions);
   navigateToSessionsRef.current = navigateToSessions;
-  const expandedProjectsRef = useRef(expandedProjects);
-  expandedProjectsRef.current = expandedProjects;
-  const setExpandedProjectsRef = useRef(setExpandedProjects);
-  setExpandedProjectsRef.current = setExpandedProjects;
 
   // Build stable label key so we re-register when session names/projects change
   const sessionLabelKey = allVisibleSessions.slice(0, 9).map(s => `${s.name}:${s.projectId}`).join('|');
@@ -189,112 +168,6 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
     }
     return () => ids.forEach(id => unregister(id));
   }, [register, unregister, sessionLabelKey]);
-
-  // Session cycling: navigates to next/prev session across ALL active sessions
-  // (not just visible ones from expanded projects). Auto-expands collapsed
-  // projects when cycling to their sessions so users can see the selection.
-  const cycleSession = useCallback((direction: 'next' | 'prev') => {
-    const sessions = allActiveSessionsRef.current;
-    if (sessions.length === 0) return;
-
-    const currentId = activeSessionIdRef.current;
-    const currentIndex = sessions.findIndex(s => s.id === currentId);
-    const nextIndex = cycleIndex(currentIndex, sessions.length, direction);
-    if (nextIndex === -1) return;
-
-    const nextSession = sessions[nextIndex];
-
-    // Auto-expand the project if it's collapsed
-    if (nextSession.projectId != null && !expandedProjectsRef.current.has(nextSession.projectId)) {
-      setExpandedProjectsRef.current(prev => {
-        const next = new Set(prev);
-        next.add(nextSession.projectId!);
-        return next;
-      });
-    }
-
-    setActiveSessionRef.current(nextSession.id);
-    navigateToSessionsRef.current();
-  }, []);
-
-  const cyclePinnedOrAllSessions = useCallback((direction: 'next' | 'prev') => {
-    const pinned = pinnedSessionsRef.current.map(item => item.session);
-    const sessions = pinned.length > 0 ? pinned : allActiveSessionsRef.current;
-    if (sessions.length === 0) return;
-
-    const currentId = activeSessionIdRef.current;
-    const currentIndex = sessions.findIndex(s => s.id === currentId);
-    const nextIndex = cycleIndex(currentIndex, sessions.length, direction);
-    if (nextIndex === -1) return;
-
-    setActiveSessionRef.current(sessions[nextIndex].id);
-    navigateToSessionsRef.current();
-  }, []);
-
-  // Register session cycling hotkeys
-  useEffect(() => {
-    const nextKeys = ['mod+Tab'];
-    const prevKeys = ['mod+shift+Tab'];
-    const ids: string[] = [];
-
-    nextKeys.forEach((keys, i) => {
-      const id = `cycle-session-next-${i}`;
-      ids.push(id);
-      register({
-        id,
-        label: 'Next Pane',
-        keys,
-        category: 'session',
-        enabled: () => allActiveSessionsRef.current.length > 1,
-        action: () => cycleSession('next'),
-      });
-    });
-
-    prevKeys.forEach((keys, i) => {
-      const id = `cycle-session-prev-${i}`;
-      ids.push(id);
-      register({
-        id,
-        label: 'Previous Pane',
-        keys,
-        category: 'session',
-        enabled: () => allActiveSessionsRef.current.length > 1,
-        action: () => cycleSession('prev'),
-      });
-    });
-
-    return () => ids.forEach(id => unregister(id));
-  }, [register, unregister, cycleSession]);
-
-  // Register pinned-aware cycling hotkeys. When anything is pinned, Cmd/Ctrl+Up
-  // and Cmd/Ctrl+Down only traverse the pinned section in visible order.
-  useEffect(() => {
-    const ids = ['cycle-pinned-or-all-next', 'cycle-pinned-or-all-prev'];
-    register({
-      id: ids[0],
-      label: 'Next Pinned Pane',
-      keys: 'mod+ArrowDown',
-      category: 'session',
-      enabled: () => {
-        const pinnedCount = pinnedSessionsRef.current.length;
-        return pinnedCount > 1 || (pinnedCount === 0 && allActiveSessionsRef.current.length > 1);
-      },
-      action: () => cyclePinnedOrAllSessions('next'),
-    });
-    register({
-      id: ids[1],
-      label: 'Previous Pinned Pane',
-      keys: 'mod+ArrowUp',
-      category: 'session',
-      enabled: () => {
-        const pinnedCount = pinnedSessionsRef.current.length;
-        return pinnedCount > 1 || (pinnedCount === 0 && allActiveSessionsRef.current.length > 1);
-      },
-      action: () => cyclePinnedOrAllSessions('prev'),
-    });
-
-    return () => ids.forEach(id => unregister(id));
-  }, [register, unregister, cyclePinnedOrAllSessions]);
 
   // Track known project IDs so we only auto-expand newly added ones
   const knownProjectIds = useRef<Set<number>>(new Set());

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import { useNavigationStore } from '../stores/navigationStore';
 import { usePanelStore } from '../stores/panelStore';
 import { API } from '../utils/api';
 import type { Project } from '../types/project';
+import { useSessionNavigationHotkeys } from '../hooks/useSessionNavigationHotkeys';
 
 // --- Collapsed sidebar tooltip content ---
 
@@ -133,6 +134,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const activeProjectId = useNavigationStore((state) => state.activeProjectId);
   const navigateToProject = useNavigationStore((state) => state.navigateToProject);
+  useSessionNavigationHotkeys({ projects, sessionSortAscending });
 
   const handleRefreshGitStatus = async () => {
     try {
@@ -144,21 +146,27 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
     }
   };
 
-  // Fetch projects for collapsed sidebar
-  useEffect(() => {
-    if (!collapsed) return;
-    const fetchProjects = async () => {
-      try {
-        const response = await API.projects.getAll();
-        if (response.success && response.data) {
-          setProjects(response.data);
-        }
-      } catch (error) {
-        console.error('Failed to fetch projects:', error);
+  const loadProjects = useCallback(async () => {
+    try {
+      const response = await API.projects.getAll();
+      if (response.success && response.data) {
+        setProjects(response.data);
       }
+    } catch (error) {
+      console.error('Failed to fetch projects:', error);
+    }
+  }, []);
+
+  // Fetch projects for collapsed sidebar rendering and always-mounted session hotkeys.
+  useEffect(() => {
+    loadProjects();
+    window.addEventListener('project-changed', loadProjects);
+    window.addEventListener('project-sessions-refresh', loadProjects);
+    return () => {
+      window.removeEventListener('project-changed', loadProjects);
+      window.removeEventListener('project-sessions-refresh', loadProjects);
     };
-    fetchProjects();
-  }, [collapsed]);
+  }, [loadProjects]);
 
   const activeProject = useMemo(() => {
     if (activeProjectId) return projects.find(p => p.id === activeProjectId);

--- a/frontend/src/hooks/useSessionNavigationHotkeys.ts
+++ b/frontend/src/hooks/useSessionNavigationHotkeys.ts
@@ -1,0 +1,151 @@
+import { useCallback, useMemo, useRef } from 'react';
+import { useHotkey } from './useHotkey';
+import { useSessionStore } from '../stores/sessionStore';
+import { useNavigationStore } from '../stores/navigationStore';
+import { cycleIndex } from '../utils/arrayUtils';
+import type { Session } from '../types/session';
+import type { Project } from '../types/project';
+
+interface UseSessionNavigationHotkeysOptions {
+  projects: Project[];
+  sessionSortAscending: boolean;
+}
+
+export function useSessionNavigationHotkeys({
+  projects,
+  sessionSortAscending,
+}: UseSessionNavigationHotkeysOptions): void {
+  const sessions = useSessionStore(s => s.sessions);
+  const activeSessionId = useSessionStore(s => s.activeSessionId);
+  const setActiveSession = useSessionStore(s => s.setActiveSession);
+  const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
+
+  const sessionsByProject = useMemo(() => {
+    const map = new Map<number, Session[]>();
+    sessions
+      .filter(s => !s.archived)
+      .forEach(s => {
+        if (s.projectId != null) {
+          const list = map.get(s.projectId) || [];
+          list.push(s);
+          map.set(s.projectId, list);
+        }
+      });
+    map.forEach((list, key) => {
+      map.set(key, list.sort((a, b) => {
+        const da = new Date(a.createdAt).getTime();
+        const db = new Date(b.createdAt).getTime();
+        return sessionSortAscending ? da - db : db - da;
+      }));
+    });
+    return map;
+  }, [sessions, sessionSortAscending]);
+
+  const projectById = useMemo(() => {
+    const map = new Map<number, Project>();
+    projects.forEach(project => map.set(project.id, project));
+    return map;
+  }, [projects]);
+
+  const allActiveSessions = useMemo(() => {
+    const result: Session[] = [];
+    projects.forEach(project => {
+      const list = sessionsByProject.get(project.id) || [];
+      result.push(...list);
+    });
+    return result;
+  }, [projects, sessionsByProject]);
+
+  const pinnedSessions = useMemo(() => {
+    return sessions
+      .filter(session => !session.archived && session.isFavorite)
+      .map(session => {
+        const projectName = session.projectId != null ? projectById.get(session.projectId)?.name : undefined;
+        return {
+          session,
+          label: `${projectName || 'Unknown'}/${session.name || 'Untitled'}`,
+        };
+      })
+      .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+  }, [sessions, projectById]);
+
+  const allActiveSessionsRef = useRef(allActiveSessions);
+  allActiveSessionsRef.current = allActiveSessions;
+  const pinnedSessionsRef = useRef(pinnedSessions);
+  pinnedSessionsRef.current = pinnedSessions;
+  const activeSessionIdRef = useRef(activeSessionId);
+  activeSessionIdRef.current = activeSessionId;
+  const setActiveSessionRef = useRef(setActiveSession);
+  setActiveSessionRef.current = setActiveSession;
+  const navigateToSessionsRef = useRef(navigateToSessions);
+  navigateToSessionsRef.current = navigateToSessions;
+
+  const cycleSession = useCallback((direction: 'next' | 'prev') => {
+    const sessions = allActiveSessionsRef.current;
+    if (sessions.length === 0) return;
+
+    const currentId = activeSessionIdRef.current;
+    const currentIndex = sessions.findIndex(s => s.id === currentId);
+    const nextIndex = cycleIndex(currentIndex, sessions.length, direction);
+    if (nextIndex === -1) return;
+
+    setActiveSessionRef.current(sessions[nextIndex].id);
+    navigateToSessionsRef.current();
+  }, []);
+
+  const cyclePinnedOrAllSessions = useCallback((direction: 'next' | 'prev') => {
+    const pinned = pinnedSessionsRef.current.map(item => item.session);
+    const sessions = pinned.length > 0 ? pinned : allActiveSessionsRef.current;
+    if (sessions.length === 0) return;
+
+    const currentId = activeSessionIdRef.current;
+    const currentIndex = sessions.findIndex(s => s.id === currentId);
+    const nextIndex = cycleIndex(currentIndex, sessions.length, direction);
+    if (nextIndex === -1) return;
+
+    setActiveSessionRef.current(sessions[nextIndex].id);
+    navigateToSessionsRef.current();
+  }, []);
+
+  useHotkey({
+    id: 'cycle-session-next-0',
+    label: 'Next Pane',
+    keys: 'mod+Tab',
+    category: 'session',
+    enabled: () => allActiveSessionsRef.current.length > 1,
+    action: () => cycleSession('next'),
+  });
+
+  useHotkey({
+    id: 'cycle-session-prev-0',
+    label: 'Previous Pane',
+    keys: 'mod+shift+Tab',
+    category: 'session',
+    enabled: () => allActiveSessionsRef.current.length > 1,
+    action: () => cycleSession('prev'),
+  });
+
+  useHotkey({
+    id: 'cycle-pinned-or-all-next',
+    label: 'Next Pinned Pane',
+    keys: 'mod+ArrowDown',
+    category: 'session',
+    enabled: () => {
+      const pinnedCount = pinnedSessionsRef.current.length;
+      return pinnedCount > 1 || (pinnedCount === 0 && allActiveSessionsRef.current.length > 1);
+    },
+    action: () => cyclePinnedOrAllSessions('next'),
+  });
+
+  useHotkey({
+    id: 'cycle-pinned-or-all-prev',
+    label: 'Previous Pinned Pane',
+    keys: 'mod+ArrowUp',
+    category: 'session',
+    enabled: () => {
+      const pinnedCount = pinnedSessionsRef.current.length;
+      return pinnedCount > 1 || (pinnedCount === 0 && allActiveSessionsRef.current.length > 1);
+    },
+    action: () => cyclePinnedOrAllSessions('prev'),
+  });
+}


### PR DESCRIPTION
## Summary
- Move session-cycling hotkeys into an always-mounted sidebar hook
- Keep Ctrl/Cmd+Up and Ctrl/Cmd+Down active when the left sidebar is collapsed
- Preserve pinned-session behavior and sidebar sort order for cycling

## Validation
- pnpm --filter frontend typecheck
- pnpm --filter frontend exec eslint src --ext .ts,.tsx --quiet
- git commit hook: pnpm run -r typecheck && pnpm run -r lint

Note: local shell reports Node v20.19.3 while repo wants >=22.14.0, but checks completed successfully.