### PR TITLE
fix: restore live Electron daemon bridge boot

### DIFF
--- a/main/src/core/importBoundary.test.ts
+++ b/main/src/core/importBoundary.test.ts
@@ -46,11 +46,28 @@ describe('daemon/client import boundary', () => {
   });
 
   it('keeps the daemon server free of Electron bootstrap imports', () => {
-    const source = readMainSrcFile('daemon/server.ts');
+    const daemonBoundaryFiles = [
+      'daemon/server.ts',
+      'ipc/daemon.ts',
+    ];
 
-    expect(source).not.toContain("from 'electron'");
-    expect(source).not.toContain('mainWindow');
-    expect(source).not.toMatch(/from ['"](?:\.\.\/)+(?:index)['"]/);
-    expect(source).not.toMatch(/from ['"](?:\.\.\/)+(?:index)\.ts['"]/);
+    for (const relativePath of daemonBoundaryFiles) {
+      const source = readMainSrcFile(relativePath);
+
+      expect(source, relativePath).not.toContain("from 'electron'");
+      expect(source, relativePath).not.toContain('mainWindow');
+      expect(source, relativePath).not.toMatch(/from ['"](?:\.\.\/)+(?:index)['"]/);
+      expect(source, relativePath).not.toMatch(/from ['"](?:\.\.\/)+(?:index)\.ts['"]/);
+    }
+  });
+
+  it('routes daemon-owned preload invokes through the shared bridge helper', () => {
+    const source = readMainSrcFile('preload.ts');
+
+    expect(source).toContain('isDaemonOwnedChannel');
+    expect(source).toContain("ipcRenderer.invoke('daemon:invoke', channel, ...args)");
+    expect(source).not.toMatch(
+      /ipcRenderer\.invoke\('(sessions:|projects:|folders:|prompts:|resource-monitor:|panels:|terminal:|logs:|git:(cancel-status-for-project|clone-repo|commit|execute-project|file-status|get-github-remote|restore|revert)|file:(copy|delete|duplicate|exists|getPath|list|move|read|read-binary|read-project|readAtRevision|rename|resolveAbsolutePath|search|write|write-binary|write-project))/,
+    );
   });
 });

--- a/main/src/core/importBoundary.test.ts
+++ b/main/src/core/importBoundary.test.ts
@@ -61,10 +61,13 @@ describe('daemon/client import boundary', () => {
     }
   });
 
-  it('routes daemon-owned preload invokes through the shared bridge helper', () => {
+  it('routes daemon-owned preload invokes through the runtime-safe bridge helper', () => {
     const source = readMainSrcFile('preload.ts');
 
+    expect(source).toContain('function isDaemonOwnedChannel');
     expect(source).toContain('isDaemonOwnedChannel');
+    expect(source).not.toContain("../../shared/types/daemon");
+    expect(source).not.toContain("from './daemon/daemonChannels'");
     expect(source).toContain("ipcRenderer.invoke('daemon:invoke', channel, ...args)");
     expect(source).not.toMatch(
       /ipcRenderer\.invoke\('(sessions:|projects:|folders:|prompts:|resource-monitor:|panels:|terminal:|logs:|git:(cancel-status-for-project|clone-repo|commit|execute-project|file-status|get-github-remote|restore|revert)|file:(copy|delete|duplicate|exists|getPath|list|move|read|read-binary|read-project|readAtRevision|rename|resolveAbsolutePath|search|write|write-binary|write-project))/,

--- a/main/src/core/importBoundary.test.ts
+++ b/main/src/core/importBoundary.test.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
+import {
+  DAEMON_OWNED_CHANNEL_PREFIXES,
+  DAEMON_OWNED_EXACT_CHANNELS,
+  ELECTRON_ADAPTER_ONLY_CHANNELS,
+} from '../../../shared/types/daemon';
 
 const MAIN_SRC_ROOT = path.resolve(process.cwd(), 'src');
 
@@ -72,5 +77,21 @@ describe('daemon/client import boundary', () => {
     expect(source).not.toMatch(
       /ipcRenderer\.invoke\('(sessions:|projects:|folders:|prompts:|resource-monitor:|panels:|terminal:|logs:|git:(cancel-status-for-project|clone-repo|commit|execute-project|file-status|get-github-remote|restore|revert)|file:(copy|delete|duplicate|exists|getPath|list|move|read|read-binary|read-project|readAtRevision|rename|resolveAbsolutePath|search|write|write-binary|write-project))/,
     );
+  });
+
+  it('keeps preload channel ownership literals aligned with the shared daemon contract', () => {
+    const source = readMainSrcFile('preload.ts');
+
+    for (const prefix of DAEMON_OWNED_CHANNEL_PREFIXES) {
+      expect(source).toContain(`'${prefix}'`);
+    }
+
+    for (const channel of DAEMON_OWNED_EXACT_CHANNELS) {
+      expect(source).toContain(`'${channel}'`);
+    }
+
+    for (const channel of ELECTRON_ADAPTER_ONLY_CHANNELS) {
+      expect(source).toContain(`'${channel}'`);
+    }
   });
 });

--- a/main/src/daemon/commandRegistry.ts
+++ b/main/src/daemon/commandRegistry.ts
@@ -1,4 +1,4 @@
-import { isDaemonOwnedChannel } from '../../../shared/types/daemon';
+import { isDaemonOwnedChannel } from './daemonChannels';
 
 export type PaneCommandHandler<TArgs extends unknown[] = unknown[], TResult = unknown> = (
   ...args: TArgs

--- a/main/src/daemon/daemonChannels.ts
+++ b/main/src/daemon/daemonChannels.ts
@@ -1,0 +1,57 @@
+const DAEMON_OWNED_CHANNEL_PREFIXES = [
+  'folders:',
+  'logs:',
+  'panels:',
+  'projects:',
+  'prompts:',
+  'resource-monitor:',
+  'sessions:',
+  'terminal:',
+] as const;
+
+const DAEMON_OWNED_EXACT_CHANNELS = [
+  'git:cancel-status-for-project',
+  'git:clone-repo',
+  'git:commit',
+  'git:execute-project',
+  'git:file-status',
+  'git:get-github-remote',
+  'git:restore',
+  'git:revert',
+  'file:copy',
+  'file:delete',
+  'file:duplicate',
+  'file:exists',
+  'file:getPath',
+  'file:list',
+  'file:move',
+  'file:read',
+  'file:read-binary',
+  'file:read-project',
+  'file:readAtRevision',
+  'file:rename',
+  'file:resolveAbsolutePath',
+  'file:search',
+  'file:write',
+  'file:write-binary',
+  'file:write-project',
+] as const;
+
+const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
+  'file:showInFolder',
+  'sessions:open-ide',
+  'sessions:set-active-session',
+  'terminal:clipboard-paste-image',
+]);
+
+export function isDaemonOwnedChannel(channel: string): boolean {
+  if (ELECTRON_ADAPTER_ONLY_CHANNELS.has(channel)) {
+    return false;
+  }
+
+  if (DAEMON_OWNED_EXACT_CHANNELS.includes(channel as (typeof DAEMON_OWNED_EXACT_CHANNELS)[number])) {
+    return true;
+  }
+
+  return DAEMON_OWNED_CHANNEL_PREFIXES.some((prefix) => channel.startsWith(prefix));
+}

--- a/main/src/daemon/daemonChannels.ts
+++ b/main/src/daemon/daemonChannels.ts
@@ -1,57 +1,6 @@
-const DAEMON_OWNED_CHANNEL_PREFIXES = [
-  'folders:',
-  'logs:',
-  'panels:',
-  'projects:',
-  'prompts:',
-  'resource-monitor:',
-  'sessions:',
-  'terminal:',
-] as const;
-
-const DAEMON_OWNED_EXACT_CHANNELS = [
-  'git:cancel-status-for-project',
-  'git:clone-repo',
-  'git:commit',
-  'git:execute-project',
-  'git:file-status',
-  'git:get-github-remote',
-  'git:restore',
-  'git:revert',
-  'file:copy',
-  'file:delete',
-  'file:duplicate',
-  'file:exists',
-  'file:getPath',
-  'file:list',
-  'file:move',
-  'file:read',
-  'file:read-binary',
-  'file:read-project',
-  'file:readAtRevision',
-  'file:rename',
-  'file:resolveAbsolutePath',
-  'file:search',
-  'file:write',
-  'file:write-binary',
-  'file:write-project',
-] as const;
-
-const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
-  'file:showInFolder',
-  'sessions:open-ide',
-  'sessions:set-active-session',
-  'terminal:clipboard-paste-image',
-]);
-
-export function isDaemonOwnedChannel(channel: string): boolean {
-  if (ELECTRON_ADAPTER_ONLY_CHANNELS.has(channel)) {
-    return false;
-  }
-
-  if (DAEMON_OWNED_EXACT_CHANNELS.includes(channel as (typeof DAEMON_OWNED_EXACT_CHANNELS)[number])) {
-    return true;
-  }
-
-  return DAEMON_OWNED_CHANNEL_PREFIXES.some((prefix) => channel.startsWith(prefix));
-}
+export {
+  DAEMON_OWNED_CHANNEL_PREFIXES,
+  DAEMON_OWNED_EXACT_CHANNELS,
+  ELECTRON_ADAPTER_ONLY_CHANNELS,
+  isDaemonOwnedChannel,
+} from '../../../shared/types/daemon';

--- a/main/src/daemon/socketFraming.test.ts
+++ b/main/src/daemon/socketFraming.test.ts
@@ -4,7 +4,6 @@ import {
   PaneDaemonFrameDecoder,
 } from './socketFraming';
 import {
-  isDaemonOwnedChannel,
   isPaneDaemonEventFrame,
   isPaneDaemonFrame,
   isPaneDaemonRequestFrame,
@@ -13,6 +12,7 @@ import {
   type PaneDaemonRequestFrame,
   type PaneDaemonResponseFrame,
 } from '../../../shared/types/daemon';
+import { isDaemonOwnedChannel } from './daemonChannels';
 
 describe('Pane daemon framing', () => {
   it('encodes frames as newline-delimited JSON', () => {

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -952,11 +952,6 @@ async function createWindow() {
     resourceMonitorService.handleVisibilityChange(true);
   });
 
-  // Pull-path query so the renderer can get the authoritative focus state on
-  // mount without waiting for the next focus-change event. Default to true
-  // (focused) if mainWindow is somehow null at call time.
-  ipcMain.handle('window:is-focused', () => mainWindow?.isFocused() ?? true);
-
   mainWindow.on('restore', () => {
     // Don't assume restore = focused. The OS will fire 'focus' if/when the user
     // actually focuses the window; that is what restarts git/resource work.
@@ -1211,6 +1206,10 @@ app.whenReady().then(async () => {
   console.log('[Main] App is ready, initializing services...');
   await initializeServices();
   console.log('[Main] Services initialized, creating window...');
+
+  // Register before any renderer loads. useNotifications pulls this on mount
+  // and will race a late registration inside createWindow/loadURL.
+  ipcMain.handle('window:is-focused', () => mainWindow?.isFocused() ?? true);
 
   // Start the ptyHost supervisor before the window opens so the renderer's
   // preload listener for 'ptyHost-port' has a port to receive when the window

--- a/main/src/ipc/daemon.ts
+++ b/main/src/ipc/daemon.ts
@@ -1,4 +1,4 @@
-import { isDaemonOwnedChannel } from '../../../shared/types/daemon';
+import { isDaemonOwnedChannel } from '../daemon/daemonChannels';
 import type { PaneCommandRegistry } from '../daemon/commandRegistry';
 
 interface IpcMainHandleLike {

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -3,7 +3,6 @@ import type { CreateSessionRequest, Session } from './types/session';
 import type { AppConfig, UpdateConfigRequest } from './types/config';
 import type { CreateProjectRequest, UpdateProjectRequest, Project } from '../../frontend/src/types/project';
 import type { ToolPanel } from '../../shared/types/panels';
-import { isDaemonOwnedChannel } from '../../shared/types/daemon';
 
 interface LogEntry {
   timestamp: string;
@@ -86,6 +85,66 @@ interface UpdaterInfo {
   path?: string;
   sha512?: string;
   size?: number;
+}
+
+const DAEMON_OWNED_CHANNEL_PREFIXES = [
+  'folders:',
+  'logs:',
+  'panels:',
+  'projects:',
+  'prompts:',
+  'resource-monitor:',
+  'sessions:',
+  'terminal:',
+] as const;
+
+const DAEMON_OWNED_EXACT_CHANNELS = [
+  'git:cancel-status-for-project',
+  'git:clone-repo',
+  'git:commit',
+  'git:execute-project',
+  'git:file-status',
+  'git:get-github-remote',
+  'git:restore',
+  'git:revert',
+  'file:copy',
+  'file:delete',
+  'file:duplicate',
+  'file:exists',
+  'file:getPath',
+  'file:list',
+  'file:move',
+  'file:read',
+  'file:read-binary',
+  'file:read-project',
+  'file:readAtRevision',
+  'file:rename',
+  'file:resolveAbsolutePath',
+  'file:search',
+  'file:write',
+  'file:write-binary',
+  'file:write-project',
+] as const;
+
+const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
+  'file:showInFolder',
+  'sessions:open-ide',
+  'sessions:set-active-session',
+  'terminal:clipboard-paste-image',
+]);
+
+// Sandboxed Electron preload scripts cannot reliably require local runtime
+// modules, so the daemon-owned channel classifier stays inline here.
+function isDaemonOwnedChannel(channel: string): boolean {
+  if (ELECTRON_ADAPTER_ONLY_CHANNELS.has(channel)) {
+    return false;
+  }
+
+  if (DAEMON_OWNED_EXACT_CHANNELS.includes(channel as (typeof DAEMON_OWNED_EXACT_CHANNELS)[number])) {
+    return true;
+  }
+
+  return DAEMON_OWNED_CHANNEL_PREFIXES.some((prefix) => channel.startsWith(prefix));
 }
 
 // Increase max listeners for ipcRenderer to prevent warnings when many components listen to events

--- a/shared/types/daemon.ts
+++ b/shared/types/daemon.ts
@@ -46,6 +46,66 @@ interface PaneDaemonResponseFrameCandidate {
   error?: unknown;
 }
 
+export const DAEMON_OWNED_CHANNEL_PREFIXES = [
+  'folders:',
+  'logs:',
+  'panels:',
+  'projects:',
+  'prompts:',
+  'resource-monitor:',
+  'sessions:',
+  'terminal:',
+] as const;
+
+export const DAEMON_OWNED_EXACT_CHANNELS = [
+  'git:cancel-status-for-project',
+  'git:clone-repo',
+  'git:commit',
+  'git:execute-project',
+  'git:file-status',
+  'git:get-github-remote',
+  'git:restore',
+  'git:revert',
+  'file:copy',
+  'file:delete',
+  'file:duplicate',
+  'file:exists',
+  'file:getPath',
+  'file:list',
+  'file:move',
+  'file:read',
+  'file:read-binary',
+  'file:read-project',
+  'file:readAtRevision',
+  'file:rename',
+  'file:resolveAbsolutePath',
+  'file:search',
+  'file:write',
+  'file:write-binary',
+  'file:write-project',
+] as const;
+
+export const ELECTRON_ADAPTER_ONLY_CHANNELS = [
+  'file:showInFolder',
+  'sessions:open-ide',
+  'sessions:set-active-session',
+  'terminal:clipboard-paste-image',
+] as const;
+
+const ELECTRON_ADAPTER_ONLY_CHANNEL_SET = new Set<string>(ELECTRON_ADAPTER_ONLY_CHANNELS);
+
+export function isDaemonOwnedChannel(channel: string): boolean {
+  if (ELECTRON_ADAPTER_ONLY_CHANNEL_SET.has(channel)) {
+    return false;
+  }
+
+  if (DAEMON_OWNED_EXACT_CHANNELS.includes(channel as (typeof DAEMON_OWNED_EXACT_CHANNELS)[number])) {
+    return true;
+  }
+
+  return DAEMON_OWNED_CHANNEL_PREFIXES.some((prefix) => channel.startsWith(prefix));
+}
+
 export function isPaneDaemonRequestFrame(frame: unknown): frame is PaneDaemonRequestFrame {
   if (typeof frame !== 'object' || frame === null) {
     return false;

--- a/shared/types/daemon.ts
+++ b/shared/types/daemon.ts
@@ -46,64 +46,6 @@ interface PaneDaemonResponseFrameCandidate {
   error?: unknown;
 }
 
-const DAEMON_OWNED_CHANNEL_PREFIXES = [
-  'folders:',
-  'logs:',
-  'panels:',
-  'projects:',
-  'prompts:',
-  'resource-monitor:',
-  'sessions:',
-  'terminal:',
-] as const;
-
-const DAEMON_OWNED_EXACT_CHANNELS = [
-  'git:cancel-status-for-project',
-  'git:clone-repo',
-  'git:commit',
-  'git:execute-project',
-  'git:file-status',
-  'git:get-github-remote',
-  'git:restore',
-  'git:revert',
-  'file:copy',
-  'file:delete',
-  'file:duplicate',
-  'file:exists',
-  'file:getPath',
-  'file:list',
-  'file:move',
-  'file:read',
-  'file:read-binary',
-  'file:read-project',
-  'file:readAtRevision',
-  'file:rename',
-  'file:resolveAbsolutePath',
-  'file:search',
-  'file:write',
-  'file:write-binary',
-  'file:write-project',
-] as const;
-
-const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
-  'file:showInFolder',
-  'sessions:open-ide',
-  'sessions:set-active-session',
-  'terminal:clipboard-paste-image',
-]);
-
-export function isDaemonOwnedChannel(channel: string): boolean {
-  if (ELECTRON_ADAPTER_ONLY_CHANNELS.has(channel)) {
-    return false;
-  }
-
-  if (DAEMON_OWNED_EXACT_CHANNELS.includes(channel as (typeof DAEMON_OWNED_EXACT_CHANNELS)[number])) {
-    return true;
-  }
-
-  return DAEMON_OWNED_CHANNEL_PREFIXES.some((prefix) => channel.startsWith(prefix));
-}
-
 export function isPaneDaemonRequestFrame(frame: unknown): frame is PaneDaemonRequestFrame {
   if (typeof frame !== 'object' || frame === null) {
     return false;


### PR DESCRIPTION
## Summary
- restore Electron preload startup after the daemon bridge split by keeping the renderer-side channel classifier runtime-safe under sandboxed preload constraints
- register `window:is-focused` before the renderer loads so focus-state IPC no longer races app startup
- keep the shared daemon channel ownership map authoritative for main/runtime code and add a regression check that preload's inline classifier stays aligned

## Testing
- pnpm typecheck
- pnpm lint
- CI=1 pnpm --filter main test -- --run
- pnpm run build:main
- PANE_DIR=/tmp/pane-phase2-final-ci xvfb-run -a pnpm test:ci
- PANE_USE_PTY_HOST=1 PANE_DIR=/tmp/pane-phase2-live-smoke-ptyhost xvfb-run -a pnpm test:ci
- PANE_DIR=/tmp/pane-phase2-review-smoke xvfb-run -a pnpm test:ci
- live Electron smoke via direct launch and Playwright-attached renderer probes covering preload boot, `getPlatform`, `getVersionInfo`, project create/list, folder create/list, session create/list, and resource monitor snapshot
