### PR TITLE
fix: restore Discord button brand colors

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,2 +1,2 @@
-model = "gpt-5.4"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"

--- a/frontend/src/styles/tokens/colors.css
+++ b/frontend/src/styles/tokens/colors.css
@@ -27,6 +27,11 @@
   --red-500: rgb(239 68 68);
   --red-600: rgb(220 38 38);
 
+  /* Brand colors */
+  --discord-primary: #5865F2;
+  --discord-hover: #4752C4;
+  --discord-secondary: #7289DA;
+
   /* GitHub Dark palette - rich OLED blacks */
   --gh-black: rgb(1 4 9);         /* True OLED black */
   --gh-900: rgb(13 17 23);        /* GitHub dark default bg */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -136,9 +136,9 @@ export default {
         },
         // Brand colors
         'discord': {
-          'DEFAULT': 'var(--discord-primary)',
-          'hover': 'var(--discord-hover)',
-          'secondary': 'var(--discord-secondary)',
+          'DEFAULT': 'var(--discord-primary, #5865F2)',
+          'hover': 'var(--discord-hover, #4752C4)',
+          'secondary': 'var(--discord-secondary, #7289DA)',
         },
         // Modal colors
         'modal': {


### PR DESCRIPTION
## Summary
- define shared Discord brand color tokens
- add Tailwind fallbacks so bg-discord remains visible if tokens are unavailable
- update repo Codex config to GPT-5.5 medium

## Testing
- pnpm --filter frontend typecheck
- pnpm --filter frontend lint (warnings only, existing)
- pnpm run build:frontend