### PR TITLE
Fix git status manager test mock

### DIFF
--- a/main/src/services/__tests__/gitStatusManager.test.ts
+++ b/main/src/services/__tests__/gitStatusManager.test.ts
@@ -85,6 +85,7 @@ describe('GitStatusManager', () => {
 
     mockWorktreeManager = {
       getProjectMainBranch: vi.fn().mockResolvedValue('main'),
+      getSessionComparisonBranch: vi.fn().mockResolvedValue('main'),
     } as Partial<WorktreeManager> as WorktreeManager;
 
     mockGitDiffManager = {} as Partial<GitDiffManager> as GitDiffManager;


### PR DESCRIPTION
## Summary
- mock the current getSessionComparisonBranch dependency in GitStatusManager tests
- restores validation coverage for git status state scenarios

## Testing
- pnpm --filter main exec vitest run src/services/__tests__/gitStatusManager.test.ts
- pnpm --filter main typecheck
- pnpm --filter main exec eslint src/services/__tests__/gitStatusManager.test.ts --quiet
- pre-commit: pnpm typecheck && pnpm lint

Note: local validation emitted existing Node engine warnings because this shell is Node v20.19.3 and repo declares >=22.14.0.