### PR TITLE
feat: daemonize permission approval flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,10 +36,15 @@ import { CreateSessionDialog } from './components/CreateSessionDialog';
 import { AddProjectDialog } from './components/AddProjectDialog';
 import { useNavigationStore } from './stores/navigationStore';
 import { initPostHog, capture, captureUnconditionally, posthog } from './services/posthog';
-import type { VersionUpdateInfo, PermissionInput } from './types/session';
+import type { VersionUpdateInfo } from './types/session';
 import type { AnalyticsIdentity, TerminalShortcut } from './types/config';
 import type { ResumableSession } from '../../shared/types/panels';
 import type { Project } from './types/project';
+import type {
+  PanePermissionRequest,
+  PanePermissionResolvedEvent,
+  PanePermissionInput,
+} from '../../shared/types/daemon';
 import { isMac } from './utils/platformUtils';
 
 // Stable empty array to avoid creating new references in render
@@ -52,14 +57,6 @@ interface IPCResponse<T = unknown> {
   error?: string;
 }
 
-interface PermissionRequest {
-  id: string;
-  sessionId: string;
-  toolName: string;
-  input: PermissionInput;
-  timestamp: number;
-}
-
 function App() {
   const [isWelcomeOpen, setIsWelcomeOpen] = useState(false);
   const [isAnalyticsConsentOpen, setIsAnalyticsConsentOpen] = useState(false);
@@ -67,7 +64,7 @@ function App() {
   const [isAboutOpen, setIsAboutOpen] = useState(false);
   const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false);
   const [updateVersionInfo, setUpdateVersionInfo] = useState<VersionUpdateInfo | null>(null);
-  const [currentPermissionRequest, setCurrentPermissionRequest] = useState<PermissionRequest | null>(null);
+  const [currentPermissionRequest, setCurrentPermissionRequest] = useState<PanePermissionRequest | null>(null);
   const [isDiscordOpen, setIsDiscordOpen] = useState(false);
   const [hasCheckedWelcome, setHasCheckedWelcome] = useState(false);
   const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
@@ -511,19 +508,41 @@ function App() {
     checkResumableSessions();
   }, [isLoaded, isAnalyticsConsentOpen]);
 
-  useEffect(() => {
-    // Set up permission request listener
-    const handlePermissionRequest = (...args: unknown[]) => {
-      const request = args[0] as PermissionRequest;
-      setCurrentPermissionRequest(request);
-    };
+  const loadNextPendingPermission = useCallback(async () => {
+    try {
+      const result = await API.permissions.getPending();
+      if (result.success) {
+        setCurrentPermissionRequest(result.data?.[0] ?? null);
+      } else {
+        console.error('Failed to fetch pending permission requests:', result.error);
+      }
+    } catch (error) {
+      console.error('Failed to load pending permission requests:', error);
+    }
+  }, []);
 
-    window.electron?.on('permission:request', handlePermissionRequest);
+  useEffect(() => {
+    if (!window.electronAPI?.events) {
+      return;
+    }
+
+    const removePermissionRequest = window.electronAPI.events.onPermissionRequest((request: PanePermissionRequest) => {
+      setCurrentPermissionRequest(request);
+    });
+    const removePermissionResolved = window.electronAPI.events.onPermissionResolved((event: PanePermissionResolvedEvent) => {
+      setCurrentPermissionRequest((currentRequest) => (
+        currentRequest?.id === event.request.id ? null : currentRequest
+      ));
+      void loadNextPendingPermission();
+    });
+
+    void loadNextPendingPermission();
 
     return () => {
-      window.electron?.off('permission:request', handlePermissionRequest);
+      removePermissionRequest();
+      removePermissionResolved();
     };
-  }, []);
+  }, [loadNextPendingPermission]);
 
   useEffect(() => {
     // Set up version update listener
@@ -561,17 +580,26 @@ function App() {
     setIsUpdateDialogOpen(true);
   };
 
-  const handlePermissionResponse = async (requestId: string, behavior: 'allow' | 'deny', _updatedInput?: PermissionInput, message?: string) => {
+  const handlePermissionResponse = useCallback(async (
+    requestId: string,
+    behavior: 'allow' | 'deny',
+    updatedInput?: PanePermissionInput,
+    message?: string,
+  ) => {
     try {
-      await API.permissions.respond(requestId, {
-        allow: behavior === 'allow',
-        reason: message
+      const result = await API.permissions.respond(requestId, {
+        behavior,
+        updatedInput,
+        message,
       });
-      setCurrentPermissionRequest(null);
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to respond to permission request');
+      }
+      await loadNextPendingPermission();
     } catch (error) {
       console.error('Failed to respond to permission request:', error);
     }
-  };
+  }, [loadNextPendingPermission]);
 
   return (
     <ContextMenuProvider>

--- a/frontend/src/components/PermissionDialog.tsx
+++ b/frontend/src/components/PermissionDialog.tsx
@@ -1,20 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import { Check, X, Shield, AlertTriangle, Code, Edit } from 'lucide-react';
+import type { PanePermissionRequest } from '../../../shared/types/daemon';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import { Textarea } from './ui/Textarea';
 
-interface PermissionRequest {
-  id: string;
-  sessionId: string;
-  toolName: string;
-  input: Record<string, unknown>;
-  timestamp: number;
-}
-
 interface PermissionDialogProps {
-  request: PermissionRequest | null;
-  onRespond: (requestId: string, behavior: 'allow' | 'deny', updatedInput?: Record<string, unknown>, message?: string) => void;
+  request: PanePermissionRequest | null;
+  onRespond: (
+    requestId: string,
+    behavior: 'allow' | 'deny',
+    updatedInput?: PanePermissionRequest['input'],
+    message?: string,
+  ) => void;
   session?: { name: string };
 }
 

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -11,6 +11,11 @@ import type {
   RemoteDaemonHostConfig,
   RemotePaneConnectionProfile,
 } from '../../../shared/types/remoteDaemon';
+import type {
+  PanePermissionRequest,
+  PanePermissionResolvedEvent,
+  PanePermissionResponse,
+} from '../../../shared/types/daemon';
 import type { ToolPanel } from '../../../shared/types/panels';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
@@ -20,11 +25,6 @@ interface LogEntry {
   level: 'info' | 'warn' | 'error' | 'debug';
   message: string;
   source?: string;
-}
-
-interface PermissionResponse {
-  allow: boolean;
-  reason?: string;
 }
 
 interface RendererDiagnosticPayload {
@@ -255,8 +255,8 @@ interface ElectronAPI {
 
   // Permissions
   permissions: {
-    respond: (requestId: string, response: PermissionResponse) => Promise<IPCResponse>;
-    getPending: () => Promise<IPCResponse>;
+    respond: (requestId: string, response: PanePermissionResponse) => Promise<IPCResponse>;
+    getPending: () => Promise<IPCResponse<PanePermissionRequest[]>>;
   };
 
   // Dashboard
@@ -278,6 +278,8 @@ interface ElectronAPI {
 
   // Event listeners for real-time updates
   events: {
+    onPermissionRequest: (callback: (request: PanePermissionRequest) => void) => () => void;
+    onPermissionResolved: (callback: (event: PanePermissionResolvedEvent) => void) => () => void;
     onSessionCreated: (callback: (session: Session) => void) => () => void;
     onSessionUpdated: (callback: (session: Session) => void) => () => void;
     onSessionDeleted: (callback: (session: Session) => void) => () => void;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -9,6 +9,10 @@ import type {
   RemoteDaemonHostConfig,
   RemotePaneConnectionProfile,
 } from '../../../shared/types/remoteDaemon';
+import type {
+  PanePermissionRequest,
+  PanePermissionResponse,
+} from '../../../shared/types/daemon';
 
 // Type for IPC response
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Generic type parameter default for flexible API responses
@@ -536,14 +540,14 @@ export class API {
 
   // Permissions
   static permissions = {
-    async respond(requestId: string, response: { allow: boolean; reason?: string }) {
+    async respond(requestId: string, response: PanePermissionResponse) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.permissions.respond(requestId, response);
     },
 
     async getPending() {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.permissions.getPending();
+      return window.electronAPI.permissions.getPending() as Promise<IPCResponse<PanePermissionRequest[]>>;
     },
   };
 

--- a/main/src/core/importBoundary.test.ts
+++ b/main/src/core/importBoundary.test.ts
@@ -91,7 +91,7 @@ describe('daemon/client import boundary', () => {
     expect(source).not.toContain("from './daemon/daemonChannels'");
     expect(source).toContain("ipcRenderer.invoke('daemon:invoke', channel, ...args)");
     expect(source).not.toMatch(
-      /ipcRenderer\.invoke\('(sessions:|projects:|folders:|prompts:|resource-monitor:|panels:|terminal:|logs:|git:(cancel-status-for-project|clone-repo|commit|execute-project|file-status|get-github-remote|restore|revert)|file:(copy|delete|duplicate|exists|getPath|list|move|read|read-binary|read-project|readAtRevision|rename|resolveAbsolutePath|search|write|write-binary|write-project))/,
+      /ipcRenderer\.invoke\('(sessions:|projects:|folders:|prompts:|resource-monitor:|panels:|terminal:|logs:|git:(cancel-status-for-project|clone-repo|commit|execute-project|file-status|get-github-remote|restore|revert)|permission:(getPending|respond)|file:(copy|delete|duplicate|exists|getPath|list|move|read|read-binary|read-project|readAtRevision|rename|resolveAbsolutePath|search|write|write-binary|write-project))/,
     );
   });
 

--- a/main/src/daemon/permissionBroker.test.ts
+++ b/main/src/daemon/permissionBroker.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resetPaneRuntimeForTests, setPaneRuntime } from '../core/runtime';
+import type {
+  PanePermissionRequest,
+  PanePermissionResolvedEvent,
+} from '../../../shared/types/daemon';
+import { PanePermissionBroker } from './permissionBroker';
+
+function installTestRuntime(events: Array<{ channel: string; args: unknown[] }>): void {
+  setPaneRuntime({
+    eventSink: {
+      send: (channel, ...args) => {
+        events.push({ channel, args });
+      },
+    },
+    getConfigManager: () => ({} as never),
+    getPtyHostRuntime: () => null,
+    getWebviewContextMap: () => new Map(),
+  });
+}
+
+afterEach(() => {
+  PanePermissionBroker.resetForTests();
+  resetPaneRuntimeForTests();
+});
+
+describe('PanePermissionBroker', () => {
+  it('broadcasts permission requests and resolutions through the pane event sink', async () => {
+    const events: Array<{ channel: string; args: unknown[] }> = [];
+    installTestRuntime(events);
+
+    const broker = PanePermissionBroker.getInstance();
+    const permissionPromise = broker.requestPermission('session-1', 'Bash', { command: 'pwd' });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.channel).toBe('permission:request');
+
+    const request = events[0]?.args[0] as PanePermissionRequest;
+    expect(broker.getPendingRequests()).toEqual([request]);
+
+    broker.respondToRequest(request.id, {
+      behavior: 'allow',
+      updatedInput: { command: 'pwd', cwd: '/tmp' },
+      message: 'approved',
+    });
+
+    await expect(permissionPromise).resolves.toEqual({
+      behavior: 'allow',
+      updatedInput: { command: 'pwd', cwd: '/tmp' },
+      message: 'approved',
+    });
+    expect(broker.getPendingRequests()).toEqual([]);
+
+    expect(events[1]).toEqual({
+      channel: 'permission:resolved',
+      args: [{
+        request,
+        response: {
+          behavior: 'allow',
+          updatedInput: { command: 'pwd', cwd: '/tmp' },
+          message: 'approved',
+        },
+      } satisfies PanePermissionResolvedEvent],
+    });
+  });
+
+  it('clears session-scoped requests by denying them and emitting resolved events', async () => {
+    const events: Array<{ channel: string; args: unknown[] }> = [];
+    installTestRuntime(events);
+
+    const broker = PanePermissionBroker.getInstance();
+    const sessionOnePromise = broker.requestPermission('session-1', 'Write', { path: 'a.txt' });
+    const sessionTwoPromise = broker.requestPermission('session-2', 'Write', { path: 'b.txt' });
+
+    broker.clearPendingRequests('session-1');
+
+    await expect(sessionOnePromise).resolves.toEqual({
+      behavior: 'deny',
+      message: 'Session terminated',
+    });
+    expect(broker.getPendingRequests()).toHaveLength(1);
+    expect(broker.getPendingRequests()[0]?.sessionId).toBe('session-2');
+
+    const resolvedEvent = events.find((event) => event.channel === 'permission:resolved');
+    expect(resolvedEvent?.args[0]).toEqual({
+      request: expect.objectContaining({ sessionId: 'session-1' }),
+      response: {
+        behavior: 'deny',
+        message: 'Session terminated',
+      },
+    });
+
+    broker.respondToRequest(broker.getPendingRequests()[0]!.id, {
+      behavior: 'allow',
+    });
+    await expect(sessionTwoPromise).resolves.toEqual({ behavior: 'allow' });
+  });
+});

--- a/main/src/daemon/permissionBroker.ts
+++ b/main/src/daemon/permissionBroker.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'crypto';
+import { EventEmitter } from 'events';
+import { getPaneEventSink } from '../core/runtime';
+import type {
+  PanePermissionInput,
+  PanePermissionRequest,
+  PanePermissionResolvedEvent,
+  PanePermissionResponse,
+} from '../../../shared/types/daemon';
+
+export class PanePermissionBroker extends EventEmitter {
+  private readonly pendingRequests = new Map<string, PanePermissionRequest>();
+  private static instance: PanePermissionBroker | null = null;
+
+  static getInstance(): PanePermissionBroker {
+    if (!PanePermissionBroker.instance) {
+      PanePermissionBroker.instance = new PanePermissionBroker();
+    }
+
+    return PanePermissionBroker.instance;
+  }
+
+  static resetForTests(): void {
+    PanePermissionBroker.instance?.removeAllListeners();
+    PanePermissionBroker.instance = null;
+  }
+
+  getPendingRequests(): PanePermissionRequest[] {
+    return [...this.pendingRequests.values()];
+  }
+
+  async requestPermission(
+    sessionId: string,
+    toolName: string,
+    input: PanePermissionInput,
+  ): Promise<PanePermissionResponse> {
+    const request: PanePermissionRequest = {
+      id: randomUUID(),
+      sessionId,
+      toolName,
+      input,
+      timestamp: Date.now(),
+    };
+
+    this.pendingRequests.set(request.id, request);
+    getPaneEventSink().send('permission:request', request);
+
+    return new Promise((resolve) => {
+      this.once(`response:${request.id}`, (response: PanePermissionResponse) => {
+        resolve(response);
+      });
+    });
+  }
+
+  respondToRequest(requestId: string, response: PanePermissionResponse): void {
+    const request = this.pendingRequests.get(requestId);
+    if (!request) {
+      throw new Error(`No pending permission request with id ${requestId}`);
+    }
+
+    this.resolveRequest(request, response);
+  }
+
+  clearPendingRequests(sessionId?: string): void {
+    const requests = [...this.pendingRequests.values()].filter((request) => (
+      sessionId ? request.sessionId === sessionId : true
+    ));
+
+    for (const request of requests) {
+      this.resolveRequest(request, {
+        behavior: 'deny',
+        message: sessionId ? 'Session terminated' : 'All requests cleared',
+      });
+    }
+  }
+
+  private resolveRequest(request: PanePermissionRequest, response: PanePermissionResponse): void {
+    this.pendingRequests.delete(request.id);
+    this.emit(`response:${request.id}`, response);
+
+    const payload: PanePermissionResolvedEvent = {
+      request,
+      response,
+    };
+    getPaneEventSink().send('permission:resolved', payload);
+  }
+}

--- a/main/src/daemon/server.test.ts
+++ b/main/src/daemon/server.test.ts
@@ -192,6 +192,66 @@ describe('PaneDaemonServer', () => {
     });
   });
 
+  it('forwards permission lifecycle events to daemon clients', async () => {
+    const registry = new PaneCommandRegistry();
+    const server = new PaneDaemonServer(registry, createTempAppDirectory());
+    activeServers.push(server);
+    await server.start();
+
+    const client = await connectClient(server);
+    server.getEventSink().send('permission:request', {
+      id: 'permission-1',
+      sessionId: 'session-1',
+      toolName: 'Bash',
+      input: { command: 'pwd' },
+      timestamp: 1,
+    });
+
+    await expect(client.nextFrame()).resolves.toEqual({
+      type: 'event',
+      channel: 'permission:request',
+      args: [{
+        id: 'permission-1',
+        sessionId: 'session-1',
+        toolName: 'Bash',
+        input: { command: 'pwd' },
+        timestamp: 1,
+      }],
+    });
+
+    server.getEventSink().send('permission:resolved', {
+      request: {
+        id: 'permission-1',
+        sessionId: 'session-1',
+        toolName: 'Bash',
+        input: { command: 'pwd' },
+        timestamp: 1,
+      },
+      response: {
+        behavior: 'allow',
+        message: 'approved',
+      },
+    });
+
+    await expect(client.nextFrame()).resolves.toEqual({
+      type: 'event',
+      channel: 'permission:resolved',
+      args: [{
+        request: {
+          id: 'permission-1',
+          sessionId: 'session-1',
+          toolName: 'Bash',
+          input: { command: 'pwd' },
+          timestamp: 1,
+        },
+        response: {
+          behavior: 'allow',
+          message: 'approved',
+        },
+      }],
+    });
+  });
+
   it('forwards script state events to daemon clients', async () => {
     const registry = new PaneCommandRegistry();
     const server = new PaneDaemonServer(registry, createTempAppDirectory());

--- a/main/src/daemon/server.ts
+++ b/main/src/daemon/server.ts
@@ -26,6 +26,8 @@ const DAEMON_EVENT_EXACT_CHANNELS = new Set<string>([
   'git-status-loading',
   'git-status-updated',
   'logs:output',
+  'permission:request',
+  'permission:resolved',
   'process:ended',
   'project-script-changed',
   'project-script-closing',

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -3,6 +3,7 @@ import { PaneCommandRegistry } from '../daemon/commandRegistry';
 import { registerFileHandlers } from './file';
 import { registerGitHandlers } from './git';
 import { registerPanelHandlers } from './panels';
+import { registerPermissionHandlers } from './permissions';
 import { registerProjectHandlers } from './project';
 import { registerPromptHandlers } from './prompt';
 import { registerScriptHandlers } from './script';
@@ -55,6 +56,11 @@ const PROMPT_CHANNELS = [
   'sessions:get-prompts',
   'prompts:get-all',
   'prompts:get-by-id',
+] as const;
+
+const PERMISSION_CHANNELS = [
+  'permission:getPending',
+  'permission:respond',
 ] as const;
 
 const FILE_CHANNELS = [
@@ -257,6 +263,16 @@ describe('daemon registry IPC bindings', () => {
 
     expect(registry.listChannels()).toEqual([...PROMPT_CHANNELS].sort());
     expect(ipcMain.boundChannels.sort()).toEqual([...PROMPT_CHANNELS].sort());
+  });
+
+  it('binds daemon-owned permission channels through the shared registry', () => {
+    const registry = new PaneCommandRegistry();
+    const ipcMain = createIpcMainStub();
+
+    registerPermissionHandlers(ipcMain, createServicesStub(), registry);
+
+    expect(registry.listChannels()).toEqual([...PERMISSION_CHANNELS].sort());
+    expect(ipcMain.boundChannels.sort()).toEqual([...PERMISSION_CHANNELS].sort());
   });
 
   it('keeps file manager shell adapters outside the daemon registry surface', () => {

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -24,6 +24,7 @@ import { registerClipboardHandlers } from './clipboard';
 import { registerResourceMonitorHandlers } from './resourceMonitor';
 import { registerOnboardingHandlers } from './onboarding';
 import { registerDaemonBridgeHandlers } from './daemon';
+import { registerPermissionHandlers } from './permissions';
 import { PaneCommandRegistry } from '../daemon/commandRegistry';
 
 
@@ -36,6 +37,7 @@ export function registerIpcHandlers(services: AppServices): PaneCommandRegistry 
   registerProjectHandlers(ipcMain, services, commandRegistry);
   registerConfigHandlers(ipcMain, services);
   registerDialogHandlers(ipcMain, services);
+  registerPermissionHandlers(ipcMain, services, commandRegistry);
   registerGitHandlers(ipcMain, services, commandRegistry);
   registerScriptHandlers(ipcMain, services, commandRegistry);
   registerPromptHandlers(ipcMain, services, commandRegistry);

--- a/main/src/ipc/permissions.ts
+++ b/main/src/ipc/permissions.ts
@@ -1,0 +1,35 @@
+import type { IpcMain } from 'electron';
+import type { PanePermissionResponse } from '../../../shared/types/daemon';
+import { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { PermissionManager } from '../services/permissionManager';
+import type { AppServices } from './types';
+
+const DAEMON_PERMISSION_CHANNELS = [
+  'permission:getPending',
+  'permission:respond',
+] as const;
+
+export function registerPermissionHandlers(
+  ipcMain: IpcMain,
+  _services: AppServices,
+  commandRegistry: PaneCommandRegistry,
+): void {
+  commandRegistry.register('permission:getPending', async () => ({
+    success: true,
+    data: PermissionManager.getInstance().getPendingRequests(),
+  }));
+
+  commandRegistry.register('permission:respond', async (requestId: string, response: PanePermissionResponse) => {
+    try {
+      PermissionManager.getInstance().respondToRequest(requestId, response);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+
+  commandRegistry.bindChannels(ipcMain, DAEMON_PERMISSION_CHANNELS);
+}

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -85,6 +85,25 @@ interface VersionInfo {
   releaseNotes?: string;
 }
 
+interface PermissionRequest {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  timestamp: number;
+}
+
+interface PermissionResponse {
+  behavior: 'allow' | 'deny';
+  updatedInput?: Record<string, unknown>;
+  message?: string;
+}
+
+interface PermissionResolvedEvent {
+  request: PermissionRequest;
+  response: PermissionResponse;
+}
+
 interface UpdaterInfo {
   version: string;
   releaseDate?: string;
@@ -114,6 +133,8 @@ const DAEMON_OWNED_EXACT_CHANNELS = [
   'git:get-github-remote',
   'git:restore',
   'git:revert',
+  'permission:getPending',
+  'permission:respond',
   'file:copy',
   'file:delete',
   'file:duplicate',
@@ -608,8 +629,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Permissions
   permissions: {
-    respond: (requestId: string, response: boolean | { approved: boolean; remember?: boolean }): Promise<IPCResponse> => invokeIpc('permission:respond', requestId, response),
-    getPending: (): Promise<IPCResponse> => invokeIpc('permission:getPending'),
+    respond: (requestId: string, response: PermissionResponse): Promise<IPCResponse> => invokeIpc('permission:respond', requestId, response),
+    getPending: (): Promise<IPCResponse<PermissionRequest[]>> => invokeIpc('permission:getPending'),
   },
 
   // Stravu OAuth integration
@@ -657,6 +678,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Event listeners for real-time updates
   events: {
+    onPermissionRequest: (callback: (request: PermissionRequest) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, request: PermissionRequest) => callback(request);
+      ipcRenderer.on('permission:request', wrappedCallback);
+      return () => ipcRenderer.removeListener('permission:request', wrappedCallback);
+    },
+    onPermissionResolved: (callback: (event: PermissionResolvedEvent) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, event: PermissionResolvedEvent) => callback(event);
+      ipcRenderer.on('permission:resolved', wrappedCallback);
+      return () => ipcRenderer.removeListener('permission:resolved', wrappedCallback);
+    },
     // Session events
     onSessionCreated: (callback: (session: Session) => void) => {
       const wrappedCallback = (_event: Electron.IpcRendererEvent, session: Session) => callback(session);
@@ -1043,7 +1074,8 @@ contextBridge.exposeInMainWorld('electron', {
   invoke: (channel: string, ...args: unknown[]) => invokeIpc(channel, ...args),
   on: (channel: string, callback: (...args: unknown[]) => void) => {
     const validChannels = [
-      'permission:request'
+      'permission:request',
+      'permission:resolved',
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.on(channel, (_event, ...args) => callback(...args));
@@ -1051,7 +1083,8 @@ contextBridge.exposeInMainWorld('electron', {
   },
   off: (channel: string, callback: (...args: unknown[]) => void) => {
     const validChannels = [
-      'permission:request'
+      'permission:request',
+      'permission:resolved',
     ];
     if (validChannels.includes(channel)) {
       ipcRenderer.removeListener(channel, callback);

--- a/main/src/services/permissionManager.ts
+++ b/main/src/services/permissionManager.ts
@@ -1,95 +1,25 @@
-import { EventEmitter } from 'events';
-import { ipcMain } from 'electron';
+import { PanePermissionBroker } from '../daemon/permissionBroker';
+import type {
+  PanePermissionInput as PermissionInput,
+  PanePermissionRequest as PermissionRequest,
+  PanePermissionResponse as PermissionResponse,
+} from '../../../shared/types/daemon';
 
-export interface PermissionRequest {
-  id: string;
-  sessionId: string;
-  toolName: string;
-  input: Record<string, unknown>;
-  timestamp: number;
-}
+export type { PermissionInput, PermissionRequest, PermissionResponse };
 
-export interface PermissionResponse {
-  behavior: 'allow' | 'deny';
-  updatedInput?: Record<string, unknown>;
-  message?: string;
-}
-
-export class PermissionManager extends EventEmitter {
-  private pendingRequests: Map<string, PermissionRequest> = new Map();
-  private static instance: PermissionManager;
-
-  private constructor() {
-    super();
-    this.setupIpcHandlers();
+/**
+ * Legacy compatibility wrapper around the daemon-owned permission broker.
+ *
+ * Existing services still import `PermissionManager.getInstance()`. The broker
+ * now owns the state and event fanout so remote clients can approve requests
+ * without reaching into BrowserWindow globals.
+ */
+export class PermissionManager {
+  static getInstance(): PanePermissionBroker {
+    return PanePermissionBroker.getInstance();
   }
 
-  static getInstance(): PermissionManager {
-    if (!PermissionManager.instance) {
-      PermissionManager.instance = new PermissionManager();
-    }
-    return PermissionManager.instance;
-  }
-
-  private setupIpcHandlers() {
-    ipcMain.handle('permission:respond', async (_, requestId: string, response: PermissionResponse) => {
-      const request = this.pendingRequests.get(requestId);
-      if (!request) {
-        throw new Error(`No pending permission request with id ${requestId}`);
-      }
-
-      this.pendingRequests.delete(requestId);
-      this.emit(`response:${requestId}`, response);
-      return { success: true };
-    });
-
-    ipcMain.handle('permission:getPending', async () => {
-      return Array.from(this.pendingRequests.values());
-    });
-  }
-
-  async requestPermission(sessionId: string, toolName: string, input: Record<string, unknown>): Promise<PermissionResponse> {
-    const request: PermissionRequest = {
-      id: `${sessionId}-${Date.now()}-${Math.random()}`,
-      sessionId,
-      toolName,
-      input,
-      timestamp: Date.now()
-    };
-
-    this.pendingRequests.set(request.id, request);
-
-    // Notify frontend about new permission request
-    const { getMainWindow } = await import('../index');
-    const mainWindow = getMainWindow();
-    if (mainWindow) {
-      console.log('[PermissionManager] Sending permission request to frontend:', request.id, request.toolName);
-      mainWindow.webContents.send('permission:request', request);
-    } else {
-      console.error('[PermissionManager] No main window available to send permission request!');
-    }
-
-    // Wait for response indefinitely (no timeout)
-    return new Promise((resolve, reject) => {
-      this.once(`response:${request.id}`, (response: PermissionResponse) => {
-        resolve(response);
-      });
-    });
-  }
-
-  clearPendingRequests(sessionId?: string) {
-    if (sessionId) {
-      for (const [id, request] of this.pendingRequests.entries()) {
-        if (request.sessionId === sessionId) {
-          this.pendingRequests.delete(id);
-          this.emit(`response:${id}`, { behavior: 'deny', message: 'Session terminated' });
-        }
-      }
-    } else {
-      for (const id of this.pendingRequests.keys()) {
-        this.emit(`response:${id}`, { behavior: 'deny', message: 'All requests cleared' });
-      }
-      this.pendingRequests.clear();
-    }
+  static resetForTests(): void {
+    PanePermissionBroker.resetForTests();
   }
 }

--- a/shared/types/daemon.ts
+++ b/shared/types/daemon.ts
@@ -30,6 +30,27 @@ export interface PaneDaemonEventFrame {
   args: unknown[];
 }
 
+export type PanePermissionInput = Record<string, unknown>;
+
+export interface PanePermissionRequest {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  input: PanePermissionInput;
+  timestamp: number;
+}
+
+export interface PanePermissionResponse {
+  behavior: 'allow' | 'deny';
+  updatedInput?: PanePermissionInput;
+  message?: string;
+}
+
+export interface PanePermissionResolvedEvent {
+  request: PanePermissionRequest;
+  response: PanePermissionResponse;
+}
+
 export type PaneDaemonResponseFrame =
   | PaneDaemonSuccessResponseFrame
   | PaneDaemonErrorResponseFrame;
@@ -66,6 +87,8 @@ export const DAEMON_OWNED_EXACT_CHANNELS = [
   'git:get-github-remote',
   'git:restore',
   'git:revert',
+  'permission:getPending',
+  'permission:respond',
   'file:copy',
   'file:delete',
   'file:duplicate',

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -4,7 +4,31 @@ export async function installElectronApiMock(page: Page) {
   await page.addInitScript(() => {
     const success = (data: unknown = null) => Promise.resolve({ success: true, data });
     const unsubscribe = () => undefined;
-    const subscribe = () => unsubscribe;
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    const pendingPermissions: Array<Record<string, unknown>> = [];
+
+    const subscribe = (channel: string, callback: (...args: unknown[]) => void) => {
+      const callbacks = listeners.get(channel) ?? new Set<(...args: unknown[]) => void>();
+      callbacks.add(callback);
+      listeners.set(channel, callbacks);
+      return () => {
+        callbacks.delete(callback);
+        if (callbacks.size === 0) {
+          listeners.delete(channel);
+        }
+      };
+    };
+
+    const emit = (channel: string, ...args: unknown[]) => {
+      const callbacks = listeners.get(channel);
+      if (!callbacks) {
+        return;
+      }
+
+      for (const callback of callbacks) {
+        callback(...args);
+      }
+    };
 
     const namespace = (overrides: Record<string, unknown> = {}) =>
       new Proxy(overrides, {
@@ -17,7 +41,15 @@ export async function installElectronApiMock(page: Page) {
       });
 
     const events = new Proxy({}, {
-      get: () => subscribe,
+      get: (_target, prop: string | symbol) => {
+        if (prop === 'onPermissionRequest') {
+          return (callback: (request: unknown) => void) => subscribe('permission:request', callback);
+        }
+        if (prop === 'onPermissionResolved') {
+          return (callback: (event: unknown) => void) => subscribe('permission:resolved', callback);
+        }
+        return () => unsubscribe;
+      },
     });
 
     const invoke = (channel: string) => {
@@ -75,6 +107,17 @@ export async function installElectronApiMock(page: Page) {
         getSessionPanels: () => success([]),
         shouldAutoCreate: () => success(false),
       }),
+      permissions: namespace({
+        getPending: () => success([...pendingPermissions]),
+        respond: (requestId: string, response: Record<string, unknown>) => {
+          const index = pendingPermissions.findIndex((request) => request.id === requestId);
+          if (index >= 0) {
+            const [request] = pendingPermissions.splice(index, 1);
+            emit('permission:resolved', { request, response });
+          }
+          return success();
+        },
+      }),
       projects: namespace({
         getAll: () => success([]),
         getActive: () => success(null),
@@ -114,8 +157,20 @@ export async function installElectronApiMock(page: Page) {
       configurable: true,
       value: {
         invoke,
-        on: subscribe,
+        on: (channel: string, callback: (...args: unknown[]) => void) => {
+          subscribe(channel, callback);
+        },
         off: () => undefined,
+      },
+    });
+
+    Object.defineProperty(window, '__paneTestElectronMock', {
+      configurable: true,
+      value: {
+        emitPermissionRequest(request: Record<string, unknown>) {
+          pendingPermissions.push(request);
+          emit('permission:request', request);
+        },
       },
     });
   });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -69,4 +69,33 @@ test.describe('Smoke Tests', () => {
     // Small wait to ensure no errors are thrown
     await page.waitForTimeout(500);
   });
+
+  test('Permission dialog can approve a daemonized permission request', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { emitPermissionRequest: (request: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.emitPermissionRequest({
+        id: 'permission-1',
+        sessionId: 'session-1',
+        toolName: 'Bash',
+        input: { command: 'pwd' },
+        timestamp: Date.now(),
+      });
+    });
+
+    await expect(page.getByText('Permission Required')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Execute shell commands')).toBeVisible();
+    await expect(page.getByText('Bash')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Allow' }).click();
+
+    await expect(page.getByText('Permission Required')).toHaveCount(0);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary
- move permission approval state and request/resolve fanout into a daemon-owned broker instead of BrowserWindow globals
- route `permission:getPending` and `permission:respond` through the shared daemon registry/bridge so local and future remote clients hit the same surface
- switch the Electron renderer to typed permission lifecycle events plus pending-request reloads, and forward permission events to daemon subscribers

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `CI=1 pnpm --filter main test -- --run`
- `PANE_DIR=/tmp/pane-phase3-permission-broker xvfb-run -a pnpm test:ci`
