### PR TITLE
Harden lifecycle logging and worktree cleanup

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -27,6 +27,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     console.error('Error caught by boundary:', error, errorInfo);
     console.error('Component stack:', errorInfo.componentStack);
     this.setState({ errorInfo });
+    window.electronAPI?.diagnostics?.rendererFatal({
+      kind: 'error-boundary',
+      message: error.message,
+      stack: error.stack,
+      componentStack: errorInfo.componentStack ?? undefined,
+      url: window.location.href,
+    }).catch(() => {});
 
     // Log to file in development mode for debugging
     if (process.env.NODE_ENV === 'development') {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,9 +7,40 @@ import './index.css';
 import './styles/markdown-preview.css';
 import './styles/notebook-preview.css';
 
+function getErrorMessage(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getErrorStack(value: unknown): string | undefined {
+  return value instanceof Error ? value.stack : undefined;
+}
+
+function reportRendererFatal(payload: {
+  kind: 'unhandledrejection' | 'error';
+  message: string;
+  stack?: string;
+  url?: string;
+  line?: number;
+  column?: number;
+}) {
+  window.electronAPI?.diagnostics?.rendererFatal(payload).catch(() => {});
+}
+
 // Global error handlers to catch errors that React error boundaries can't
 window.addEventListener('unhandledrejection', (event) => {
   console.error('Unhandled promise rejection:', event.reason);
+  reportRendererFatal({
+    kind: 'unhandledrejection',
+    message: getErrorMessage(event.reason),
+    stack: getErrorStack(event.reason),
+    url: window.location.href,
+  });
   // Prevent default browser behavior (showing error in console)
   event.preventDefault();
 
@@ -19,6 +50,14 @@ window.addEventListener('unhandledrejection', (event) => {
 
 window.addEventListener('error', (event) => {
   console.error('Uncaught error:', event.error);
+  reportRendererFatal({
+    kind: 'error',
+    message: getErrorMessage(event.error || event.message),
+    stack: getErrorStack(event.error),
+    url: event.filename || window.location.href,
+    line: event.lineno,
+    column: event.colno,
+  });
   // Note: We don't prevent default here as the error boundary should catch React errors
 });
 

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -19,6 +19,16 @@ interface PermissionResponse {
   reason?: string;
 }
 
+interface RendererDiagnosticPayload {
+  kind: 'unhandledrejection' | 'error' | 'error-boundary';
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  url?: string;
+  line?: number;
+  column?: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic type parameter default for flexible API responses
 interface IPCResponse<T = any> {
   success: boolean;
@@ -51,6 +61,10 @@ interface ElectronAPI {
 
   // System utilities
   openExternal: (url: string) => Promise<void>;
+
+  diagnostics: {
+    rendererFatal: (payload: RendererDiagnosticPayload) => Promise<IPCResponse>;
+  };
 
   // Session management
   sessions: {

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -3919,34 +3919,6 @@ export class DatabaseService {
     // Get existing panel first to merge state
     const existingPanel = this.getPanel(panelId);
 
-    // Helper to strip large fields (scrollbackBuffer, outputBuffer) from state for logging
-    const sanitizeForLog = (state: unknown): string => {
-      if (!state || typeof state !== 'object') return JSON.stringify(state);
-      const obj = state as Record<string, unknown>;
-      const clean = { ...obj };
-      if (clean.customState && typeof clean.customState === 'object') {
-        const cs = { ...(clean.customState as Record<string, unknown>) };
-        if ('scrollbackBuffer' in cs) cs.scrollbackBuffer = `[${typeof cs.scrollbackBuffer === 'string' ? cs.scrollbackBuffer.length : 0} chars]`;
-        if ('outputBuffer' in cs && Array.isArray(cs.outputBuffer)) cs.outputBuffer = `[${cs.outputBuffer.length} lines]`;
-        clean.customState = cs;
-      }
-      return JSON.stringify(clean);
-    };
-
-    // Add debug logging to track panel state changes
-    if (updates.state !== undefined) {
-      console.log(
-        `[DB-DEBUG] updatePanel called for ${panelId} with state:`,
-        sanitizeForLog(updates.state),
-      );
-      if (existingPanel) {
-        console.log(
-          `[DB-DEBUG] Existing panel state before update:`,
-          sanitizeForLog(existingPanel.state),
-        );
-      }
-    }
-
     this.transaction(() => {
       const setClauses: string[] = [];
       const values: (string | number | boolean | null)[] = [];
@@ -3997,8 +3969,6 @@ export class DatabaseService {
           }
         }
 
-        console.log(`[DB-DEBUG] Merged state:`, sanitizeForLog(mergedState));
-
         setClauses.push("state = ?");
         values.push(JSON.stringify(mergedState));
       }
@@ -4012,7 +3982,7 @@ export class DatabaseService {
         setClauses.push("updated_at = CURRENT_TIMESTAMP");
         values.push(panelId);
 
-        const result = this.db
+        this.db
           .prepare(
             `
           UPDATE tool_panels
@@ -4021,18 +3991,6 @@ export class DatabaseService {
         `,
           )
           .run(...values);
-
-        console.log(
-          `[DB-DEBUG] Update result for panel ${panelId}: ${result.changes} rows affected`,
-        );
-
-        if (updates.state !== undefined && result.changes > 0) {
-          const afterPanel = this.getPanel(panelId);
-          console.log(
-            `[DB-DEBUG] Panel state after update:`,
-            sanitizeForLog(afterPanel?.state),
-          );
-        }
       }
     });
   }

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -18,7 +18,7 @@ if (process.platform === 'win32') {
 }
 
 // Now import the rest of electron
-import { BrowserWindow, Menu, ipcMain, shell, dialog, IpcMainInvokeEvent, session, WebContents, webContents, WebContentsView } from 'electron';
+import { BrowserWindow, Menu, ipcMain, shell, dialog, IpcMainInvokeEvent, session, WebContents, webContents, WebContentsView, powerMonitor } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
 import { TaskQueue } from './services/taskQueue';
@@ -66,6 +66,7 @@ export const webviewContextMap = new Map<number, { panelId: string; sessionId: s
 // Active DevTools WebContentsViews, keyed by the page webContentsId they inspect
 const activeDevToolsViews = new Map<number, Electron.WebContentsView>();
 let devToolsHandlersRegistered = false;
+let powerMonitorDiagnosticsRegistered = false;
 
 // Track partitions that already have the localhost header-stripping hook registered,
 // so we don't add duplicate listeners when multiple webviews share the same partition.
@@ -73,6 +74,57 @@ const registeredPartitions = new Set<string>();
 
 // Module-level shutdown guard to prevent multiple shutdown attempts
 let shutdownInProgress = false;
+
+type RendererDiagnosticPayload = {
+  kind?: string;
+  message?: string;
+  stack?: string;
+  componentStack?: string;
+  url?: string;
+  line?: number;
+  column?: number;
+};
+
+function safeDiagnosticValue(value: unknown, maxLength = 4_000): string {
+  let serialized: string;
+  if (value instanceof Error) {
+    serialized = `${value.name}: ${value.message}\n${value.stack || ''}`;
+  } else if (typeof value === 'string') {
+    serialized = value;
+  } else {
+    try {
+      serialized = JSON.stringify(value);
+    } catch {
+      serialized = String(value);
+    }
+  }
+
+  return serialized.length > maxLength
+    ? `${serialized.slice(0, maxLength)} ... [truncated ${serialized.length - maxLength} chars]`
+    : serialized;
+}
+
+function formatRendererDiagnostic(payload: RendererDiagnosticPayload): string {
+  return [
+    `kind=${JSON.stringify(payload.kind || 'unknown')}`,
+    `message=${JSON.stringify(safeDiagnosticValue(payload.message || ''))}`,
+    payload.url ? `url=${JSON.stringify(payload.url)}` : undefined,
+    payload.line !== undefined ? `line=${payload.line}` : undefined,
+    payload.column !== undefined ? `column=${payload.column}` : undefined,
+    payload.stack ? `stack=${JSON.stringify(safeDiagnosticValue(payload.stack))}` : undefined,
+    payload.componentStack ? `componentStack=${JSON.stringify(safeDiagnosticValue(payload.componentStack))}` : undefined,
+  ].filter(Boolean).join(' ');
+}
+
+function registerPowerMonitorDiagnostics(): void {
+  if (powerMonitorDiagnosticsRegistered) return;
+  powerMonitorDiagnosticsRegistered = true;
+
+  powerMonitor.on('suspend', () => logger?.info('[Lifecycle] power:suspend'));
+  powerMonitor.on('resume', () => logger?.info('[Lifecycle] power:resume'));
+  powerMonitor.on('lock-screen', () => logger?.info('[Lifecycle] power:lock-screen'));
+  powerMonitor.on('unlock-screen', () => logger?.info('[Lifecycle] power:unlock-screen'));
+}
 
 /**
  * Set the application title based on development mode and worktree
@@ -827,7 +879,7 @@ async function createWindow() {
 
   // Handle renderer process crashes with recovery
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
-    console.error('[Main] Renderer process crashed:', details.reason, details);
+    console.error('[RendererLifecycle] render-process-gone:', details.reason, details);
     if (details.reason === 'crashed' || details.reason === 'oom' || details.reason === 'killed') {
       // Attempt to reload the renderer
       console.log('[Main] Attempting to recover renderer...');
@@ -837,6 +889,14 @@ async function createWindow() {
         console.error('[Main] Failed to reload renderer after crash:', err);
       }
     }
+  });
+
+  mainWindow.webContents.on('unresponsive', () => {
+    console.warn('[RendererLifecycle] unresponsive');
+  });
+
+  mainWindow.webContents.on('responsive', () => {
+    console.log('[RendererLifecycle] responsive');
   });
 
   // Handle window focus/blur/minimize for smart git status polling and
@@ -896,6 +956,7 @@ async function initializeServices() {
   // Initialize logger early so it can capture all logs
   logger = new Logger(configManager);
   console.log('[Main] Logger initialized with file logging to ~/.pane/logs');
+  registerPowerMonitorDiagnostics();
 
   // Log the scrollback retention result captured at database module load.
   // The sweep itself runs before panelManager's constructor caches rows into
@@ -1081,6 +1142,11 @@ async function initializeServices() {
         logger.info(forwarded);
       }
     }
+  });
+
+  ipcMain.handle('diagnostics:renderer-fatal', (_event, payload: RendererDiagnosticPayload) => {
+    logger.error(`[RendererFatal] ${formatRendererDiagnostic(payload || {})}`);
+    return { success: true };
   });
   
   // Start periodic version checking (only if enabled in settings)

--- a/main/src/ipc/project.ts
+++ b/main/src/ipc/project.ts
@@ -367,15 +367,26 @@ export function registerProjectHandlers(ipcMain: IpcMain, services: AppServices)
           }
 
           try {
-            console.log(`[Main] Removing worktree '${session.worktree_name}' for session ${session.id}`);
+            console.log(`[WorktreeAudit] remove_requested source="project-delete" sessionId=${JSON.stringify(session.id)} projectId=${projectIdNum} projectPath=${JSON.stringify(project.path)} worktreeName=${JSON.stringify(session.worktree_name)} worktreePath=${JSON.stringify(session.worktree_path || '')}`);
             // Pass session creation date for analytics tracking
             const sessionCreatedAt = session.created_at ? new Date(session.created_at) : undefined;
-            await worktreeManager.removeWorktree(project.path, session.worktree_name, project.worktree_folder || undefined, sessionCreatedAt, ctx.pathResolver, ctx.commandRunner);
+            await worktreeManager.removeWorktree(project.path, session.worktree_name, project.worktree_folder || undefined, sessionCreatedAt, ctx.pathResolver, ctx.commandRunner, {
+              source: 'project-delete',
+              sessionId: session.id,
+              projectId: projectIdNum,
+            });
             worktreeCleanupCount++;
           } catch (error) {
             // Log error but continue with other worktrees
             console.error(`[Main] Failed to remove worktree '${session.worktree_name}' for session ${session.id}:`, error);
           }
+        }
+      } else {
+        for (const session of allProjectSessions) {
+          if (session.is_main_repo || !session.worktree_name) {
+            continue;
+          }
+          console.warn(`[WorktreeAudit] remove_skipped source="project-delete" sessionId=${JSON.stringify(session.id)} projectId=${projectIdNum} projectPath=${JSON.stringify(project.path)} worktreeName=${JSON.stringify(session.worktree_name)} worktreePath=${JSON.stringify(session.worktree_path || '')} reason="missing_project_context"`);
         }
       }
       
@@ -712,4 +723,4 @@ export function registerProjectHandlers(ipcMain: IpcMain, services: AppServices)
       return { success: false, error: error instanceof Error ? error.message : 'Failed to run project script' };
     }
   });
-} 
+}

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -249,11 +249,15 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
       await sessionManager.archiveSession(sessionId);
 
       // Add the archive message to session output
-      sessionManager.addSessionOutput(sessionId, {
-        type: 'stdout',
-        data: archiveMessage,
-        timestamp: new Date()
-      });
+      try {
+        sessionManager.addSessionOutput(sessionId, {
+          type: 'stdout',
+          data: archiveMessage,
+          timestamp: new Date()
+        });
+      } catch (error) {
+        console.warn(`[ArchiveCleanup] archive_message_output_failed sessionId=${sessionId}:`, error);
+      }
 
       // Kill all panel processes for this session before worktree cleanup
       // This prevents leaked node-pty processes and ensures worktree removal succeeds.
@@ -288,6 +292,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
 
       // Create cleanup callback for background operations
       const cleanupCallback = async () => {
+        console.log(`[ArchiveCleanup] cleanup_started sessionId=${sessionId} sessionName=${JSON.stringify(dbSession.name)} worktreeName=${JSON.stringify(dbSession.worktree_name || '')}`);
         let cleanupMessage = '';
 
         // Stop any active run commands for this session so their file handles are released
@@ -359,12 +364,18 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
 
                 // Pass session creation date for analytics tracking
                 const sessionCreatedAt = dbSession.created_at ? new Date(dbSession.created_at) : undefined;
-                await worktreeManager.removeWorktree(project.path, dbSession.worktree_name, project.worktree_folder || undefined, sessionCreatedAt, ctx.pathResolver, ctx.commandRunner);
+                console.log(`[WorktreeAudit] remove_requested source="session-delete" sessionId=${JSON.stringify(sessionId)} projectId=${dbSession.project_id} projectPath=${JSON.stringify(project.path)} worktreeName=${JSON.stringify(dbSession.worktree_name)} worktreePath=${JSON.stringify(dbSession.worktree_path || '')}`);
+                await worktreeManager.removeWorktree(project.path, dbSession.worktree_name, project.worktree_folder || undefined, sessionCreatedAt, ctx.pathResolver, ctx.commandRunner, {
+                  source: 'session-delete',
+                  sessionId,
+                  projectId: dbSession.project_id,
+                });
 
                 cleanupMessage += `\x1b[32m✓ Worktree removed successfully\x1b[0m\r\n`;
               } catch (worktreeError) {
                 // Log the error but don't fail
                 console.error(`[Main] Failed to remove worktree ${dbSession.worktree_name}:`, worktreeError);
+                console.error(`[ArchiveCleanup] worktree_remove_failed sessionId=${sessionId} worktreeName=${dbSession.worktree_name}:`, worktreeError);
                 cleanupMessage += `\x1b[33m⚠ Failed to remove worktree (manual cleanup may be needed)\x1b[0m\r\n`;
 
                 // Update progress: failed
@@ -372,8 +383,14 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
                   archiveProgressManager.updateTaskStatus(sessionId, 'failed', 'Failed to remove worktree');
                 }
               }
+            } else {
+              console.warn(`[WorktreeAudit] remove_skipped source="session-delete" sessionId=${JSON.stringify(sessionId)} projectId=${dbSession.project_id} worktreeName=${JSON.stringify(dbSession.worktree_name)} reason="missing_project_context"`);
             }
+          } else {
+            console.warn(`[WorktreeAudit] remove_skipped source="session-delete" sessionId=${JSON.stringify(sessionId)} projectId=${dbSession.project_id} worktreeName=${JSON.stringify(dbSession.worktree_name)} reason="missing_project"`);
           }
+        } else {
+          console.log(`[WorktreeAudit] remove_skipped source="session-delete" sessionId=${JSON.stringify(sessionId)} worktreeName=${JSON.stringify(dbSession.worktree_name || '')} reason="no_session_worktree_cleanup_needed"`);
         }
 
         // Clean up session artifacts (images)
@@ -421,18 +438,25 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
 
         // If there were any cleanup messages, add them to the session output
         if (cleanupMessage) {
-          sessionManager.addSessionOutput(sessionId, {
-            type: 'stdout',
-            data: cleanupMessage,
-            timestamp: new Date()
-          });
+          try {
+            sessionManager.addSessionOutput(sessionId, {
+              type: 'stdout',
+              data: cleanupMessage,
+              timestamp: new Date()
+            });
+          } catch (error) {
+            console.warn(`[ArchiveCleanup] cleanup_output_failed sessionId=${sessionId}:`, error);
+          }
         }
+        console.log(`[ArchiveCleanup] cleanup_completed sessionId=${sessionId}`);
       };
 
       // Queue the cleanup task if we have worktree cleanup to do
       if (dbSession.worktree_name && dbSession.project_id && !dbSession.is_main_repo) {
         const project = databaseService.getProject(dbSession.project_id);
         if (project && archiveProgressManager) {
+          console.log(`[ArchiveCleanup] archive_queued sessionId=${sessionId} sessionName=${JSON.stringify(dbSession.name)} worktreeName=${JSON.stringify(dbSession.worktree_name)} projectName=${JSON.stringify(project.name)}`);
+          console.log(`[WorktreeAudit] remove_queued source="session-delete" sessionId=${JSON.stringify(sessionId)} projectId=${dbSession.project_id} projectPath=${JSON.stringify(project.path)} worktreeName=${JSON.stringify(dbSession.worktree_name)} worktreePath=${JSON.stringify(dbSession.worktree_path || '')}`);
           archiveProgressManager.addTask(
             sessionId,
             dbSession.name,
@@ -440,6 +464,9 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
             project.name,
             cleanupCallback
           );
+        } else {
+          console.warn(`[ArchiveCleanup] archive_queue_skipped sessionId=${sessionId} reason=${archiveProgressManager ? '"missing_project"' : '"missing_archive_progress_manager"'}`);
+          setImmediate(() => cleanupCallback());
         }
       } else {
         // No worktree cleanup needed, just run artifact cleanup immediately

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -324,6 +324,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // System utilities
   openExternal: (url: string): Promise<IPCResponse> => ipcRenderer.invoke('openExternal', url),
 
+  diagnostics: {
+    rendererFatal: (payload: {
+      kind: string;
+      message: string;
+      stack?: string;
+      componentStack?: string;
+      url?: string;
+      line?: number;
+      column?: number;
+    }): Promise<IPCResponse> => ipcRenderer.invoke('diagnostics:renderer-fatal', payload),
+  },
+
   // Session management
   sessions: {
     getAll: (): Promise<IPCResponse> => ipcRenderer.invoke('sessions:get-all'),

--- a/main/src/services/archiveProgressManager.ts
+++ b/main/src/services/archiveProgressManager.ts
@@ -61,6 +61,7 @@ export class ArchiveProgressManager extends EventEmitter {
     
     this.activeTasks.set(sessionId, task);
     this.taskQueue.push(task);
+    console.log(`[ArchiveProgressManager] queued sessionId=${sessionId} sessionName=${JSON.stringify(sessionName)} worktreeName=${JSON.stringify(worktreeName)} projectName=${JSON.stringify(projectName)} queueLength=${this.taskQueue.length}`);
     this.emitProgress();
     
     // Start processing if not already processing
@@ -82,6 +83,7 @@ export class ArchiveProgressManager extends EventEmitter {
 
       // Update status to pending (actively processing)
       task.status = 'pending';
+      console.log(`[ArchiveProgressManager] pending sessionId=${task.sessionId} worktreeName=${JSON.stringify(task.worktreeName)} remainingQueue=${this.taskQueue.length}`);
       this.emitProgress();
 
       if (task.executeCallback) {
@@ -110,6 +112,7 @@ export class ArchiveProgressManager extends EventEmitter {
     if (!task) return;
 
     task.status = status;
+    console.log(`[ArchiveProgressManager] status sessionId=${sessionId} status=${status}${error ? ` error=${JSON.stringify(error)}` : ''}`);
     
     if (error) {
       task.error = error;

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -15,6 +15,7 @@ export class ConfigManager extends EventEmitter {
   private configDir: string;
   private fileWatcher: FSWatcher | null = null;
   private lastConfigJson: string = '';
+  private saveConfigQueue: Promise<void> = Promise.resolve();
 
   constructor(defaultGitPath?: string) {
     super();
@@ -152,10 +153,24 @@ export class ConfigManager extends EventEmitter {
   }
 
   private async saveConfig(): Promise<void> {
-    await fs.mkdir(this.configDir, { recursive: true });
-    const tmpPath = this.configPath + '.tmp';
-    await fs.writeFile(tmpPath, JSON.stringify(this.config, null, 2));
-    await fs.rename(tmpPath, this.configPath);
+    const configJson = JSON.stringify(this.config, null, 2);
+    const writeConfig = async () => {
+      await fs.mkdir(this.configDir, { recursive: true });
+      const tmpPath = `${this.configPath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+
+      try {
+        await fs.writeFile(tmpPath, configJson);
+        await fs.rename(tmpPath, this.configPath);
+        this.lastConfigJson = configJson;
+      } catch (error) {
+        await fs.unlink(tmpPath).catch(() => {});
+        throw error;
+      }
+    };
+
+    const queuedWrite = this.saveConfigQueue.then(writeConfig, writeConfig);
+    this.saveConfigQueue = queuedWrite.catch(() => {});
+    await queuedWrite;
   }
 
   getConfig(): AppConfig {

--- a/main/src/services/gitFileWatcher.ts
+++ b/main/src/services/gitFileWatcher.ts
@@ -397,7 +397,14 @@ export class GitFileWatcher extends EventEmitter {
     try {
       // First, refresh the index to ensure it's up to date
       // This is very fast and updates git's internal cache
-      this.execGit('git update-index --refresh --ignore-submodules', worktreePath);
+      try {
+        this.execGit('git update-index --refresh --ignore-submodules', worktreePath);
+      } catch (error) {
+        // `git update-index --refresh` exits non-zero for dirty/racy paths.
+        // That is a refresh signal, not an application error.
+        this.logger?.verbose(`[GitFileWatcher] update-index indicated refresh needed for ${worktreePath}: ${error instanceof Error ? error.message : String(error)}`);
+        return true;
+      }
 
       // Check for unstaged changes (modified files)
       try {
@@ -426,7 +433,7 @@ export class GitFileWatcher extends EventEmitter {
       return false;
     } catch (error) {
       // If any command fails unexpectedly, assume refresh is needed
-      this.logger?.error('[GitFileWatcher] Error in checkIfRefreshNeeded:', error as Error);
+      this.logger?.warn(`[GitFileWatcher] Unexpected refresh check failure for ${worktreePath}; scheduling refresh`, error as Error);
       return true;
     }
   }

--- a/main/src/services/projectConfigDetector.ts
+++ b/main/src/services/projectConfigDetector.ts
@@ -75,7 +75,7 @@ async function fileExists(
       return true;
     }
     if (!commandRunner) return false;
-    await commandRunner.execAsync(`test -e "${filePath}"`, cwd || filePath);
+    await commandRunner.execAsync(`test -e "${filePath}"`, cwd || filePath, { silent: true });
     return true;
   } catch {
     return false;

--- a/main/src/services/worktreeFileSyncService.ts
+++ b/main/src/services/worktreeFileSyncService.ts
@@ -124,7 +124,7 @@ async function existsAt(
     }
   }
   try {
-    await commandRunner.execAsync(`test -e "${filePath}"`, cwd);
+    await commandRunner.execAsync(`test -e "${filePath}"`, cwd, { silent: true });
     return true;
   } catch {
     return false;
@@ -153,7 +153,7 @@ async function isFilePath(
     }
   }
   try {
-    await commandRunner.execAsync(`test -f "${filePath}"`, cwd);
+    await commandRunner.execAsync(`test -f "${filePath}"`, cwd, { silent: true });
     return true;
   } catch {
     return false;

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -8,6 +8,25 @@ import { CommandRunner } from '../utils/commandRunner';
 import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
 import { worktreePoolManager } from './worktreePoolManager';
 
+export type WorktreeAuditSource = 'session-delete' | 'project-delete' | 'create-cleanup';
+
+export interface WorktreeAuditContext {
+  source: WorktreeAuditSource;
+  sessionId?: string;
+  projectId?: number;
+}
+
+function formatWorktreeAuditDetails(details: Record<string, unknown>): string {
+  return Object.entries(details)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([key, value]) => `${key}=${JSON.stringify(String(value))}`)
+    .join(' ');
+}
+
+function logWorktreeAudit(phase: string, details: Record<string, unknown>): void {
+  console.log(`[WorktreeAudit] ${phase} ${formatWorktreeAuditDetails(details)}`);
+}
+
 // Interface for raw commit data
 interface RawCommitData {
   hash: string;
@@ -155,8 +174,34 @@ export class WorktreeManager {
       try {
         // Use cross-platform approach without shell redirection
         try {
+          logWorktreeAudit('remove_requested', {
+            source: 'create-cleanup',
+            projectPath,
+            worktreeName: name,
+            worktreePath,
+          });
+          logWorktreeAudit('remove_started', {
+            source: 'create-cleanup',
+            projectPath,
+            worktreeName: name,
+            worktreePath,
+          });
           await commandRunner.execAsync(`git worktree remove "${worktreePath}" --force`, projectPath);
-        } catch {
+          logWorktreeAudit('remove_succeeded', {
+            source: 'create-cleanup',
+            projectPath,
+            worktreeName: name,
+            worktreePath,
+          });
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          logWorktreeAudit('remove_skipped', {
+            source: 'create-cleanup',
+            projectPath,
+            worktreeName: name,
+            worktreePath,
+            reason: errorMessage,
+          });
           // Ignore cleanup errors
         }
       } catch {
@@ -310,13 +355,23 @@ export class WorktreeManager {
     return { worktreePath: projectPath, baseCommit, baseBranch: detectedBranch };
   }
 
-  async removeWorktree(projectPath: string, name: string, worktreeFolder: string | undefined, sessionCreatedAt: Date | undefined, pathResolver: PathResolver, commandRunner: CommandRunner): Promise<void> {
+  async removeWorktree(projectPath: string, name: string, worktreeFolder: string | undefined, sessionCreatedAt: Date | undefined, pathResolver: PathResolver, commandRunner: CommandRunner, auditContext?: WorktreeAuditContext): Promise<void> {
     return await withLock(`worktree-remove-${projectPath}-${name}`, async () => {
       const { baseDir } = this.getProjectPaths(projectPath, worktreeFolder, pathResolver);
       const worktreePath = pathResolver.join(baseDir, name);
+      const auditDetails = {
+        source: auditContext?.source,
+        sessionId: auditContext?.sessionId,
+        projectId: auditContext?.projectId,
+        projectPath,
+        worktreeName: name,
+        worktreePath,
+      };
 
       try {
+        logWorktreeAudit('remove_started', auditDetails);
         await commandRunner.execAsync(`git worktree remove "${worktreePath}" --force`, projectPath);
+        logWorktreeAudit('remove_succeeded', auditDetails);
 
         // Track worktree cleanup
         if (this.analyticsManager && sessionCreatedAt) {
@@ -333,9 +388,17 @@ export class WorktreeManager {
         if (errorMessage.includes('is not a working tree') ||
             errorMessage.includes('does not exist') ||
             errorMessage.includes('No such file or directory')) {
-          console.log(`Worktree ${worktreePath} already removed or doesn't exist, skipping...`);
+          logWorktreeAudit('remove_skipped', {
+            ...auditDetails,
+            reason: errorMessage,
+          });
           return;
         }
+
+        logWorktreeAudit('remove_failed', {
+          ...auditDetails,
+          reason: errorMessage,
+        });
 
         // For other errors, still throw
         throw new Error(`Failed to remove worktree: ${errorMessage}`);

--- a/main/src/utils/commandExecutor.ts
+++ b/main/src/utils/commandExecutor.ts
@@ -31,6 +31,11 @@ export interface ExtendedExecSyncOptions extends ExecSyncOptions {
   silent?: boolean;
 }
 
+export interface ExtendedExecAsyncOptions extends ExecOptions {
+  timeout?: number;
+  silent?: boolean;
+}
+
 class CommandExecutor {
   execSync(command: string, options: ExecSyncOptionsWithStringEncoding & { silent?: boolean }, wslContext?: WSLContext | null): string;
   execSync(command: string, options?: ExecSyncOptionsWithBufferEncoding & { silent?: boolean }, wslContext?: WSLContext | null): Buffer;
@@ -126,19 +131,22 @@ class CommandExecutor {
     }
   }
 
-  async execAsync(command: string, options?: ExecOptions & { timeout?: number }, wslContext?: WSLContext | null): Promise<{ stdout: string; stderr: string }> {
+  async execAsync(command: string, options?: ExtendedExecAsyncOptions, wslContext?: WSLContext | null): Promise<{ stdout: string; stderr: string }> {
     const cwd = options?.cwd || process.cwd();
     const shellPath = getShellPath();
+    const silentMode = options?.silent === true;
 
     if (wslContext) {
       // Invoke wsl.exe directly via execFile — bypasses cmd.exe entirely
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { cwd: _cwd, ...cleanOptions } = options || {};
+      const { cwd: _cwd, silent: _silent, ...cleanOptions } = options || {};
       const wslCwd = typeof cwd === 'string' ? cwd : undefined;
       const extraEnv = getExtraEnvVars(cleanOptions?.env as Record<string, string | undefined>);
       const { file, args } = getWSLExecArgs(command, wslContext.distribution, wslCwd, extraEnv);
 
-      console.log(`[CommandExecutor] Executing async (WSL): ${file} ${args.join(' ')} in ${cwd}`);
+      if (!silentMode) {
+        console.log(`[CommandExecutor] Executing async (WSL): ${file} ${args.join(' ')} in ${cwd}`);
+      }
       const timeout = cleanOptions?.timeout || 60_000;
       const maxBuffer = cleanOptions?.maxBuffer || 10 * 1024 * 1024;
       const wslOptions: ExecFileOptions = {
@@ -151,7 +159,7 @@ class CommandExecutor {
       try {
         const result = await nodeExecFileAsync(file, args, wslOptions);
 
-        if (result.stdout) {
+        if (result.stdout && !silentMode) {
           const stdout = String(result.stdout);
           const lines = stdout.split('\n');
           const preview = lines[0].substring(0, 100) +
@@ -161,24 +169,30 @@ class CommandExecutor {
 
         return { stdout: String(result.stdout), stderr: String(result.stderr) };
       } catch (error: unknown) {
-        console.error(`[CommandExecutor] Async Failed (WSL): ${command}`);
-        console.error(`[CommandExecutor] Async Error: ${error instanceof Error ? error.message : String(error)}`);
+        if (!silentMode) {
+          console.error(`[CommandExecutor] Async Failed (WSL): ${command}`);
+          console.error(`[CommandExecutor] Async Error: ${error instanceof Error ? error.message : String(error)}`);
+        }
         throw error;
       }
     }
 
-    console.log(`[CommandExecutor] Executing async: ${command} in ${cwd}`);
+    if (!silentMode) {
+      console.log(`[CommandExecutor] Executing async: ${command} in ${cwd}`);
+    }
 
     const timeout = options?.timeout || 60_000;
     const maxBuffer = options?.maxBuffer || 10 * 1024 * 1024;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { silent: _silent, ...cleanOptions } = options || {};
 
     const enhancedOptions: ExecOptions = {
-      ...options,
+      ...cleanOptions,
       timeout,
       maxBuffer,
       env: {
         ...process.env,
-        ...options?.env,
+        ...cleanOptions?.env,
         PATH: shellPath
       }
     };
@@ -186,7 +200,7 @@ class CommandExecutor {
     try {
       const result = await nodeExecAsync(command, enhancedOptions);
 
-      if (result.stdout) {
+      if (result.stdout && !silentMode) {
         const stdout = String(result.stdout);
         const lines = stdout.split('\n');
         const preview = lines[0].substring(0, 100) +
@@ -196,8 +210,10 @@ class CommandExecutor {
 
       return { stdout: String(result.stdout), stderr: String(result.stderr) };
     } catch (error: unknown) {
-      console.error(`[CommandExecutor] Async Failed: ${command}`);
-      console.error(`[CommandExecutor] Async Error: ${error instanceof Error ? error.message : String(error)}`);
+      if (!silentMode) {
+        console.error(`[CommandExecutor] Async Failed: ${command}`);
+        console.error(`[CommandExecutor] Async Error: ${error instanceof Error ? error.message : String(error)}`);
+      }
       throw error;
     }
   }

--- a/main/src/utils/commandRunner.ts
+++ b/main/src/utils/commandRunner.ts
@@ -20,7 +20,7 @@ export class CommandRunner {
   }
 
   /** Execute command asynchronously, wrapping for WSL if needed */
-  async execAsync(command: string, cwd: string, options?: { timeout?: number; maxBuffer?: number; env?: Record<string, string> }): Promise<{ stdout: string; stderr: string }> {
+  async execAsync(command: string, cwd: string, options?: { timeout?: number; maxBuffer?: number; env?: Record<string, string>; silent?: boolean }): Promise<{ stdout: string; stderr: string }> {
     return commandExecutor.execAsync(command, {
       cwd,
       ...options,

--- a/main/src/utils/logger.ts
+++ b/main/src/utils/logger.ts
@@ -13,6 +13,25 @@ const ORIGINAL_CONSOLE = {
   info: console.info
 };
 
+const MAX_LOG_EVENT_CHARS = 16 * 1024;
+
+function sanitizeLogControls(message: string): string {
+  let sanitized = '';
+
+  for (const char of message) {
+    const code = char.charCodeAt(0);
+    if (code === 0) {
+      sanitized += '\\0';
+    } else if ((code < 32 && code !== 9 && code !== 10 && code !== 13) || code === 127) {
+      sanitized += `\\x${code.toString(16).padStart(2, '0')}`;
+    } else {
+      sanitized += char;
+    }
+  }
+
+  return sanitized;
+}
+
 export class Logger {
   private logDir: string;
   private currentLogFile: string;
@@ -212,10 +231,21 @@ export class Logger {
     }
   }
 
+  private normalizeLogEvent(message: string): string {
+    const sanitized = sanitizeLogControls(message);
+
+    if (sanitized.length <= MAX_LOG_EVENT_CHARS) {
+      return sanitized;
+    }
+
+    const omittedChars = sanitized.length - MAX_LOG_EVENT_CHARS;
+    return `${sanitized.slice(0, MAX_LOG_EVENT_CHARS)} ... [truncated ${omittedChars} chars, original=${sanitized.length}]`;
+  }
+
   private log(level: string, message: string, error?: Error) {
     const timestamp = formatForDatabase();
     const errorInfo = error ? ` Error: ${error.message}\nStack: ${error.stack}` : '';
-    const fullMessage = `[${timestamp}] ${level}: ${message}${errorInfo}`;
+    const fullMessage = this.normalizeLogEvent(`[${timestamp}] ${level}: ${message}${errorInfo}`);
     
     // Try to log to console, but handle EPIPE errors gracefully
     try {


### PR DESCRIPTION
## Summary
- add bounded production diagnostics for renderer fatal errors, renderer lifecycle, and macOS power lifecycle events
- add auditable worktree cleanup logs for session archive, project delete, and create-time cleanup paths
- reduce log volume/noise by truncating logger events, removing DB-DEBUG panel state dumps, silencing expected config probes, and demoting git watcher refresh noise
- serialize config writes with unique temp files to avoid config.json.tmp rename races

## Validation
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm build:main