### PR TITLE
Fix Codex resume launch resolution

### DIFF
--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -1844,33 +1844,28 @@ export class SessionManager extends EventEmitter {
             const agentType = customState.agentType ?? this.getTerminalAgentType(customState.initialCommand);
 
             if (agentType === 'claude') {
-              // Panel ID was passed as --session-id on original launch, so use it as resume ID.
-              customState.initialCommand = `claude --resume ${panel.id} --dangerously-skip-permissions`;
+              customState.hasClaudeSessionId = true;
+              customState.agentType = 'claude';
             } else if (agentType === 'codex') {
-              customState.initialCommand = customState.agentSessionId
-                ? `codex resume --yolo ${customState.agentSessionId}`
-                : 'codex resume --yolo';
               customState.agentType = 'codex';
               if (customState.agentSessionId) {
-                console.log(`[SessionManager] Resuming Codex panel ${panel.id} with captured session ${customState.agentSessionId}`);
+                console.log(`[SessionManager] Preparing Codex panel ${panel.id} for captured-session resume`);
               } else {
-                console.warn(`[SessionManager] Codex panel ${panel.id} has no captured session id; opening interactive resume picker`);
+                console.warn(`[SessionManager] Codex panel ${panel.id} has no captured session id; terminal launch will open interactive resume picker`);
               }
             } else {
               continue;
             }
 
-            customState.wasInterrupted = undefined;
             state.customState = customState;
 
-            // Save to DB first (critical: initializeTerminal reads from state)
-            this.db.updatePanel(panel.id, { state });
+            // Keep DB, PanelManager cache, and renderer state aligned before terminal launch.
+            await panelManager.updatePanel(panel.id, { state });
 
-            // Reload panel from DB to get fresh state
-            const reloadedPanel = this.db.getPanel(panel.id);
+            const reloadedPanel = panelManager.getPanel(panel.id) ?? this.db.getPanel(panel.id);
             if (reloadedPanel) {
               await terminalPanelManager.initializeTerminal(reloadedPanel, worktreePath);
-              console.log(`[SessionManager] Resumed terminal panel ${panel.id} with ${customState.initialCommand}`);
+              console.log(`[SessionManager] Resumed terminal panel ${panel.id} via launch-time ${agentType} resolver`);
               resumedPanelCount++;
             }
           }

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -172,6 +172,66 @@ export class TerminalPanelManager {
     return undefined;
   }
 
+  private resolveCliLaunchCommand(panelId: string, initialCommand: string, customState: TerminalPanelState): {
+    commandToRun: string;
+    customState: TerminalPanelState;
+    isCliCommand: boolean;
+  } {
+    const agentType = customState.agentType ?? this.getCliAgentType(initialCommand);
+    if (!agentType) {
+      return { commandToRun: initialCommand, customState, isCliCommand: false };
+    }
+
+    const nextState: TerminalPanelState = {
+      ...customState,
+      isCliPanel: true,
+      isCliReady: false,
+      agentType,
+    };
+
+    if (
+      agentType === 'claude' &&
+      !initialCommand.includes('--session-id') &&
+      !initialCommand.includes('--resume')
+    ) {
+      nextState.hasClaudeSessionId = true;
+      nextState.wasInterrupted = undefined;
+      return {
+        commandToRun: customState.hasClaudeSessionId
+          ? `claude --resume ${panelId} --dangerously-skip-permissions`
+          : `${initialCommand} --session-id ${panelId}`,
+        customState: nextState,
+        isCliCommand: true,
+      };
+    }
+
+    if (agentType === 'claude' && customState.wasInterrupted) {
+      nextState.wasInterrupted = undefined;
+      return { commandToRun: initialCommand, customState: nextState, isCliCommand: true };
+    }
+
+    if (agentType === 'codex' && customState.wasInterrupted) {
+      nextState.wasInterrupted = undefined;
+      const commandToRun = customState.agentSessionId
+        ? `codex resume --yolo ${customState.agentSessionId}`
+        : 'codex resume --yolo';
+
+      if (customState.agentSessionId) {
+        console.log(`[TerminalPanelManager] Resolved interrupted Codex panel ${panelId} to direct resume`);
+      } else {
+        console.log(`[TerminalPanelManager] Resolved interrupted Codex panel ${panelId} to interactive resume picker`);
+      }
+
+      return {
+        commandToRun,
+        customState: nextState,
+        isCliCommand: true,
+      };
+    }
+
+    return { commandToRun: initialCommand, customState: nextState, isCliCommand: true };
+  }
+
   private stripAnsiSequences(output: string): string {
     // eslint-disable-next-line no-control-regex
     return output.replace(/\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\))/g, '');
@@ -636,44 +696,15 @@ export class TerminalPanelManager {
     // setupTerminalHandlers so we don't miss early shell output.
     let commandToRun: string | undefined;
     if (initialCommand) {
-      commandToRun = initialCommand;
-      const cliAgentType = this.getCliAgentType(initialCommand);
+      const launchResolution = this.resolveCliLaunchCommand(panel.id, initialCommand, existingState || {});
+      commandToRun = launchResolution.commandToRun;
+      const isCliCommand = launchResolution.isCliCommand;
 
-      // Mark CLI tool panels so the frontend can show an init overlay
-      const isCliCommand = cliAgentType !== undefined;
       if (isCliCommand) {
-        const cliState = panel.state;
-        const cliCs = (cliState.customState || {}) as TerminalPanelState;
-        cliCs.isCliPanel = true;
-        cliCs.isCliReady = false; // Reset on (re-)launch so the overlay shows for fresh CLI processes
-        cliCs.agentType = cliAgentType;
-        cliState.customState = cliCs;
-        // Will be persisted below — either by the claude-specific block or the explicit call after it
-      }
-
-      // If this is a Claude CLI command, inject --session-id or --resume
-      if (
-        cliAgentType === 'claude' &&
-        !initialCommand.includes('--session-id') &&
-        !initialCommand.includes('--resume')
-      ) {
-        const termState = existingState as TerminalPanelState | undefined;
-        if (termState?.hasClaudeSessionId) {
-          commandToRun = `claude --resume ${panel.id} --dangerously-skip-permissions`;
-        } else {
-          commandToRun = `${initialCommand} --session-id ${panel.id}`;
-        }
-
-        // Mark that we've assigned a session ID to this panel
-        // (isCliPanel is already set above and will be included here)
-        const updatedState = panel.state;
-        const cs = (updatedState.customState || {}) as TerminalPanelState;
-        cs.hasClaudeSessionId = true;
-        updatedState.customState = cs;
-        panelManager.updatePanel(panel.id, { state: updatedState });
-      } else if (isCliCommand) {
-        // Non-claude CLI (e.g. codex) — persist the isCliPanel flag explicitly
-        panelManager.updatePanel(panel.id, { state: panel.state });
+        panel.state.customState = launchResolution.customState;
+        await panelManager.updatePanel(panel.id, { state: panel.state }).catch(error => {
+          console.warn(`[TerminalPanelManager] Failed to persist CLI launch state for panel ${panel.id}:`, error);
+        });
       }
 
       // Detect the interactive prompt before injecting the command.


### PR DESCRIPTION
## Summary
- resolve interrupted Codex terminal commands at terminal launch time
- launch `codex resume --yolo <session>` when a Codex session id exists, otherwise open `codex resume --yolo` picker
- keep explicit resume state writes aligned through PanelManager before terminal initialization

## Testing
- pnpm --filter main typecheck
- pnpm typecheck
- pnpm lint
- pnpm --filter main exec eslint src/services/terminalPanelManager.ts src/services/sessionManager.ts --quiet
- pnpm --filter main exec vitest run src/ptyHost/flowControl.test.ts src/services/__tests__/worktreeFileSyncService.test.ts

Note: `pnpm --filter main exec vitest run` still fails in existing `gitStatusManager.test.ts` cases where status resolves to `unknown`; those tests are outside this two-file resume change.