### PR TITLE
Update command palette and terminal clear shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Other tools build custom chat UIs that only work with agents they've explicitly 
 
 | Shortcut | Action |
 |----------|--------|
-| `⌘K` / `Ctrl+K` | Open command palette |
+| `⌘⇧P` / `Ctrl+Shift+P` | Open command palette |
+| `⌘K` / `Ctrl+K` | Clear terminal scrollback |
 | `⌘Enter` / `Ctrl+Enter` | Send message to AI agent |
 | `⌘N` / `Ctrl+N` | New pane |
 | `⌘⇧W` / `Ctrl+Shift+W` | Archive pane |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -134,7 +134,7 @@ function App() {
   useHotkey({
     id: 'open-command-palette',
     label: 'Open Command Palette',
-    keys: 'mod+k',
+    keys: 'mod+shift+p',
     category: 'navigation',
     action: () => setIsCommandPaletteOpen(true),
   });

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -877,7 +877,7 @@ export const SessionView = memo(() => {
         id: 'push',
         label: 'Push',
         icon: Upload,
-        shortcut: 'mod+shift+p',
+        shortcut: 'mod+shift+u',
         onClick: hook.handleGitPush,
         disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing' || !activeSession.gitStatus?.ahead,
         variant: 'default' as const,

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -479,11 +479,25 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
         // Intercept app-level shortcuts before xterm consumes them
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+          const ctrlOrMeta = e.ctrlKey || e.metaKey;
+
+          // Ctrl/Cmd+K: clear xterm scrollback without writing ^K to the PTY.
+          if (ctrlOrMeta && e.key.toLowerCase() === 'k') {
+            if (e.type === 'keydown') {
+              xtermRef.current?.clear();
+              window.electronAPI
+                .invoke('terminal:clearScrollback', panel.id)
+                .catch((error: unknown) => {
+                  console.warn('[TerminalPanel] Failed to persist scrollback clear:', error);
+                });
+            }
+            return false;
+          }
+
           // When a TUI app is running, pass most keys through to the PTY
           // but still let Ctrl/Cmd+V use the browser's native paste path
           if (tuiActiveRef.current) {
-            const cm = e.ctrlKey || e.metaKey;
-            if (cm && e.key.toLowerCase() === 'v') return false;
+            if (ctrlOrMeta && e.key.toLowerCase() === 'v') return false;
             return true;
           }
 
@@ -497,8 +511,6 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             }
             return false;
           }
-
-          const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
           // Ctrl/Cmd+1-9: switch sessions
           if (ctrlOrMeta && e.key >= '1' && e.key <= '9') return false;
@@ -522,9 +534,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           if (ctrlOrMeta && (e.key.toLowerCase() === 'w' || e.key.toLowerCase() === 'q')) return false;
           // Ctrl/Cmd+T: open Add Tool dropdown
           if (ctrlOrMeta && e.key.toLowerCase() === 't') return false;
-          // Ctrl/Cmd+K: command palette
-          if (ctrlOrMeta && e.key.toLowerCase() === 'k') return false;
-          // Ctrl/Cmd+P: prompt history
+          // Ctrl/Cmd+P: prompt history; Ctrl/Cmd+Shift+P: command palette
           if (ctrlOrMeta && e.key.toLowerCase() === 'p') return false;
           // Ctrl/Cmd+N: new workspace
           if (ctrlOrMeta && e.key.toLowerCase() === 'n') return false;
@@ -534,7 +544,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'r') return false;
           // Git shortcuts - release to DOM for hotkeyStore
           if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'm') return false;
-          if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'p') return false;
+          if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'u') return false;
           if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'l') return false;
           // Ctrl/Cmd+Shift+N: new project
           if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'n') return false;

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -687,7 +687,7 @@ export const useSessionView = (
   useHotkey({
     id: 'git-push',
     label: 'Git: Push',
-    keys: 'mod+shift+p',
+    keys: 'mod+shift+u',
     category: 'session',
     action: () => handleGitPush(),
     enabled: () => !!activeSession && !isMerging && !isSessionBusy && !activeSession.isMainRepo && (activeSession.gitStatus?.ahead ?? 0) > 0,

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -330,7 +330,7 @@ async function createWindow() {
     // Whitelist of Pane hotkeys that should be forwarded from webviews.
     // mod+key (no extra modifiers):
     const paneHotkeys: ReadonlySet<string> = new Set([
-      'k', 'b', ',', 'n', 'a', 'd', 'w', 't', '`',
+      'b', ',', 'n', 'a', 'd', 'w', 't', '`',
       // mod+1..9 switch session, mod+Tab/ArrowDown cycle next
       '1', '2', '3', '4', '5', '6', '7', '8', '9',
       'tab', 'arrowdown', 'arrowup',
@@ -339,7 +339,7 @@ async function createWindow() {
     // input.key reports the shifted symbol (e.g. '!' for Shift+1) which
     // varies by keyboard layout.
     const paneShiftCodes: ReadonlySet<string> = new Set([
-      'KeyE', 'KeyN', 'KeyK', 'KeyP', 'KeyZ', 'KeyL', 'KeyR', 'KeyM',
+      'KeyE', 'KeyN', 'KeyK', 'KeyP', 'KeyZ', 'KeyL', 'KeyR', 'KeyM', 'KeyU',
       'KeyB', 'KeyW', 'KeyD',
       'Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5',
       'Digit6', 'Digit7', 'Digit8', 'Digit9',

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -500,6 +500,16 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
     }
   });
 
+  ipcMain.handle('terminal:clearScrollback', async (_event, panelId: string) => {
+    try {
+      await terminalPanelManager.clearTerminalScrollback(panelId);
+      return { success: true };
+    } catch (error) {
+      console.error('[terminal:clearScrollback] Failed:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  });
+
   // Renderer tells main when a terminal panel becomes (in)visible so PTY
   // output cadence can drop to OUTPUT_BATCH_INTERVAL_HIDDEN while hidden.
   // No-op when the panel's PTY isn't in the map (pre-init / post-destroy).

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -1162,6 +1162,26 @@ export class TerminalPanelManager {
       serializedBuffer: this.serializedBuffers.get(panelId)
     };
   }
+
+  async clearTerminalScrollback(panelId: string): Promise<void> {
+    const terminal = this.terminals.get(panelId);
+    if (terminal) {
+      terminal.scrollbackBuffer = '';
+    }
+    this.serializedBuffers.delete(panelId);
+
+    const panel = panelManager.getPanel(panelId);
+    if (!panel) return;
+
+    const state = panel.state;
+    state.customState = {
+      ...(state.customState ?? {}),
+      scrollbackBuffer: '',
+      serializedBuffer: undefined,
+    } as TerminalPanelState;
+
+    await panelManager.updatePanel(panelId, { state });
+  }
   
   private emitActivityStatus(terminal: TerminalProcess): void {
     if (mainWindow) {


### PR DESCRIPTION
## Summary
- move the command palette shortcut from Cmd/Ctrl+K to Cmd/Ctrl+Shift+P
- make Cmd/Ctrl+K clear xterm scrollback without writing input to the running PTY
- clear persisted terminal scrollback/snapshots so cleared output does not reappear after refresh/remount
- move Git Push from Cmd/Ctrl+Shift+P to Cmd/Ctrl+Shift+U to avoid shortcut collision
- update README shortcut docs

## Testing
- pnpm --filter frontend typecheck
- pnpm --filter main typecheck
- pre-commit pnpm run -r typecheck
- pre-commit pnpm run -r lint

Note: local checks show the existing Node engine warning because this shell uses Node v20.19.3 while the repo wants >=22.14.0.