### PR TITLE
feat: add Electron remote daemon client adapter

### DIFF
--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -78,6 +78,7 @@ function actionTooltip(action: { description?: string; disabled?: boolean; disab
 export function DetailPanel({ isVisible, width, height, onResize, mergeError, projectGitActions, orientation, isCollapsed, onToggleCollapse, onSwapLayout, terminalShortcuts, onCommitClick }: DetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(s => s.immersiveMode);
+  const remoteIdeTooltip = 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.';
 
   // Build IDE dropdown items, sending safe IDE keys (resolved to commands server-side)
   const ideItems = useMemo(() => {
@@ -98,7 +99,7 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
 
   if (!sessionContext) return null;
 
-  const { session, gitBranchActions, isMerging, gitCommands, onOpenIDEWithCommand, onConfigureIDE, onSetTracking, trackingBranch } = sessionContext;
+  const { session, gitBranchActions, isMerging, gitCommands, onOpenIDEWithCommand, onConfigureIDE, onSetTracking, trackingBranch, isRemoteMode } = sessionContext;
   const gitStatus = session.gitStatus;
   const isProject = !!session.isMainRepo;
   // Treat git as unavailable only when status has loaded but indicates failure.
@@ -186,25 +187,35 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
 
           {/* IDE button */}
           {onOpenIDEWithCommand && (
-            <Dropdown
-              trigger={
-                <Tooltip content="Open in IDE" side="top">
-                  <Button variant="ghost" size="sm" className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0">
+            isRemoteMode ? (
+              <Tooltip content={remoteIdeTooltip} side="top">
+                <span>
+                  <Button variant="ghost" size="sm" className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0" disabled>
                     <Code2 className="w-3 h-3" />
                   </Button>
-                </Tooltip>
-              }
-              items={ideItems}
-              footer={
-                <DropdownMenuItem
-                  icon={Settings}
-                  label="Configure..."
-                  onClick={onConfigureIDE}
-                />
-              }
-              position="auto"
-              width="sm"
-            />
+                </span>
+              </Tooltip>
+            ) : (
+              <Dropdown
+                trigger={
+                  <Tooltip content="Open in IDE" side="top">
+                    <Button variant="ghost" size="sm" className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0">
+                      <Code2 className="w-3 h-3" />
+                    </Button>
+                  </Tooltip>
+                }
+                items={ideItems}
+                footer={
+                  <DropdownMenuItem
+                    icon={Settings}
+                    label="Configure..."
+                    onClick={onConfigureIDE}
+                  />
+                }
+                position="auto"
+                width="sm"
+              />
+            )
           )}
 
           {/* Terminal shortcut pills — inline with git actions */}
@@ -333,24 +344,35 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
                 </Tooltip>
               )}
               {onOpenIDEWithCommand && (
-                <Dropdown
-                  trigger={
-                    <Button variant="ghost" size="sm" className={sidebarBtn}>
-                      <Code2 className="w-4 h-4 mr-2 flex-shrink-0" />
-                      <span className="truncate">Open in IDE</span>
-                    </Button>
-                  }
-                  items={ideItems}
-                  footer={
-                    <DropdownMenuItem
-                      icon={Settings}
-                      label="Configure..."
-                      onClick={onConfigureIDE}
-                    />
-                  }
-                  position="auto"
-                  width="sm"
-                />
+                isRemoteMode ? (
+                  <Tooltip content={remoteIdeTooltip} side="left">
+                    <span>
+                      <Button variant="ghost" size="sm" className={sidebarBtn} disabled>
+                        <Code2 className="w-4 h-4 mr-2 flex-shrink-0" />
+                        <span className="truncate">Open in IDE</span>
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Dropdown
+                    trigger={
+                      <Button variant="ghost" size="sm" className={sidebarBtn}>
+                        <Code2 className="w-4 h-4 mr-2 flex-shrink-0" />
+                        <span className="truncate">Open in IDE</span>
+                      </Button>
+                    }
+                    items={ideItems}
+                    footer={
+                      <DropdownMenuItem
+                        icon={Settings}
+                        label="Configure..."
+                        onClick={onConfigureIDE}
+                      />
+                    }
+                    position="auto"
+                    width="sm"
+                  />
+                )
               )}
             </div>
           </DetailSection>

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -53,6 +53,7 @@ export const SessionView = memo(() => {
     () => (config?.customCommands ?? []).filter(cmd => cmd?.name && cmd?.command),
     [config?.customCommands]
   );
+  const isRemoteMode = config?.remoteDaemon?.client.mode === 'remote';
   const deleteCustomCommand = useCallback((index: number) => {
     const existing = config?.customCommands ?? [];
     updateConfig({ customCommands: existing.filter((_, i) => i !== index) }).catch(() => {});
@@ -598,6 +599,13 @@ export const SessionView = memo(() => {
 
   const handleOpenIDEWithCommand = useCallback(async (ideKey?: string) => {
     if (!activeSession) return;
+    if (isRemoteMode) {
+      useErrorStore.getState().showError({
+        title: 'Open IDE unavailable',
+        error: 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.',
+      });
+      return;
+    }
     try {
       const response = await API.sessions.openIDE(activeSession.id, ideKey);
       if (!response.success) {
@@ -612,7 +620,7 @@ export const SessionView = memo(() => {
         error: error instanceof Error ? error.message : 'Unknown error occurred',
       });
     }
-  }, [activeSession]);
+  }, [activeSession, isRemoteMode]);
 
   // Detail panel state
   const [detailVisible, setDetailVisible] = useState(() => {
@@ -963,7 +971,7 @@ export const SessionView = memo(() => {
   return (
     <div className="pane-session-shell flex-1 flex flex-col overflow-hidden bg-bg-primary">
       {/* SINGLE SessionProvider wraps everything */}
-      <SessionProvider session={activeSession} gitBranchActions={branchActions} isMerging={hook.isMerging} gitCommands={hook.gitCommands} onOpenIDEWithCommand={handleOpenIDEWithCommand} onConfigureIDE={() => setShowProjectSettings(true)} onSetTracking={handleOpenSetTracking} trackingBranch={currentUpstream} configuredIDECommand={sessionProject?.open_ide_command}>
+      <SessionProvider session={activeSession} gitBranchActions={branchActions} isMerging={hook.isMerging} gitCommands={hook.gitCommands} onOpenIDEWithCommand={handleOpenIDEWithCommand} onConfigureIDE={() => setShowProjectSettings(true)} onSetTracking={handleOpenSetTracking} trackingBranch={currentUpstream} configuredIDECommand={sessionProject?.open_ide_command} isRemoteMode={isRemoteMode}>
 
         {/* Tab bar at top */}
         <PanelTabBar

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -59,6 +59,14 @@ type AvailableShell = {
   path: string;
 };
 
+function formatRemoteBaseUrl(host: string, port: number): string {
+  const trimmedHost = host.trim();
+  const normalizedHost = trimmedHost.includes(':') && !trimmedHost.startsWith('[') && !trimmedHost.endsWith(']')
+    ? `[${trimmedHost}]`
+    : trimmedHost;
+  return `http://${normalizedHost}:${port}`;
+}
+
 export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [verbose, setVerbose] = useState(false);
   const [claudeExecutablePath, setClaudeExecutablePath] = useState('');
@@ -113,7 +121,10 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
       setRemoteHostConfigDraft(configResponse.data.host.config);
       setRemotePairBaseUrl((currentValue) => (
         currentValue === 'http://127.0.0.1:42137'
-          ? `http://${configResponse.data!.host.config.listenHost}:${configResponse.data!.host.config.listenPort}`
+          ? formatRemoteBaseUrl(
+              configResponse.data!.host.config.listenHost,
+              configResponse.data!.host.config.listenPort,
+            )
           : currentValue
       ));
     }

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { NotificationSettings } from './NotificationSettings';
 import { useNotifications } from '../hooks/useNotifications';
 import { API } from '../utils/api';
@@ -6,6 +6,13 @@ import { optIn, capture, captureAndOptOut } from '../services/posthog';
 import type { PreferredShell, TerminalShortcut } from '../types/config';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
 import { DEFAULT_WORKTREE_FILE_SYNC_ENTRIES } from '../../../shared/types/worktreeFileSync';
+import {
+  createDefaultRemoteDaemonConfig,
+  createDefaultRemotePaneConnectionState,
+  type RemoteDaemonConfig,
+  type RemoteDaemonHostConfig,
+  type RemotePaneConnectionState,
+} from '../../../shared/types/remoteDaemon';
 import { useConfigStore } from '../stores/configStore';
 import { formatKeyDisplay } from '../utils/hotkeyUtils';
 import {
@@ -84,63 +91,39 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [availableShells, setAvailableShells] = useState<AvailableShell[]>([]);
   const [terminalShortcuts, setTerminalShortcuts] = useState<TerminalShortcut[]>([]);
   const [worktreeFileSync, setWorktreeFileSync] = useState<WorktreeFileSyncEntry[]>([]);
+  const [remoteDaemonConfig, setRemoteDaemonConfig] = useState<RemoteDaemonConfig>(createDefaultRemoteDaemonConfig());
+  const [remoteConnectionState, setRemoteConnectionState] = useState<RemotePaneConnectionState>(createDefaultRemotePaneConnectionState());
+  const [remoteHostConfigDraft, setRemoteHostConfigDraft] = useState<RemoteDaemonHostConfig>(createDefaultRemoteDaemonConfig().host.config);
+  const [remotePairLabel, setRemotePairLabel] = useState('');
+  const [remotePairBaseUrl, setRemotePairBaseUrl] = useState('http://127.0.0.1:42137');
+  const [remoteCreatedToken, setRemoteCreatedToken] = useState<string | null>(null);
+  const [remoteBusy, setRemoteBusy] = useState(false);
   const { updateSettings } = useNotifications();
   const { theme, setTheme } = useTheme();
   const { fetchConfig: refreshConfigStore } = useConfigStore();
 
-  useEffect(() => {
-    if (isOpen) {
-      // Get platform first, then fetch config (needed for Windows shell detection)
-      window.electronAPI.getPlatform().then((p) => {
-        setPlatform(p);
-        fetchConfig(p);
-      });
+  const refreshRemoteDaemonSettings = useCallback(async () => {
+    const [configResponse, connectionStateResponse] = await Promise.all([
+      API.remoteDaemon.getConfig(),
+      API.remoteDaemon.getConnectionState(),
+    ]);
 
-      // Load system monospace fonts for the font picker
-      window.electronAPI.config.getMonospaceFonts().then((result) => {
-        if (result?.data && Array.isArray(result.data)) {
-          setSystemMonoFonts(result.data as string[]);
-        }
-      }).catch(() => { /* fc-list not available — dropdown will be empty */ });
-
-      const loadAutoRename = async () => {
-        try {
-          const result = await window.electron?.invoke('preferences:get', 'auto_rename_sessions_to_pr') as IPCResponse<string>;
-          if (result?.data !== undefined && result?.data !== null) {
-            setAutoRenameToPR(result.data !== 'false');
-          }
-        } catch (error) {
-          console.error('Failed to load auto-rename preference:', error);
-        }
-      };
-      loadAutoRename();
-
-      // Load @terminal preferences
-      const loadAtTerminalPrefs = async () => {
-        try {
-          const [modeResult, lineResult] = await Promise.all([
-            window.electron?.invoke('preferences:get', 'at_terminal_paste_mode') as Promise<IPCResponse<string>>,
-            window.electron?.invoke('preferences:get', 'at_terminal_line_count') as Promise<IPCResponse<string>>,
-          ]);
-          if (modeResult?.data === 'raw' || modeResult?.data === 'embed') {
-            setAtPasteMode(modeResult.data);
-          }
-          if (lineResult?.data) {
-            const val = parseInt(lineResult.data, 10);
-            if ([100, 300, 500, -1].includes(val)) setAtLineCount(val);
-          }
-        } catch { /* ignore */ }
-      };
-      loadAtTerminalPrefs();
-
-      // Navigate to shortcuts tab when opened via Ctrl+Alt+/
-      if (initialSection === 'terminal-shortcuts') {
-        setActiveTab('shortcuts');
-      }
+    if (configResponse.success && configResponse.data) {
+      setRemoteDaemonConfig(configResponse.data);
+      setRemoteHostConfigDraft(configResponse.data.host.config);
+      setRemotePairBaseUrl((currentValue) => (
+        currentValue === 'http://127.0.0.1:42137'
+          ? `http://${configResponse.data!.host.config.listenHost}:${configResponse.data!.host.config.listenPort}`
+          : currentValue
+      ));
     }
-  }, [isOpen, initialSection]);
 
-  const fetchConfig = async (currentPlatform?: string) => {
+    if (connectionStateResponse.success && connectionStateResponse.data) {
+      setRemoteConnectionState(connectionStateResponse.data);
+    }
+  }, []);
+
+  const fetchConfig = useCallback(async (currentPlatform?: string) => {
     try {
       const response = await API.config.get();
       if (!response.success || !response.data) {
@@ -191,9 +174,143 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
 
       // Load worktree file sync entries
       setWorktreeFileSync(data.worktreeFileSync ?? DEFAULT_WORKTREE_FILE_SYNC_ENTRIES);
+
+      await refreshRemoteDaemonSettings();
     } catch {
       setError('Failed to load configuration');
     }
+  }, [platform, refreshRemoteDaemonSettings, updateSettings]);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Get platform first, then fetch config (needed for Windows shell detection)
+      window.electronAPI.getPlatform().then((p) => {
+        setPlatform(p);
+        fetchConfig(p);
+      });
+
+      const unsubscribeRemoteConnectionState = window.electronAPI.remoteDaemon.onConnectionStateChanged((state) => {
+        setRemoteConnectionState(state);
+      });
+
+      // Load system monospace fonts for the font picker
+      window.electronAPI.config.getMonospaceFonts().then((result) => {
+        if (result?.data && Array.isArray(result.data)) {
+          setSystemMonoFonts(result.data as string[]);
+        }
+      }).catch(() => { /* fc-list not available — dropdown will be empty */ });
+
+      const loadAutoRename = async () => {
+        try {
+          const result = await window.electron?.invoke('preferences:get', 'auto_rename_sessions_to_pr') as IPCResponse<string>;
+          if (result?.data !== undefined && result?.data !== null) {
+            setAutoRenameToPR(result.data !== 'false');
+          }
+        } catch (error) {
+          console.error('Failed to load auto-rename preference:', error);
+        }
+      };
+      loadAutoRename();
+
+      // Load @terminal preferences
+      const loadAtTerminalPrefs = async () => {
+        try {
+          const [modeResult, lineResult] = await Promise.all([
+            window.electron?.invoke('preferences:get', 'at_terminal_paste_mode') as Promise<IPCResponse<string>>,
+            window.electron?.invoke('preferences:get', 'at_terminal_line_count') as Promise<IPCResponse<string>>,
+          ]);
+          if (modeResult?.data === 'raw' || modeResult?.data === 'embed') {
+            setAtPasteMode(modeResult.data);
+          }
+          if (lineResult?.data) {
+            const val = parseInt(lineResult.data, 10);
+            if ([100, 300, 500, -1].includes(val)) setAtLineCount(val);
+          }
+        } catch { /* ignore */ }
+      };
+      loadAtTerminalPrefs();
+
+      // Navigate to shortcuts tab when opened via Ctrl+Alt+/
+      if (initialSection === 'terminal-shortcuts') {
+        setActiveTab('shortcuts');
+      }
+
+      return () => {
+        unsubscribeRemoteConnectionState();
+      };
+    }
+  }, [fetchConfig, initialSection, isOpen]);
+
+  const runRemoteDaemonAction = async (action: () => Promise<void>) => {
+    setRemoteBusy(true);
+    setError(null);
+    try {
+      await action();
+      await Promise.all([
+        refreshRemoteDaemonSettings(),
+        refreshConfigStore(),
+      ]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Remote daemon action failed');
+    } finally {
+      setRemoteBusy(false);
+    }
+  };
+
+  const handleSaveRemoteHostConfig = async () => {
+    await runRemoteDaemonAction(async () => {
+      const response = await API.remoteDaemon.updateHostConfig(remoteHostConfigDraft);
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to save remote daemon host config');
+      }
+    });
+  };
+
+  const handleCreateRemoteConnectionPair = async () => {
+    await runRemoteDaemonAction(async () => {
+      const response = await API.remoteDaemon.createConnectionPair({
+        label: remotePairLabel,
+        baseUrl: remotePairBaseUrl,
+      });
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to create remote daemon connection pair');
+      }
+
+      setRemotePairLabel('');
+      setRemoteCreatedToken(response.data?.token ?? null);
+    });
+  };
+
+  const handleUseRemoteProfile = async (profileId: string) => {
+    await runRemoteDaemonAction(async () => {
+      const response = await API.remoteDaemon.updateClientState({
+        activeProfileId: profileId,
+        mode: 'remote',
+      });
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to connect to remote daemon profile');
+      }
+    });
+  };
+
+  const handleSwitchToLocalMode = async () => {
+    await runRemoteDaemonAction(async () => {
+      const response = await API.remoteDaemon.updateClientState({
+        mode: 'local',
+      });
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to return to local mode');
+      }
+    });
+  };
+
+  const handleDeleteRemoteProfile = async (profileId: string) => {
+    await runRemoteDaemonAction(async () => {
+      const response = await API.remoteDaemon.deleteConnectionProfile(profileId);
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to delete remote daemon connection profile');
+      }
+    });
   };
 
   const handleAutoRenameToggle = async (checked: boolean) => {
@@ -813,6 +930,207 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                   Uses fast copy (hard links on Linux, APFS clones on macOS) when possible.
                   Package manager install runs automatically in the background terminal.
                 </p>
+              </SettingsSection>
+            </CollapsibleCard>
+
+            <CollapsibleCard
+              title="Self-Hosted Remote Daemon"
+              subtitle="Run Pane remotely on your own machine and connect this desktop app to it"
+              icon={<Terminal className="w-5 h-5" />}
+              defaultExpanded={false}
+            >
+              <SettingsSection
+                title="Client Mode"
+                description="Choose whether this Pane desktop app should talk to the local runtime or a remote self-hosted daemon"
+                icon={<Terminal className="w-4 h-4" />}
+              >
+                <div className="flex items-center justify-between gap-4 p-3 rounded-lg bg-surface-secondary border border-border-secondary">
+                  <div>
+                    <p className="text-sm font-medium text-text-primary">
+                      {remoteConnectionState.mode === 'remote' ? 'Remote mode' : 'Local mode'}
+                    </p>
+                    <p className="text-xs text-text-tertiary mt-1">
+                      Status: {remoteConnectionState.status}
+                      {remoteConnectionState.activeProfileLabel ? ` via ${remoteConnectionState.activeProfileLabel}` : ''}
+                    </p>
+                    {remoteConnectionState.lastError && (
+                      <p className="text-xs text-status-error mt-2">{remoteConnectionState.lastError}</p>
+                    )}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={handleSwitchToLocalMode}
+                    disabled={remoteBusy || remoteConnectionState.mode === 'local'}
+                  >
+                    Use Local Runtime
+                  </Button>
+                </div>
+              </SettingsSection>
+
+              <SettingsSection
+                title="Remote Host"
+                description="Controls the loopback HTTP/SSE listener for a self-hosted Pane daemon. Expose it through SSH, Tailscale, VPN, or a reverse proxy."
+                icon={<Eye className="w-4 h-4" />}
+              >
+                <div className="space-y-3">
+                  <Checkbox
+                    label="Enable remote daemon listener"
+                    checked={remoteHostConfigDraft.enabled}
+                    onChange={(e) => setRemoteHostConfigDraft({
+                      ...remoteHostConfigDraft,
+                      enabled: e.target.checked,
+                    })}
+                  />
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    <Input
+                      label="Listen Host"
+                      value={remoteHostConfigDraft.listenHost}
+                      onChange={(e) => setRemoteHostConfigDraft({
+                        ...remoteHostConfigDraft,
+                        listenHost: e.target.value,
+                      })}
+                      placeholder="127.0.0.1"
+                      fullWidth
+                    />
+                    <Input
+                      label="Listen Port"
+                      type="number"
+                      value={String(remoteHostConfigDraft.listenPort)}
+                      onChange={(e) => setRemoteHostConfigDraft({
+                        ...remoteHostConfigDraft,
+                        listenPort: Number.parseInt(e.target.value, 10) || 42137,
+                      })}
+                      placeholder="42137"
+                      fullWidth
+                    />
+                  </div>
+                  <Checkbox
+                    label="Require pairing / saved bearer tokens"
+                    checked={remoteHostConfigDraft.pairingRequired}
+                    onChange={(e) => setRemoteHostConfigDraft({
+                      ...remoteHostConfigDraft,
+                      pairingRequired: e.target.checked,
+                    })}
+                  />
+                  <Checkbox
+                    label="Allow direct HTTP on loopback"
+                    checked={remoteHostConfigDraft.allowInsecureHttpOnLoopback}
+                    onChange={(e) => setRemoteHostConfigDraft({
+                      ...remoteHostConfigDraft,
+                      allowInsecureHttpOnLoopback: e.target.checked,
+                    })}
+                  />
+                  <div className="flex items-center justify-between gap-4">
+                    <p className="text-xs text-text-tertiary">
+                      Paired remote clients on this machine: {remoteDaemonConfig.host.clients.length}
+                    </p>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={handleSaveRemoteHostConfig}
+                      disabled={remoteBusy}
+                    >
+                      Save Host Settings
+                    </Button>
+                  </div>
+                </div>
+              </SettingsSection>
+
+              <SettingsSection
+                title="Create Paired Connection"
+                description="Mint a remote token and save a matching client profile in one step"
+                icon={<Plus className="w-4 h-4" />}
+              >
+                <div className="space-y-3">
+                  <Input
+                    label="Connection Label"
+                    value={remotePairLabel}
+                    onChange={(e) => setRemotePairLabel(e.target.value)}
+                    placeholder="Mac mini in office"
+                    fullWidth
+                  />
+                  <Input
+                    label="Remote Base URL"
+                    value={remotePairBaseUrl}
+                    onChange={(e) => setRemotePairBaseUrl(e.target.value)}
+                    placeholder="http://127.0.0.1:42137"
+                    fullWidth
+                  />
+                  <div className="flex justify-end">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={handleCreateRemoteConnectionPair}
+                      disabled={remoteBusy || remotePairLabel.trim().length === 0 || remotePairBaseUrl.trim().length === 0}
+                    >
+                      Create Paired Profile
+                    </Button>
+                  </div>
+                  {remoteCreatedToken && (
+                    <div className="p-3 rounded-lg bg-surface-secondary border border-border-secondary space-y-2">
+                      <p className="text-sm font-medium text-text-primary">Latest generated remote token</p>
+                      <Textarea
+                        value={remoteCreatedToken}
+                        onChange={() => {}}
+                        rows={2}
+                        readOnly
+                        fullWidth
+                      />
+                      <p className="text-xs text-text-tertiary">
+                        Use this token when creating a matching remote profile on another client machine.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </SettingsSection>
+
+              <SettingsSection
+                title="Saved Remote Profiles"
+                description="Connect this desktop app to a paired self-hosted Pane daemon"
+                icon={<FileText className="w-4 h-4" />}
+              >
+                <div className="space-y-2">
+                  {remoteDaemonConfig.client.profiles.length === 0 && (
+                    <p className="text-sm text-text-tertiary italic">No remote profiles saved yet.</p>
+                  )}
+
+                  {remoteDaemonConfig.client.profiles.map((profile) => {
+                    const isActive = remoteDaemonConfig.client.activeProfileId === profile.id;
+                    return (
+                      <div
+                        key={profile.id}
+                        className="flex items-center justify-between gap-3 p-3 rounded-lg bg-surface-secondary border border-border-secondary"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-text-primary">
+                            {profile.label}
+                            {isActive && <span className="ml-2 text-xs text-interactive">active</span>}
+                          </p>
+                          <p className="text-xs text-text-tertiary truncate">{profile.baseUrl}</p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={() => handleUseRemoteProfile(profile.id)}
+                            disabled={remoteBusy}
+                          >
+                            Connect
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={() => handleDeleteRemoteProfile(profile.id)}
+                            disabled={remoteBusy}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
               </SettingsSection>
             </CollapsibleCard>
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -1478,10 +1478,14 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             Open in Editor
           </span>
         </PopoverButton>
-        <PopoverButton onClick={handleShowInExplorer}>
+        <PopoverButton
+          onClick={handleShowInExplorer}
+          disabled={isRemoteMode}
+          title={isRemoteMode ? 'Only available in local mode' : undefined}
+        >
           <span className="flex items-center gap-2">
             <FolderOpen className="w-4 h-4" />
-            Show in Explorer
+            Show in Explorer{isRemoteMode ? ' (local only)' : ''}
           </span>
         </PopoverButton>
       </TerminalPopover>
@@ -1493,6 +1497,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         text={selectionPopover.text}
         workingDirectory={workingDirectory}
         sessionId={panel.sessionId}
+        isRemoteMode={isRemoteMode}
         onClose={closeSelectionPopover}
       />
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -24,6 +24,7 @@ import { createAtTerminalHandler } from '../../services/terminalInterceptor/hand
 import { InterceptorDropdown } from '../terminal/InterceptorDropdown';
 import { InterceptorToast } from '../terminal/InterceptorToast';
 import { usePanelStore } from '../../stores/panelStore';
+import { useConfigStore } from '../../stores/configStore';
 import type { InterceptorState, AtTerminalHandlerState, TerminalSuggestion } from '../../services/terminalInterceptor/types';
 import '@xterm/xterm/css/xterm.css';
 
@@ -59,6 +60,10 @@ function buildTerminalFontFamily(userFont: string): string {
   return `"${userFont}", "Symbols Nerd Font Mono", monospace`;
 }
 
+function isClipboardImagePlaceholderText(text: string): boolean {
+  return text.trim() === '[Image]';
+}
+
 export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActive, autoFocus = true }) => {
   renderLog('[TerminalPanel] Component rendering, panel:', panel.id, 'isActive:', isActive);
   
@@ -88,6 +93,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   const terminalState = panel.state?.customState as TerminalPanelState | undefined;
   const isCliPanel = !!terminalState?.isCliPanel;
   const [isCliReady, setIsCliReady] = useState(!!terminalState?.isCliReady);
+  const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
 
   // ptyId for the current PTY behind this panel, delivered via
   // `terminal:ptyReady` when spawned through the ptyHost UtilityProcess.
@@ -844,6 +850,16 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             const text = textVal;
             e.stopPropagation();
             e.preventDefault();
+
+            if (isRemoteMode) {
+              if (text && !isClipboardImagePlaceholderText(text) && !disposed && terminal) {
+                terminal.paste(text);
+              } else {
+                setToastMessage('Native image clipboard paste is unavailable in remote mode. Use drag and drop or browser image paste instead.');
+                setTimeout(() => setToastMessage(null), 2500);
+              }
+              return;
+            }
 
             (async () => {
               if (disposed || !terminal) return;

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -15,6 +15,7 @@ import { ExplorerPanelState } from '../../../../../shared/types/panels';
 import { isMac, isWindows } from '../../../utils/platformUtils';
 import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
 import { TerminalPopover, PopoverButton } from '../../terminal/TerminalPopover';
+import { useConfigStore } from '../../../stores/configStore';
 
 interface FileItem {
   name: string;
@@ -86,6 +87,7 @@ function HeadlessFileTree({
 
   // Platform-adaptive label
   const revealLabel = isMac() ? 'Reveal in Finder' : isWindows() ? 'Show in Explorer' : 'Show in File Manager';
+  const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
 
   // Initialize expanded state from persisted state or default to root expanded.
   // Normalize legacy '' root to ROOT_ID so saved state from the old FileTree still works.
@@ -301,6 +303,11 @@ function HeadlessFileTree({
 
   const handleRevealInFileManager = useCallback(async () => {
     if (!contextMenu?.file) return;
+    if (isRemoteMode) {
+      setError('Show in file manager is only available in local mode. Switch this client back to the local runtime to reveal workspace files in your OS file manager.');
+      setContextMenu(null);
+      return;
+    }
     try {
       await window.electronAPI.invoke('file:showInFolder', {
         sessionId,
@@ -310,7 +317,7 @@ function HeadlessFileTree({
       console.error('Failed to reveal in file manager:', err);
     }
     setContextMenu(null);
-  }, [contextMenu, sessionId]);
+  }, [contextMenu, isRemoteMode, sessionId]);
 
   // Delete handler
   const handleDelete = useCallback(async (file: FileItem) => {
@@ -1130,10 +1137,15 @@ function HeadlessFileTree({
                 Copy Absolute Path
               </span>
             </PopoverButton>
-            <PopoverButton onClick={handleRevealInFileManager}>
+            <PopoverButton
+              onClick={handleRevealInFileManager}
+              disabled={isRemoteMode}
+              title={isRemoteMode ? 'Only available in local mode' : undefined}
+            >
               <span className="flex items-center gap-2">
                 <FolderOpen className="w-4 h-4" />
                 {revealLabel}
+                {isRemoteMode ? ' (local only)' : ''}
               </span>
             </PopoverButton>
             <div className="my-1 border-t border-border-primary" />

--- a/frontend/src/components/terminal/SelectionPopover.tsx
+++ b/frontend/src/components/terminal/SelectionPopover.tsx
@@ -10,6 +10,7 @@ export interface SelectionPopoverProps {
   text: string;
   workingDirectory?: string;
   sessionId?: string;
+  isRemoteMode?: boolean;
   onClose: () => void;
 }
 
@@ -57,6 +58,7 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
   text,
   workingDirectory,
   sessionId,
+  isRemoteMode = false,
   onClose,
 }) => {
   // Early return when not visible to avoid unnecessary computation
@@ -96,6 +98,12 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
 
   const handleShowInExplorer = async () => {
     if (isFile) {
+      if (isRemoteMode) {
+        console.warn('Show in Explorer is only available in local mode.');
+        onClose();
+        return;
+      }
+
       const resolvedPath = resolveFilePath(trimmedText, workingDirectory);
       try {
         await window.electronAPI.invoke('app:showItemInFolder', resolvedPath);
@@ -131,10 +139,14 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
         </PopoverButton>
       )}
       {isFile && (
-        <PopoverButton onClick={handleShowInExplorer}>
+        <PopoverButton
+          onClick={handleShowInExplorer}
+          disabled={isRemoteMode}
+          title={isRemoteMode ? 'Only available in local mode' : undefined}
+        >
           <span className="flex items-center gap-2">
             <FolderOpen className="w-4 h-4" />
-            Show in Explorer
+            Show in Explorer{isRemoteMode ? ' (local only)' : ''}
           </span>
         </PopoverButton>
       )}

--- a/frontend/src/components/terminal/hooks/useTerminalLinks.ts
+++ b/frontend/src/components/terminal/hooks/useTerminalLinks.ts
@@ -4,6 +4,7 @@ import type { LinkProviderConfig } from '../linkProviders/types';
 import { registerAllLinkProviders } from '../linkProviders';
 import { panelApi } from '../../../services/panelApi';
 import { usePanelStore } from '../../../stores/panelStore';
+import { useConfigStore } from '../../../stores/configStore';
 
 export interface UseTerminalLinksConfig {
   workingDirectory: string;
@@ -58,6 +59,7 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
   });
 
   const [githubRemoteUrl, setGithubRemoteUrl] = useState<string | null>(null);
+  const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
   const mousePositionRef = useRef({ x: 0, y: 0 });
 
   // Track mouse position for selection popover
@@ -168,6 +170,12 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
   const handleShowInExplorer = useCallback(async () => {
     const { path } = filePopover;
 
+    if (isRemoteMode) {
+      console.warn('Show in Explorer is only available in local mode.');
+      setFilePopover((prev) => ({ ...prev, visible: false }));
+      return;
+    }
+
     try {
       await window.electronAPI.invoke('app:showItemInFolder', path);
     } catch (error) {
@@ -175,7 +183,7 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
     }
 
     setFilePopover((prev) => ({ ...prev, visible: false }));
-  }, [filePopover]);
+  }, [filePopover, isRemoteMode]);
 
   const closeTooltip = useCallback(() => {
     setTooltip((prev) => ({ ...prev, visible: false }));
@@ -193,6 +201,7 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
     onMouseMove,
     tooltip,
     filePopover,
+    isRemoteMode,
     selectionPopover,
     handleOpenInEditor,
     handleShowInExplorer,

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -26,6 +26,7 @@ interface SessionContextValue {
   onSetTracking?: () => void;
   trackingBranch?: string | null;
   configuredIDECommand?: string | null;
+  isRemoteMode?: boolean;
 }
 
 export const SessionContext = createContext<SessionContextValue | undefined>(undefined);
@@ -52,7 +53,8 @@ export const SessionProvider: React.FC<{
   onSetTracking?: () => void;
   trackingBranch?: string | null;
   configuredIDECommand?: string | null;
-}> = ({ children, session, projectName, gitBranchActions, isMerging, gitCommands, onOpenIDEWithCommand, onConfigureIDE, onSetTracking, trackingBranch, configuredIDECommand }) => {
+  isRemoteMode?: boolean;
+}> = ({ children, session, projectName, gitBranchActions, isMerging, gitCommands, onOpenIDEWithCommand, onConfigureIDE, onSetTracking, trackingBranch, configuredIDECommand, isRemoteMode }) => {
   // FIX: Don't render children without a valid session
   // This prevents components that require session from rendering
   if (!session) {
@@ -76,7 +78,8 @@ export const SessionProvider: React.FC<{
     onConfigureIDE,
     onSetTracking,
     trackingBranch,
-    configuredIDECommand
+    configuredIDECommand,
+    isRemoteMode,
   };
 
   return (

--- a/frontend/src/hooks/useIPCEvents.ts
+++ b/frontend/src/hooks/useIPCEvents.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { useSessionStore } from '../stores/sessionStore';
 import { useErrorStore } from '../stores/errorStore';
+import { usePanelStore } from '../stores/panelStore';
+import { panelApi } from '../services/panelApi';
 import { API } from '../utils/api';
 import type { Session, SessionOutput, GitStatus } from '../types/session';
 
@@ -367,6 +369,40 @@ export function useIPCEvents() {
     });
     if (unsubscribeSpotlightTamper) {
       unsubscribeFunctions.push(unsubscribeSpotlightTamper);
+    }
+
+    const unsubscribeRemoteResync = window.electronAPI.events.onRemoteDaemonResyncRequested?.(() => {
+      void (async () => {
+        try {
+          const sessionsResponse = await API.sessions.getAll();
+          if (sessionsResponse.success && sessionsResponse.data) {
+            const sessionsWithJsonMessages = sessionsResponse.data.map((session: Session) => ({
+              ...session,
+              jsonMessages: session.jsonMessages || [],
+            }));
+            loadSessions(sessionsWithJsonMessages);
+          }
+
+          const activeSessionId = useSessionStore.getState().activeSessionId;
+          if (activeSessionId) {
+            const panels = await panelApi.loadPanelsForSession(activeSessionId);
+            usePanelStore.getState().setPanels(activeSessionId, panels);
+
+            const activePanel = panels.find((panel) => panel.state.isActive);
+            if (activePanel) {
+              usePanelStore.getState().setActivePanel(activeSessionId, activePanel.id);
+            }
+          }
+
+          window.dispatchEvent(new Event('project-changed'));
+          window.dispatchEvent(new Event('project-sessions-refresh'));
+        } catch (error) {
+          console.error('[useIPCEvents] Failed to resync renderer state after remote reconnect:', error);
+        }
+      })();
+    });
+    if (unsubscribeRemoteResync) {
+      unsubscribeFunctions.push(unsubscribeRemoteResync);
     }
 
     // Load initial sessions

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -9,6 +9,7 @@ import { Session, GitCommands, GitErrorDetails, AttachedImage, AttachedText } fr
 import { getScriptTerminalTheme } from '../utils/terminalTheme';
 import { createVisibilityAwareInterval } from '../utils/performanceUtils';
 import { useHotkey } from './useHotkey';
+import { useConfigStore } from '../stores/configStore';
 
 interface PromptMarker {
   id: number;
@@ -27,6 +28,7 @@ export const useSessionView = (
 ) => {
   const { theme } = useTheme();
   const activeSessionId = activeSession?.id;
+  const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
 
   // Terminal instances
   const scriptTerminalInstance = useRef<Terminal | null>(null);
@@ -1364,6 +1366,14 @@ export const useSessionView = (
 
   const handleOpenIDE = async () => {
     if (!activeSession) return;
+    if (isRemoteMode) {
+      const { showError } = useErrorStore.getState();
+      showError({
+        title: 'Open IDE unavailable',
+        error: 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.',
+      });
+      return;
+    }
     
     setIsOpeningIDE(true);
     

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -341,6 +341,7 @@ interface ElectronAPI {
 
     // Window focus state from BrowserWindow (more reliable than document.hasFocus())
     onWindowFocusChanged: (callback: (focused: boolean) => void) => () => void;
+    onRemoteDaemonResyncRequested: (callback: () => void) => () => void;
 
     // Spotlight events
     onSpotlightStatusChanged?: (callback: (data: { sessionId: string; projectId: number; active: boolean }) => void) => () => void;

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -6,9 +6,11 @@ import type { AppConfig, UpdateConfigRequest } from './config';
 import type { SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import type {
   RemoteDaemonClientRecord,
+  RemoteDaemonConnectionPair,
   RemoteDaemonClientSettings,
   RemoteDaemonConfig,
   RemoteDaemonHostConfig,
+  RemotePaneConnectionState,
   RemotePaneConnectionProfile,
 } from '../../../shared/types/remoteDaemon';
 import type {
@@ -226,12 +228,15 @@ interface ElectronAPI {
 
   remoteDaemon: {
     getConfig: () => Promise<IPCResponse<RemoteDaemonConfig>>;
+    getConnectionState: () => Promise<IPCResponse<RemotePaneConnectionState>>;
+    createConnectionPair: (input: { label: string; baseUrl: string }) => Promise<IPCResponse<RemoteDaemonConnectionPair>>;
     updateHostConfig: (updates: Partial<RemoteDaemonHostConfig>) => Promise<IPCResponse<RemoteDaemonHostConfig>>;
     upsertClientRecord: (record: RemoteDaemonClientRecord) => Promise<IPCResponse<RemoteDaemonClientRecord[]>>;
     deleteClientRecord: (clientId: string) => Promise<IPCResponse<RemoteDaemonClientRecord[]>>;
     upsertConnectionProfile: (profile: RemotePaneConnectionProfile) => Promise<IPCResponse<RemotePaneConnectionProfile[]>>;
     deleteConnectionProfile: (profileId: string) => Promise<IPCResponse<RemoteDaemonClientSettings>>;
     updateClientState: (updates: Partial<Pick<RemoteDaemonClientSettings, 'activeProfileId' | 'mode'>>) => Promise<IPCResponse<RemoteDaemonClientSettings>>;
+    onConnectionStateChanged: (callback: (state: RemotePaneConnectionState) => void) => () => void;
   };
 
   // Prompts

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -5,8 +5,10 @@ import type { UpdateConfigRequest } from '../types/config';
 import type { SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import type {
   RemoteDaemonClientRecord,
+  RemoteDaemonConnectionPair,
   RemoteDaemonClientSettings,
   RemoteDaemonHostConfig,
+  RemotePaneConnectionState,
   RemotePaneConnectionProfile,
 } from '../../../shared/types/remoteDaemon';
 import type {
@@ -481,6 +483,20 @@ export class API {
       return window.electronAPI.remoteDaemon.getConfig();
     },
 
+    async getConnectionState() {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.remoteDaemon.getConnectionState();
+    },
+
+    async createConnectionPair(input: { label: string; baseUrl: string }) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.remoteDaemon.createConnectionPair(input) as Promise<{
+        success: boolean;
+        data?: RemoteDaemonConnectionPair;
+        error?: string;
+      }>;
+    },
+
     async updateHostConfig(updates: Partial<RemoteDaemonHostConfig>) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.remoteDaemon.updateHostConfig(updates);
@@ -509,6 +525,11 @@ export class API {
     async updateClientState(updates: Partial<Pick<RemoteDaemonClientSettings, 'activeProfileId' | 'mode'>>) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.remoteDaemon.updateClientState(updates);
+    },
+
+    onConnectionStateChanged(callback: (state: RemotePaneConnectionState) => void) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.remoteDaemon.onConnectionStateChanged(callback);
     },
   };
 

--- a/main/src/daemon/auth.ts
+++ b/main/src/daemon/auth.ts
@@ -1,4 +1,4 @@
-import { createHash, timingSafeEqual } from 'crypto';
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
 import type { RemoteDaemonClientRecord } from '../../../shared/types/remoteDaemon';
 
 interface RemoteDaemonAuthSuccess {
@@ -16,6 +16,10 @@ interface RemoteDaemonAuthFailure {
 }
 
 export type RemoteDaemonAuthResult = RemoteDaemonAuthSuccess | RemoteDaemonAuthFailure;
+
+export function createRemoteDaemonToken(): string {
+  return randomBytes(24).toString('hex');
+}
 
 export function hashRemoteDaemonToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -182,6 +182,49 @@ describe('RemotePaneClientController', () => {
       activeProfileId: 'profile-retry',
     });
   });
+
+  it('restores the saved local state when a manual activation fails', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+    server.setEventsReady(false);
+
+    const configManager = createConfigManagerStub(createDefaultRemoteDaemonConfig());
+    const controller = new RemotePaneClientController();
+    controller.initialize({
+      configManager,
+      rendererEventSink: { send() {} },
+    });
+
+    await expect(controller.activateProfile({
+      id: 'profile-manual-failure',
+      label: 'Tunnel host',
+      baseUrl: server.baseUrl,
+      token: 'secret-token',
+      transport: 'http+sse',
+    })).rejects.toThrow('Remote daemon not ready yet');
+
+    expect(controller.getConnectionState()).toMatchObject({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+    expect(controller.shouldForwardLocalRendererEvent('session:created')).toBe(true);
+
+    server.setEventsReady(true);
+    await sleep(1_250);
+
+    expect(controller.getConnectionState()).toMatchObject({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+  });
 });
 
 async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteServer> {
@@ -311,4 +354,8 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<voi
 
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
+}
+
+async function sleep(timeoutMs: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, timeoutMs));
 }

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -1,0 +1,239 @@
+import http, { type IncomingMessage, type ServerResponse } from 'http';
+import { EventEmitter } from 'events';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createDefaultRemoteDaemonConfig, type RemoteDaemonConfig } from '../../../../shared/types/remoteDaemon';
+import type { PaneEventSink } from '../../core/eventSink';
+import { RemotePaneClient, RemotePaneClientController } from './remotePaneClient';
+
+interface TestRemoteServer {
+  baseUrl: string;
+  close(): Promise<void>;
+  emitDaemonEvent(payload: unknown): void;
+  getLastInvokeAuth(): string | undefined;
+  getLastInvokeBody(): string | undefined;
+}
+
+interface ConfigManagerStub extends EventEmitter {
+  getConfig(): { remoteDaemon: RemoteDaemonConfig };
+  setRemoteConfig(remoteDaemon: RemoteDaemonConfig): void;
+}
+
+const activeServers: TestRemoteServer[] = [];
+
+afterEach(async () => {
+  while (activeServers.length > 0) {
+    await activeServers.pop()?.close();
+  }
+});
+
+describe('RemotePaneClient', () => {
+  it('sends authenticated invoke requests to the remote daemon', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+
+    const client = new RemotePaneClient({
+      id: 'profile-1',
+      label: 'Mac mini',
+      baseUrl: server.baseUrl,
+      token: 'secret-token',
+      transport: 'http+sse',
+    });
+
+    await expect(client.invoke('sessions:get-all', ['session-1'])).resolves.toEqual({
+      channel: 'sessions:get-all',
+      args: ['session-1'],
+    });
+
+    expect(server.getLastInvokeAuth()).toBe('Bearer secret-token');
+    expect(server.getLastInvokeBody()).toBe(JSON.stringify({
+      channel: 'sessions:get-all',
+      args: ['session-1'],
+    }));
+  });
+
+  it('forwards remote daemon SSE events through the provided renderer sink', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+    const receivedEvents: Array<{ channel: string; args: unknown[] }> = [];
+
+    const eventSink: PaneEventSink = {
+      send(channel, ...args) {
+        receivedEvents.push({ channel, args });
+      },
+    };
+
+    const client = new RemotePaneClient({
+      id: 'profile-2',
+      label: 'Workstation',
+      baseUrl: server.baseUrl,
+      token: 'secret-token',
+      transport: 'http+sse',
+    }, { eventSink });
+
+    await client.connect();
+    server.emitDaemonEvent({
+      channel: 'session:created',
+      args: [{ id: 'session-1' }],
+      timestamp: new Date().toISOString(),
+    });
+
+    await waitFor(() => receivedEvents.length === 1);
+    expect(receivedEvents).toEqual([{
+      channel: 'session:created',
+      args: [{ id: 'session-1' }],
+    }]);
+
+    await client.disconnect();
+  });
+});
+
+describe('RemotePaneClientController', () => {
+  it('syncs into remote mode and suppresses local daemon renderer events', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+
+    const remoteConfig = createDefaultRemoteDaemonConfig();
+    remoteConfig.client = {
+      profiles: [{
+        id: 'profile-1',
+        label: 'Remote host',
+        baseUrl: server.baseUrl,
+        token: 'secret-token',
+        transport: 'http+sse',
+      }],
+      activeProfileId: 'profile-1',
+      mode: 'remote',
+    };
+    const configManager = createConfigManagerStub(remoteConfig);
+
+    const controller = new RemotePaneClientController();
+    controller.initialize({
+      configManager,
+      rendererEventSink: { send() {} },
+    });
+
+    await waitFor(() => controller.getConnectionState().status === 'connected');
+    expect(controller.getConnectionState()).toMatchObject({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'profile-1',
+    });
+    expect(controller.shouldForwardLocalRendererEvent('session:created')).toBe(false);
+    expect(controller.shouldForwardLocalRendererEvent('window:focus-changed')).toBe(true);
+  });
+});
+
+async function createTestRemoteServer(): Promise<TestRemoteServer> {
+  let streamResponse: ServerResponse | null = null;
+  let lastInvokeAuth: string | undefined;
+  let lastInvokeBody: string | undefined;
+
+  const server = http.createServer(async (request: IncomingMessage, response: ServerResponse) => {
+    if (request.url === '/invoke') {
+      lastInvokeAuth = request.headers.authorization;
+      lastInvokeBody = await readRequestBody(request);
+      const parsed = JSON.parse(lastInvokeBody) as { channel: string; args: unknown[] };
+      response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+      response.end(JSON.stringify({
+        ok: true,
+        result: parsed,
+      }));
+      return;
+    }
+
+    if (request.url === '/events') {
+      response.writeHead(200, {
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Content-Type': 'text/event-stream; charset=utf-8',
+      });
+      response.flushHeaders();
+      response.write('event: ready\n');
+      response.write(`data: ${JSON.stringify({ replay: 'none', resync: 'refetch-state-after-reconnect', timestamp: new Date().toISOString() })}\n\n`);
+      streamResponse = response;
+      request.on('close', () => {
+        if (streamResponse === response) {
+          streamResponse = null;
+        }
+      });
+      return;
+    }
+
+    response.writeHead(404);
+    response.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+    server.once('error', reject);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Test remote server failed to bind');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    emitDaemonEvent(payload: unknown) {
+      if (!streamResponse) {
+        throw new Error('Remote event stream is not connected');
+      }
+
+      streamResponse.write('event: daemon-event\n');
+      streamResponse.write(`data: ${JSON.stringify(payload)}\n\n`);
+    },
+    getLastInvokeAuth() {
+      return lastInvokeAuth;
+    },
+    getLastInvokeBody() {
+      return lastInvokeBody;
+    },
+    async close() {
+      if (streamResponse && !streamResponse.writableEnded) {
+        streamResponse.end();
+      }
+
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+function createConfigManagerStub(initialConfig: RemoteDaemonConfig): ConfigManagerStub {
+  class Stub extends EventEmitter implements ConfigManagerStub {
+    private remoteDaemon = initialConfig;
+
+    getConfig(): { remoteDaemon: RemoteDaemonConfig } {
+      return { remoteDaemon: this.remoteDaemon };
+    }
+
+    setRemoteConfig(remoteDaemon: RemoteDaemonConfig): void {
+      this.remoteDaemon = remoteDaemon;
+      this.emit('config-updated', { remoteDaemon });
+    }
+  }
+
+  return new Stub();
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error('Timed out waiting for test condition');
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -258,17 +258,60 @@ describe('RemotePaneClientController', () => {
     });
 
     await waitFor(() => controller.getConnectionState().status === 'connected');
+    await waitFor(() => {
+      return rendererEvents.filter((event) => event.channel === 'remote-daemon:resync-required').length === 1;
+    });
     server.closeEventStream();
 
     await waitFor(() => {
-      return rendererEvents.some((event) => event.channel === 'remote-daemon:resync-required');
+      return rendererEvents.filter((event) => event.channel === 'remote-daemon:resync-required').length === 2;
     }, 3_000);
 
-    expect(rendererEvents.filter((event) => event.channel === 'remote-daemon:resync-required')).toHaveLength(1);
+    expect(rendererEvents.filter((event) => event.channel === 'remote-daemon:resync-required')).toHaveLength(2);
     expect(controller.getConnectionState()).toMatchObject({
       mode: 'remote',
       status: 'connected',
       activeProfileId: 'profile-resync',
+    });
+  });
+
+  it('requests a renderer state resync on the first successful remote event stream connection', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+
+    const rendererEvents: Array<{ channel: string; args: unknown[] }> = [];
+    const remoteConfig = createDefaultRemoteDaemonConfig();
+    remoteConfig.client = {
+      profiles: [{
+        id: 'profile-initial-resync',
+        label: 'Remote host',
+        baseUrl: server.baseUrl,
+        token: 'secret-token',
+        transport: 'http+sse',
+      }],
+      activeProfileId: 'profile-initial-resync',
+      mode: 'remote',
+    };
+    const configManager = createConfigManagerStub(remoteConfig);
+
+    const controller = new RemotePaneClientController();
+    controller.initialize({
+      configManager,
+      rendererEventSink: {
+        send(channel, ...args) {
+          rendererEvents.push({ channel, args });
+        },
+      },
+    });
+
+    await waitFor(() => {
+      return rendererEvents.filter((event) => event.channel === 'remote-daemon:resync-required').length === 1;
+    });
+
+    expect(controller.getConnectionState()).toMatchObject({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'profile-initial-resync',
     });
   });
 

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -14,6 +14,7 @@ interface TestRemoteServer {
   getLastInvokeBody(): string | undefined;
   getLastInvokePath(): string | undefined;
   getLastEventsPath(): string | undefined;
+  setEmitReadyEvent(emitReadyEvent: boolean): void;
   setEventsReady(ready: boolean): void;
 }
 
@@ -148,6 +149,34 @@ describe('RemotePaneClient', () => {
       channel: 'session:updated',
       args: [{ id: 'session-1', status: 'running' }],
     }]);
+
+    await client.disconnect();
+  });
+
+  it('times out event streams that never emit the initial ready event', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+    server.setEmitReadyEvent(false);
+    const connectionStates: string[] = [];
+
+    const client = new RemotePaneClient({
+      id: 'profile-timeout',
+      label: 'Buffered proxy',
+      baseUrl: server.baseUrl,
+      token: 'secret-token',
+      transport: 'http+sse',
+    }, {
+      initialHandshakeTimeoutMs: 25,
+      onConnectionStateChange(status) {
+        connectionStates.push(status);
+      },
+    });
+
+    await expect(client.connect({ retryOnInitialFailure: false })).rejects.toThrow(
+      'Timed out waiting for remote daemon ready event after 25ms',
+    );
+    expect(connectionStates).toContain('connecting');
+    expect(connectionStates).toContain('error');
 
     await client.disconnect();
   });
@@ -366,6 +395,7 @@ async function createTestRemoteServer(host = '127.0.0.1', basePath = ''): Promis
   let lastInvokePath: string | undefined;
   let lastEventsPath: string | undefined;
   let eventsReady = true;
+  let emitReadyEvent = true;
   const normalizedBasePath = normalizeTestBasePath(basePath);
   const invokePath = `${normalizedBasePath}/invoke`;
   const eventsPath = `${normalizedBasePath}/events`;
@@ -402,9 +432,11 @@ async function createTestRemoteServer(host = '127.0.0.1', basePath = ''): Promis
         'Content-Type': 'text/event-stream; charset=utf-8',
       });
       response.flushHeaders();
-      response.write('event: ready\n');
-      response.write(`data: ${JSON.stringify({ replay: 'none', resync: 'refetch-state-after-reconnect', timestamp: new Date().toISOString() })}\n\n`);
       streamResponse = response;
+      if (emitReadyEvent) {
+        response.write('event: ready\n');
+        response.write(`data: ${JSON.stringify({ replay: 'none', resync: 'refetch-state-after-reconnect', timestamp: new Date().toISOString() })}\n\n`);
+      }
       request.on('close', () => {
         if (streamResponse === response) {
           streamResponse = null;
@@ -453,6 +485,9 @@ async function createTestRemoteServer(host = '127.0.0.1', basePath = ''): Promis
     },
     getLastEventsPath() {
       return lastEventsPath;
+    },
+    setEmitReadyEvent(nextEmitReadyEvent: boolean) {
+      emitReadyEvent = nextEmitReadyEvent;
     },
     setEventsReady(nextReady: boolean) {
       eventsReady = nextReady;

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -85,6 +85,26 @@ describe('RemotePaneClient', () => {
 
     await client.disconnect();
   });
+
+  it('supports IPv6 loopback connection profiles', async () => {
+    const server = await createTestRemoteServer('::1');
+    activeServers.push(server);
+
+    const client = new RemotePaneClient({
+      id: 'profile-ipv6',
+      label: 'IPv6 host',
+      baseUrl: server.baseUrl,
+      token: 'secret-token',
+      transport: 'http+sse',
+    });
+
+    await expect(client.invoke('sessions:get-all', ['session-1'])).resolves.toEqual({
+      channel: 'sessions:get-all',
+      args: ['session-1'],
+    });
+
+    expect(server.getLastInvokeAuth()).toBe('Bearer secret-token');
+  });
 });
 
 describe('RemotePaneClientController', () => {
@@ -123,7 +143,7 @@ describe('RemotePaneClientController', () => {
   });
 });
 
-async function createTestRemoteServer(): Promise<TestRemoteServer> {
+async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteServer> {
   let streamResponse: ServerResponse | null = null;
   let lastInvokeAuth: string | undefined;
   let lastInvokeBody: string | undefined;
@@ -164,7 +184,7 @@ async function createTestRemoteServer(): Promise<TestRemoteServer> {
   });
 
   await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => resolve());
+    server.listen(0, host, () => resolve());
     server.once('error', reject);
   });
 
@@ -174,7 +194,7 @@ async function createTestRemoteServer(): Promise<TestRemoteServer> {
   }
 
   return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
+    baseUrl: `http://${host.includes(':') ? `[${host}]` : host}:${address.port}`,
     emitDaemonEvent(payload: unknown) {
       if (!streamResponse) {
         throw new Error('Remote event stream is not connected');

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -11,6 +11,8 @@ interface TestRemoteServer {
   emitDaemonEvent(payload: unknown): void;
   getLastInvokeAuth(): string | undefined;
   getLastInvokeBody(): string | undefined;
+  getLastInvokePath(): string | undefined;
+  getLastEventsPath(): string | undefined;
   setEventsReady(ready: boolean): void;
 }
 
@@ -105,6 +107,48 @@ describe('RemotePaneClient', () => {
     });
 
     expect(server.getLastInvokeAuth()).toBe('Bearer secret-token');
+  });
+
+  it('preserves reverse-proxy base path prefixes for invoke and event routes', async () => {
+    const server = await createTestRemoteServer('127.0.0.1', '/pane');
+    activeServers.push(server);
+    const receivedEvents: Array<{ channel: string; args: unknown[] }> = [];
+
+    const client = new RemotePaneClient({
+      id: 'profile-subpath',
+      label: 'Reverse proxy',
+      baseUrl: server.baseUrl,
+      token: 'secret-token',
+      transport: 'http+sse',
+    }, {
+      eventSink: {
+        send(channel, ...args) {
+          receivedEvents.push({ channel, args });
+        },
+      },
+    });
+
+    await client.connect();
+    await expect(client.invoke('sessions:get-all', ['session-1'])).resolves.toEqual({
+      channel: 'sessions:get-all',
+      args: ['session-1'],
+    });
+
+    server.emitDaemonEvent({
+      channel: 'session:updated',
+      args: [{ id: 'session-1', status: 'running' }],
+      timestamp: new Date().toISOString(),
+    });
+
+    await waitFor(() => receivedEvents.length === 1);
+    expect(server.getLastInvokePath()).toBe('/pane/invoke');
+    expect(server.getLastEventsPath()).toBe('/pane/events');
+    expect(receivedEvents).toEqual([{
+      channel: 'session:updated',
+      args: [{ id: 'session-1', status: 'running' }],
+    }]);
+
+    await client.disconnect();
   });
 });
 
@@ -227,16 +271,22 @@ describe('RemotePaneClientController', () => {
   });
 });
 
-async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteServer> {
+async function createTestRemoteServer(host = '127.0.0.1', basePath = ''): Promise<TestRemoteServer> {
   let streamResponse: ServerResponse | null = null;
   let lastInvokeAuth: string | undefined;
   let lastInvokeBody: string | undefined;
+  let lastInvokePath: string | undefined;
+  let lastEventsPath: string | undefined;
   let eventsReady = true;
+  const normalizedBasePath = normalizeTestBasePath(basePath);
+  const invokePath = `${normalizedBasePath}/invoke`;
+  const eventsPath = `${normalizedBasePath}/events`;
 
   const server = http.createServer(async (request: IncomingMessage, response: ServerResponse) => {
-    if (request.url === '/invoke') {
+    if (request.url === invokePath) {
       lastInvokeAuth = request.headers.authorization;
       lastInvokeBody = await readRequestBody(request);
+      lastInvokePath = request.url;
       const parsed = JSON.parse(lastInvokeBody) as { channel: string; args: unknown[] };
       response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
       response.end(JSON.stringify({
@@ -246,7 +296,8 @@ async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteSer
       return;
     }
 
-    if (request.url === '/events') {
+    if (request.url === eventsPath) {
+      lastEventsPath = request.url;
       if (!eventsReady) {
         response.writeHead(503, { 'Content-Type': 'application/json; charset=utf-8' });
         response.end(JSON.stringify({
@@ -289,7 +340,7 @@ async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteSer
   }
 
   return {
-    baseUrl: `http://${host.includes(':') ? `[${host}]` : host}:${address.port}`,
+    baseUrl: `http://${host.includes(':') ? `[${host}]` : host}:${address.port}${normalizedBasePath}`,
     emitDaemonEvent(payload: unknown) {
       if (!streamResponse) {
         throw new Error('Remote event stream is not connected');
@@ -304,6 +355,12 @@ async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteSer
     getLastInvokeBody() {
       return lastInvokeBody;
     },
+    getLastInvokePath() {
+      return lastInvokePath;
+    },
+    getLastEventsPath() {
+      return lastEventsPath;
+    },
     setEventsReady(nextReady: boolean) {
       eventsReady = nextReady;
     },
@@ -317,6 +374,15 @@ async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteSer
       });
     },
   };
+}
+
+function normalizeTestBasePath(basePath: string): string {
+  if (basePath.length === 0 || basePath === '/') {
+    return '';
+  }
+
+  const withLeadingSlash = basePath.startsWith('/') ? basePath : `/${basePath}`;
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash.slice(0, -1) : withLeadingSlash;
 }
 
 function createConfigManagerStub(initialConfig: RemoteDaemonConfig): ConfigManagerStub {

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -11,6 +11,7 @@ interface TestRemoteServer {
   emitDaemonEvent(payload: unknown): void;
   getLastInvokeAuth(): string | undefined;
   getLastInvokeBody(): string | undefined;
+  setEventsReady(ready: boolean): void;
 }
 
 interface ConfigManagerStub extends EventEmitter {
@@ -141,12 +142,53 @@ describe('RemotePaneClientController', () => {
     expect(controller.shouldForwardLocalRendererEvent('session:created')).toBe(false);
     expect(controller.shouldForwardLocalRendererEvent('window:focus-changed')).toBe(true);
   });
+
+  it('keeps retrying after an initial remote connection failure', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+    server.setEventsReady(false);
+
+    const remoteConfig = createDefaultRemoteDaemonConfig();
+    remoteConfig.client = {
+      profiles: [{
+        id: 'profile-retry',
+        label: 'Remote host',
+        baseUrl: server.baseUrl,
+        token: 'secret-token',
+        transport: 'http+sse',
+      }],
+      activeProfileId: 'profile-retry',
+      mode: 'remote',
+    };
+    const configManager = createConfigManagerStub(remoteConfig);
+
+    const controller = new RemotePaneClientController();
+    controller.initialize({
+      configManager,
+      rendererEventSink: { send() {} },
+    });
+
+    await waitFor(() => {
+      const state = controller.getConnectionState();
+      return state.status === 'error' || state.status === 'reconnecting';
+    });
+
+    server.setEventsReady(true);
+
+    await waitFor(() => controller.getConnectionState().status === 'connected', 3_000);
+    expect(controller.getConnectionState()).toMatchObject({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'profile-retry',
+    });
+  });
 });
 
 async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteServer> {
   let streamResponse: ServerResponse | null = null;
   let lastInvokeAuth: string | undefined;
   let lastInvokeBody: string | undefined;
+  let eventsReady = true;
 
   const server = http.createServer(async (request: IncomingMessage, response: ServerResponse) => {
     if (request.url === '/invoke') {
@@ -162,6 +204,16 @@ async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteSer
     }
 
     if (request.url === '/events') {
+      if (!eventsReady) {
+        response.writeHead(503, { 'Content-Type': 'application/json; charset=utf-8' });
+        response.end(JSON.stringify({
+          error: {
+            message: 'Remote daemon not ready yet',
+          },
+        }));
+        return;
+      }
+
       response.writeHead(200, {
         'Cache-Control': 'no-cache',
         Connection: 'keep-alive',
@@ -208,6 +260,9 @@ async function createTestRemoteServer(host = '127.0.0.1'): Promise<TestRemoteSer
     },
     getLastInvokeBody() {
       return lastInvokeBody;
+    },
+    setEventsReady(nextReady: boolean) {
+      eventsReady = nextReady;
     },
     async close() {
       if (streamResponse && !streamResponse.writableEnded) {

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -8,6 +8,7 @@ import { RemotePaneClient, RemotePaneClientController } from './remotePaneClient
 interface TestRemoteServer {
   baseUrl: string;
   close(): Promise<void>;
+  closeEventStream(): void;
   emitDaemonEvent(payload: unknown): void;
   getLastInvokeAuth(): string | undefined;
   getLastInvokeBody(): string | undefined;
@@ -227,6 +228,50 @@ describe('RemotePaneClientController', () => {
     });
   });
 
+  it('requests a renderer state resync after reconnecting the remote event stream', async () => {
+    const server = await createTestRemoteServer();
+    activeServers.push(server);
+
+    const rendererEvents: Array<{ channel: string; args: unknown[] }> = [];
+    const remoteConfig = createDefaultRemoteDaemonConfig();
+    remoteConfig.client = {
+      profiles: [{
+        id: 'profile-resync',
+        label: 'Remote host',
+        baseUrl: server.baseUrl,
+        token: 'secret-token',
+        transport: 'http+sse',
+      }],
+      activeProfileId: 'profile-resync',
+      mode: 'remote',
+    };
+    const configManager = createConfigManagerStub(remoteConfig);
+
+    const controller = new RemotePaneClientController();
+    controller.initialize({
+      configManager,
+      rendererEventSink: {
+        send(channel, ...args) {
+          rendererEvents.push({ channel, args });
+        },
+      },
+    });
+
+    await waitFor(() => controller.getConnectionState().status === 'connected');
+    server.closeEventStream();
+
+    await waitFor(() => {
+      return rendererEvents.some((event) => event.channel === 'remote-daemon:resync-required');
+    }, 3_000);
+
+    expect(rendererEvents.filter((event) => event.channel === 'remote-daemon:resync-required')).toHaveLength(1);
+    expect(controller.getConnectionState()).toMatchObject({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'profile-resync',
+    });
+  });
+
   it('restores the saved local state when a manual activation fails', async () => {
     const server = await createTestRemoteServer();
     activeServers.push(server);
@@ -341,6 +386,11 @@ async function createTestRemoteServer(host = '127.0.0.1', basePath = ''): Promis
 
   return {
     baseUrl: `http://${host.includes(':') ? `[${host}]` : host}:${address.port}${normalizedBasePath}`,
+    closeEventStream() {
+      if (streamResponse && !streamResponse.destroyed) {
+        streamResponse.destroy();
+      }
+    },
     emitDaemonEvent(payload: unknown) {
       if (!streamResponse) {
         throw new Error('Remote event stream is not connected');

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -94,7 +94,7 @@ export class RemotePaneClient {
   }
 
   async invoke(channel: string, args: unknown[]): Promise<unknown> {
-    const endpoint = new URL('/invoke', this.normalizedBaseUrl);
+    const endpoint = buildRemoteEndpoint(this.normalizedBaseUrl, 'invoke');
     const response = await requestJson(endpoint, {
       method: 'POST',
       headers: {
@@ -119,7 +119,7 @@ export class RemotePaneClient {
     this.clearReconnectTimer();
     this.onConnectionStateChange?.(isReconnect ? 'reconnecting' : 'connecting', null);
 
-    const endpoint = new URL('/events', this.normalizedBaseUrl);
+    const endpoint = buildRemoteEndpoint(this.normalizedBaseUrl, 'events');
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
@@ -481,6 +481,10 @@ export const remotePaneClientController = new RemotePaneClientController();
 function normalizeBaseUrl(baseUrl: string): URL {
   const normalized = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
   return new URL(normalized);
+}
+
+function buildRemoteEndpoint(baseUrl: URL, path: 'invoke' | 'events'): URL {
+  return new URL(path, baseUrl);
 }
 
 function createRequest(

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -162,10 +162,7 @@ export class RemotePaneClient {
               readyReceived = true;
               this.onConnectionStateChange?.('connected', null);
               const readyPayload = parseRemoteReadyEventPayload(event.data);
-              if (
-                isReconnect &&
-                readyPayload?.resync === 'refetch-state-after-reconnect'
-              ) {
+              if (readyPayload?.resync === 'refetch-state-after-reconnect') {
                 this.onResyncRequired?.();
               }
               if (!settled) {

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -17,6 +17,7 @@ import { PaneSseParser } from './sseParser';
 interface RemotePaneClientOptions {
   eventSink?: PaneEventSink;
   onConnectionStateChange?: (status: RemotePaneConnectionStatus, errorMessage?: string | null) => void;
+  onResyncRequired?: () => void;
 }
 
 interface RemotePaneClientConnectOptions {
@@ -43,12 +44,19 @@ interface JsonResponse {
   body: string;
 }
 
+interface RemoteReadyEventPayload {
+  replay: 'none';
+  resync: 'refetch-state-after-reconnect';
+  timestamp: string;
+}
+
 const REMOTE_DAEMON_RECONNECT_DELAY_MS = 1_000;
 
 export class RemotePaneClient {
   private readonly normalizedBaseUrl: URL;
   private readonly eventSink: PaneEventSink;
   private readonly onConnectionStateChange?: (status: RemotePaneConnectionStatus, errorMessage?: string | null) => void;
+  private readonly onResyncRequired?: () => void;
   private eventParser = new PaneSseParser();
   private eventRequest: http.ClientRequest | null = null;
   private eventResponse: IncomingMessage | null = null;
@@ -62,6 +70,7 @@ export class RemotePaneClient {
     this.normalizedBaseUrl = normalizeBaseUrl(profile.baseUrl);
     this.eventSink = options.eventSink ?? noopPaneEventSink;
     this.onConnectionStateChange = options.onConnectionStateChange;
+    this.onResyncRequired = options.onResyncRequired;
   }
 
   isSameProfile(profile: RemotePaneConnectionProfile): boolean {
@@ -152,6 +161,13 @@ export class RemotePaneClient {
             if (event.event === 'ready') {
               readyReceived = true;
               this.onConnectionStateChange?.('connected', null);
+              const readyPayload = parseRemoteReadyEventPayload(event.data);
+              if (
+                isReconnect &&
+                readyPayload?.resync === 'refetch-state-after-reconnect'
+              ) {
+                this.onResyncRequired?.();
+              }
               if (!settled) {
                 settled = true;
                 resolve();
@@ -427,6 +443,9 @@ export class RemotePaneClientController extends EventEmitter {
           lastError: errorMessage ?? null,
         });
       },
+      onResyncRequired: () => {
+        this.rendererEventSink.send('remote-daemon:resync-required');
+      },
     });
 
     this.activeClient = client;
@@ -553,6 +572,27 @@ function extractRemoteErrorMessage(body: string): string | null {
   } catch {
     return body;
   }
+}
+
+function parseRemoteReadyEventPayload(data: string): RemoteReadyEventPayload | null {
+  if (data.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(data) as Partial<RemoteReadyEventPayload>;
+    if (
+      parsed.replay === 'none' &&
+      parsed.resync === 'refetch-state-after-reconnect' &&
+      typeof parsed.timestamp === 'string'
+    ) {
+      return parsed as RemoteReadyEventPayload;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 function isRemoteDaemonEventEnvelope(value: unknown): value is RemoteDaemonEventEnvelope {

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -16,6 +16,7 @@ import { PaneSseParser } from './sseParser';
 
 interface RemotePaneClientOptions {
   eventSink?: PaneEventSink;
+  initialHandshakeTimeoutMs?: number;
   onConnectionStateChange?: (status: RemotePaneConnectionStatus, errorMessage?: string | null) => void;
   onResyncRequired?: () => void;
 }
@@ -51,10 +52,12 @@ interface RemoteReadyEventPayload {
 }
 
 const REMOTE_DAEMON_RECONNECT_DELAY_MS = 1_000;
+const REMOTE_DAEMON_INITIAL_HANDSHAKE_TIMEOUT_MS = 10_000;
 
 export class RemotePaneClient {
   private readonly normalizedBaseUrl: URL;
   private readonly eventSink: PaneEventSink;
+  private readonly initialHandshakeTimeoutMs: number;
   private readonly onConnectionStateChange?: (status: RemotePaneConnectionStatus, errorMessage?: string | null) => void;
   private readonly onResyncRequired?: () => void;
   private eventParser = new PaneSseParser();
@@ -69,6 +72,8 @@ export class RemotePaneClient {
   ) {
     this.normalizedBaseUrl = normalizeBaseUrl(profile.baseUrl);
     this.eventSink = options.eventSink ?? noopPaneEventSink;
+    this.initialHandshakeTimeoutMs = options.initialHandshakeTimeoutMs
+      ?? REMOTE_DAEMON_INITIAL_HANDSHAKE_TIMEOUT_MS;
     this.onConnectionStateChange = options.onConnectionStateChange;
     this.onResyncRequired = options.onResyncRequired;
   }
@@ -133,7 +138,48 @@ export class RemotePaneClient {
     await new Promise<void>((resolve, reject) => {
       let settled = false;
       let readyReceived = false;
-      const request = createRequest(endpoint, {
+      let handshakeTimer: NodeJS.Timeout | null = null;
+      let request: http.ClientRequest | null = null;
+
+      const clearHandshakeTimer = (): void => {
+        if (handshakeTimer) {
+          clearTimeout(handshakeTimer);
+          handshakeTimer = null;
+        }
+      };
+
+      const rejectBeforeReady = (message: string, destroyStream = false): void => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearHandshakeTimer();
+        const activeResponse = this.eventResponse;
+        const activeRequest = this.eventRequest ?? request;
+        this.handleInitialConnectionFailure(message, retryOnInitialFailure);
+
+        if (destroyStream) {
+          if (activeResponse && !activeResponse.destroyed) {
+            activeResponse.destroy(new Error(message));
+          }
+
+          if (activeRequest && !activeRequest.destroyed) {
+            activeRequest.destroy(new Error(message));
+          }
+        }
+
+        reject(new Error(message));
+      };
+
+      handshakeTimer = setTimeout(() => {
+        rejectBeforeReady(
+          `Timed out waiting for remote daemon ready event after ${this.initialHandshakeTimeoutMs}ms`,
+          true,
+        );
+      }, this.initialHandshakeTimeoutMs);
+
+      request = createRequest(endpoint, {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${this.profile.token}`,
@@ -144,11 +190,7 @@ export class RemotePaneClient {
           const body = await readResponseBody(response);
           const message = extractRemoteErrorMessage(body)
             ?? `Remote daemon event stream failed with status ${response.statusCode ?? 'unknown'}`;
-          this.handleInitialConnectionFailure(message, retryOnInitialFailure);
-          if (!settled) {
-            settled = true;
-            reject(new Error(message));
-          }
+          rejectBeforeReady(message);
           return;
         }
 
@@ -160,6 +202,7 @@ export class RemotePaneClient {
           for (const event of events) {
             if (event.event === 'ready') {
               readyReceived = true;
+              clearHandshakeTimer();
               this.onConnectionStateChange?.('connected', null);
               const readyPayload = parseRemoteReadyEventPayload(event.data);
               if (readyPayload?.resync === 'refetch-state-after-reconnect') {
@@ -193,39 +236,30 @@ export class RemotePaneClient {
           const message = getErrorMessage(error, 'Remote daemon event stream errored');
           if (readyReceived) {
             this.handleUnexpectedDisconnect(message);
-          } else {
-            this.handleInitialConnectionFailure(message, retryOnInitialFailure);
+            return;
           }
-          if (!settled) {
-            settled = true;
-            reject(new Error(message));
-          }
+
+          rejectBeforeReady(message);
         });
 
         response.on('end', () => {
           const message = 'Remote daemon event stream ended';
           if (readyReceived) {
             this.handleUnexpectedDisconnect(message);
-          } else {
-            this.handleInitialConnectionFailure(message, retryOnInitialFailure);
+            return;
           }
-          if (!settled) {
-            settled = true;
-            reject(new Error(message));
-          }
+
+          rejectBeforeReady(message);
         });
 
         response.on('close', () => {
           const message = 'Remote daemon event stream closed';
           if (readyReceived) {
             this.handleUnexpectedDisconnect(message);
-          } else {
-            this.handleInitialConnectionFailure(message, retryOnInitialFailure);
+            return;
           }
-          if (!settled) {
-            settled = true;
-            reject(new Error(message));
-          }
+
+          rejectBeforeReady(message);
         });
       });
 
@@ -233,11 +267,7 @@ export class RemotePaneClient {
 
       request.on('error', (error) => {
         const message = getErrorMessage(error, 'Failed to connect to remote daemon event stream');
-        this.handleInitialConnectionFailure(message, retryOnInitialFailure);
-        if (!settled) {
-          settled = true;
-          reject(new Error(message));
-        }
+        rejectBeforeReady(message);
       });
 
       request.end();

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -19,6 +19,10 @@ interface RemotePaneClientOptions {
   onConnectionStateChange?: (status: RemotePaneConnectionStatus, errorMessage?: string | null) => void;
 }
 
+interface RemotePaneClientConnectOptions {
+  retryOnInitialFailure?: boolean;
+}
+
 interface RemoteInvokeSuccessPayload {
   ok: true;
   result?: unknown;
@@ -68,9 +72,9 @@ export class RemotePaneClient {
     );
   }
 
-  async connect(): Promise<void> {
+  async connect(options: RemotePaneClientConnectOptions = {}): Promise<void> {
     this.closedByClient = false;
-    await this.openEventStream(false);
+    await this.openEventStream(false, options.retryOnInitialFailure ?? true);
   }
 
   async disconnect(): Promise<void> {
@@ -111,7 +115,7 @@ export class RemotePaneClient {
     return payload.result;
   }
 
-  private async openEventStream(isReconnect: boolean): Promise<void> {
+  private async openEventStream(isReconnect: boolean, retryOnInitialFailure: boolean): Promise<void> {
     this.clearReconnectTimer();
     this.onConnectionStateChange?.(isReconnect ? 'reconnecting' : 'connecting', null);
 
@@ -119,6 +123,7 @@ export class RemotePaneClient {
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
+      let readyReceived = false;
       const request = createRequest(endpoint, {
         method: 'GET',
         headers: {
@@ -130,8 +135,7 @@ export class RemotePaneClient {
           const body = await readResponseBody(response);
           const message = extractRemoteErrorMessage(body)
             ?? `Remote daemon event stream failed with status ${response.statusCode ?? 'unknown'}`;
-          this.onConnectionStateChange?.('error', message);
-          this.scheduleReconnect(message);
+          this.handleInitialConnectionFailure(message, retryOnInitialFailure);
           if (!settled) {
             settled = true;
             reject(new Error(message));
@@ -146,6 +150,7 @@ export class RemotePaneClient {
           const events = this.eventParser.push(chunk);
           for (const event of events) {
             if (event.event === 'ready') {
+              readyReceived = true;
               this.onConnectionStateChange?.('connected', null);
               if (!settled) {
                 settled = true;
@@ -173,7 +178,11 @@ export class RemotePaneClient {
 
         response.on('error', (error) => {
           const message = getErrorMessage(error, 'Remote daemon event stream errored');
-          this.handleUnexpectedDisconnect(message);
+          if (readyReceived) {
+            this.handleUnexpectedDisconnect(message);
+          } else {
+            this.handleInitialConnectionFailure(message, retryOnInitialFailure);
+          }
           if (!settled) {
             settled = true;
             reject(new Error(message));
@@ -182,7 +191,11 @@ export class RemotePaneClient {
 
         response.on('end', () => {
           const message = 'Remote daemon event stream ended';
-          this.handleUnexpectedDisconnect(message);
+          if (readyReceived) {
+            this.handleUnexpectedDisconnect(message);
+          } else {
+            this.handleInitialConnectionFailure(message, retryOnInitialFailure);
+          }
           if (!settled) {
             settled = true;
             reject(new Error(message));
@@ -191,7 +204,11 @@ export class RemotePaneClient {
 
         response.on('close', () => {
           const message = 'Remote daemon event stream closed';
-          this.handleUnexpectedDisconnect(message);
+          if (readyReceived) {
+            this.handleUnexpectedDisconnect(message);
+          } else {
+            this.handleInitialConnectionFailure(message, retryOnInitialFailure);
+          }
           if (!settled) {
             settled = true;
             reject(new Error(message));
@@ -203,8 +220,7 @@ export class RemotePaneClient {
 
       request.on('error', (error) => {
         const message = getErrorMessage(error, 'Failed to connect to remote daemon event stream');
-        this.onConnectionStateChange?.('error', message);
-        this.scheduleReconnect(message);
+        this.handleInitialConnectionFailure(message, retryOnInitialFailure);
         if (!settled) {
           settled = true;
           reject(new Error(message));
@@ -213,6 +229,21 @@ export class RemotePaneClient {
 
       request.end();
     });
+  }
+
+  private handleInitialConnectionFailure(message: string, retryOnInitialFailure: boolean): void {
+    this.eventResponse = null;
+    this.eventRequest = null;
+    this.eventParser.reset();
+
+    if (this.closedByClient) {
+      return;
+    }
+
+    this.onConnectionStateChange?.('error', message);
+    if (retryOnInitialFailure) {
+      this.scheduleReconnect(message);
+    }
   }
 
   private handleUnexpectedDisconnect(message: string): void {
@@ -235,7 +266,7 @@ export class RemotePaneClient {
     this.onConnectionStateChange?.('reconnecting', message);
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
-      void this.openEventStream(true).catch((error) => {
+      void this.openEventStream(true, true).catch((error) => {
         const nextMessage = getErrorMessage(error, 'Failed to reconnect to remote daemon event stream');
         this.onConnectionStateChange?.('error', nextMessage);
         this.scheduleReconnect(nextMessage);
@@ -320,8 +351,15 @@ export class RemotePaneClientController extends EventEmitter {
   }
 
   async activateProfile(profile: RemotePaneConnectionProfile): Promise<RemotePaneConnectionState> {
-    await this.connectProfile(profile);
-    return this.getConnectionState();
+    try {
+      await this.connectProfile(profile, { retryOnInitialFailure: false });
+      return this.getConnectionState();
+    } catch (error) {
+      await this.syncToConfig().catch((syncError) => {
+        console.error('[Pane remote daemon] Failed to restore saved client state after activation error', syncError);
+      });
+      throw error;
+    }
   }
 
   async switchToLocalMode(): Promise<RemotePaneConnectionState> {
@@ -368,10 +406,13 @@ export class RemotePaneClientController extends EventEmitter {
       return;
     }
 
-    await this.connectProfile(activeProfile);
+    await this.connectProfile(activeProfile, { retryOnInitialFailure: true });
   }
 
-  private async connectProfile(profile: RemotePaneConnectionProfile): Promise<void> {
+  private async connectProfile(
+    profile: RemotePaneConnectionProfile,
+    options: RemotePaneClientConnectOptions,
+  ): Promise<void> {
     await this.disconnectActiveClient();
 
     const client = new RemotePaneClient(profile, {
@@ -390,7 +431,9 @@ export class RemotePaneClientController extends EventEmitter {
 
     this.activeClient = client;
     try {
-      await client.connect();
+      await client.connect({
+        retryOnInitialFailure: options.retryOnInitialFailure,
+      });
       this.setConnectionState({
         mode: 'remote',
         status: 'connected',
@@ -400,7 +443,10 @@ export class RemotePaneClientController extends EventEmitter {
         lastError: null,
       });
     } catch (error) {
-      if (this.activeClient !== client) {
+      if (!options.retryOnInitialFailure || this.activeClient !== client) {
+        if (this.activeClient === client) {
+          this.activeClient = null;
+        }
         await client.disconnect();
       }
       this.setConnectionState({

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -1,0 +1,528 @@
+import { EventEmitter } from 'events';
+import http, { type IncomingMessage, type RequestOptions } from 'http';
+import https from 'https';
+import { noopPaneEventSink, type PaneEventSink } from '../../core/eventSink';
+import type { ConfigManager } from '../../services/configManager';
+import { isPaneDaemonEventChannel } from '../server';
+import {
+  createDefaultRemotePaneConnectionState,
+  normalizeRemoteDaemonConfig,
+  type RemotePaneConnectionProfile,
+  type RemotePaneConnectionState,
+  type RemotePaneConnectionStatus,
+} from '../../../../shared/types/remoteDaemon';
+import type { RemoteDaemonEventEnvelope } from '../../../../shared/types/remoteDaemon';
+import { PaneSseParser } from './sseParser';
+
+interface RemotePaneClientOptions {
+  eventSink?: PaneEventSink;
+  onConnectionStateChange?: (status: RemotePaneConnectionStatus, errorMessage?: string | null) => void;
+}
+
+interface RemoteInvokeSuccessPayload {
+  ok: true;
+  result?: unknown;
+}
+
+interface RemoteInvokeErrorPayload {
+  ok: false;
+  error: {
+    message: string;
+    code?: string;
+  };
+}
+
+type RemoteInvokeResponsePayload = RemoteInvokeSuccessPayload | RemoteInvokeErrorPayload;
+
+interface JsonResponse {
+  statusCode: number;
+  body: string;
+}
+
+const REMOTE_DAEMON_RECONNECT_DELAY_MS = 1_000;
+
+export class RemotePaneClient {
+  private readonly normalizedBaseUrl: URL;
+  private readonly eventSink: PaneEventSink;
+  private readonly onConnectionStateChange?: (status: RemotePaneConnectionStatus, errorMessage?: string | null) => void;
+  private eventParser = new PaneSseParser();
+  private eventRequest: http.ClientRequest | null = null;
+  private eventResponse: IncomingMessage | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private closedByClient = false;
+
+  constructor(
+    readonly profile: RemotePaneConnectionProfile,
+    options: RemotePaneClientOptions = {},
+  ) {
+    this.normalizedBaseUrl = normalizeBaseUrl(profile.baseUrl);
+    this.eventSink = options.eventSink ?? noopPaneEventSink;
+    this.onConnectionStateChange = options.onConnectionStateChange;
+  }
+
+  isSameProfile(profile: RemotePaneConnectionProfile): boolean {
+    return (
+      this.profile.id === profile.id &&
+      this.profile.baseUrl === profile.baseUrl &&
+      this.profile.token === profile.token
+    );
+  }
+
+  async connect(): Promise<void> {
+    this.closedByClient = false;
+    await this.openEventStream(false);
+  }
+
+  async disconnect(): Promise<void> {
+    this.closedByClient = true;
+    this.clearReconnectTimer();
+    this.eventParser.reset();
+
+    if (this.eventResponse && !this.eventResponse.destroyed) {
+      this.eventResponse.destroy();
+    }
+    this.eventResponse = null;
+
+    if (this.eventRequest) {
+      this.eventRequest.destroy();
+    }
+    this.eventRequest = null;
+  }
+
+  async invoke(channel: string, args: unknown[]): Promise<unknown> {
+    const endpoint = new URL('/invoke', this.normalizedBaseUrl);
+    const response = await requestJson(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.profile.token}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+    }, JSON.stringify({ channel, args }));
+
+    const payload = parseJsonResponse<RemoteInvokeResponsePayload>(
+      response,
+      'Remote daemon returned an invalid invoke response',
+    );
+
+    if (!payload.ok) {
+      throw new Error(payload.error.message);
+    }
+
+    return payload.result;
+  }
+
+  private async openEventStream(isReconnect: boolean): Promise<void> {
+    this.clearReconnectTimer();
+    this.onConnectionStateChange?.(isReconnect ? 'reconnecting' : 'connecting', null);
+
+    const endpoint = new URL('/events', this.normalizedBaseUrl);
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const request = createRequest(endpoint, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.profile.token}`,
+          Accept: 'text/event-stream',
+        },
+      }, async (response) => {
+        if (response.statusCode !== 200) {
+          const body = await readResponseBody(response);
+          const message = extractRemoteErrorMessage(body)
+            ?? `Remote daemon event stream failed with status ${response.statusCode ?? 'unknown'}`;
+          this.onConnectionStateChange?.('error', message);
+          this.scheduleReconnect(message);
+          if (!settled) {
+            settled = true;
+            reject(new Error(message));
+          }
+          return;
+        }
+
+        this.eventResponse = response;
+        this.eventParser.reset();
+
+        response.on('data', (chunk: Buffer) => {
+          const events = this.eventParser.push(chunk);
+          for (const event of events) {
+            if (event.event === 'ready') {
+              this.onConnectionStateChange?.('connected', null);
+              if (!settled) {
+                settled = true;
+                resolve();
+              }
+              continue;
+            }
+
+            if (event.event !== 'daemon-event') {
+              continue;
+            }
+
+            try {
+              const envelope = JSON.parse(event.data) as RemoteDaemonEventEnvelope;
+              if (!isRemoteDaemonEventEnvelope(envelope) || !isPaneDaemonEventChannel(envelope.channel)) {
+                continue;
+              }
+
+              this.eventSink.send(envelope.channel, ...envelope.args);
+            } catch (error) {
+              console.error('[Pane remote daemon] Failed to parse daemon event payload', error);
+            }
+          }
+        });
+
+        response.on('error', (error) => {
+          const message = getErrorMessage(error, 'Remote daemon event stream errored');
+          this.handleUnexpectedDisconnect(message);
+          if (!settled) {
+            settled = true;
+            reject(new Error(message));
+          }
+        });
+
+        response.on('end', () => {
+          const message = 'Remote daemon event stream ended';
+          this.handleUnexpectedDisconnect(message);
+          if (!settled) {
+            settled = true;
+            reject(new Error(message));
+          }
+        });
+
+        response.on('close', () => {
+          const message = 'Remote daemon event stream closed';
+          this.handleUnexpectedDisconnect(message);
+          if (!settled) {
+            settled = true;
+            reject(new Error(message));
+          }
+        });
+      });
+
+      this.eventRequest = request;
+
+      request.on('error', (error) => {
+        const message = getErrorMessage(error, 'Failed to connect to remote daemon event stream');
+        this.onConnectionStateChange?.('error', message);
+        this.scheduleReconnect(message);
+        if (!settled) {
+          settled = true;
+          reject(new Error(message));
+        }
+      });
+
+      request.end();
+    });
+  }
+
+  private handleUnexpectedDisconnect(message: string): void {
+    this.eventResponse = null;
+    this.eventRequest = null;
+    this.eventParser.reset();
+
+    if (this.closedByClient) {
+      return;
+    }
+
+    this.scheduleReconnect(message);
+  }
+
+  private scheduleReconnect(message: string): void {
+    if (this.closedByClient || this.reconnectTimer) {
+      return;
+    }
+
+    this.onConnectionStateChange?.('reconnecting', message);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.openEventStream(true).catch((error) => {
+        const nextMessage = getErrorMessage(error, 'Failed to reconnect to remote daemon event stream');
+        this.onConnectionStateChange?.('error', nextMessage);
+        this.scheduleReconnect(nextMessage);
+      });
+    }, REMOTE_DAEMON_RECONNECT_DELAY_MS);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}
+
+interface RemotePaneClientControllerOptions {
+  configManager: ConfigManager;
+  rendererEventSink: PaneEventSink;
+}
+
+export class RemotePaneClientController extends EventEmitter {
+  private configManager: ConfigManager | null = null;
+  private rendererEventSink: PaneEventSink = noopPaneEventSink;
+  private activeClient: RemotePaneClient | null = null;
+  private state = createDefaultRemotePaneConnectionState();
+  private configListenerAttached = false;
+
+  private readonly configUpdatedListener = () => {
+    void this.syncToConfig().catch((error) => {
+      this.setConnectionState({
+        ...this.state,
+        mode: 'remote',
+        status: 'error',
+        lastError: getErrorMessage(error, 'Failed to sync remote daemon client state'),
+      });
+    });
+  };
+
+  initialize(options: RemotePaneClientControllerOptions): void {
+    if (this.configManager && this.configListenerAttached) {
+      this.configManager.off('config-updated', this.configUpdatedListener);
+      this.configListenerAttached = false;
+    }
+
+    this.configManager = options.configManager;
+    this.rendererEventSink = options.rendererEventSink;
+    this.configManager.on('config-updated', this.configUpdatedListener);
+    this.configListenerAttached = true;
+
+    void this.syncToConfig().catch((error) => {
+      this.setConnectionState({
+        ...this.state,
+        mode: 'remote',
+        status: 'error',
+        lastError: getErrorMessage(error, 'Failed to initialize remote daemon client'),
+      });
+    });
+  }
+
+  getConnectionState(): RemotePaneConnectionState {
+    return { ...this.state };
+  }
+
+  isRemoteModeActive(): boolean {
+    return this.state.mode === 'remote';
+  }
+
+  shouldForwardLocalRendererEvent(channel: string): boolean {
+    return !this.isRemoteModeActive() || !isPaneDaemonEventChannel(channel);
+  }
+
+  async invoke(channel: string, args: unknown[], invokeLocal: () => Promise<unknown>): Promise<unknown> {
+    if (!this.isRemoteModeActive()) {
+      return invokeLocal();
+    }
+
+    if (!this.activeClient) {
+      throw new Error(this.state.lastError ?? 'Remote Pane client is not connected');
+    }
+
+    return this.activeClient.invoke(channel, args);
+  }
+
+  async activateProfile(profile: RemotePaneConnectionProfile): Promise<RemotePaneConnectionState> {
+    await this.connectProfile(profile);
+    return this.getConnectionState();
+  }
+
+  async switchToLocalMode(): Promise<RemotePaneConnectionState> {
+    await this.disconnectActiveClient();
+    this.setConnectionState(createDefaultRemotePaneConnectionState());
+    return this.getConnectionState();
+  }
+
+  async syncToConfig(): Promise<void> {
+    if (!this.configManager) {
+      return;
+    }
+
+    const remoteConfig = normalizeRemoteDaemonConfig(this.configManager.getConfig().remoteDaemon);
+    const activeProfileId = remoteConfig.client.activeProfileId;
+    if (remoteConfig.client.mode !== 'remote' || !activeProfileId) {
+      await this.disconnectActiveClient();
+      this.setConnectionState(createDefaultRemotePaneConnectionState());
+      return;
+    }
+
+    const activeProfile = remoteConfig.client.profiles.find((profile) => profile.id === activeProfileId);
+    if (!activeProfile) {
+      await this.disconnectActiveClient();
+      this.setConnectionState({
+        mode: 'remote',
+        status: 'error',
+        activeProfileId,
+        activeProfileLabel: null,
+        activeBaseUrl: null,
+        lastError: `Remote daemon connection profile "${activeProfileId}" does not exist`,
+      });
+      return;
+    }
+
+    if (this.activeClient?.isSameProfile(activeProfile)) {
+      this.setConnectionState({
+        ...this.state,
+        mode: 'remote',
+        activeProfileId: activeProfile.id,
+        activeProfileLabel: activeProfile.label,
+        activeBaseUrl: activeProfile.baseUrl,
+      });
+      return;
+    }
+
+    await this.connectProfile(activeProfile);
+  }
+
+  private async connectProfile(profile: RemotePaneConnectionProfile): Promise<void> {
+    await this.disconnectActiveClient();
+
+    const client = new RemotePaneClient(profile, {
+      eventSink: this.rendererEventSink,
+      onConnectionStateChange: (status, errorMessage) => {
+        this.setConnectionState({
+          mode: 'remote',
+          status,
+          activeProfileId: profile.id,
+          activeProfileLabel: profile.label,
+          activeBaseUrl: profile.baseUrl,
+          lastError: errorMessage ?? null,
+        });
+      },
+    });
+
+    this.activeClient = client;
+    try {
+      await client.connect();
+      this.setConnectionState({
+        mode: 'remote',
+        status: 'connected',
+        activeProfileId: profile.id,
+        activeProfileLabel: profile.label,
+        activeBaseUrl: profile.baseUrl,
+        lastError: null,
+      });
+    } catch (error) {
+      this.activeClient = null;
+      await client.disconnect();
+      this.setConnectionState({
+        mode: 'remote',
+        status: 'error',
+        activeProfileId: profile.id,
+        activeProfileLabel: profile.label,
+        activeBaseUrl: profile.baseUrl,
+        lastError: getErrorMessage(error, `Failed to connect to remote daemon profile "${profile.label}"`),
+      });
+      throw error;
+    }
+  }
+
+  private async disconnectActiveClient(): Promise<void> {
+    const client = this.activeClient;
+    this.activeClient = null;
+    if (client) {
+      await client.disconnect();
+    }
+  }
+
+  private setConnectionState(nextState: RemotePaneConnectionState): void {
+    this.state = nextState;
+    this.emit('state-changed', this.getConnectionState());
+    this.rendererEventSink.send('remote-daemon:connection-state-changed', this.getConnectionState());
+  }
+}
+
+export const remotePaneClientController = new RemotePaneClientController();
+
+function normalizeBaseUrl(baseUrl: string): URL {
+  const normalized = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL(normalized);
+}
+
+function createRequest(
+  url: URL,
+  options: RequestOptions,
+  onResponse: (response: IncomingMessage) => void,
+): http.ClientRequest {
+  const transport = url.protocol === 'https:' ? https : http;
+  return transport.request({
+    ...options,
+    protocol: url.protocol,
+    hostname: url.hostname,
+    port: url.port ? Number(url.port) : undefined,
+    path: `${url.pathname}${url.search}`,
+  }, onResponse);
+}
+
+async function requestJson(
+  url: URL,
+  options: RequestOptions,
+  body: string,
+): Promise<JsonResponse> {
+  return await new Promise<JsonResponse>((resolve, reject) => {
+    const request = createRequest(url, {
+      ...options,
+      headers: {
+        ...(options.headers ?? {}),
+        'Content-Length': Buffer.byteLength(body),
+      },
+    }, (response) => {
+      void readResponseBody(response).then((responseBody) => {
+        resolve({
+          statusCode: response.statusCode ?? 500,
+          body: responseBody,
+        });
+      }).catch(reject);
+    });
+
+    request.on('error', reject);
+    request.write(body);
+    request.end();
+  });
+}
+
+async function readResponseBody(response: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of response) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function parseJsonResponse<T>(response: JsonResponse, fallbackMessage: string): T {
+  try {
+    return JSON.parse(response.body) as T;
+  } catch (error) {
+    throw new Error(
+      `${fallbackMessage}: ${getErrorMessage(error, 'Unknown JSON parse failure')}`,
+    );
+  }
+}
+
+function extractRemoteErrorMessage(body: string): string | null {
+  if (body.trim().length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(body) as Partial<RemoteInvokeErrorPayload>;
+    return parsed.error?.message ?? null;
+  } catch {
+    return body;
+  }
+}
+
+function isRemoteDaemonEventEnvelope(value: unknown): value is RemoteDaemonEventEnvelope {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Partial<RemoteDaemonEventEnvelope>;
+  return (
+    typeof candidate.channel === 'string' &&
+    Array.isArray(candidate.args) &&
+    typeof candidate.timestamp === 'string'
+  );
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -400,8 +400,9 @@ export class RemotePaneClientController extends EventEmitter {
         lastError: null,
       });
     } catch (error) {
-      this.activeClient = null;
-      await client.disconnect();
+      if (this.activeClient !== client) {
+        await client.disconnect();
+      }
       this.setConnectionState({
         mode: 'remote',
         status: 'error',

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -442,13 +442,7 @@ function createRequest(
   onResponse: (response: IncomingMessage) => void,
 ): http.ClientRequest {
   const transport = url.protocol === 'https:' ? https : http;
-  return transport.request({
-    ...options,
-    protocol: url.protocol,
-    hostname: url.hostname,
-    port: url.port ? Number(url.port) : undefined,
-    path: `${url.pathname}${url.search}`,
-  }, onResponse);
+  return transport.request(url, options, onResponse);
 }
 
 async function requestJson(

--- a/main/src/daemon/client/sseParser.test.ts
+++ b/main/src/daemon/client/sseParser.test.ts
@@ -30,6 +30,19 @@ describe('PaneSseParser', () => {
     }]);
   });
 
+  it('preserves UTF-8 characters split across buffer boundaries', () => {
+    const parser = new PaneSseParser();
+    const message = 'hello 🙂';
+    const encoded = Buffer.from(`event: ready\ndata: ${message}\n\n`, 'utf8');
+    const splitIndex = encoded.indexOf(Buffer.from('🙂')) + 2;
+
+    expect(parser.push(encoded.subarray(0, splitIndex))).toEqual([]);
+    expect(parser.push(encoded.subarray(splitIndex))).toEqual([{
+      event: 'ready',
+      data: message,
+    }]);
+  });
+
   it('ignores comments and blank events', () => {
     const parser = new PaneSseParser();
 

--- a/main/src/daemon/client/sseParser.test.ts
+++ b/main/src/daemon/client/sseParser.test.ts
@@ -43,6 +43,16 @@ describe('PaneSseParser', () => {
     }]);
   });
 
+  it('preserves CRLF line endings split across chunk boundaries', () => {
+    const parser = new PaneSseParser();
+
+    expect(parser.push('event: daemon-event\r')).toEqual([]);
+    expect(parser.push('\ndata: {"channel":"session:updated"}\r\n\r\n')).toEqual([{
+      event: 'daemon-event',
+      data: '{"channel":"session:updated"}',
+    }]);
+  });
+
   it('ignores comments and blank events', () => {
     const parser = new PaneSseParser();
 

--- a/main/src/daemon/client/sseParser.test.ts
+++ b/main/src/daemon/client/sseParser.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { PaneSseParser } from './sseParser';
+
+describe('PaneSseParser', () => {
+  it('parses named SSE events with JSON payloads', () => {
+    const parser = new PaneSseParser();
+
+    expect(parser.push('event: daemon-event\ndata: {"channel":"session:created"}\n\n')).toEqual([{
+      event: 'daemon-event',
+      data: '{"channel":"session:created"}',
+    }]);
+  });
+
+  it('joins multiline data fields with newlines', () => {
+    const parser = new PaneSseParser();
+
+    expect(parser.push('event: ready\ndata: line one\ndata: line two\n\n')).toEqual([{
+      event: 'ready',
+      data: 'line one\nline two',
+    }]);
+  });
+
+  it('buffers partial chunks until an event boundary arrives', () => {
+    const parser = new PaneSseParser();
+
+    expect(parser.push('event: daemon-event\ndata: {"channel"')).toEqual([]);
+    expect(parser.push(':"session:updated"}\n\n')).toEqual([{
+      event: 'daemon-event',
+      data: '{"channel":"session:updated"}',
+    }]);
+  });
+
+  it('ignores comments and blank events', () => {
+    const parser = new PaneSseParser();
+
+    expect(parser.push(': keep-alive\n\n')).toEqual([]);
+    expect(parser.push('event: ready\n\n')).toEqual([]);
+  });
+});

--- a/main/src/daemon/client/sseParser.ts
+++ b/main/src/daemon/client/sseParser.ts
@@ -1,3 +1,5 @@
+import { StringDecoder } from 'string_decoder';
+
 export interface ParsedSseEvent {
   event: string;
   data: string;
@@ -5,9 +7,10 @@ export interface ParsedSseEvent {
 
 export class PaneSseParser {
   private buffer = '';
+  private decoder = new StringDecoder('utf8');
 
   push(chunk: Buffer | string): ParsedSseEvent[] {
-    this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    this.buffer += typeof chunk === 'string' ? chunk : this.decoder.write(chunk);
     this.buffer = this.buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
     const events: ParsedSseEvent[] = [];
@@ -29,6 +32,7 @@ export class PaneSseParser {
 
   reset(): void {
     this.buffer = '';
+    this.decoder = new StringDecoder('utf8');
   }
 }
 

--- a/main/src/daemon/client/sseParser.ts
+++ b/main/src/daemon/client/sseParser.ts
@@ -8,10 +8,21 @@ export interface ParsedSseEvent {
 export class PaneSseParser {
   private buffer = '';
   private decoder = new StringDecoder('utf8');
+  private pendingCarriageReturn = false;
 
   push(chunk: Buffer | string): ParsedSseEvent[] {
-    this.buffer += typeof chunk === 'string' ? chunk : this.decoder.write(chunk);
-    this.buffer = this.buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    let decodedChunk = typeof chunk === 'string' ? chunk : this.decoder.write(chunk);
+    if (this.pendingCarriageReturn) {
+      decodedChunk = `\r${decodedChunk}`;
+      this.pendingCarriageReturn = false;
+    }
+
+    if (decodedChunk.endsWith('\r')) {
+      decodedChunk = decodedChunk.slice(0, -1);
+      this.pendingCarriageReturn = true;
+    }
+
+    this.buffer += decodedChunk.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
     const events: ParsedSseEvent[] = [];
     let boundaryIndex = this.buffer.indexOf('\n\n');
@@ -33,6 +44,7 @@ export class PaneSseParser {
   reset(): void {
     this.buffer = '';
     this.decoder = new StringDecoder('utf8');
+    this.pendingCarriageReturn = false;
   }
 }
 

--- a/main/src/daemon/client/sseParser.ts
+++ b/main/src/daemon/client/sseParser.ts
@@ -1,0 +1,70 @@
+export interface ParsedSseEvent {
+  event: string;
+  data: string;
+}
+
+export class PaneSseParser {
+  private buffer = '';
+
+  push(chunk: Buffer | string): ParsedSseEvent[] {
+    this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    this.buffer = this.buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+    const events: ParsedSseEvent[] = [];
+    let boundaryIndex = this.buffer.indexOf('\n\n');
+    while (boundaryIndex !== -1) {
+      const rawEvent = this.buffer.slice(0, boundaryIndex);
+      this.buffer = this.buffer.slice(boundaryIndex + 2);
+
+      const parsedEvent = parseSseEvent(rawEvent);
+      if (parsedEvent) {
+        events.push(parsedEvent);
+      }
+
+      boundaryIndex = this.buffer.indexOf('\n\n');
+    }
+
+    return events;
+  }
+
+  reset(): void {
+    this.buffer = '';
+  }
+}
+
+function parseSseEvent(rawEvent: string): ParsedSseEvent | null {
+  const lines = rawEvent.split('\n');
+  let eventName = 'message';
+  const dataLines: string[] = [];
+
+  for (const line of lines) {
+    if (line.length === 0 || line.startsWith(':')) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(':');
+    const field = separatorIndex === -1 ? line : line.slice(0, separatorIndex);
+    let value = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1);
+    if (value.startsWith(' ')) {
+      value = value.slice(1);
+    }
+
+    if (field === 'event') {
+      eventName = value || 'message';
+      continue;
+    }
+
+    if (field === 'data') {
+      dataLines.push(value);
+    }
+  }
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+
+  return {
+    event: eventName,
+    data: dataLines.join('\n'),
+  };
+}

--- a/main/src/daemon/httpApiServer.test.ts
+++ b/main/src/daemon/httpApiServer.test.ts
@@ -101,7 +101,7 @@ async function requestJson(
   });
 }
 
-async function openEventStream(server: PaneRemoteHttpApiServer, token: string): Promise<TestEventStream> {
+async function openEventStream(server: PaneRemoteHttpApiServer, token?: string): Promise<TestEventStream> {
   const address = server.getAddress();
   if (!address) {
     throw new Error('Remote HTTP API server is not listening');
@@ -113,9 +113,9 @@ async function openEventStream(server: PaneRemoteHttpApiServer, token: string): 
       port: address.port,
       path: '/events',
       method: 'GET',
-      headers: {
+      headers: token ? {
         Authorization: `Bearer ${token}`,
-      },
+      } : undefined,
     });
 
     activeRequests.add(request);
@@ -240,6 +240,35 @@ describe('PaneRemoteHttpApiServer', () => {
         },
       },
     });
+  });
+
+  it('allows unauthenticated remote requests when pairing is disabled', async () => {
+    const registry = new PaneCommandRegistry();
+    registry.register('sessions:get-all', async () => [{ id: 'session-1' }]);
+
+    const server = new PaneRemoteHttpApiServer(
+      registry,
+      createConfigManagerStub(createEnabledRemoteConfig({ pairingRequired: false })) as never,
+    );
+    activeServers.push(server);
+    await server.start();
+
+    await expect(requestJson(server, 'POST', '/invoke', {
+      channel: 'sessions:get-all',
+      args: [],
+    })).resolves.toEqual({
+      statusCode: 200,
+      body: {
+        ok: true,
+        result: [{ id: 'session-1' }],
+      },
+    });
+
+    const stream = await openEventStream(server);
+    const readyEvent = await stream.nextEvent();
+    expect(readyEvent.event).toBe('ready');
+
+    stream.close();
   });
 
   it('rejects oversized invoke request bodies with a client error', async () => {

--- a/main/src/daemon/httpApiServer.ts
+++ b/main/src/daemon/httpApiServer.ts
@@ -20,8 +20,8 @@ interface RemoteHttpAddress {
 interface ConnectedRemoteEventClient {
   id: string;
   response: ServerResponse;
-  remoteClientId: string;
-  remoteClientTokenHash: string;
+  remoteClientId: string | null;
+  remoteClientTokenHash: string | null;
 }
 
 interface RemoteInvokeSuccessPayload {
@@ -42,6 +42,23 @@ interface RemoteReadyEventPayload {
   resync: 'refetch-state-after-reconnect';
   timestamp: string;
 }
+
+type RemoteRequestAuthResult =
+  | {
+    ok: true;
+    client: {
+      id: string;
+      tokenHash: string;
+    } | null;
+  }
+  | {
+    ok: false;
+    statusCode: number;
+    error: {
+      message: string;
+      code: string;
+    };
+  };
 
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 
@@ -292,8 +309,8 @@ export class PaneRemoteHttpApiServer {
     this.eventClients.set(clientConnectionId, {
       id: clientConnectionId,
       response,
-      remoteClientId: auth.client.id,
-      remoteClientTokenHash: auth.client.tokenHash,
+      remoteClientId: auth.client?.id ?? null,
+      remoteClientTokenHash: auth.client?.tokenHash ?? null,
     });
 
     const cleanup = () => {
@@ -304,7 +321,7 @@ export class PaneRemoteHttpApiServer {
     response.on('close', cleanup);
   }
 
-  private authenticateRequest(request: IncomingMessage) {
+  private authenticateRequest(request: IncomingMessage): RemoteRequestAuthResult {
     const remoteConfig = this.getRemoteConfig();
     if (!remoteConfig.host.config.enabled) {
       return {
@@ -314,6 +331,13 @@ export class PaneRemoteHttpApiServer {
           message: 'Remote daemon HTTP API is disabled',
           code: 'ERR_REMOTE_DAEMON_HTTP_DISABLED',
         },
+      };
+    }
+
+    if (!remoteConfig.host.config.pairingRequired) {
+      return {
+        ok: true,
+        client: null,
       };
     }
 
@@ -377,9 +401,17 @@ export class PaneRemoteHttpApiServer {
     }));
   }
 
-  private shouldKeepEventClient(remoteClientId: string, remoteClientTokenHash: string): boolean {
+  private shouldKeepEventClient(remoteClientId: string | null, remoteClientTokenHash: string | null): boolean {
     const remoteConfig = this.getRemoteConfig();
     if (!remoteConfig.host.config.enabled) {
+      return false;
+    }
+
+    if (!remoteConfig.host.config.pairingRequired) {
+      return true;
+    }
+
+    if (!remoteClientId || !remoteClientTokenHash) {
       return false;
     }
 

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -46,6 +46,7 @@ import { TerminalPanelState } from '../../shared/types/panels';
 import { worktreePoolManager } from './services/worktreePoolManager';
 import { PtyHostSupervisor } from './ptyHost/ptyHostSupervisor';
 import { createPaneDaemonHost, type PaneDaemonHost } from './daemon/bootstrap';
+import { remotePaneClientController } from './daemon/client/remotePaneClient';
 
 export let mainWindow: BrowserWindow | null = null;
 
@@ -895,6 +896,10 @@ async function createWindow() {
 async function initializeServices() {
   const electronPaneEventSink = {
     send(channel: string, ...args: unknown[]) {
+      if (!remotePaneClientController.shouldForwardLocalRendererEvent(channel)) {
+        return;
+      }
+
       const window = mainWindow;
       if (!window || window.isDestroyed()) {
         return;

--- a/main/src/ipc/daemon.test.ts
+++ b/main/src/ipc/daemon.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PaneCommandRegistry } from '../daemon/commandRegistry';
-import { registerDaemonBridgeHandlers } from './daemon';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
+import { createDaemonBridgeRouter, registerDaemonBridgeHandlers } from './daemon';
 
 interface IpcMainStub {
   handlers: Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>;
@@ -19,13 +20,17 @@ function createIpcMainStub(): IpcMainStub {
 }
 
 describe('daemon IPC bridge', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('forwards daemon-owned channels into the shared command registry', async () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();
     const handler = vi.fn(async (sessionId: string) => ({ success: true, data: sessionId }));
 
     registry.register('sessions:get', handler);
-    registerDaemonBridgeHandlers(ipcMain, registry);
+    registerDaemonBridgeHandlers(ipcMain, createDaemonBridgeRouter(registry));
 
     const bridge = ipcMain.handlers.get('daemon:invoke');
     expect(bridge).toBeDefined();
@@ -41,7 +46,7 @@ describe('daemon IPC bridge', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();
 
-    registerDaemonBridgeHandlers(ipcMain, registry);
+    registerDaemonBridgeHandlers(ipcMain, createDaemonBridgeRouter(registry));
 
     const bridge = ipcMain.handlers.get('daemon:invoke');
     await expect(bridge?.({}, 'sessions:open-ide', 'session-1')).rejects.toThrow(
@@ -53,9 +58,26 @@ describe('daemon IPC bridge', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();
 
-    registerDaemonBridgeHandlers(ipcMain, registry);
+    registerDaemonBridgeHandlers(ipcMain, createDaemonBridgeRouter(registry));
 
     const bridge = ipcMain.handlers.get('daemon:invoke');
     await expect(bridge?.({}, 123)).rejects.toThrow('Pane daemon bridge requires a string channel');
+  });
+
+  it('routes daemon-owned invokes through the remote client controller when remote mode is active', async () => {
+    const registry = new PaneCommandRegistry();
+    const ipcMain = createIpcMainStub();
+
+    vi.spyOn(remotePaneClientController, 'invoke').mockResolvedValue({ source: 'remote' });
+    vi.spyOn(remotePaneClientController, 'isRemoteModeActive').mockReturnValue(true);
+    registerDaemonBridgeHandlers(ipcMain, createDaemonBridgeRouter(registry));
+
+    const bridge = ipcMain.handlers.get('daemon:invoke');
+    await expect(bridge?.({}, 'sessions:get', 'session-9')).resolves.toEqual({ source: 'remote' });
+    expect(remotePaneClientController.invoke).toHaveBeenCalledWith(
+      'sessions:get',
+      ['session-9'],
+      expect.any(Function),
+    );
   });
 });

--- a/main/src/ipc/daemon.ts
+++ b/main/src/ipc/daemon.ts
@@ -1,13 +1,26 @@
 import { isDaemonOwnedChannel } from '../daemon/daemonChannels';
 import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 
 interface IpcMainHandleLike {
   handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
 }
 
+interface PaneDaemonBridgeRouter {
+  invoke(channel: string, args: unknown[]): Promise<unknown>;
+}
+
+export function createDaemonBridgeRouter(commandRegistry: PaneCommandRegistry): PaneDaemonBridgeRouter {
+  return {
+    async invoke(channel: string, args: unknown[]): Promise<unknown> {
+      return remotePaneClientController.invoke(channel, args, () => commandRegistry.invoke(channel, args));
+    },
+  };
+}
+
 export function registerDaemonBridgeHandlers(
   ipcMain: IpcMainHandleLike,
-  commandRegistry: PaneCommandRegistry,
+  bridgeRouter: PaneDaemonBridgeRouter,
 ): void {
   ipcMain.handle('daemon:invoke', async (_event, channel: unknown, ...args: unknown[]) => {
     if (typeof channel !== 'string') {
@@ -18,6 +31,6 @@ export function registerDaemonBridgeHandlers(
       throw new Error(`Channel "${channel}" is not daemon-owned`);
     }
 
-    return commandRegistry.invoke(channel, args);
+    return bridgeRouter.invoke(channel, args);
   });
 }

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import { registerFileHandlers } from './file';
 import { registerGitHandlers } from './git';
 import { registerPanelHandlers } from './panels';
@@ -211,21 +212,25 @@ const GIT_CHANNELS = [
 
 interface IpcMainStub {
   boundChannels: string[];
+  listeners: Map<string, (_event: unknown, ...args: unknown[]) => unknown>;
   handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => unknown): void;
 }
 
 function createIpcMainStub(): IpcMainStub {
   const boundChannels: string[] = [];
+  const listeners = new Map<string, (_event: unknown, ...args: unknown[]) => unknown>();
 
   return {
     boundChannels,
-    handle(channel: string) {
+    listeners,
+    handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => unknown) {
       boundChannels.push(channel);
+      listeners.set(channel, listener);
     },
   };
 }
 
-function createServicesStub(): AppServices {
+function createServicesStub(overrides: Partial<AppServices> = {}): AppServices {
   return {
     sessionManager: {},
     gitStatusManager: {},
@@ -241,6 +246,7 @@ function createServicesStub(): AppServices {
     archiveProgressManager: {},
     spotlightManager: {},
     runCommandManager: {},
+    ...overrides,
   } as AppServices;
 }
 
@@ -320,13 +326,32 @@ describe('daemon registry IPC bindings', () => {
     expect(registry.has('sessions:open-ide')).toBe(false);
   });
 
-  it('keeps active-session polling hints outside the daemon registry surface', () => {
+  it('routes active-session polling hints through the remote daemon bridge when active', async () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();
+    const setActiveSession = vi.fn();
+    const remoteInvoke = vi
+      .spyOn(remotePaneClientController, 'invoke')
+      .mockImplementation((_channel, _args, invokeLocal) => invokeLocal());
 
-    registerSessionHandlers(ipcMain, createServicesStub(), registry);
+    registerSessionHandlers(
+      ipcMain,
+      createServicesStub({ gitStatusManager: { setActiveSession } } as Partial<AppServices>),
+      registry,
+    );
 
-    expect(registry.listChannels()).toEqual([...SESSION_CHANNELS].sort());
+    const listener = ipcMain.listeners.get('sessions:set-active-session');
+    expect(listener).toBeDefined();
+    await listener?.({}, 'session-1');
+
+    expect(remoteInvoke).toHaveBeenCalledWith(
+      'sessions:set-active-session',
+      ['session-1'],
+      expect.any(Function),
+    );
+    expect(setActiveSession).toHaveBeenCalledWith('session-1');
+
+    expect(registry.listChannels()).toEqual([...SESSION_CHANNELS, 'sessions:set-active-session'].sort());
     expect(ipcMain.boundChannels).toContain('sessions:set-active-session');
     expect(ipcMain.boundChannels).toContain('debug:get-table-structure');
     expect(ipcMain.boundChannels).toContain('archive:get-progress');
@@ -338,7 +363,7 @@ describe('daemon registry IPC bindings', () => {
           channel !== 'archive:get-progress',
       ).sort(),
     ).toEqual([...SESSION_CHANNELS].sort());
-    expect(registry.has('sessions:set-active-session')).toBe(false);
+    expect(registry.has('sessions:set-active-session')).toBe(true);
   });
 
   it('routes all daemon-owned git handlers through the shared registry', () => {

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -23,13 +23,29 @@ import { registerRemoteDaemonHandlers } from './remoteDaemon';
 import { registerClipboardHandlers } from './clipboard';
 import { registerResourceMonitorHandlers } from './resourceMonitor';
 import { registerOnboardingHandlers } from './onboarding';
-import { registerDaemonBridgeHandlers } from './daemon';
+import { createDaemonBridgeRouter, registerDaemonBridgeHandlers } from './daemon';
 import { registerPermissionHandlers } from './permissions';
 import { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 
 
 export function registerIpcHandlers(services: AppServices): PaneCommandRegistry {
   const commandRegistry = new PaneCommandRegistry();
+  const rendererEventSink = {
+    send(channel: string, ...args: unknown[]) {
+      const window = services.getMainWindow();
+      if (!window || window.isDestroyed()) {
+        return;
+      }
+
+      window.webContents.send(channel, ...args);
+    },
+  };
+  remotePaneClientController.initialize({
+    configManager: services.configManager,
+    rendererEventSink,
+  });
+  const bridgeRouter = createDaemonBridgeRouter(commandRegistry);
 
   registerAppHandlers(ipcMain, services);
   registerUpdaterHandlers(ipcMain, services);
@@ -55,7 +71,7 @@ export function registerIpcHandlers(services: AppServices): PaneCommandRegistry 
   registerClipboardHandlers(ipcMain, services);
   registerResourceMonitorHandlers(ipcMain, services, commandRegistry);
   registerOnboardingHandlers(ipcMain, services);
-  registerDaemonBridgeHandlers(ipcMain, commandRegistry);
+  registerDaemonBridgeHandlers(ipcMain, bridgeRouter);
 
   return commandRegistry;
 } 

--- a/main/src/ipc/remoteDaemon.test.ts
+++ b/main/src/ipc/remoteDaemon.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createDefaultRemoteDaemonConfig, type RemoteDaemonConfig } from '../../../shared/types/remoteDaemon';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import { registerRemoteDaemonHandlers } from './remoteDaemon';
 
 interface IpcMainStub {
@@ -38,6 +39,10 @@ function createConfigManagerStub(initialConfig?: RemoteDaemonConfig): ConfigMana
 }
 
 describe('remote daemon IPC', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('returns normalized remote daemon defaults when config is missing', async () => {
     const ipcMain = createIpcMainStub();
     const configManager = createConfigManagerStub();
@@ -59,6 +64,14 @@ describe('remote daemon IPC', () => {
     const upsertProfile = ipcMain.handlers.get('remote-daemon:upsert-connection-profile');
     const updateClientState = ipcMain.handlers.get('remote-daemon:update-client-state');
     const getConfig = ipcMain.handlers.get('remote-daemon:get-config');
+    vi.spyOn(remotePaneClientController, 'activateProfile').mockResolvedValue({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'profile-1',
+      activeProfileLabel: 'Mac mini',
+      activeBaseUrl: 'http://127.0.0.1:42137',
+      lastError: null,
+    });
 
     await expect(upsertProfile?.({}, {
       id: 'profile-1',
@@ -117,6 +130,33 @@ describe('remote daemon IPC', () => {
     });
   });
 
+  it('returns the current remote daemon connection state', async () => {
+    const ipcMain = createIpcMainStub();
+    const configManager = createConfigManagerStub();
+    vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+
+    registerRemoteDaemonHandlers(ipcMain, { configManager });
+
+    await expect(ipcMain.handlers.get('remote-daemon:get-connection-state')?.({})).resolves.toEqual({
+      success: true,
+      data: {
+        mode: 'local',
+        status: 'local',
+        activeProfileId: null,
+        activeProfileLabel: null,
+        activeBaseUrl: null,
+        lastError: null,
+      },
+    });
+  });
+
   it('falls back to local mode when deleting the active connection profile', async () => {
     const initialConfig = createDefaultRemoteDaemonConfig();
     initialConfig.client = {
@@ -133,6 +173,14 @@ describe('remote daemon IPC', () => {
 
     const ipcMain = createIpcMainStub();
     const configManager = createConfigManagerStub(initialConfig);
+    vi.spyOn(remotePaneClientController, 'switchToLocalMode').mockResolvedValue({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
 
     registerRemoteDaemonHandlers(ipcMain, { configManager });
 
@@ -146,6 +194,25 @@ describe('remote daemon IPC', () => {
         mode: 'local',
       },
     });
+  });
+
+  it('creates a paired host client record and saved connection profile together', async () => {
+    const ipcMain = createIpcMainStub();
+    const configManager = createConfigManagerStub();
+
+    registerRemoteDaemonHandlers(ipcMain, { configManager });
+
+    const createPair = ipcMain.handlers.get('remote-daemon:create-connection-pair');
+    const response = await createPair?.({}, {
+      label: 'Office Mac mini',
+      baseUrl: 'http://127.0.0.1:42137',
+    });
+
+    expect(response?.success).toBe(true);
+    expect(response?.data?.client.label).toBe('Office Mac mini');
+    expect(response?.data?.profile.label).toBe('Office Mac mini');
+    expect(response?.data?.profile.baseUrl).toBe('http://127.0.0.1:42137');
+    expect(response?.data?.token).toMatch(/^[0-9a-f]{48}$/);
   });
 
   it('normalizes stale remote mode back to local when no active profile remains', async () => {

--- a/main/src/ipc/remoteDaemon.test.ts
+++ b/main/src/ipc/remoteDaemon.test.ts
@@ -254,6 +254,56 @@ describe('remote daemon IPC', () => {
     });
   });
 
+  it('keeps the saved client mode local when remote activation fails', async () => {
+    const ipcMain = createIpcMainStub();
+    const configManager = createConfigManagerStub();
+
+    registerRemoteDaemonHandlers(ipcMain, { configManager });
+
+    const upsertProfile = ipcMain.handlers.get('remote-daemon:upsert-connection-profile');
+    const updateClientState = ipcMain.handlers.get('remote-daemon:update-client-state');
+    const getConfig = ipcMain.handlers.get('remote-daemon:get-config');
+
+    vi.spyOn(remotePaneClientController, 'activateProfile').mockRejectedValue(new Error('Remote daemon not ready yet'));
+
+    await upsertProfile?.({}, {
+      id: 'profile-1',
+      label: 'Mac mini',
+      baseUrl: 'http://127.0.0.1:42137',
+      token: 'secret-token',
+      transport: 'http+sse',
+    });
+
+    await expect(updateClientState?.({}, {
+      activeProfileId: 'profile-1',
+      mode: 'remote',
+    })).resolves.toEqual({
+      success: false,
+      error: 'Remote daemon not ready yet',
+    });
+
+    await expect(getConfig?.({})).resolves.toEqual({
+      success: true,
+      data: {
+        host: {
+          config: createDefaultRemoteDaemonConfig().host.config,
+          clients: [],
+        },
+        client: {
+          profiles: [{
+            id: 'profile-1',
+            label: 'Mac mini',
+            baseUrl: 'http://127.0.0.1:42137',
+            token: 'secret-token',
+            transport: 'http+sse',
+          }],
+          activeProfileId: null,
+          mode: 'local',
+        },
+      },
+    });
+  });
+
   it('rejects enabling direct HTTP on a non-loopback listen host', async () => {
     const ipcMain = createIpcMainStub();
     const configManager = createConfigManagerStub();

--- a/main/src/ipc/remoteDaemon.ts
+++ b/main/src/ipc/remoteDaemon.ts
@@ -3,11 +3,15 @@ import {
   isRemoteDaemonClientRecord,
   isRemotePaneConnectionProfile,
   normalizeRemoteDaemonConfig,
+  type RemoteDaemonConnectionPair,
   type RemoteDaemonClientMode,
   type RemoteDaemonClientSettings,
   type RemoteDaemonConfig,
 } from '../../../shared/types/remoteDaemon';
 import type { AppServices } from './types';
+import { createRemoteDaemonToken, hashRemoteDaemonToken } from '../daemon/auth';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
+import { randomUUID } from 'crypto';
 
 interface IpcMainHandleLike {
   handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
@@ -22,6 +26,76 @@ export function registerRemoteDaemonHandlers(
       return { success: true, data: getRemoteDaemonConfig(configManager.getConfig().remoteDaemon) };
     } catch (error) {
       return { success: false, error: getErrorMessage(error, 'Failed to get remote daemon config') };
+    }
+  });
+
+  ipcMain.handle('remote-daemon:get-connection-state', async () => {
+    try {
+      return { success: true, data: remotePaneClientController.getConnectionState() };
+    } catch (error) {
+      return { success: false, error: getErrorMessage(error, 'Failed to get remote daemon connection state') };
+    }
+  });
+
+  ipcMain.handle('remote-daemon:create-connection-pair', async (_event, input: unknown) => {
+    try {
+      if (!isRecord(input)) {
+        throw new Error('Remote daemon connection pair request must be an object');
+      }
+
+      const label = typeof input.label === 'string' ? input.label.trim() : '';
+      const baseUrl = typeof input.baseUrl === 'string' ? input.baseUrl.trim() : '';
+      if (label.length === 0) {
+        throw new Error('Remote daemon connection pair label is required');
+      }
+      if (baseUrl.length === 0) {
+        throw new Error('Remote daemon connection pair base URL is required');
+      }
+
+      const token = createRemoteDaemonToken();
+      const id = randomUUID();
+      const client = {
+        id,
+        label,
+        createdAt: new Date().toISOString(),
+        tokenHash: hashRemoteDaemonToken(token),
+      };
+      const profile = {
+        id,
+        label,
+        baseUrl,
+        token,
+        transport: 'http+sse' as const,
+      };
+
+      if (!isRemotePaneConnectionProfile(profile)) {
+        throw new Error('Generated remote daemon connection profile is invalid');
+      }
+
+      const current = getRemoteDaemonConfig(configManager.getConfig().remoteDaemon);
+      const next = normalizeRemoteDaemonConfig({
+        ...current,
+        host: {
+          ...current.host,
+          clients: upsertById(current.host.clients, client),
+        },
+        client: {
+          ...current.client,
+          profiles: upsertById(current.client.profiles, profile),
+        },
+      });
+
+      await configManager.updateConfig({ remoteDaemon: next });
+      return {
+        success: true,
+        data: {
+          client,
+          profile,
+          token,
+        } satisfies RemoteDaemonConnectionPair,
+      };
+    } catch (error) {
+      return { success: false, error: getErrorMessage(error, 'Failed to create remote daemon connection pair') };
     }
   });
 
@@ -144,6 +218,10 @@ export function registerRemoteDaemonHandlers(
         },
       });
 
+      if (current.client.mode === 'remote' && current.client.activeProfileId === profileId) {
+        await remotePaneClientController.switchToLocalMode();
+      }
+
       await configManager.updateConfig({ remoteDaemon: next });
       return { success: true, data: next.client };
     } catch (error) {
@@ -166,6 +244,17 @@ export function registerRemoteDaemonHandlers(
           ...nextState,
         },
       });
+
+      if (next.client.mode === 'remote') {
+        const activeProfile = next.client.profiles.find((profile) => profile.id === next.client.activeProfileId);
+        if (!activeProfile) {
+          throw new Error(`Remote daemon connection profile "${next.client.activeProfileId}" does not exist`);
+        }
+
+        await remotePaneClientController.activateProfile(activeProfile);
+      } else {
+        await remotePaneClientController.switchToLocalMode();
+      }
 
       await configManager.updateConfig({ remoteDaemon: next });
       return { success: true, data: next.client };

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -16,6 +16,7 @@ import { convertDbFolderToRendererFolder } from '../services/folderEvents';
 import { sessionImageCounters } from './panels';
 import { panelManager } from '../services/panelManager';
 import { terminalPanelManager } from '../services/terminalPanelManager';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import {
   validateSessionExists,
   validatePanelSessionOwnership,
@@ -57,6 +58,8 @@ const DAEMON_SESSION_CHANNELS = [
   'sessions:resume-interrupted',
   'sessions:dismiss-interrupted',
 ] as const;
+
+const ACTIVE_SESSION_HINT_CHANNEL = 'sessions:set-active-session';
 
 const DAEMON_SESSION_PANEL_CHANNELS = [
   'panels:get-output',
@@ -1599,9 +1602,7 @@ export function registerSessionHandlers(
     }
   });
 
-  // Set active session for smart git status polling.
-  // This is a client-local visibility hint, not shared runtime state.
-  ipcMain.handle('sessions:set-active-session', async (_event, sessionId: string | null) => {
+  commandRegistry.register(ACTIVE_SESSION_HINT_CHANNEL, async (sessionId: string | null) => {
     try {
       // Notify GitStatusManager about the active session change
       gitStatusManager.setActiveSession(sessionId);
@@ -1610,6 +1611,16 @@ export function registerSessionHandlers(
       console.error('Failed to set active session:', error);
       return { success: false, error: 'Failed to set active session' };
     }
+  });
+
+  // Set active session for smart git status polling. In remote mode the daemon
+  // needs this same visibility hint so it can prioritize the visible session.
+  ipcMain.handle(ACTIVE_SESSION_HINT_CHANNEL, async (_event, sessionId: string | null) => {
+    return remotePaneClientController.invoke(
+      ACTIVE_SESSION_HINT_CHANNEL,
+      [sessionId],
+      () => commandRegistry.invoke(ACTIVE_SESSION_HINT_CHANNEL, [sessionId]),
+    );
   });
 
   // Resume session handlers

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -4,9 +4,11 @@ import type { AppConfig, UpdateConfigRequest } from './types/config';
 import type { CreateProjectRequest, UpdateProjectRequest, Project } from '../../frontend/src/types/project';
 import type {
   RemoteDaemonClientRecord,
+  RemoteDaemonConnectionPair,
   RemoteDaemonClientSettings,
   RemoteDaemonConfig,
   RemoteDaemonHostConfig,
+  RemotePaneConnectionState,
   RemotePaneConnectionProfile,
 } from '../../shared/types/remoteDaemon';
 import type { ToolPanel } from '../../shared/types/panels';
@@ -594,6 +596,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   remoteDaemon: {
     getConfig: (): Promise<IPCResponse<RemoteDaemonConfig>> => invokeIpc('remote-daemon:get-config'),
+    getConnectionState: (): Promise<IPCResponse<RemotePaneConnectionState>> => invokeIpc('remote-daemon:get-connection-state'),
+    createConnectionPair: (input: { label: string; baseUrl: string }): Promise<IPCResponse<RemoteDaemonConnectionPair>> =>
+      invokeIpc('remote-daemon:create-connection-pair', input),
     updateHostConfig: (updates: Partial<RemoteDaemonHostConfig>): Promise<IPCResponse<RemoteDaemonHostConfig>> =>
       invokeIpc('remote-daemon:update-host-config', updates),
     upsertClientRecord: (record: RemoteDaemonClientRecord): Promise<IPCResponse<RemoteDaemonClientRecord[]>> =>
@@ -606,6 +611,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       invokeIpc('remote-daemon:delete-connection-profile', profileId),
     updateClientState: (updates: Partial<Pick<RemoteDaemonClientSettings, 'activeProfileId' | 'mode'>>): Promise<IPCResponse<RemoteDaemonClientSettings>> =>
       invokeIpc('remote-daemon:update-client-state', updates),
+    onConnectionStateChanged: (callback: (state: RemotePaneConnectionState) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, state: RemotePaneConnectionState) => callback(state);
+      ipcRenderer.on('remote-daemon:connection-state-changed', wrappedCallback);
+      return () => ipcRenderer.removeListener('remote-daemon:connection-state-changed', wrappedCallback);
+    },
   },
 
   // Prompts

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -933,6 +933,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('window:focus-changed', wrappedCallback);
       return () => ipcRenderer.removeListener('window:focus-changed', wrappedCallback);
     },
+    onRemoteDaemonResyncRequested: (callback: () => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent) => callback();
+      ipcRenderer.on('remote-daemon:resync-required', wrappedCallback);
+      return () => ipcRenderer.removeListener('remote-daemon:resync-required', wrappedCallback);
+    },
   },
 
   // Panels API for Claude panels and other panel types

--- a/shared/types/daemon.ts
+++ b/shared/types/daemon.ts
@@ -111,7 +111,6 @@ export const DAEMON_OWNED_EXACT_CHANNELS = [
 export const ELECTRON_ADAPTER_ONLY_CHANNELS = [
   'file:showInFolder',
   'sessions:open-ide',
-  'sessions:set-active-session',
   'terminal:clipboard-paste-image',
 ] as const;
 

--- a/shared/types/remoteDaemon.ts
+++ b/shared/types/remoteDaemon.ts
@@ -1,5 +1,6 @@
 export type RemoteDaemonTransport = 'http+sse';
 export type RemoteDaemonClientMode = 'local' | 'remote';
+export type RemotePaneConnectionStatus = 'local' | 'connecting' | 'connected' | 'reconnecting' | 'error';
 
 export interface RemoteDaemonHostConfig {
   enabled: boolean;
@@ -39,6 +40,21 @@ export interface RemoteDaemonClientSettings {
 export interface RemoteDaemonConfig {
   host: RemoteDaemonHostSettings;
   client: RemoteDaemonClientSettings;
+}
+
+export interface RemoteDaemonConnectionPair {
+  client: RemoteDaemonClientRecord;
+  profile: RemotePaneConnectionProfile;
+  token: string;
+}
+
+export interface RemotePaneConnectionState {
+  mode: RemoteDaemonClientMode;
+  status: RemotePaneConnectionStatus;
+  activeProfileId: string | null;
+  activeProfileLabel: string | null;
+  activeBaseUrl: string | null;
+  lastError: string | null;
 }
 
 export interface RemoteInvokeRequest {
@@ -92,6 +108,17 @@ export function createDefaultRemoteDaemonConfig(): RemoteDaemonConfig {
       activeProfileId: null,
       mode: 'local',
     },
+  };
+}
+
+export function createDefaultRemotePaneConnectionState(): RemotePaneConnectionState {
+  return {
+    mode: 'local',
+    status: 'local',
+    activeProfileId: null,
+    activeProfileLabel: null,
+    activeBaseUrl: null,
+    lastError: null,
   };
 }
 


### PR DESCRIPTION
## Summary
- add a main-process remote Pane client controller plus SSE parser so Electron can invoke daemon-owned channels against a remote self-hosted daemon
- route the existing `daemon:invoke` bridge through the remote client when a remote profile is active while keeping the preload/renderer API shape stable
- add remote client settings/pairing UI and explicitly gate local-only actions like open-in-IDE, reveal-in-file-manager, and native clipboard image fallback while in remote mode

## Testing
- `pnpm typecheck`
- `pnpm lint` (warning-only repo baseline)
- `CI=1 pnpm --filter main exec vitest run`
- `PANE_DIR=/tmp/pane-phase3-remote-client-smoke-3 xvfb-run -a pnpm test:ci`

## Stacking
- Base branch: `phase3-daemon-permission-broker`
- Phase: Task 5 of `tmp/ready-plans/2026-05-14-self-hosted-remote-daemon.md`