### PR TITLE
Show unavailable commands in palette

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -5,6 +5,8 @@ import { Input } from './ui/Input';
 import { useHotkeyStore, type HotkeyDefinition } from '../stores/hotkeyStore';
 import { formatKeyDisplay, CATEGORY_LABELS, CATEGORY_ORDER } from '../utils/hotkeyUtils';
 import { Kbd } from './ui/Kbd';
+import { Tooltip } from './ui/Tooltip';
+import { cn } from '../utils/cn';
 
 interface CommandPaletteProps {
   isOpen: boolean;
@@ -13,7 +15,7 @@ interface CommandPaletteProps {
 
 type ListItem =
   | { type: 'header'; category: string }
-  | { type: 'command'; hotkey: HotkeyDefinition; flatIndex: number };
+  | { type: 'command'; hotkey: HotkeyDefinition; flatIndex: number; disabled: boolean; disabledReason: string | null };
 
 export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   const [searchTerm, setSearchTerm] = useState('');
@@ -24,11 +26,12 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   const getAll = useHotkeyStore((s) => s.getAll);
   const search = useHotkeyStore((s) => s.search);
 
-  // Get filtered results — exclude the command palette's own hotkey, disabled hotkeys, and showInPalette: false
+  // Get filtered results — exclude the command palette's own hotkey and showInPalette: false.
+  // Disabled commands remain visible, sorted after enabled commands.
   const results = (searchTerm
     ? search(searchTerm, { paletteOnly: true })
     : getAll({ paletteOnly: true })
-  ).filter((h) => h.id !== 'open-command-palette' && (!h.enabled || h.enabled()));
+  ).filter((h) => h.id !== 'open-command-palette');
 
   const { listItems, commandCount } = buildListItems(results);
 
@@ -59,6 +62,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     );
     const selected = commandItems[selectedIndex];
     if (selected) {
+      if (selected.disabled) return;
       onClose();
       setTimeout(() => selected.hotkey.action(), 50);
     }
@@ -126,17 +130,23 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
               );
             }
             const isSelected = item.flatIndex === selectedIndex;
-            return (
+            const button = (
               <button
                 key={item.hotkey.id}
                 data-selected={isSelected}
-                className={`w-full flex items-center justify-between px-4 py-2 text-sm cursor-pointer transition-colors ${
-                  isSelected
-                    ? 'bg-interactive/15 text-text-primary'
-                    : 'text-text-secondary hover:bg-surface-hover'
-                }`}
+                aria-disabled={item.disabled}
+                className={cn(
+                  'w-full flex items-center justify-between px-4 py-2 text-sm transition-colors',
+                  item.disabled
+                    ? 'text-text-tertiary opacity-60 cursor-not-allowed'
+                    : 'cursor-pointer',
+                  isSelected && !item.disabled && 'bg-interactive/15 text-text-primary',
+                  isSelected && item.disabled && 'bg-surface-hover/60',
+                  !isSelected && !item.disabled && 'text-text-secondary hover:bg-surface-hover'
+                )}
                 onClick={() => {
                   setSelectedIndex(item.flatIndex);
+                  if (item.disabled) return;
                   onClose();
                   setTimeout(() => item.hotkey.action(), 50);
                 }}
@@ -149,6 +159,18 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                   </Kbd>
                 )}
               </button>
+            );
+
+            if (item.disabled && item.disabledReason) {
+              return (
+                <Tooltip key={item.hotkey.id} content={item.disabledReason} side="right" className="block">
+                  {button}
+                </Tooltip>
+              );
+            }
+
+            return (
+              button
             );
           })
         )}
@@ -165,22 +187,35 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
 }
 
 function buildListItems(results: HotkeyDefinition[]) {
-  const grouped: Record<string, HotkeyDefinition[]> = {};
+  const grouped: Record<string, Array<{ hotkey: HotkeyDefinition; disabled: boolean; disabledReason: string | null }>> = {};
   for (const def of results) {
     if (!grouped[def.category]) grouped[def.category] = [];
-    grouped[def.category].push(def);
+    const disabled = !!def.enabled && !def.enabled();
+    grouped[def.category].push({
+      hotkey: def,
+      disabled,
+      disabledReason: disabled ? def.disabledReason?.() ?? 'Command unavailable' : null,
+    });
   }
 
   const listItems: ListItem[] = [];
   let flatIndex = 0;
-  for (const category of CATEGORY_ORDER) {
+  const appendCategoryItems = (category: HotkeyDefinition['category'], disabled: boolean) => {
     const hotkeys = grouped[category];
-    if (!hotkeys) continue;
+    const filteredHotkeys = hotkeys?.filter((item) => item.disabled === disabled);
+    if (!filteredHotkeys?.length) return;
     listItems.push({ type: 'header', category });
-    for (const hotkey of hotkeys) {
-      listItems.push({ type: 'command', hotkey, flatIndex });
+    for (const item of filteredHotkeys) {
+      listItems.push({ type: 'command', ...item, flatIndex });
       flatIndex++;
     }
+  };
+
+  for (const category of CATEGORY_ORDER) {
+    appendCategoryItems(category, false);
+  }
+  for (const category of CATEGORY_ORDER) {
+    appendCategoryItems(category, true);
   }
 
   return { listItems, commandCount: flatIndex };

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -6,6 +6,8 @@ import { Button } from './ui/Button';
 import { Tooltip } from './ui/Tooltip';
 import { Dropdown, DropdownMenuItem } from './ui/Dropdown';
 import { GitHistoryGraph } from './GitHistoryGraph';
+import { Kbd } from './ui/Kbd';
+import { formatKeyDisplay } from '../utils/hotkeyUtils';
 
 interface DetailPanelProps {
   isVisible: boolean;
@@ -52,6 +54,23 @@ function DetailSection({ title, children }: { title: string; children: React.Rea
     <div className="px-2 py-2 border-b border-border-primary">
       <SectionHeader>{title}</SectionHeader>
       {children}
+    </div>
+  );
+}
+
+function actionTooltip(action: { description?: string; disabled?: boolean; disabledReason?: string; shortcut?: string }, disabled = action.disabled): React.ReactNode {
+  const message = disabled ? action.disabledReason ?? action.description : action.description;
+  return (
+    <div className="space-y-1">
+      {message && (
+        <div>{disabled ? `Unavailable: ${message}` : message}</div>
+      )}
+      {action.shortcut && (
+        <div className="flex items-center gap-2 text-text-tertiary">
+          <span>Shortcut</span>
+          <Kbd size="xs" variant="muted">{formatKeyDisplay(action.shortcut)}</Kbd>
+        </div>
+      )}
     </div>
   );
 }
@@ -428,7 +447,7 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
 
                   return (
                     <div key={`${left.id}-${right.id}`} className="flex gap-0.5 [&>*]:min-w-[90px]">
-                      <Tooltip content={left.description} side="left">
+                      <Tooltip content={actionTooltip(left, left.disabled || isMerging)} side="left">
                         <Button variant="ghost" size="sm" className={pairBtnClass} onClick={left.onClick} disabled={left.disabled || isMerging}>
                           <left.icon className={pairIconClass} />
                           {isRebaseMerge ? (
@@ -449,7 +468,7 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
                           )}
                         </Button>
                       </Tooltip>
-                      <Tooltip content={right.description} side="left">
+                      <Tooltip content={actionTooltip(right, right.disabled || isMerging)} side="left">
                         <Button variant="ghost" size="sm" className={pairBtnClass} onClick={right.onClick} disabled={right.disabled || isMerging}>
                           <right.icon className={pairIconClass} />
                           {isRebaseMerge ? (
@@ -482,7 +501,7 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
                 const isFetch = action.id === 'fetch';
 
                 return (
-                  <Tooltip key={action.id} content={action.description} side="left">
+                  <Tooltip key={action.id} content={actionTooltip(action, action.disabled || isMerging)} side="left">
                     <Button variant="ghost" size="sm" className={sidebarBtn} onClick={action.onClick} disabled={action.disabled || isMerging}>
                       <action.icon className="w-4 h-4 mr-2 flex-shrink-0" />
                       {isFetch && fetchedAgo ? (

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -783,6 +783,11 @@ export const SessionView = memo(() => {
   // Create branch actions for the panel bar
   const branchActions = useMemo(() => {
     if (!activeSession) return [];
+    const busyReason = hook.isMerging
+      ? 'Git operation already in progress'
+      : activeSession.status === 'running' || activeSession.status === 'initializing'
+        ? 'Session is currently running'
+        : undefined;
     
     return activeSession.isMainRepo ? [
       {
@@ -792,7 +797,8 @@ export const SessionView = memo(() => {
         onClick: hook.handleGitPull,
         disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing',
         variant: 'default' as const,
-        description: hook.gitCommands?.getPullCommand ? `git ${hook.gitCommands.getPullCommand()}` : 'git pull'
+        description: hook.gitCommands?.getPullCommand ? `git ${hook.gitCommands.getPullCommand()}` : 'git pull',
+        disabledReason: busyReason,
       },
       {
         id: 'push',
@@ -801,7 +807,8 @@ export const SessionView = memo(() => {
         onClick: hook.handleGitPush,
         disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing',
         variant: 'success' as const,
-        description: hook.gitCommands?.getPushCommand ? `git ${hook.gitCommands.getPushCommand()}` : 'git push'
+        description: hook.gitCommands?.getPushCommand ? `git ${hook.gitCommands.getPushCommand()}` : 'git push',
+        disabledReason: busyReason,
       }
     ] : [
       // --- Sync ---
@@ -812,7 +819,8 @@ export const SessionView = memo(() => {
         onClick: hook.handleGitFetch,
         disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing',
         variant: 'default' as const,
-        description: `Fetch from remote into ${hook.gitCommands?.currentBranch || 'current branch'} without merging`
+        description: `Fetch from remote into ${hook.gitCommands?.currentBranch || 'current branch'} without merging`,
+        disabledReason: busyReason,
       },
       // --- Update working tree ---
       {
@@ -824,7 +832,8 @@ export const SessionView = memo(() => {
         variant: 'default' as const,
         description: activeSession.gitStatus?.hasUncommittedChanges
           ? `Stash uncommitted changes on ${hook.gitCommands?.currentBranch || 'current branch'}`
-          : 'No changes to stash'
+          : 'No changes to stash',
+        disabledReason: busyReason ?? (activeSession.gitStatus?.hasUncommittedChanges ? undefined : 'No changes to stash'),
       },
       {
         id: 'stash-pop',
@@ -833,7 +842,8 @@ export const SessionView = memo(() => {
         onClick: hook.handleGitStashPop,
         disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing' || !hook.hasStash,
         variant: 'default' as const,
-        description: hook.hasStash ? 'Apply and remove most recent stash' : 'No stash to pop'
+        description: hook.hasStash ? 'Apply and remove most recent stash' : 'No stash to pop',
+        disabledReason: busyReason ?? (hook.hasStash ? undefined : 'No stash to pop'),
       },
       // --- Commit & push ---
       {
@@ -849,7 +859,8 @@ export const SessionView = memo(() => {
         variant: 'default' as const,
         description: (activeSession.gitStatus?.hasUncommittedChanges || activeSession.gitStatus?.hasUntrackedFiles)
           ? `Stage all changes and commit on ${hook.gitCommands?.currentBranch || 'current branch'}`
-          : 'No changes to commit'
+          : 'No changes to commit',
+        disabledReason: busyReason ?? ((activeSession.gitStatus?.hasUncommittedChanges || activeSession.gitStatus?.hasUntrackedFiles) ? undefined : 'No changes to commit'),
       },
       {
         id: 'undo-commit',
@@ -861,7 +872,8 @@ export const SessionView = memo(() => {
         variant: 'default' as const,
         description: activeSession.gitStatus?.ahead
           ? 'Undo last commit, keeping changes staged (git reset --soft HEAD~1)'
-          : 'No commits to undo'
+          : 'No commits to undo',
+        disabledReason: busyReason ?? (activeSession.gitStatus?.ahead ? undefined : 'No commits to undo'),
       },
       {
         id: 'pull',
@@ -871,7 +883,8 @@ export const SessionView = memo(() => {
         onClick: hook.handleGitPull,
         disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing',
         variant: 'default' as const,
-        description: `Pull latest changes into ${hook.gitCommands?.currentBranch || 'current branch'}`
+        description: `Pull latest changes into ${hook.gitCommands?.currentBranch || 'current branch'}`,
+        disabledReason: busyReason,
       },
       {
         id: 'push',
@@ -883,7 +896,8 @@ export const SessionView = memo(() => {
         variant: 'default' as const,
         description: activeSession.gitStatus?.ahead
           ? `Push ${activeSession.gitStatus.ahead} commit(s)${hook.gitCommands?.currentBranch ? ` from ${hook.gitCommands.currentBranch}` : ''} to remote`
-          : 'No commits to push'
+          : 'No commits to push',
+        disabledReason: busyReason ?? (activeSession.gitStatus?.ahead ? undefined : 'No commits to push'),
       },
       // --- Main branch operations (last) ---
       {
@@ -894,7 +908,8 @@ export const SessionView = memo(() => {
         onClick: hook.handleRebaseMainIntoWorktree,
         disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing' || !hook.hasChangesToRebase,
         variant: 'default' as const,
-        description: hook.gitCommands?.getRebaseFromMainCommand ? hook.gitCommands.getRebaseFromMainCommand() : `Pulls latest changes from ${hook.gitCommands?.comparisonBaseBranch || 'main'}`
+        description: hook.gitCommands?.getRebaseFromMainCommand ? hook.gitCommands.getRebaseFromMainCommand() : `Pulls latest changes from ${hook.gitCommands?.comparisonBaseBranch || 'main'}`,
+        disabledReason: busyReason ?? (hook.hasChangesToRebase ? undefined : 'No changes to rebase from main'),
       },
       {
         id: 'rebase-to-main',
@@ -907,7 +922,8 @@ export const SessionView = memo(() => {
         variant: 'success' as const,
         description: (!activeSession.gitStatus?.totalCommits || activeSession.gitStatus?.totalCommits === 0 || activeSession.gitStatus?.ahead === 0) ?
                      'No commits to merge' :
-                     (hook.gitCommands?.getSquashAndRebaseToMainCommand ? hook.gitCommands.getSquashAndRebaseToMainCommand() : `Merges all commits to ${hook.gitCommands?.comparisonBaseBranch || 'main'} (with safety checks)`)
+                     (hook.gitCommands?.getSquashAndRebaseToMainCommand ? hook.gitCommands.getSquashAndRebaseToMainCommand() : `Merges all commits to ${hook.gitCommands?.comparisonBaseBranch || 'main'} (with safety checks)`),
+        disabledReason: busyReason ?? ((!activeSession.gitStatus?.totalCommits || activeSession.gitStatus?.totalCommits === 0 || activeSession.gitStatus?.ahead === 0) ? 'No commits to merge' : undefined),
       }
     ];
   }, [activeSession, hook.isMerging, hook.gitCommands, hook.hasChangesToRebase, hook.hasStash, hook.handleGitPull, hook.handleGitPush, hook.handleGitSoftReset, hook.handleGitFetch, hook.handleGitStash, hook.handleGitStashPop, hook.setShowCommitMessageDialog, hook.setDialogType, hook.handleRebaseMainIntoWorktree, hook.handleSquashAndRebaseToMain, activeSession?.gitStatus]);

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -132,7 +132,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
         <div
           ref={tooltipRef}
           className={cn(
-            'fixed z-[9999] px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border-primary rounded-lg shadow-lg transition-opacity duration-150',
+            'fixed z-tooltip px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border-primary rounded-lg shadow-lg transition-opacity duration-150',
             interactive ? 'whitespace-normal' : 'whitespace-nowrap pointer-events-none'
           )}
           style={style}

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -16,6 +16,8 @@ interface SessionContextValue {
     disabled: boolean;
     variant: 'default' | 'success' | 'danger';
     description: string;
+    shortcut?: string;
+    disabledReason?: string;
   }>;
   isMerging?: boolean;
   gitCommands?: GitCommands;
@@ -40,6 +42,8 @@ export const SessionProvider: React.FC<{
     disabled: boolean;
     variant: 'default' | 'success' | 'danger';
     description: string;
+    shortcut?: string;
+    disabledReason?: string;
   }>;
   isMerging?: boolean;
   gitCommands?: GitCommands | null;

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -30,11 +30,15 @@ export function useHotkey(def: HotkeyDefinition): void {
   const enabledRef = useRef(def.enabled);
   enabledRef.current = def.enabled;
 
+  const disabledReasonRef = useRef(def.disabledReason);
+  disabledReasonRef.current = def.disabledReason;
+
   useEffect(() => {
     register({
       ...def,
       action: () => actionRef.current(),
       enabled: def.enabled ? () => enabledRef.current!() : undefined,
+      disabledReason: def.disabledReason ? () => disabledReasonRef.current?.() ?? null : undefined,
     });
     return () => unregister(def.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -670,6 +670,31 @@ export const useSessionView = (
   }, [activeSession?.status, activeSessionId]);
   
   const isSessionBusy = activeSession?.status === 'running' || activeSession?.status === 'initializing';
+  const getGitCommandDisabledReason = (command: 'commit' | 'push' | 'undo' | 'pull' | 'rebase' | 'merge'): string | null => {
+    if (!activeSession) return 'No active session';
+    if (isMerging) return 'Git operation already in progress';
+    if (isSessionBusy) return 'Session is currently running';
+    if (activeSession.isMainRepo) return 'Only available in worktree panes';
+
+    switch (command) {
+      case 'commit':
+        return (activeSession.gitStatus?.hasUncommittedChanges || activeSession.gitStatus?.hasUntrackedFiles)
+          ? null
+          : 'No changes to commit';
+      case 'push':
+        return (activeSession.gitStatus?.ahead ?? 0) > 0 ? null : 'No commits to push';
+      case 'undo':
+        return (activeSession.gitStatus?.ahead ?? 0) > 0 ? null : 'No local commits to undo';
+      case 'pull':
+        return null;
+      case 'rebase':
+        return hasChangesToRebase ? null : 'No changes to rebase from main';
+      case 'merge':
+        return !!activeSession.gitStatus?.totalCommits && activeSession.gitStatus.totalCommits > 0 && (activeSession.gitStatus?.ahead ?? 0) > 0
+          ? null
+          : 'No commits to merge';
+    }
+  };
 
   useHotkey({
     id: 'git-commit',
@@ -682,6 +707,7 @@ export const useSessionView = (
     },
     enabled: () => !!activeSession && !isMerging && !isSessionBusy && !activeSession.isMainRepo &&
       ((activeSession.gitStatus?.hasUncommittedChanges ?? false) || (activeSession.gitStatus?.hasUntrackedFiles ?? false)),
+    disabledReason: () => getGitCommandDisabledReason('commit'),
   });
 
   useHotkey({
@@ -691,6 +717,7 @@ export const useSessionView = (
     category: 'session',
     action: () => handleGitPush(),
     enabled: () => !!activeSession && !isMerging && !isSessionBusy && !activeSession.isMainRepo && (activeSession.gitStatus?.ahead ?? 0) > 0,
+    disabledReason: () => getGitCommandDisabledReason('push'),
   });
 
   useHotkey({
@@ -700,6 +727,7 @@ export const useSessionView = (
     category: 'session',
     action: () => handleGitSoftReset(),
     enabled: () => !!activeSession && !isMerging && !isSessionBusy && !activeSession.isMainRepo && (activeSession.gitStatus?.ahead ?? 0) > 0,
+    disabledReason: () => getGitCommandDisabledReason('undo'),
   });
 
   useHotkey({
@@ -709,6 +737,7 @@ export const useSessionView = (
     category: 'session',
     action: () => handleGitPull(),
     enabled: () => !!activeSession && !isMerging && !isSessionBusy && !activeSession.isMainRepo,
+    disabledReason: () => getGitCommandDisabledReason('pull'),
   });
 
   useHotkey({
@@ -718,6 +747,7 @@ export const useSessionView = (
     category: 'session',
     action: () => handleRebaseMainIntoWorktree(),
     enabled: () => !!activeSession && !isMerging && !isSessionBusy && !activeSession.isMainRepo && hasChangesToRebase,
+    disabledReason: () => getGitCommandDisabledReason('rebase'),
   });
 
   useHotkey({
@@ -729,6 +759,7 @@ export const useSessionView = (
     enabled: () => !!activeSession && !isMerging && !isSessionBusy && !activeSession.isMainRepo &&
       !!activeSession.gitStatus?.totalCommits && activeSession.gitStatus.totalCommits > 0 &&
       (activeSession.gitStatus?.ahead ?? 0) > 0,
+    disabledReason: () => getGitCommandDisabledReason('merge'),
   });
 
   const handleSendInput = async (attachedImages?: AttachedImage[], attachedTexts?: AttachedText[]) => {

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -45,6 +45,8 @@ export interface HotkeyDefinition {
   devOnly?: boolean;
   /** Is this hotkey currently enabled? Checked on every keypress. */
   enabled?: () => boolean;
+  /** Explanation shown when a command is present but unavailable. */
+  disabledReason?: () => string | null;
   /** If false, hotkey works but doesn't appear in Command Palette/Help. Defaults to true. */
   showInPalette?: boolean;
 }


### PR DESCRIPTION
## Summary
- keep unavailable command-palette actions visible, sorted after enabled actions
- gray disabled commands and show unavailable reasons on hover
- add disabled reasons and shortcut hints to the git actions menu tooltips

Stacked on #177.

## Testing
- pnpm typecheck
- pnpm lint
- git diff --check

Note: local checks report the repo's existing lint warnings and Node engine warning (current v20.19.3, required >=22.14.0), but pass with 0 errors.