### PR TITLE
test: harden self-hosted remote validation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,10 +34,13 @@ jobs:
     - name: Run linting
       run: pnpm lint
 
+    - name: Run main process test suite
+      run: CI=1 pnpm --filter main exec vitest run
+
     - name: Install Playwright browser dependencies
       run: pnpm exec playwright install --with-deps chromium
 
-    - name: Run minimal functional smoke tests
+    - name: Run maintained functional smoke tests
       run: xvfb-run -a pnpm test:ci:minimal
       env:
         PANE_DIR: ${{ runner.temp }}/pane-ci

--- a/docs/SELF_HOSTED_REMOTE_DAEMON.md
+++ b/docs/SELF_HOSTED_REMOTE_DAEMON.md
@@ -1,0 +1,199 @@
+# Self-Hosted Remote Daemon
+
+This guide covers the current Phase 3 self-hosted workflow for running Pane on a user-managed machine and connecting to it from another Pane desktop client.
+
+## What This Supports Today
+
+- A headless Pane daemon host started with `pnpm daemon:headless`
+- Daemon-owned commands and events over the remote HTTP/SSE transport
+- Electron as the first remote client through the existing preload/renderer API
+- Remote permission approval through the daemon-owned permission broker
+
+This is intentionally not a hosted Pane Cloud workflow. It is for your own workstation, Mac mini, Linux box, or self-managed VM.
+
+## Current Constraints
+
+- The remote daemon listener only supports loopback hosts today: `127.0.0.1`, `::1`, or `localhost`
+- Direct public or LAN binding is intentionally rejected
+- Expose the daemon through a user-managed path such as:
+  - SSH local port forwarding
+  - Tailscale Serve / a trusted reverse proxy that forwards to loopback
+  - Another secure tunnel that terminates on the host and proxies to `127.0.0.1:<port>`
+- Local-only desktop actions stay local-only in remote mode:
+  - `Open in IDE`
+  - `Show in file manager`
+  - native clipboard image fallback from the client machine
+
+## Prerequisites
+
+- Node `>=22.14.0`
+- `pnpm >= 8`
+- Pane dependencies installed with `pnpm install`
+- A dedicated Pane data directory for the remote host, for example `~/.pane_remote`
+
+## 1. Choose the Host Data Directory
+
+Pick a host-side Pane directory and keep using it for both host configuration and the headless daemon.
+
+Example:
+
+```bash
+export PANE_DIR="$HOME/.pane_remote"
+mkdir -p "$PANE_DIR"
+```
+
+Pane stores the config and database under that directory. The headless daemon reads the same config file that the desktop app writes.
+
+## 2. Configure the Remote Listener
+
+Today the easiest way to configure the listener is from the Pane desktop app on the host machine, pointed at the same `PANE_DIR`.
+
+Example launch:
+
+```bash
+PANE_DIR="$HOME/.pane_remote" pnpm dev
+```
+
+In `Settings > Self-Hosted Remote Daemon`:
+
+1. Enable `Enable remote daemon listener`
+2. Keep `Listen Host` on `127.0.0.1`
+3. Keep or change `Listen Port` as needed, default `42137`
+4. Leave `Require pairing / saved bearer tokens` enabled
+5. Leave `Allow direct HTTP on loopback` enabled
+6. Save host settings
+
+This writes the listener config into `config.json` under your chosen `PANE_DIR`.
+
+## 3. Create a Paired Connection
+
+From the same settings section, create a paired connection:
+
+1. Enter a label such as `Office Mac mini`
+2. Enter the base URL the client will use after tunneling, for example `http://127.0.0.1:42137`
+3. Click `Create Paired Profile`
+
+Pane will:
+
+- add a host-side allowed client record
+- add a matching saved client profile
+- show the generated bearer token once
+
+Treat that token like a secret.
+
+## 4. Start the Headless Daemon Host
+
+Start the daemon against the same `PANE_DIR`:
+
+```bash
+PANE_DIR="$HOME/.pane_remote" pnpm daemon:headless
+```
+
+On success you should see a log line like:
+
+```text
+[Pane daemon] Headless host ready on tcp:127.0.0.1:42137
+```
+
+The local same-machine daemon socket will also be available for the desktop app on that host when relevant.
+
+## 5. Expose the Loopback Listener Securely
+
+### Option A: SSH tunnel
+
+From the client machine:
+
+```bash
+ssh -N -L 42137:127.0.0.1:42137 user@your-host
+```
+
+Then use `http://127.0.0.1:42137` as the remote base URL in the client Pane app.
+
+### Option B: Reverse proxy to loopback
+
+Put a trusted reverse proxy on the host machine and forward traffic to `127.0.0.1:42137`.
+
+Keep TLS and access control at the proxy layer. The current Pane daemon itself is not intended to be exposed directly on a public interface.
+
+### Option C: Tailscale Serve or equivalent
+
+Use a tunnel/proxy product that can reach the loopback listener on the host machine and expose it only to trusted devices.
+
+## 6. Connect the Desktop Client
+
+On the client machine, open Pane and go to `Settings > Self-Hosted Remote Daemon`.
+
+If you already created the paired profile on that machine, click `Connect`.
+
+If not, create or save a matching profile with:
+
+- the same base URL the tunnel exposes locally on the client machine
+- the token generated when the host-side pair was created
+
+When connected successfully, the client mode should show:
+
+- `Remote mode`
+- `Status: connected via <profile label>`
+
+## 7. Validate the Remote Flow
+
+Recommended checks after connecting:
+
+1. Verify projects and sessions load in the client
+2. Open a terminal-backed session and confirm output streaming works
+3. Send terminal input and verify the remote runtime receives it
+4. Resize a terminal and confirm the remote terminal resizes
+5. Open a file and confirm read/write works
+6. Check git status and commit/diff flows
+7. Run an `approve`-mode command and confirm the permission dialog appears on the client
+
+## Permission Behavior
+
+`approve` mode remains supported remotely.
+
+The remote daemon owns pending permission state, and the desktop client receives:
+
+- `permission:request`
+- `permission:resolved`
+
+Approving or denying on the client unblocks the remote daemon process.
+
+## Reconnect / Disconnect Notes
+
+- The Electron remote client will attempt to reconnect if the SSE event stream drops
+- Returning to `Use Local Runtime` switches the client back to local mode without deleting the saved remote profile
+- Deleting the active remote profile forces the client back to local mode
+
+## Troubleshooting
+
+### The headless daemon starts but remote connect fails
+
+Check:
+
+- the headless daemon is using the same `PANE_DIR` as the config you edited
+- the tunnel/proxy is forwarding to the same loopback port as the host config
+- the client profile base URL matches the client-side tunnel endpoint
+- the bearer token matches the host-side paired client record
+
+### I changed host settings but nothing happened
+
+The headless daemon watches the config and will start or stop the remote transport based on the saved host config. If behavior still looks stale, restart the daemon once and verify the correct `PANE_DIR` is in use.
+
+### Why can’t I bind to `0.0.0.0` or a LAN IP?
+
+That is intentionally blocked in the current implementation. The present security model assumes loopback plus a user-managed secure exposure layer.
+
+### Why are some actions disabled in remote mode?
+
+Some actions operate on the local desktop client machine rather than the remote workspace. Pane currently disables or keeps local-only behavior for:
+
+- opening a local IDE from the client
+- revealing files in the client OS file manager
+- the native clipboard-image fallback path
+
+## Current Limitations
+
+- No hosted relay, NAT traversal, or account-based multi-tenant auth
+- No web/mobile client in this phase
+- No direct non-loopback listener support
+- Validation is strong on the main-process seams and maintained smoke suite, but it is not yet a full live remote end-to-end harness

--- a/docs/SELF_HOSTED_REMOTE_DAEMON.md
+++ b/docs/SELF_HOSTED_REMOTE_DAEMON.md
@@ -67,7 +67,7 @@ This writes the listener config into `config.json` under your chosen `PANE_DIR`.
 
 ## 3. Create a Paired Connection
 
-From the same settings section, create a paired connection:
+From the same settings section on the host machine, create a paired connection:
 
 1. Enter a label such as `Office Mac mini`
 2. Enter the base URL the client will use after tunneling, for example `http://127.0.0.1:42137`
@@ -76,10 +76,12 @@ From the same settings section, create a paired connection:
 Pane will:
 
 - add a host-side allowed client record
-- add a matching saved client profile
+- add a matching saved client profile on that same host-side Pane config
 - show the generated bearer token once
 
 Treat that token like a secret.
+
+If you are connecting from another machine, copy that generated token and keep it available for Step 6.
 
 ## 4. Start the Headless Daemon Host
 
@@ -123,12 +125,13 @@ Use a tunnel/proxy product that can reach the loopback listener on the host mach
 
 On the client machine, open Pane and go to `Settings > Self-Hosted Remote Daemon`.
 
-If you already created the paired profile on that machine, click `Connect`.
+Under `Save Existing Remote Profile`, save a matching client profile with:
 
-If not, create or save a matching profile with:
-
+- a label for this remote host
 - the same base URL the tunnel exposes locally on the client machine
 - the token generated when the host-side pair was created
+
+Then click `Connect` on that saved profile.
 
 When connected successfully, the client mode should show:
 

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -11,6 +11,7 @@ import {
   createDefaultRemotePaneConnectionState,
   type RemoteDaemonConfig,
   type RemoteDaemonHostConfig,
+  type RemotePaneConnectionProfile,
   type RemotePaneConnectionState,
 } from '../../../shared/types/remoteDaemon';
 import { useConfigStore } from '../stores/configStore';
@@ -105,6 +106,9 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [remotePairLabel, setRemotePairLabel] = useState('');
   const [remotePairBaseUrl, setRemotePairBaseUrl] = useState('http://127.0.0.1:42137');
   const [remoteCreatedToken, setRemoteCreatedToken] = useState<string | null>(null);
+  const [remoteImportedProfileLabel, setRemoteImportedProfileLabel] = useState('');
+  const [remoteImportedProfileBaseUrl, setRemoteImportedProfileBaseUrl] = useState('http://127.0.0.1:42137');
+  const [remoteImportedProfileToken, setRemoteImportedProfileToken] = useState('');
   const [remoteBusy, setRemoteBusy] = useState(false);
   const { updateSettings } = useNotifications();
   const { theme, setTheme } = useTheme();
@@ -125,6 +129,11 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
               configResponse.data!.host.config.listenHost,
               configResponse.data!.host.config.listenPort,
             )
+          : currentValue
+      ));
+      setRemoteImportedProfileBaseUrl((currentValue) => (
+        currentValue === 'http://127.0.0.1:42137'
+          ? `http://${configResponse.data!.host.config.listenHost}:${configResponse.data!.host.config.listenPort}`
           : currentValue
       ));
     }
@@ -321,6 +330,26 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
       if (!response.success) {
         throw new Error(response.error || 'Failed to delete remote daemon connection profile');
       }
+    });
+  };
+
+  const handleSaveRemoteProfile = async () => {
+    await runRemoteDaemonAction(async () => {
+      const profile: RemotePaneConnectionProfile = {
+        id: crypto.randomUUID(),
+        label: remoteImportedProfileLabel.trim(),
+        baseUrl: remoteImportedProfileBaseUrl.trim(),
+        token: remoteImportedProfileToken.trim(),
+        transport: 'http+sse',
+      };
+
+      const response = await API.remoteDaemon.upsertConnectionProfile(profile);
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to save remote daemon connection profile');
+      }
+
+      setRemoteImportedProfileLabel('');
+      setRemoteImportedProfileToken('');
     });
   };
 
@@ -1093,6 +1122,52 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                       </p>
                     </div>
                   )}
+                </div>
+              </SettingsSection>
+
+              <SettingsSection
+                title="Save Existing Remote Profile"
+                description="Save a token minted on the host so this desktop client can connect from another machine"
+                icon={<Plus className="w-4 h-4" />}
+              >
+                <div className="space-y-3">
+                  <Input
+                    label="Existing Profile Label"
+                    value={remoteImportedProfileLabel}
+                    onChange={(e) => setRemoteImportedProfileLabel(e.target.value)}
+                    placeholder="Office Mac mini tunnel"
+                    fullWidth
+                  />
+                  <Input
+                    label="Existing Remote Base URL"
+                    value={remoteImportedProfileBaseUrl}
+                    onChange={(e) => setRemoteImportedProfileBaseUrl(e.target.value)}
+                    placeholder="http://127.0.0.1:42137"
+                    fullWidth
+                  />
+                  <Textarea
+                    label="Existing Remote Token"
+                    value={remoteImportedProfileToken}
+                    onChange={(e) => setRemoteImportedProfileToken(e.target.value)}
+                    placeholder="Paste the token generated on the host machine"
+                    rows={2}
+                    fullWidth
+                  />
+                  <div className="flex justify-end">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={handleSaveRemoteProfile}
+                      disabled={
+                        remoteBusy ||
+                        remoteImportedProfileLabel.trim().length === 0 ||
+                        remoteImportedProfileBaseUrl.trim().length === 0 ||
+                        remoteImportedProfileToken.trim().length === 0
+                      }
+                    >
+                      Save Remote Profile
+                    </Button>
+                  </div>
                 </div>
               </SettingsSection>
 

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -133,7 +133,10 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
       ));
       setRemoteImportedProfileBaseUrl((currentValue) => (
         currentValue === 'http://127.0.0.1:42137'
-          ? `http://${configResponse.data!.host.config.listenHost}:${configResponse.data!.host.config.listenPort}`
+          ? formatRemoteBaseUrl(
+              configResponse.data!.host.config.listenHost,
+              configResponse.data!.host.config.listenPort,
+            )
           : currentValue
       ));
     }

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -6,6 +6,36 @@ export async function installElectronApiMock(page: Page) {
     const unsubscribe = () => undefined;
     const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
     const pendingPermissions: Array<Record<string, unknown>> = [];
+    const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+    let nextRemoteConnectionId = 1;
+    const remoteDaemonConfig = {
+      host: {
+        config: {
+          enabled: false,
+          listenHost: '127.0.0.1',
+          listenPort: 42137,
+          pairingRequired: true,
+          allowInsecureHttpOnLoopback: true,
+        },
+        clients: [] as Array<Record<string, unknown>>,
+      },
+      client: {
+        profiles: [] as Array<Record<string, unknown>>,
+        activeProfileId: null as string | null,
+        mode: 'local' as 'local' | 'remote',
+      },
+    };
+    const remoteConnectionState = {
+      mode: 'local' as 'local' | 'remote',
+      status: 'local' as 'local' | 'connecting' | 'connected' | 'reconnecting' | 'error',
+      activeProfileId: null as string | null,
+      activeProfileLabel: null as string | null,
+      activeBaseUrl: null as string | null,
+      lastError: null as string | null,
+    };
+    const configState: Record<string, unknown> = {
+      remoteDaemon: clone(remoteDaemonConfig),
+    };
 
     const subscribe = (channel: string, callback: (...args: unknown[]) => void) => {
       const callbacks = listeners.get(channel) ?? new Set<(...args: unknown[]) => void>();
@@ -28,6 +58,15 @@ export async function installElectronApiMock(page: Page) {
       for (const callback of callbacks) {
         callback(...args);
       }
+    };
+
+    const syncRemoteDaemonConfig = () => {
+      configState.remoteDaemon = clone(remoteDaemonConfig);
+    };
+
+    const setRemoteConnectionState = (updates: Partial<typeof remoteConnectionState>) => {
+      Object.assign(remoteConnectionState, updates);
+      emit('remote-daemon:connection-state-changed', clone(remoteConnectionState));
     };
 
     const namespace = (overrides: Record<string, unknown> = {}) =>
@@ -90,7 +129,11 @@ export async function installElectronApiMock(page: Page) {
         stopPolling: () => success(),
       }),
       config: namespace({
-        get: () => success({}),
+        get: () => success(clone(configState)),
+        update: (updates: Record<string, unknown>) => {
+          Object.assign(configState, updates);
+          return success();
+        },
         getAvailableShells: () => success([]),
         getMonospaceFonts: () => success([]),
         getSessionPreferences: () => success({}),
@@ -141,6 +184,119 @@ export async function installElectronApiMock(page: Page) {
         getAllWithProjects: () => success([]),
         getArchivedWithProjects: () => success([]),
         getResumable: () => success([]),
+      }),
+      remoteDaemon: namespace({
+        getConfig: () => success(clone(remoteDaemonConfig)),
+        getConnectionState: () => success(clone(remoteConnectionState)),
+        createConnectionPair: (input: { label?: string; baseUrl?: string }) => {
+          const id = `remote-${nextRemoteConnectionId++}`;
+          const label = input.label ?? 'Remote host';
+          const baseUrl = input.baseUrl ?? 'http://127.0.0.1:42137';
+          const token = `token-${id}`;
+          const client = {
+            id,
+            label,
+            createdAt: new Date().toISOString(),
+            tokenHash: `hash-${token}`,
+          };
+          const profile = {
+            id,
+            label,
+            baseUrl,
+            token,
+            transport: 'http+sse',
+          };
+          remoteDaemonConfig.host.clients.push(client);
+          remoteDaemonConfig.client.profiles.push(profile);
+          syncRemoteDaemonConfig();
+          return success({ client, profile, token });
+        },
+        updateHostConfig: (updates: Record<string, unknown>) => {
+          remoteDaemonConfig.host.config = {
+            ...remoteDaemonConfig.host.config,
+            ...updates,
+          };
+          syncRemoteDaemonConfig();
+          return success(clone(remoteDaemonConfig.host.config));
+        },
+        upsertClientRecord: (record: Record<string, unknown>) => {
+          const existingIndex = remoteDaemonConfig.host.clients.findIndex((client) => client.id === record.id);
+          if (existingIndex >= 0) {
+            remoteDaemonConfig.host.clients[existingIndex] = record;
+          } else {
+            remoteDaemonConfig.host.clients.push(record);
+          }
+          syncRemoteDaemonConfig();
+          return success(clone(remoteDaemonConfig.host.clients));
+        },
+        deleteClientRecord: (clientId: string) => {
+          remoteDaemonConfig.host.clients = remoteDaemonConfig.host.clients.filter((client) => client.id !== clientId);
+          syncRemoteDaemonConfig();
+          return success(clone(remoteDaemonConfig.host.clients));
+        },
+        upsertConnectionProfile: (profile: Record<string, unknown>) => {
+          const existingIndex = remoteDaemonConfig.client.profiles.findIndex((existing) => existing.id === profile.id);
+          if (existingIndex >= 0) {
+            remoteDaemonConfig.client.profiles[existingIndex] = profile;
+          } else {
+            remoteDaemonConfig.client.profiles.push(profile);
+          }
+          syncRemoteDaemonConfig();
+          return success(clone(remoteDaemonConfig.client.profiles));
+        },
+        deleteConnectionProfile: (profileId: string) => {
+          remoteDaemonConfig.client.profiles = remoteDaemonConfig.client.profiles.filter((profile) => profile.id !== profileId);
+          if (remoteDaemonConfig.client.activeProfileId === profileId) {
+            remoteDaemonConfig.client.activeProfileId = null;
+            remoteDaemonConfig.client.mode = 'local';
+            setRemoteConnectionState({
+              mode: 'local',
+              status: 'local',
+              activeProfileId: null,
+              activeProfileLabel: null,
+              activeBaseUrl: null,
+              lastError: null,
+            });
+          }
+          syncRemoteDaemonConfig();
+          return success(clone(remoteDaemonConfig.client));
+        },
+        updateClientState: (updates: { activeProfileId?: string | null; mode?: 'local' | 'remote' }) => {
+          if (updates.activeProfileId !== undefined) {
+            remoteDaemonConfig.client.activeProfileId = updates.activeProfileId;
+          }
+          if (updates.mode) {
+            remoteDaemonConfig.client.mode = updates.mode;
+          }
+
+          if (remoteDaemonConfig.client.mode === 'remote' && remoteDaemonConfig.client.activeProfileId) {
+            const activeProfile = remoteDaemonConfig.client.profiles.find(
+              (profile) => profile.id === remoteDaemonConfig.client.activeProfileId
+            );
+            setRemoteConnectionState({
+              mode: 'remote',
+              status: activeProfile ? 'connected' : 'error',
+              activeProfileId: remoteDaemonConfig.client.activeProfileId,
+              activeProfileLabel: activeProfile?.label ?? null,
+              activeBaseUrl: activeProfile?.baseUrl ?? null,
+              lastError: activeProfile ? null : 'Missing remote profile',
+            });
+          } else {
+            setRemoteConnectionState({
+              mode: 'local',
+              status: 'local',
+              activeProfileId: remoteDaemonConfig.client.activeProfileId,
+              activeProfileLabel: null,
+              activeBaseUrl: null,
+              lastError: null,
+            });
+          }
+
+          syncRemoteDaemonConfig();
+          return success(clone(remoteDaemonConfig.client));
+        },
+        onConnectionStateChanged: (callback: (state: unknown) => void) =>
+          subscribe('remote-daemon:connection-state-changed', callback),
       }),
       uiState: namespace({
         getExpanded: () => success([]),

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -21,6 +21,39 @@ async function dismissStartupDialogs(page: Page) {
   }
 }
 
+async function clickDomNode(locator: ReturnType<Page['locator']>) {
+  await locator.evaluate((node: HTMLElement) => {
+    node.click();
+  });
+}
+
+async function setInputValue(locator: ReturnType<Page['locator']>, value: string) {
+  await locator.evaluate((node: HTMLElement, nextValue) => {
+    const input = node as HTMLInputElement | HTMLTextAreaElement;
+    const prototype = input instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : HTMLInputElement.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, 'value');
+
+    input.focus();
+    descriptor?.set?.call(input, nextValue);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }, value);
+}
+
+async function openSettings(page: Page) {
+  const collapseSidebarButton = page.getByRole('button', { name: 'Collapse sidebar' });
+  await expect(collapseSidebarButton).toBeVisible({ timeout: 5000 });
+  await collapseSidebarButton.click();
+
+  const settingsButton = page.getByRole('button', { name: 'Settings' }).first();
+  await expect(settingsButton).toBeVisible({ timeout: 5000 });
+  await clickDomNode(settingsButton);
+
+  await expect(page.getByText('Pane Settings')).toBeVisible({ timeout: 5000 });
+}
+
 test.describe('Smoke Tests', () => {
   test('Application should start successfully', async ({ page }) => {
     // Navigate to the app
@@ -56,18 +89,44 @@ test.describe('Smoke Tests', () => {
 
     await dismissStartupDialogs(page);
 
-    const sidebarMenuButton = page.getByRole('button', { name: 'Sidebar menu' });
-    await expect(sidebarMenuButton).toBeVisible({ timeout: 5000 });
-
-    await expect(sidebarMenuButton).toBeEnabled();
-    await sidebarMenuButton.click();
-
-    const settingsItem = page.getByRole('button', { name: 'Settings' });
-    await expect(settingsItem).toBeVisible({ timeout: 5000 });
-    await settingsItem.click();
+    await openSettings(page);
 
     // Small wait to ensure no errors are thrown
     await page.waitForTimeout(500);
+  });
+
+  test('Remote daemon settings can create a paired profile and switch modes', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await openSettings(page);
+    const remoteDaemonSectionButton = page.getByRole('button', { name: /Self-Hosted Remote Daemon/i });
+    await expect(remoteDaemonSectionButton).toBeVisible({ timeout: 5000 });
+    await clickDomNode(remoteDaemonSectionButton);
+
+    await expect(page.getByText('Local mode')).toBeVisible();
+    await expect(page.getByText(/Status: local/i)).toBeVisible();
+
+    await setInputValue(page.getByLabel('Connection Label'), 'Office Mac mini');
+    await setInputValue(page.getByLabel('Remote Base URL'), 'http://127.0.0.1:42137');
+    await clickDomNode(page.getByRole('button', { name: 'Create Paired Profile' }));
+
+    await expect(page.getByText('Latest generated remote token')).toBeVisible();
+    await expect(page.getByText('Office Mac mini')).toBeVisible();
+
+    await clickDomNode(page.getByRole('button', { name: 'Connect', exact: true }));
+
+    await expect(page.getByText('Remote mode')).toBeVisible();
+    await expect(page.getByText(/Status: connected via Office Mac mini/i)).toBeVisible();
+
+    const useLocalRuntimeButton = page.getByRole('button', { name: 'Use Local Runtime' });
+    await expect(useLocalRuntimeButton).toBeEnabled();
+    await clickDomNode(useLocalRuntimeButton);
+
+    await expect(page.getByText('Local mode')).toBeVisible();
+    await expect(page.getByText(/Status: local/i)).toBeVisible();
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 
   test('Permission dialog can approve a daemonized permission request', async ({ page }) => {

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -148,6 +148,27 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 
+  test('Remote daemon settings seed IPv6 loopback defaults with brackets', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(async () => {
+      await window.electronAPI.remoteDaemon.updateHostConfig({
+        listenHost: '::1',
+        listenPort: 42137,
+      });
+    });
+
+    await openSettings(page);
+    const remoteDaemonSectionButton = page.getByRole('button', { name: /Self-Hosted Remote Daemon/i });
+    await expect(remoteDaemonSectionButton).toBeVisible({ timeout: 5000 });
+    await clickDomNode(remoteDaemonSectionButton);
+
+    await expect(page.getByLabel('Existing Remote Base URL')).toHaveValue('http://[::1]:42137');
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
   test('Permission dialog can approve a daemonized permission request', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -108,8 +108,8 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Local mode')).toBeVisible();
     await expect(page.getByText(/Status: local/i)).toBeVisible();
 
-    await setInputValue(page.getByLabel('Connection Label'), 'Office Mac mini');
-    await setInputValue(page.getByLabel('Remote Base URL'), 'http://127.0.0.1:42137');
+    await setInputValue(page.getByLabel('Connection Label', { exact: true }), 'Office Mac mini');
+    await setInputValue(page.getByLabel('Remote Base URL', { exact: true }), 'http://127.0.0.1:42137');
     await clickDomNode(page.getByRole('button', { name: 'Create Paired Profile' }));
 
     await expect(page.getByText('Latest generated remote token')).toBeVisible();
@@ -126,6 +126,25 @@ test.describe('Smoke Tests', () => {
 
     await expect(page.getByText('Local mode')).toBeVisible();
     await expect(page.getByText(/Status: local/i)).toBeVisible();
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
+  test('Remote daemon settings can save an existing remote profile', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await openSettings(page);
+    const remoteDaemonSectionButton = page.getByRole('button', { name: /Self-Hosted Remote Daemon/i });
+    await expect(remoteDaemonSectionButton).toBeVisible({ timeout: 5000 });
+    await clickDomNode(remoteDaemonSectionButton);
+
+    await setInputValue(page.getByLabel('Existing Profile Label'), 'Tunnel from laptop');
+    await setInputValue(page.getByLabel('Existing Remote Base URL'), 'http://127.0.0.1:42137');
+    await setInputValue(page.getByLabel('Existing Remote Token'), 'shared-host-token');
+    await clickDomNode(page.getByRole('button', { name: 'Save Remote Profile' }));
+
+    await expect(page.getByText('Tunnel from laptop')).toBeVisible();
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- enforce the maintained CI gate with main-process Vitest coverage plus maintained Playwright smoke
- extend the Electron mock and smoke suite to exercise the self-hosted remote daemon settings flow
- add a self-hosted operator guide for configuring, tunneling, and validating the current remote daemon workflow

## Testing
- pnpm typecheck
- pnpm lint
- CI=1 pnpm --filter main exec vitest run
- PANE_DIR=/tmp/pane-phase3-validation-docs-smoke xvfb-run -a pnpm test:ci