### PR TITLE
Fix multiline paste in AI terminal panels

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -201,6 +201,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   const isCliPanel = !!terminalState?.isCliPanel;
   const [isCliReady, setIsCliReady] = useState(!!terminalState?.isCliReady);
   const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
+  const isCliPanelRef = useRef(isCliPanel);
 
   // ptyId for the current PTY behind this panel, delivered via
   // `terminal:ptyReady` when spawned through the ptyHost UtilityProcess.
@@ -227,6 +228,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
   // Sync isCliReady from panel prop when it changes (e.g. backend persisted isCliReady
   // before this component subscribed to the IPC event, or panel state was updated externally)
+  useEffect(() => {
+    isCliPanelRef.current = isCliPanel;
+  }, [isCliPanel]);
+
   useEffect(() => {
     if (terminalState?.isCliReady && !isCliReady) {
       setIsCliReady(true);
@@ -1069,7 +1074,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // never attach it to the API call (see commit 7b76ee5).
           const pasteText = (text: string) => {
             if (!terminal) return;
-            const shouldProtectMultilinePaste = isCliPanel && !tuiActiveRef.current && /[\r\n]/.test(text);
+            const shouldProtectMultilinePaste = isCliPanelRef.current && !tuiActiveRef.current && /[\r\n]/.test(text);
             if (shouldProtectMultilinePaste) {
               window.electronAPI.invoke(
                 'terminal:input',

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -1067,6 +1067,21 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // The "[Image] " prefix we used to add actually broke the parser's
           // path-detection — on Windows+WSL it caused Claude to cache the file but
           // never attach it to the API call (see commit 7b76ee5).
+          const pasteText = (text: string) => {
+            if (!terminal) return;
+            const shouldProtectMultilinePaste = isCliPanel && !tuiActiveRef.current && /[\r\n]/.test(text);
+            if (shouldProtectMultilinePaste) {
+              window.electronAPI.invoke(
+                'terminal:input',
+                panel.id,
+                text.replace(/\r\n|\r|\n/g, '\x1b\r'),
+              );
+              return;
+            }
+
+            terminal.paste(text);
+          };
+
           const handlePaste = (e: ClipboardEvent) => {
             // Step 1: Check for images in browser clipboard (works on native Windows/macOS)
             const items = e.clipboardData?.items;
@@ -1150,7 +1165,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
               // No image found — forward the text content xterm would have pasted.
               if (text && !disposed && terminal) {
-                terminal.paste(text);
+                pasteText(text);
               }
             })();
           };


### PR DESCRIPTION
## Summary
- protect multiline text paste in AI CLI terminal panels by converting pasted line breaks to Pane's existing Alt/Shift+Enter newline sequence
- keep single-line text paste, image paste, drag/drop, and TUI paste behavior on the existing xterm path

## Testing
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm build (frontend and main build pass; build:electron fails in this WSL environment while rebuilding msgpackr-extract because g++ rejects -m64)

## Notes
- The change is intentionally scoped to CLI panels when no alternate-screen TUI is active.

<!-- codex-pr-test-automation-summary -->
## Automated QA

**Status:** Passed on rebased commit `0b96284`.

- Real Electron renderer/IPC test on macOS arm64 with an isolated `PANE_DIR`.
- Multiline CLI paste converted LF, CRLF, and CR boundaries to Pane's `<ESC><CR>` newline sequence without submitting.
- Single-line paste remained on xterm bracketed paste.
- Image clipboard data reached `terminal:paste-image` and pasted the returned path through xterm.
- Alternate-screen/TUI multiline paste remained raw and bypassed the protected conversion.
- `pnpm typecheck`, `pnpm lint`, and `pnpm run build:frontend` passed under Node 22.23.1; lint has the existing warning-only baseline.

**Human follow-up:** physical Cmd+V in Codex and Claude, plus one real screenshot paste to verify on-disk image persistence. Local evidence: `tmp/pr-203-qa/`.
<!-- /codex-pr-test-automation-summary -->