### PR TITLE
feat: add remote daemon HTTP transport

### DIFF
--- a/main/src/core/runtime.ts
+++ b/main/src/core/runtime.ts
@@ -46,6 +46,11 @@ export interface PtyHostRuntime {
  */
 export interface PaneRuntime {
   eventSink: PaneEventSink;
+  /**
+   * Non-renderer daemon subscribers, such as the local socket server and the
+   * remote HTTP/SSE transport. This stream is live-only; reconnecting clients
+   * are expected to refetch state instead of relying on server-side replay.
+   */
   daemonEventSink?: PaneEventSink;
   getConfigManager(): ConfigManager;
   getPtyHostRuntime(): PtyHostRuntime | null;

--- a/main/src/daemon/auth.test.ts
+++ b/main/src/daemon/auth.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { RemoteDaemonClientRecord } from '../../../shared/types/remoteDaemon';
+import { authenticateRemoteDaemonBearerToken, hashRemoteDaemonToken } from './auth';
+
+function createClientRecord(id: string, token: string): RemoteDaemonClientRecord {
+  return {
+    id,
+    label: `Client ${id}`,
+    createdAt: new Date('2026-05-14T00:00:00.000Z').toISOString(),
+    tokenHash: hashRemoteDaemonToken(token),
+  };
+}
+
+describe('remote daemon auth', () => {
+  it('authenticates matching bearer tokens against paired clients', () => {
+    const result = authenticateRemoteDaemonBearerToken(
+      'Bearer secret-token',
+      [createClientRecord('client-1', 'secret-token')],
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      client: createClientRecord('client-1', 'secret-token'),
+    });
+  });
+
+  it('rejects missing bearer tokens', () => {
+    expect(authenticateRemoteDaemonBearerToken(undefined, [createClientRecord('client-1', 'secret-token')])).toEqual({
+      ok: false,
+      statusCode: 401,
+      error: {
+        message: 'Remote daemon bearer token is required',
+        code: 'ERR_REMOTE_DAEMON_AUTH_REQUIRED',
+      },
+    });
+  });
+
+  it('rejects invalid bearer tokens', () => {
+    expect(authenticateRemoteDaemonBearerToken('Bearer wrong-token', [createClientRecord('client-1', 'secret-token')])).toEqual({
+      ok: false,
+      statusCode: 403,
+      error: {
+        message: 'Remote daemon bearer token is invalid',
+        code: 'ERR_REMOTE_DAEMON_AUTH_INVALID',
+      },
+    });
+  });
+
+  it('rejects malformed authorization schemes', () => {
+    expect(authenticateRemoteDaemonBearerToken('Basic abc123', [createClientRecord('client-1', 'secret-token')])).toEqual({
+      ok: false,
+      statusCode: 401,
+      error: {
+        message: 'Remote daemon bearer token is required',
+        code: 'ERR_REMOTE_DAEMON_AUTH_REQUIRED',
+      },
+    });
+  });
+});

--- a/main/src/daemon/auth.ts
+++ b/main/src/daemon/auth.ts
@@ -1,0 +1,92 @@
+import { createHash, timingSafeEqual } from 'crypto';
+import type { RemoteDaemonClientRecord } from '../../../shared/types/remoteDaemon';
+
+interface RemoteDaemonAuthSuccess {
+  ok: true;
+  client: RemoteDaemonClientRecord;
+}
+
+interface RemoteDaemonAuthFailure {
+  ok: false;
+  statusCode: number;
+  error: {
+    message: string;
+    code: string;
+  };
+}
+
+export type RemoteDaemonAuthResult = RemoteDaemonAuthSuccess | RemoteDaemonAuthFailure;
+
+export function hashRemoteDaemonToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function authenticateRemoteDaemonBearerToken(
+  authorizationHeader: string | string[] | undefined,
+  clients: readonly RemoteDaemonClientRecord[],
+): RemoteDaemonAuthResult {
+  const token = extractBearerToken(authorizationHeader);
+  if (!token) {
+    return {
+      ok: false,
+      statusCode: 401,
+      error: {
+        message: 'Remote daemon bearer token is required',
+        code: 'ERR_REMOTE_DAEMON_AUTH_REQUIRED',
+      },
+    };
+  }
+
+  const tokenHash = hashRemoteDaemonToken(token);
+  const client = clients.find((candidate) => safeTokenHashEquals(candidate.tokenHash, tokenHash));
+  if (!client) {
+    return {
+      ok: false,
+      statusCode: 403,
+      error: {
+        message: 'Remote daemon bearer token is invalid',
+        code: 'ERR_REMOTE_DAEMON_AUTH_INVALID',
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    client,
+  };
+}
+
+function extractBearerToken(authorizationHeader: string | string[] | undefined): string | null {
+  if (Array.isArray(authorizationHeader)) {
+    return authorizationHeader.length === 1
+      ? extractBearerToken(authorizationHeader[0])
+      : null;
+  }
+
+  if (typeof authorizationHeader !== 'string') {
+    return null;
+  }
+
+  const [scheme, ...rest] = authorizationHeader.trim().split(/\s+/);
+  if (scheme.toLowerCase() !== 'bearer') {
+    return null;
+  }
+
+  const token = rest.join(' ').trim();
+  return token.length > 0 ? token : null;
+}
+
+function safeTokenHashEquals(expectedHash: string, actualHash: string): boolean {
+  try {
+    const expected = Buffer.from(expectedHash, 'hex');
+    const actual = Buffer.from(actualHash, 'hex');
+
+    if (expected.length === 0 || expected.length !== actual.length) {
+      return false;
+    }
+
+    return timingSafeEqual(expected, actual);
+  } catch {
+    return false;
+  }
+}

--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -21,6 +21,7 @@ import { TaskQueue } from '../services/taskQueue';
 import { registerIpcHandlers } from '../ipc';
 import { PaneDaemonServer } from './server';
 import { PaneRemoteHttpApiServer } from './httpApiServer';
+import { PaneRemoteTransportController } from './remoteTransportController';
 import { createFanoutEventSink, noopPaneEventSink, type PaneEventSink } from '../core/eventSink';
 import {
   setPaneRuntime,
@@ -208,7 +209,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
   const commandRegistry = registerIpcHandlers(services);
 
   let paneDaemonServer: PaneDaemonServer | null = null;
-  let remoteHttpApiServer: PaneRemoteHttpApiServer | null = null;
+  const remoteTransportController = new PaneRemoteTransportController(commandRegistry, configManager);
   try {
     paneDaemonServer = new PaneDaemonServer(commandRegistry, getAppDirectory());
     await paneDaemonServer.start();
@@ -216,13 +217,12 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
     console.error('[Pane daemon] Failed to start local daemon server; continuing with renderer-only runtime events', error);
   }
 
-  if (startRemoteTransport && configManager.getConfig().remoteDaemon?.host.config.enabled) {
+  if (startRemoteTransport) {
+    remoteTransportController.startWatchingConfig();
     try {
-      remoteHttpApiServer = new PaneRemoteHttpApiServer(commandRegistry, configManager);
-      await remoteHttpApiServer.start();
+      await remoteTransportController.syncToConfig();
     } catch (error) {
       console.error('[Pane remote daemon] Failed to start remote HTTP transport; continuing without remote access', error);
-      remoteHttpApiServer = null;
     }
   }
 
@@ -230,8 +230,8 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
   if (paneDaemonServer) {
     daemonSinks.push(paneDaemonServer.getEventSink());
   }
-  if (remoteHttpApiServer) {
-    daemonSinks.push(remoteHttpApiServer.getEventSink());
+  if (startRemoteTransport) {
+    daemonSinks.push(remoteTransportController.getEventSink());
   }
 
   installPaneRuntime(
@@ -269,7 +269,9 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
     daemonServices,
     commandRegistry,
     paneDaemonServer,
-    remoteHttpApiServer,
+    get remoteHttpApiServer() {
+      return remoteTransportController.getServer();
+    },
     permissionIpcServer,
     async shutdown(): Promise<void> {
       resourceMonitorService.stop();
@@ -281,7 +283,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
       await cliManagerFactory.shutdown();
       await taskQueue.close();
       await permissionIpcServer?.stop();
-      await remoteHttpApiServer?.stop();
+      await remoteTransportController.stopWatchingAndShutdown();
       if (paneDaemonServer) {
         await paneDaemonServer.stop();
       }

--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -20,6 +20,7 @@ import { VersionChecker } from '../services/versionChecker';
 import { TaskQueue } from '../services/taskQueue';
 import { registerIpcHandlers } from '../ipc';
 import { PaneDaemonServer } from './server';
+import { PaneRemoteHttpApiServer } from './httpApiServer';
 import { createFanoutEventSink, noopPaneEventSink, type PaneEventSink } from '../core/eventSink';
 import {
   setPaneRuntime,
@@ -40,6 +41,7 @@ interface PaneDaemonHostOptions {
   rendererEventSink?: PaneEventSink;
   mode?: 'desktop' | 'headless';
   restoreSpotlights?: boolean;
+  startRemoteTransport?: boolean;
 }
 
 export interface PaneDaemonHost {
@@ -47,6 +49,7 @@ export interface PaneDaemonHost {
   daemonServices: DaemonHostServices;
   commandRegistry: PaneCommandRegistry;
   paneDaemonServer: PaneDaemonServer | null;
+  remoteHttpApiServer: PaneRemoteHttpApiServer | null;
   permissionIpcServer: PermissionIpcServer | null;
   shutdown(): Promise<void>;
 }
@@ -83,6 +86,7 @@ function registerPowerMonitorDiagnostics(logger: Logger): void {
 
 export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Promise<PaneDaemonHost> {
   const mode = options.mode ?? 'desktop';
+  const startRemoteTransport = options.startRemoteTransport ?? true;
   const rendererEventSink = options.rendererEventSink ?? noopPaneEventSink;
   const headlessWebviewContextMap = new Map<number, PaneWebviewContext>();
   const getWebviewContextMap = options.getWebviewContextMap ?? (() => headlessWebviewContextMap);
@@ -204,19 +208,39 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
   const commandRegistry = registerIpcHandlers(services);
 
   let paneDaemonServer: PaneDaemonServer | null = null;
+  let remoteHttpApiServer: PaneRemoteHttpApiServer | null = null;
   try {
     paneDaemonServer = new PaneDaemonServer(commandRegistry, getAppDirectory());
     await paneDaemonServer.start();
-    installPaneRuntime(
-      createFanoutEventSink([rendererEventSink, paneDaemonServer.getEventSink()]),
-      configManager,
-      options.getPtyHostRuntime,
-      getWebviewContextMap,
-      paneDaemonServer.getEventSink(),
-    );
   } catch (error) {
     console.error('[Pane daemon] Failed to start local daemon server; continuing with renderer-only runtime events', error);
   }
+
+  if (startRemoteTransport && configManager.getConfig().remoteDaemon?.host.config.enabled) {
+    try {
+      remoteHttpApiServer = new PaneRemoteHttpApiServer(commandRegistry, configManager);
+      await remoteHttpApiServer.start();
+    } catch (error) {
+      console.error('[Pane remote daemon] Failed to start remote HTTP transport; continuing without remote access', error);
+      remoteHttpApiServer = null;
+    }
+  }
+
+  const daemonSinks: PaneEventSink[] = [];
+  if (paneDaemonServer) {
+    daemonSinks.push(paneDaemonServer.getEventSink());
+  }
+  if (remoteHttpApiServer) {
+    daemonSinks.push(remoteHttpApiServer.getEventSink());
+  }
+
+  installPaneRuntime(
+    createFanoutEventSink([rendererEventSink, ...daemonSinks]),
+    configManager,
+    options.getPtyHostRuntime,
+    getWebviewContextMap,
+    createFanoutEventSink(daemonSinks),
+  );
 
   setupEventListeners(services);
 
@@ -245,6 +269,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
     daemonServices,
     commandRegistry,
     paneDaemonServer,
+    remoteHttpApiServer,
     permissionIpcServer,
     async shutdown(): Promise<void> {
       resourceMonitorService.stop();
@@ -256,6 +281,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
       await cliManagerFactory.shutdown();
       await taskQueue.close();
       await permissionIpcServer?.stop();
+      await remoteHttpApiServer?.stop();
       if (paneDaemonServer) {
         await paneDaemonServer.stop();
       }

--- a/main/src/daemon/httpApiServer.test.ts
+++ b/main/src/daemon/httpApiServer.test.ts
@@ -1,0 +1,341 @@
+import http from 'http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDefaultRemoteDaemonConfig, type RemoteDaemonConfig } from '../../../shared/types/remoteDaemon';
+import { PaneCommandRegistry } from './commandRegistry';
+import { hashRemoteDaemonToken } from './auth';
+import { PaneRemoteHttpApiServer } from './httpApiServer';
+
+interface ConfigManagerStub {
+  getConfig(): { remoteDaemon?: RemoteDaemonConfig };
+}
+
+interface TestEventStream {
+  close(): void;
+  nextEvent(timeoutMs?: number): Promise<{ event: string | null; data: string[] }>;
+}
+
+const activeServers: PaneRemoteHttpApiServer[] = [];
+const activeRequests = new Set<http.ClientRequest>();
+
+afterEach(async () => {
+  for (const request of activeRequests) {
+    request.destroy();
+  }
+  activeRequests.clear();
+
+  for (const server of activeServers.splice(0)) {
+    await server.stop();
+  }
+});
+
+function createConfigManagerStub(config?: RemoteDaemonConfig): ConfigManagerStub {
+  const remoteDaemon = config;
+
+  return {
+    getConfig() {
+      return { remoteDaemon };
+    },
+  };
+}
+
+function createEnabledRemoteConfig(overrides?: Partial<RemoteDaemonConfig['host']['config']>): RemoteDaemonConfig {
+  const config = createDefaultRemoteDaemonConfig();
+  config.host.config = {
+    ...config.host.config,
+    enabled: true,
+    listenHost: '127.0.0.1',
+    listenPort: 0,
+    ...overrides,
+  };
+  config.host.clients = [{
+    id: 'client-1',
+    label: 'Mac mini',
+    createdAt: new Date('2026-05-14T00:00:00.000Z').toISOString(),
+    tokenHash: hashRemoteDaemonToken('secret-token'),
+  }];
+  return config;
+}
+
+async function requestJson(
+  server: PaneRemoteHttpApiServer,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: unknown,
+  token?: string,
+): Promise<{ statusCode: number; body: unknown }> {
+  const address = server.getAddress();
+  if (!address) {
+    throw new Error('Remote HTTP API server is not listening');
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      host: address.host,
+      port: address.port,
+      path,
+      method,
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      },
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on('data', (chunk) => {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+      });
+      response.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8');
+        resolve({
+          statusCode: response.statusCode ?? 0,
+          body: text.length > 0 ? JSON.parse(text) : null,
+        });
+      });
+    });
+
+    activeRequests.add(request);
+    request.once('error', reject);
+    if (body !== undefined) {
+      request.write(JSON.stringify(body));
+    }
+    request.end();
+  });
+}
+
+async function openEventStream(server: PaneRemoteHttpApiServer, token: string): Promise<TestEventStream> {
+  const address = server.getAddress();
+  if (!address) {
+    throw new Error('Remote HTTP API server is not listening');
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      host: address.host,
+      port: address.port,
+      path: '/events',
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    activeRequests.add(request);
+    request.once('error', reject);
+    request.on('response', (response) => {
+      const queuedEvents: Array<{ event: string | null; data: string[] }> = [];
+      const waiters: Array<(event: { event: string | null; data: string[] }) => void> = [];
+      let buffer = '';
+
+      response.on('data', (chunk) => {
+        buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+
+        let boundaryIndex = buffer.indexOf('\n\n');
+        while (boundaryIndex !== -1) {
+          const rawEvent = buffer.slice(0, boundaryIndex);
+          buffer = buffer.slice(boundaryIndex + 2);
+
+          const parsedEvent = parseSseEvent(rawEvent);
+          if (parsedEvent) {
+            const waiter = waiters.shift();
+            if (waiter) {
+              waiter(parsedEvent);
+            } else {
+              queuedEvents.push(parsedEvent);
+            }
+          }
+
+          boundaryIndex = buffer.indexOf('\n\n');
+        }
+      });
+
+      resolve({
+        close() {
+          request.destroy();
+        },
+        nextEvent(timeoutMs = 1000) {
+          if (queuedEvents.length > 0) {
+            return Promise.resolve(queuedEvents.shift() as { event: string | null; data: string[] });
+          }
+
+          return new Promise((eventResolve, eventReject) => {
+            const timeout = setTimeout(() => {
+              eventReject(new Error('Timed out waiting for SSE event'));
+            }, timeoutMs);
+
+            waiters.push((event) => {
+              clearTimeout(timeout);
+              eventResolve(event);
+            });
+          });
+        },
+      });
+    });
+
+    request.end();
+  });
+}
+
+function parseSseEvent(rawEvent: string): { event: string | null; data: string[] } | null {
+  const lines = rawEvent.split('\n');
+  let event: string | null = null;
+  const data: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith('event: ')) {
+      event = line.slice('event: '.length);
+      continue;
+    }
+
+    if (line.startsWith('data: ')) {
+      data.push(line.slice('data: '.length));
+    }
+  }
+
+  if (!event && data.length === 0) {
+    return null;
+  }
+
+  return { event, data };
+}
+
+describe('PaneRemoteHttpApiServer', () => {
+  it('invokes daemon-owned commands over authenticated HTTP', async () => {
+    const registry = new PaneCommandRegistry();
+    registry.register('sessions:get-all', async () => [{ id: 'session-1' }]);
+
+    const server = new PaneRemoteHttpApiServer(registry, createConfigManagerStub(createEnabledRemoteConfig()) as never);
+    activeServers.push(server);
+    await server.start();
+
+    await expect(requestJson(server, 'POST', '/invoke', {
+      channel: 'sessions:get-all',
+      args: [],
+    }, 'secret-token')).resolves.toEqual({
+      statusCode: 200,
+      body: {
+        ok: true,
+        result: [{ id: 'session-1' }],
+      },
+    });
+  });
+
+  it('rejects invoke requests without bearer auth', async () => {
+    const registry = new PaneCommandRegistry();
+    registry.register('sessions:get-all', async () => []);
+
+    const server = new PaneRemoteHttpApiServer(registry, createConfigManagerStub(createEnabledRemoteConfig()) as never);
+    activeServers.push(server);
+    await server.start();
+
+    await expect(requestJson(server, 'POST', '/invoke', {
+      channel: 'sessions:get-all',
+      args: [],
+    })).resolves.toEqual({
+      statusCode: 401,
+      body: {
+        ok: false,
+        statusCode: 401,
+        error: {
+          message: 'Remote daemon bearer token is required',
+          code: 'ERR_REMOTE_DAEMON_AUTH_REQUIRED',
+        },
+      },
+    });
+  });
+
+  it('rejects oversized invoke request bodies with a client error', async () => {
+    const registry = new PaneCommandRegistry();
+    registry.register('sessions:get-all', async () => []);
+
+    const server = new PaneRemoteHttpApiServer(registry, createConfigManagerStub(createEnabledRemoteConfig()) as never);
+    activeServers.push(server);
+    await server.start();
+
+    const oversizedArgs = ['x'.repeat(1024 * 1024)];
+    await expect(requestJson(server, 'POST', '/invoke', {
+      channel: 'sessions:get-all',
+      args: oversizedArgs,
+    }, 'secret-token')).resolves.toEqual({
+      statusCode: 413,
+      body: {
+        ok: false,
+        error: {
+          message: 'Remote daemon request body exceeds the 1 MB limit',
+          code: 'ERR_REMOTE_DAEMON_REQUEST_TOO_LARGE',
+        },
+      },
+    });
+  });
+
+  it('streams a ready event and daemon-owned runtime events over SSE', async () => {
+    const registry = new PaneCommandRegistry();
+    const server = new PaneRemoteHttpApiServer(registry, createConfigManagerStub(createEnabledRemoteConfig()) as never);
+    activeServers.push(server);
+    await server.start();
+
+    const stream = await openEventStream(server, 'secret-token');
+    const readyEvent = await stream.nextEvent();
+    expect(readyEvent.event).toBe('ready');
+    expect(JSON.parse(readyEvent.data.join('\n'))).toMatchObject({
+      replay: 'none',
+      resync: 'refetch-state-after-reconnect',
+    });
+
+    server.getEventSink().send('session:created', { id: 'session-1' });
+
+    const daemonEvent = await stream.nextEvent();
+    expect(daemonEvent.event).toBe('daemon-event');
+    expect(JSON.parse(daemonEvent.data.join('\n'))).toEqual({
+      channel: 'session:created',
+      args: [{ id: 'session-1' }],
+      timestamp: expect.any(String),
+    });
+
+    stream.close();
+  });
+
+  it('filters non-daemon events from the remote SSE stream', async () => {
+    const registry = new PaneCommandRegistry();
+    const server = new PaneRemoteHttpApiServer(registry, createConfigManagerStub(createEnabledRemoteConfig()) as never);
+    activeServers.push(server);
+    await server.start();
+
+    const stream = await openEventStream(server, 'secret-token');
+    await stream.nextEvent();
+
+    server.getEventSink().send('version:update-available', { version: '1.2.3' });
+    await expect(stream.nextEvent(100)).rejects.toThrow('Timed out waiting for SSE event');
+
+    stream.close();
+  });
+
+  it('drops existing SSE subscribers when the paired client token rotates', async () => {
+    const registry = new PaneCommandRegistry();
+    const remoteConfig = createEnabledRemoteConfig();
+    const server = new PaneRemoteHttpApiServer(registry, createConfigManagerStub(remoteConfig) as never);
+    activeServers.push(server);
+    await server.start();
+
+    const stream = await openEventStream(server, 'secret-token');
+    await stream.nextEvent();
+
+    remoteConfig.host.clients = [{
+      ...remoteConfig.host.clients[0],
+      tokenHash: hashRemoteDaemonToken('rotated-token'),
+    }];
+
+    server.getEventSink().send('session:created', { id: 'session-1' });
+    await expect(stream.nextEvent(100)).rejects.toThrow('Timed out waiting for SSE event');
+
+    stream.close();
+  });
+
+  it('refuses direct loopback HTTP when config disables insecure loopback mode', async () => {
+    const registry = new PaneCommandRegistry();
+    const server = new PaneRemoteHttpApiServer(
+      registry,
+      createConfigManagerStub(createEnabledRemoteConfig({ allowInsecureHttpOnLoopback: false })) as never,
+    );
+
+    await expect(server.start()).rejects.toThrow('Remote daemon HTTP API loopback transport is disabled by config');
+  });
+});

--- a/main/src/daemon/httpApiServer.test.ts
+++ b/main/src/daemon/httpApiServer.test.ts
@@ -338,4 +338,16 @@ describe('PaneRemoteHttpApiServer', () => {
 
     await expect(server.start()).rejects.toThrow('Remote daemon HTTP API loopback transport is disabled by config');
   });
+
+  it('refuses direct HTTP on non-loopback listen hosts', async () => {
+    const registry = new PaneCommandRegistry();
+    const server = new PaneRemoteHttpApiServer(
+      registry,
+      createConfigManagerStub(createEnabledRemoteConfig({ listenHost: '0.0.0.0' })) as never,
+    );
+
+    await expect(server.start()).rejects.toThrow(
+      'Remote daemon direct HTTP only supports loopback listen hosts; keep listenHost on 127.0.0.1, ::1, or localhost and expose it through an SSH tunnel, Tailscale/VPN, or a reverse proxy.',
+    );
+  });
 });

--- a/main/src/daemon/httpApiServer.ts
+++ b/main/src/daemon/httpApiServer.ts
@@ -1,0 +1,445 @@
+import http, { type IncomingMessage, type ServerResponse } from 'http';
+import { createFanoutEventSink, noopPaneEventSink, type PaneEventSink } from '../core/eventSink';
+import type { ConfigManager } from '../services/configManager';
+import type { PaneCommandRegistry } from './commandRegistry';
+import { authenticateRemoteDaemonBearerToken } from './auth';
+import { isPaneDaemonEventChannel } from './server';
+import {
+  createDefaultRemoteDaemonConfig,
+  type RemoteDaemonConfig,
+  type RemoteDaemonEventEnvelope,
+  type RemoteInvokeRequest,
+} from '../../../shared/types/remoteDaemon';
+
+interface RemoteHttpAddress {
+  host: string;
+  port: number;
+}
+
+interface ConnectedRemoteEventClient {
+  id: string;
+  response: ServerResponse;
+  remoteClientId: string;
+  remoteClientTokenHash: string;
+}
+
+interface RemoteInvokeSuccessPayload {
+  ok: true;
+  result: unknown;
+}
+
+interface RemoteInvokeErrorPayload {
+  ok: false;
+  error: {
+    message: string;
+    code: string;
+  };
+}
+
+interface RemoteReadyEventPayload {
+  replay: 'none';
+  resync: 'refetch-state-after-reconnect';
+  timestamp: string;
+}
+
+const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+
+class RemoteDaemonBadRequestError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly statusCode: number = 400,
+  ) {
+    super(message);
+    this.name = 'RemoteDaemonBadRequestError';
+  }
+}
+
+export class PaneRemoteHttpApiServer {
+  private server: http.Server | null = null;
+  private readonly eventClients = new Map<string, ConnectedRemoteEventClient>();
+  private readonly daemonEventSink: PaneEventSink;
+  private address: RemoteHttpAddress | null = null;
+  private nextClientConnectionId = 1;
+
+  constructor(
+    private readonly commandRegistry: PaneCommandRegistry,
+    private readonly configManager: ConfigManager,
+  ) {
+    this.daemonEventSink = createFanoutEventSink([
+      {
+        send: (channel, ...args) => {
+          if (!isPaneDaemonEventChannel(channel) || this.eventClients.size === 0) {
+            return;
+          }
+
+          const payload: RemoteDaemonEventEnvelope = {
+            channel,
+            args,
+            timestamp: new Date().toISOString(),
+          };
+
+          for (const [clientConnectionId, client] of this.eventClients) {
+            if (!this.shouldKeepEventClient(client.remoteClientId, client.remoteClientTokenHash)) {
+              this.dropEventClient(clientConnectionId);
+              continue;
+            }
+
+            try {
+              writeSseEvent(client.response, 'daemon-event', payload);
+            } catch {
+              this.dropEventClient(clientConnectionId);
+            }
+          }
+        },
+      },
+      noopPaneEventSink,
+    ]);
+  }
+
+  getAddress(): RemoteHttpAddress | null {
+    return this.address;
+  }
+
+  getEventSink(): PaneEventSink {
+    return this.daemonEventSink;
+  }
+
+  async start(): Promise<void> {
+    if (this.server) {
+      throw new Error('Remote daemon HTTP API server is already running');
+    }
+
+    const hostConfig = this.getRemoteConfig().host.config;
+    if (!hostConfig.enabled) {
+      throw new Error('Remote daemon HTTP API server is disabled in config');
+    }
+
+    if (isLoopbackHost(hostConfig.listenHost) && !hostConfig.allowInsecureHttpOnLoopback) {
+      throw new Error('Remote daemon HTTP API loopback transport is disabled by config');
+    }
+
+    const server = http.createServer((request, response) => {
+      void this.handleRequest(request, response).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!response.headersSent) {
+          this.writeJson(response, 500, {
+            ok: false,
+            error: {
+              message,
+              code: 'ERR_REMOTE_DAEMON_HTTP_INTERNAL',
+            },
+          });
+          return;
+        }
+
+        response.destroy(error instanceof Error ? error : new Error(message));
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const handleError = (error: Error) => {
+        server.removeListener('listening', handleListening);
+        reject(error);
+      };
+
+      const handleListening = () => {
+        server.removeListener('error', handleError);
+        resolve();
+      };
+
+      server.once('error', handleError);
+      server.once('listening', handleListening);
+      server.listen(hostConfig.listenPort, hostConfig.listenHost);
+    });
+
+    server.on('error', (error) => {
+      console.error('[Pane remote daemon] HTTP server error:', error);
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Remote daemon HTTP API server did not expose a TCP address');
+    }
+
+    this.server = server;
+    this.address = {
+      host: hostConfig.listenHost,
+      port: address.port,
+    };
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    this.server = null;
+    this.address = null;
+
+    for (const clientConnectionId of [...this.eventClients.keys()]) {
+      this.dropEventClient(clientConnectionId);
+    }
+
+    if (server) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  }
+
+  private async handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    const url = new URL(request.url ?? '/', `http://${request.headers.host ?? 'localhost'}`);
+
+    if (url.pathname === '/invoke') {
+      await this.handleInvokeRequest(request, response);
+      return;
+    }
+
+    if (url.pathname === '/events') {
+      this.handleEventStreamRequest(request, response);
+      return;
+    }
+
+    this.writeJson(response, 404, {
+      ok: false,
+      error: {
+        message: `Remote daemon endpoint "${url.pathname}" does not exist`,
+        code: 'ERR_REMOTE_DAEMON_HTTP_NOT_FOUND',
+      },
+    });
+  }
+
+  private async handleInvokeRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    if (request.method !== 'POST') {
+      this.writeMethodNotAllowed(response, 'POST');
+      return;
+    }
+
+    const auth = this.authenticateRequest(request);
+    if (!auth.ok) {
+      this.writeJson(response, auth.statusCode, auth);
+      return;
+    }
+
+    let invokeRequest: RemoteInvokeRequest;
+    try {
+      invokeRequest = await this.readInvokeRequest(request);
+    } catch (error) {
+      if (error instanceof RemoteDaemonBadRequestError) {
+        this.writeJson(response, error.statusCode, {
+          ok: false,
+          error: {
+            message: error.message,
+            code: error.code,
+          },
+        });
+        return;
+      }
+
+      throw error;
+    }
+
+    try {
+      const result = await this.commandRegistry.invoke(invokeRequest.channel, invokeRequest.args);
+      this.writeJson(response, 200, {
+        ok: true,
+        result,
+      } satisfies RemoteInvokeSuccessPayload);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const code = message.includes('No Pane daemon command registered')
+        ? 'ERR_UNKNOWN_CHANNEL'
+        : 'ERR_REMOTE_DAEMON_REQUEST_FAILED';
+      const statusCode = code === 'ERR_UNKNOWN_CHANNEL' ? 404 : 500;
+
+      this.writeJson(response, statusCode, {
+        ok: false,
+        error: {
+          message,
+          code,
+        },
+      } satisfies RemoteInvokeErrorPayload);
+    }
+  }
+
+  private handleEventStreamRequest(request: IncomingMessage, response: ServerResponse): void {
+    if (request.method !== 'GET') {
+      this.writeMethodNotAllowed(response, 'GET');
+      return;
+    }
+
+    const auth = this.authenticateRequest(request);
+    if (!auth.ok) {
+      this.writeJson(response, auth.statusCode, auth);
+      return;
+    }
+
+    response.writeHead(200, {
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'X-Accel-Buffering': 'no',
+    });
+    response.flushHeaders();
+    response.write('retry: 1000\n\n');
+    writeSseEvent(response, 'ready', {
+      replay: 'none',
+      resync: 'refetch-state-after-reconnect',
+      timestamp: new Date().toISOString(),
+    } satisfies RemoteReadyEventPayload);
+
+    const clientConnectionId = String(this.nextClientConnectionId++);
+    this.eventClients.set(clientConnectionId, {
+      id: clientConnectionId,
+      response,
+      remoteClientId: auth.client.id,
+      remoteClientTokenHash: auth.client.tokenHash,
+    });
+
+    const cleanup = () => {
+      this.eventClients.delete(clientConnectionId);
+    };
+
+    request.on('close', cleanup);
+    response.on('close', cleanup);
+  }
+
+  private authenticateRequest(request: IncomingMessage) {
+    const remoteConfig = this.getRemoteConfig();
+    if (!remoteConfig.host.config.enabled) {
+      return {
+        ok: false as const,
+        statusCode: 503,
+        error: {
+          message: 'Remote daemon HTTP API is disabled',
+          code: 'ERR_REMOTE_DAEMON_HTTP_DISABLED',
+        },
+      };
+    }
+
+    return authenticateRemoteDaemonBearerToken(
+      request.headers.authorization,
+      remoteConfig.host.clients,
+    );
+  }
+
+  private async readInvokeRequest(
+    request: IncomingMessage,
+  ): Promise<RemoteInvokeRequest> {
+    const body = await readRequestBody(request);
+    if (body.length === 0) {
+      throw new RemoteDaemonBadRequestError(
+        'ERR_REMOTE_DAEMON_BAD_REQUEST',
+        'Remote daemon invoke request body is required',
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body) as unknown;
+    } catch (error) {
+      throw new RemoteDaemonBadRequestError(
+        'ERR_REMOTE_DAEMON_BAD_REQUEST',
+        `Failed to parse remote daemon invoke request: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    if (!isRemoteInvokeRequest(parsed)) {
+      throw new RemoteDaemonBadRequestError(
+        'ERR_REMOTE_DAEMON_BAD_REQUEST',
+        'Remote daemon invoke request must contain a channel string and args array',
+      );
+    }
+
+    return parsed;
+  }
+
+  private writeJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+    response.writeHead(statusCode, {
+      'Content-Type': 'application/json; charset=utf-8',
+    });
+    response.end(JSON.stringify(payload));
+  }
+
+  private writeMethodNotAllowed(response: ServerResponse, method: 'GET' | 'POST'): void {
+    response.writeHead(405, {
+      Allow: method,
+      'Content-Type': 'application/json; charset=utf-8',
+    });
+    response.end(JSON.stringify({
+      ok: false,
+      error: {
+        message: `Remote daemon endpoint only supports ${method}`,
+        code: 'ERR_REMOTE_DAEMON_METHOD_NOT_ALLOWED',
+      },
+    }));
+  }
+
+  private shouldKeepEventClient(remoteClientId: string, remoteClientTokenHash: string): boolean {
+    const remoteConfig = this.getRemoteConfig();
+    if (!remoteConfig.host.config.enabled) {
+      return false;
+    }
+
+    return remoteConfig.host.clients.some((client) => (
+      client.id === remoteClientId &&
+      client.tokenHash === remoteClientTokenHash
+    ));
+  }
+
+  private dropEventClient(clientConnectionId: string): void {
+    const client = this.eventClients.get(clientConnectionId);
+    if (!client) {
+      return;
+    }
+
+    this.eventClients.delete(clientConnectionId);
+    if (!client.response.writableEnded) {
+      client.response.end();
+    }
+  }
+
+  private getRemoteConfig(): RemoteDaemonConfig {
+    return this.configManager.getConfig().remoteDaemon ?? createDefaultRemoteDaemonConfig();
+  }
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  for await (const chunk of request) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    totalBytes += buffer.length;
+
+    if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+      throw new RemoteDaemonBadRequestError(
+        'ERR_REMOTE_DAEMON_REQUEST_TOO_LARGE',
+        'Remote daemon request body exceeds the 1 MB limit',
+        413,
+      );
+    }
+
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function writeSseEvent(response: ServerResponse, eventName: string, payload: RemoteReadyEventPayload | RemoteDaemonEventEnvelope): void {
+  response.write(`event: ${eventName}\n`);
+  response.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1' || host === '::1' || host === 'localhost';
+}
+
+function isRemoteInvokeRequest(value: unknown): value is RemoteInvokeRequest {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Partial<RemoteInvokeRequest>;
+  return typeof candidate.channel === 'string' && candidate.channel.length > 0 && Array.isArray(candidate.args);
+}

--- a/main/src/daemon/httpApiServer.ts
+++ b/main/src/daemon/httpApiServer.ts
@@ -6,6 +6,7 @@ import { authenticateRemoteDaemonBearerToken } from './auth';
 import { isPaneDaemonEventChannel } from './server';
 import {
   createDefaultRemoteDaemonConfig,
+  getRemoteDaemonHostConfigValidationError,
   type RemoteDaemonConfig,
   type RemoteDaemonEventEnvelope,
   type RemoteInvokeRequest,
@@ -115,8 +116,9 @@ export class PaneRemoteHttpApiServer {
       throw new Error('Remote daemon HTTP API server is disabled in config');
     }
 
-    if (isLoopbackHost(hostConfig.listenHost) && !hostConfig.allowInsecureHttpOnLoopback) {
-      throw new Error('Remote daemon HTTP API loopback transport is disabled by config');
+    const hostConfigError = getRemoteDaemonHostConfigValidationError(hostConfig);
+    if (hostConfigError) {
+      throw new Error(hostConfigError);
     }
 
     const server = http.createServer((request, response) => {
@@ -429,10 +431,6 @@ async function readRequestBody(request: IncomingMessage): Promise<string> {
 function writeSseEvent(response: ServerResponse, eventName: string, payload: RemoteReadyEventPayload | RemoteDaemonEventEnvelope): void {
   response.write(`event: ${eventName}\n`);
   response.write(`data: ${JSON.stringify(payload)}\n\n`);
-}
-
-function isLoopbackHost(host: string): boolean {
-  return host === '127.0.0.1' || host === '::1' || host === 'localhost';
 }
 
 function isRemoteInvokeRequest(value: unknown): value is RemoteInvokeRequest {

--- a/main/src/daemon/remoteTransportController.test.ts
+++ b/main/src/daemon/remoteTransportController.test.ts
@@ -1,0 +1,222 @@
+import http from 'http';
+import { EventEmitter } from 'events';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDefaultRemoteDaemonConfig, type RemoteDaemonConfig } from '../../../shared/types/remoteDaemon';
+import { hashRemoteDaemonToken } from './auth';
+import { PaneCommandRegistry } from './commandRegistry';
+import { PaneRemoteTransportController } from './remoteTransportController';
+
+interface TestEventStream {
+  close(): void;
+  nextEvent(timeoutMs?: number): Promise<{ event: string | null; data: string[] }>;
+}
+
+class ConfigManagerStub extends EventEmitter {
+  private remoteDaemon: RemoteDaemonConfig;
+
+  constructor(initialConfig: RemoteDaemonConfig) {
+    super();
+    this.remoteDaemon = initialConfig;
+  }
+
+  getConfig(): { remoteDaemon: RemoteDaemonConfig } {
+    return { remoteDaemon: this.remoteDaemon };
+  }
+
+  async updateRemoteDaemonConfig(remoteDaemon: RemoteDaemonConfig): Promise<void> {
+    this.remoteDaemon = remoteDaemon;
+    this.emit('config-updated', { remoteDaemon });
+  }
+}
+
+const activeControllers: PaneRemoteTransportController[] = [];
+const activeRequests = new Set<http.ClientRequest>();
+
+afterEach(async () => {
+  for (const request of activeRequests) {
+    request.destroy();
+  }
+  activeRequests.clear();
+
+  for (const controller of activeControllers.splice(0)) {
+    await controller.stopWatchingAndShutdown();
+  }
+});
+
+function createEnabledRemoteConfig(overrides?: Partial<RemoteDaemonConfig['host']['config']>): RemoteDaemonConfig {
+  const config = createDefaultRemoteDaemonConfig();
+  config.host.config = {
+    ...config.host.config,
+    enabled: true,
+    listenHost: '127.0.0.1',
+    listenPort: 0,
+    ...overrides,
+  };
+  config.host.clients = [{
+    id: 'client-1',
+    label: 'Mac mini',
+    createdAt: new Date('2026-05-14T00:00:00.000Z').toISOString(),
+    tokenHash: hashRemoteDaemonToken('secret-token'),
+  }];
+  return config;
+}
+
+async function openEventStream(server: NonNullable<ReturnType<PaneRemoteTransportController['getServer']>>, token: string): Promise<TestEventStream> {
+  const address = server.getAddress();
+  if (!address) {
+    throw new Error('Remote HTTP API server is not listening');
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      host: address.host,
+      port: address.port,
+      path: '/events',
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    activeRequests.add(request);
+    request.once('error', reject);
+    request.on('response', (response) => {
+      const queuedEvents: Array<{ event: string | null; data: string[] }> = [];
+      const waiters: Array<(event: { event: string | null; data: string[] }) => void> = [];
+      let buffer = '';
+
+      response.on('data', (chunk) => {
+        buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+
+        let boundaryIndex = buffer.indexOf('\n\n');
+        while (boundaryIndex !== -1) {
+          const rawEvent = buffer.slice(0, boundaryIndex);
+          buffer = buffer.slice(boundaryIndex + 2);
+
+          const parsedEvent = parseSseEvent(rawEvent);
+          if (parsedEvent) {
+            const waiter = waiters.shift();
+            if (waiter) {
+              waiter(parsedEvent);
+            } else {
+              queuedEvents.push(parsedEvent);
+            }
+          }
+
+          boundaryIndex = buffer.indexOf('\n\n');
+        }
+      });
+
+      resolve({
+        close() {
+          request.destroy();
+        },
+        nextEvent(timeoutMs = 1000) {
+          if (queuedEvents.length > 0) {
+            return Promise.resolve(queuedEvents.shift() as { event: string | null; data: string[] });
+          }
+
+          return new Promise((eventResolve, eventReject) => {
+            const timeout = setTimeout(() => {
+              eventReject(new Error('Timed out waiting for SSE event'));
+            }, timeoutMs);
+
+            waiters.push((event) => {
+              clearTimeout(timeout);
+              eventResolve(event);
+            });
+          });
+        },
+      });
+    });
+
+    request.end();
+  });
+}
+
+function parseSseEvent(rawEvent: string): { event: string | null; data: string[] } | null {
+  const lines = rawEvent.split('\n');
+  let event: string | null = null;
+  const data: string[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith('event: ')) {
+      event = line.slice('event: '.length);
+      continue;
+    }
+
+    if (line.startsWith('data: ')) {
+      data.push(line.slice('data: '.length));
+    }
+  }
+
+  if (!event && data.length === 0) {
+    return null;
+  }
+
+  return { event, data };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1500): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('Timed out waiting for condition');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+describe('PaneRemoteTransportController', () => {
+  it('starts and stops remote HTTP transport on config updates while keeping a stable event sink', async () => {
+    const registry = new PaneCommandRegistry();
+    const configManager = new ConfigManagerStub(createDefaultRemoteDaemonConfig());
+    const controller = new PaneRemoteTransportController(registry, configManager as never);
+    activeControllers.push(controller);
+    controller.startWatchingConfig();
+
+    const daemonEventSink = controller.getEventSink();
+    await controller.syncToConfig();
+    expect(controller.getServer()).toBeNull();
+
+    await configManager.updateRemoteDaemonConfig(createEnabledRemoteConfig());
+    await waitFor(() => controller.getServer() !== null);
+
+    const server = controller.getServer();
+    if (!server) {
+      throw new Error('Remote HTTP API server did not start');
+    }
+
+    const stream = await openEventStream(server, 'secret-token');
+    await stream.nextEvent();
+
+    daemonEventSink.send('session:created', { id: 'session-1' });
+
+    const daemonEvent = await stream.nextEvent();
+    expect(daemonEvent.event).toBe('daemon-event');
+    expect(JSON.parse(daemonEvent.data.join('\n'))).toEqual({
+        channel: 'session:created',
+        args: [{ id: 'session-1' }],
+        timestamp: expect.any(String),
+    });
+
+    stream.close();
+    await configManager.updateRemoteDaemonConfig(createDefaultRemoteDaemonConfig());
+    await waitFor(() => controller.getServer() === null);
+  });
+
+  it('stops the active remote HTTP transport when config changes to an invalid non-loopback bind', async () => {
+    const registry = new PaneCommandRegistry();
+    const configManager = new ConfigManagerStub(createEnabledRemoteConfig());
+    const controller = new PaneRemoteTransportController(registry, configManager as never);
+    activeControllers.push(controller);
+    controller.startWatchingConfig();
+
+    await controller.syncToConfig();
+    expect(controller.getServer()).not.toBeNull();
+
+    await configManager.updateRemoteDaemonConfig(createEnabledRemoteConfig({ listenHost: '0.0.0.0' }));
+    await waitFor(() => controller.getServer() === null);
+  });
+});

--- a/main/src/daemon/remoteTransportController.ts
+++ b/main/src/daemon/remoteTransportController.ts
@@ -1,0 +1,110 @@
+import type { PaneEventSink } from '../core/eventSink';
+import type { ConfigManager } from '../services/configManager';
+import { getRemoteDaemonHostConfigValidationError } from '../../../shared/types/remoteDaemon';
+import type { RemoteDaemonHostConfig } from '../../../shared/types/remoteDaemon';
+import type { PaneCommandRegistry } from './commandRegistry';
+import { PaneRemoteHttpApiServer } from './httpApiServer';
+
+export class PaneRemoteTransportController {
+  private remoteHttpApiServer: PaneRemoteHttpApiServer | null = null;
+  private activeBindingKey: string | null = null;
+  private syncQueue: Promise<void> = Promise.resolve();
+  private configListenerAttached = false;
+
+  private readonly configUpdatedListener = () => {
+    void this.syncToConfig().catch((error) => {
+      console.error('[Pane remote daemon] Failed to apply remote transport config update', error);
+    });
+  };
+
+  private readonly eventSink: PaneEventSink = {
+    send: (channel, ...args) => {
+      this.remoteHttpApiServer?.getEventSink().send(channel, ...args);
+    },
+  };
+
+  constructor(
+    private readonly commandRegistry: PaneCommandRegistry,
+    private readonly configManager: ConfigManager,
+  ) {}
+
+  getEventSink(): PaneEventSink {
+    return this.eventSink;
+  }
+
+  getServer(): PaneRemoteHttpApiServer | null {
+    return this.remoteHttpApiServer;
+  }
+
+  startWatchingConfig(): void {
+    if (this.configListenerAttached) {
+      return;
+    }
+
+    this.configManager.on('config-updated', this.configUpdatedListener);
+    this.configListenerAttached = true;
+  }
+
+  async stopWatchingAndShutdown(): Promise<void> {
+    if (this.configListenerAttached) {
+      this.configManager.off('config-updated', this.configUpdatedListener);
+      this.configListenerAttached = false;
+    }
+
+    await this.enqueueSync(async () => {
+      await this.stopRemoteHttpServer();
+    });
+  }
+
+  async syncToConfig(): Promise<void> {
+    await this.enqueueSync(async () => {
+      const hostConfig = this.configManager.getConfig().remoteDaemon?.host.config;
+      if (!hostConfig?.enabled) {
+        await this.stopRemoteHttpServer();
+        return;
+      }
+
+      const validationError = getRemoteDaemonHostConfigValidationError(hostConfig);
+      if (validationError) {
+        await this.stopRemoteHttpServer();
+        throw new Error(validationError);
+      }
+
+      const nextBindingKey = this.getBindingKey(hostConfig);
+      if (this.remoteHttpApiServer && this.activeBindingKey === nextBindingKey) {
+        return;
+      }
+
+      await this.stopRemoteHttpServer();
+
+      const remoteHttpApiServer = new PaneRemoteHttpApiServer(this.commandRegistry, this.configManager);
+      await remoteHttpApiServer.start();
+      this.remoteHttpApiServer = remoteHttpApiServer;
+      this.activeBindingKey = nextBindingKey;
+    });
+  }
+
+  private async stopRemoteHttpServer(): Promise<void> {
+    const remoteHttpApiServer = this.remoteHttpApiServer;
+    this.remoteHttpApiServer = null;
+    this.activeBindingKey = null;
+
+    if (remoteHttpApiServer) {
+      await remoteHttpApiServer.stop();
+    }
+  }
+
+  private enqueueSync(work: () => Promise<void>): Promise<void> {
+    const nextSync = this.syncQueue.then(work, work);
+    this.syncQueue = nextSync.catch(() => {});
+    return nextSync;
+  }
+
+  private getBindingKey(config: RemoteDaemonHostConfig): string {
+    return JSON.stringify({
+      listenHost: config.listenHost.trim().toLowerCase(),
+      listenPort: config.listenPort,
+      allowInsecureHttpOnLoopback: config.allowInsecureHttpOnLoopback,
+    });
+  }
+}

--- a/main/src/daemon/server.ts
+++ b/main/src/daemon/server.ts
@@ -35,7 +35,7 @@ const DAEMON_EVENT_EXACT_CHANNELS = new Set<string>([
   'script-session-changed',
 ]);
 
-function isPaneDaemonEventChannel(channel: string): boolean {
+export function isPaneDaemonEventChannel(channel: string): boolean {
   if (DAEMON_EVENT_EXACT_CHANNELS.has(channel)) {
     return true;
   }

--- a/main/src/ipc/remoteDaemon.test.ts
+++ b/main/src/ipc/remoteDaemon.test.ts
@@ -186,4 +186,22 @@ describe('remote daemon IPC', () => {
       error: 'Remote daemon connection profile is invalid',
     });
   });
+
+  it('rejects enabling direct HTTP on a non-loopback listen host', async () => {
+    const ipcMain = createIpcMainStub();
+    const configManager = createConfigManagerStub();
+
+    registerRemoteDaemonHandlers(ipcMain, { configManager });
+
+    const updateHostConfig = ipcMain.handlers.get('remote-daemon:update-host-config');
+
+    await expect(updateHostConfig?.({}, {
+      enabled: true,
+      listenHost: '0.0.0.0',
+      listenPort: 42137,
+    })).resolves.toEqual({
+      success: false,
+      error: 'Remote daemon direct HTTP only supports loopback listen hosts; keep listenHost on 127.0.0.1, ::1, or localhost and expose it through an SSH tunnel, Tailscale/VPN, or a reverse proxy.',
+    });
+  });
 });

--- a/main/src/ipc/remoteDaemon.ts
+++ b/main/src/ipc/remoteDaemon.ts
@@ -1,4 +1,5 @@
 import {
+  getRemoteDaemonHostConfigValidationError,
   isRemoteDaemonClientRecord,
   isRemotePaneConnectionProfile,
   normalizeRemoteDaemonConfig,
@@ -41,6 +42,11 @@ export function registerRemoteDaemonHandlers(
           },
         },
       });
+
+      const validationError = getRemoteDaemonHostConfigValidationError(next.host.config);
+      if (validationError) {
+        throw new Error(validationError);
+      }
 
       await configManager.updateConfig({ remoteDaemon: next });
       return { success: true, data: next.host.config };

--- a/shared/types/remoteDaemon.ts
+++ b/shared/types/remoteDaemon.ts
@@ -60,6 +60,27 @@ export const DEFAULT_REMOTE_DAEMON_HOST_CONFIG: RemoteDaemonHostConfig = {
   allowInsecureHttpOnLoopback: true,
 };
 
+export function isLoopbackRemoteDaemonHost(host: string): boolean {
+  const normalizedHost = host.trim().toLowerCase();
+  return normalizedHost === '127.0.0.1' || normalizedHost === '::1' || normalizedHost === 'localhost';
+}
+
+export function getRemoteDaemonHostConfigValidationError(config: RemoteDaemonHostConfig): string | null {
+  if (!config.enabled) {
+    return null;
+  }
+
+  if (!isLoopbackRemoteDaemonHost(config.listenHost)) {
+    return 'Remote daemon direct HTTP only supports loopback listen hosts; keep listenHost on 127.0.0.1, ::1, or localhost and expose it through an SSH tunnel, Tailscale/VPN, or a reverse proxy.';
+  }
+
+  if (!config.allowInsecureHttpOnLoopback) {
+    return 'Remote daemon HTTP API loopback transport is disabled by config';
+  }
+
+  return null;
+}
+
 export function createDefaultRemoteDaemonConfig(): RemoteDaemonConfig {
   return {
     host: {


### PR DESCRIPTION
## Summary
- add authenticated remote daemon bearer-token helpers for the self-hosted host config
- add an HTTP invoke endpoint plus SSE daemon-event stream above the existing command registry/runtime
- wire the optional remote transport into daemon bootstrap fanout so remote subscribers receive the same daemon-owned event surface as local clients

## Validation
- `pnpm typecheck`
- `CI=1 pnpm --filter main test -- --run`
- `pnpm lint` (warning-only repo baseline)
- `PANE_DIR=/tmp/pane-phase3-remote-http-sse-auth xvfb-run -a pnpm test:ci`
