### PR TITLE
feat: add hosted cloud workspace state contract

### DIFF
--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -130,18 +130,23 @@ export function CloudWidget() {
   const isRunning = vmState.status === 'running';
   const isOff = vmState.status === 'off';
   const isUnknown = vmState.status === 'unknown'; // Usually means auth failed
-  const tunnelConnecting = isRunning && vmState.tunnelStatus === 'starting';
-  const tunnelReady = isRunning && vmState.tunnelStatus === 'running';
-  const tunnelError = isRunning && vmState.tunnelStatus === 'error';
-  const tunnelDisconnected = isRunning && vmState.tunnelStatus === 'off';
+  const daemonAccess = isRunning && vmState.preferredAccess === 'daemon';
+  const daemonBootstrapping = daemonAccess && vmState.daemonStatus === 'bootstrapping';
+  const daemonReady = daemonAccess && vmState.daemonStatus === 'ready';
+  const daemonError = daemonAccess && vmState.daemonStatus === 'error';
+  const tunnelConnecting = isRunning && !daemonAccess && vmState.tunnelStatus === 'starting';
+  const tunnelReady = isRunning && !daemonAccess && vmState.tunnelStatus === 'running';
+  const tunnelError = isRunning && !daemonAccess && vmState.tunnelStatus === 'error';
+  const tunnelDisconnected = isRunning && !daemonAccess && vmState.tunnelStatus === 'off';
 
   // Show reconnect button for: tunnel issues OR unknown status (auth failed)
-  const needsReconnect = (tunnelError || tunnelDisconnected || isUnknown) && !loading && activeSessionId;
+  const needsReconnect = (daemonError || tunnelError || tunnelDisconnected || isUnknown) && !loading && activeSessionId;
 
   // Compute transitioning label
   const getTransitionLabel = () => {
     if (vmState.status === 'stopping') return 'Stopping...';
     if (vmState.status === 'starting' || vmState.status === 'initializing') return 'Starting VM...';
+    if (daemonBootstrapping) return 'Starting workspace daemon...';
     if (tunnelConnecting) return 'Connecting tunnel...';
     return 'Loading...';
   };
@@ -159,7 +164,7 @@ export function CloudWidget() {
       )}
 
       {/* Transitioning state (VM starting/stopping or tunnel connecting) */}
-      {(isTransitioning || tunnelConnecting || loading) && (
+      {(isTransitioning || daemonBootstrapping || tunnelConnecting || loading) && (
         <div className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg">
           <Loader2 className="w-4 h-4 animate-spin text-yellow-400" />
           <span className="text-xs text-text-secondary">
@@ -242,6 +247,25 @@ export function CloudWidget() {
               </>
             )}
           </button>
+        </>
+      )}
+
+      {daemonReady && !loading && (
+        <>
+          <button
+            onClick={handleStop}
+            className="flex items-center gap-1.5 px-2.5 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
+            title="Stop Cloud VM"
+          >
+            <Square className="w-3.5 h-3.5 text-red-400 fill-red-400" />
+          </button>
+          <div
+            className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
+            title="Hosted workspace daemon is ready"
+          >
+            <Cloud className="w-4 h-4 text-interactive" />
+            <span className="text-xs text-text-primary">Daemon Ready</span>
+          </div>
         </>
       )}
     </div>

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -134,6 +134,7 @@ export function CloudWidget() {
   const daemonBootstrapping = daemonAccess && vmState.daemonStatus === 'bootstrapping';
   const daemonReady = daemonAccess && vmState.daemonStatus === 'ready';
   const daemonError = daemonAccess && vmState.daemonStatus === 'error';
+  const canManageCloudVmLifecycle = isRunning && vmState.noVncUrl !== null;
   const tunnelConnecting = isRunning && !daemonAccess && vmState.tunnelStatus === 'starting';
   const tunnelReady = isRunning && !daemonAccess && vmState.tunnelStatus === 'running';
   const tunnelError = isRunning && !daemonAccess && vmState.tunnelStatus === 'error';
@@ -189,7 +190,7 @@ export function CloudWidget() {
       {needsReconnect && (
         <>
           {/* Only show stop button if VM is confirmed running */}
-          {isRunning && (
+          {canManageCloudVmLifecycle && (
             <button
               onClick={handleStop}
               className="flex items-center gap-1.5 px-2.5 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
@@ -252,13 +253,15 @@ export function CloudWidget() {
 
       {daemonReady && !loading && (
         <>
-          <button
-            onClick={handleStop}
-            className="flex items-center gap-1.5 px-2.5 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
-            title="Stop Cloud VM"
-          >
-            <Square className="w-3.5 h-3.5 text-red-400 fill-red-400" />
-          </button>
+          {canManageCloudVmLifecycle && (
+            <button
+              onClick={handleStop}
+              className="flex items-center gap-1.5 px-2.5 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
+              title="Stop Cloud VM"
+            >
+              <Square className="w-3.5 h-3.5 text-red-400 fill-red-400" />
+            </button>
+          )}
           <div
             className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
             title="Hosted workspace daemon is ready"

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -135,7 +135,15 @@ export function CloudWidget() {
     || vmState.linkedRemoteProfileId
     || vmState.daemonStatus !== 'unknown',
   );
-  const daemonAccess = isRunning && vmState.preferredAccess === 'daemon' && hasDaemonMetadata;
+  const noVncFallbackReady = vmState.allowNoVncFallback && Boolean(vmState.noVncUrl);
+  const daemonUnavailableWithFallback =
+    noVncFallbackReady &&
+    (vmState.daemonStatus === 'unknown' || vmState.daemonStatus === 'error');
+  const daemonAccess =
+    isRunning &&
+    vmState.preferredAccess === 'daemon' &&
+    hasDaemonMetadata &&
+    !daemonUnavailableWithFallback;
   const daemonBootstrapping = daemonAccess && vmState.daemonStatus === 'bootstrapping';
   const daemonReady = daemonAccess && vmState.daemonStatus === 'ready';
   const daemonError = daemonAccess && vmState.daemonStatus === 'error';

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useCallback, useState } from 'react';
 import { Play, Square, Loader2, Cloud, Monitor, Terminal } from 'lucide-react';
+import { createDefaultCloudVmState } from '../../../shared/types/cloud';
 import { useCloudStore } from '../stores/cloudStore';
 import { useSessionStore } from '../stores/sessionStore';
 import { panelApi } from '../services/panelApi';
+
+const DEFAULT_CLOUD_STATE = createDefaultCloudVmState();
 
 export function CloudWidget() {
   const { vmState, showCloudView, loading, setVmState, setLoading, setShowCloudView, toggleCloudView } = useCloudStore();
@@ -56,7 +59,7 @@ export function CloudWidget() {
       }
     } catch (err) {
       setVmState({
-        ...(vmState ?? { status: 'unknown', ip: null, noVncUrl: null, provider: null, serverId: null, lastChecked: null, tunnelStatus: 'off' as const }),
+        ...(vmState ?? DEFAULT_CLOUD_STATE),
         error: err instanceof Error ? err.message : 'Failed to start VM',
         status: 'unknown',
       });
@@ -75,7 +78,7 @@ export function CloudWidget() {
       }
     } catch (err) {
       setVmState({
-        ...(vmState ?? { status: 'unknown', ip: null, noVncUrl: null, provider: null, serverId: null, lastChecked: null, tunnelStatus: 'off' as const }),
+        ...(vmState ?? DEFAULT_CLOUD_STATE),
         error: err instanceof Error ? err.message : 'Failed to stop VM',
         status: 'unknown',
       });
@@ -87,7 +90,7 @@ export function CloudWidget() {
   const handleOpenSetupTerminal = useCallback(async () => {
     if (!activeSessionId) {
       setVmState({
-        ...(vmState ?? { status: 'unknown', ip: null, noVncUrl: null, provider: null, serverId: null, lastChecked: null, tunnelStatus: 'off' as const }),
+        ...(vmState ?? DEFAULT_CLOUD_STATE),
         error: 'Select a session first to open the setup terminal',
       });
       return;

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -130,7 +130,12 @@ export function CloudWidget() {
   const isRunning = vmState.status === 'running';
   const isOff = vmState.status === 'off';
   const isUnknown = vmState.status === 'unknown'; // Usually means auth failed
-  const daemonAccess = isRunning && vmState.preferredAccess === 'daemon';
+  const hasDaemonMetadata = Boolean(
+    vmState.daemonBaseUrl
+    || vmState.linkedRemoteProfileId
+    || vmState.daemonStatus !== 'unknown',
+  );
+  const daemonAccess = isRunning && vmState.preferredAccess === 'daemon' && hasDaemonMetadata;
   const daemonBootstrapping = daemonAccess && vmState.daemonStatus === 'bootstrapping';
   const daemonReady = daemonAccess && vmState.daemonStatus === 'ready';
   const daemonError = daemonAccess && vmState.daemonStatus === 'error';

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -21,6 +21,7 @@ import type {
 import type { ToolPanel } from '../../../shared/types/panels';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
+import type { CloudVmState } from '../../../shared/types/cloud';
 
 interface LogEntry {
   timestamp: string;
@@ -471,17 +472,6 @@ interface ElectronAPI {
     /** Write `data` over the port without round-tripping through IPC invoke. */
     write: (ptyId: string, data: string) => void;
   };
-}
-
-interface CloudVmState {
-  status: 'off' | 'starting' | 'running' | 'stopping' | 'unknown' | 'initializing' | 'not_provisioned';
-  ip: string | null;
-  noVncUrl: string | null;
-  provider: 'gcp' | null;
-  serverId: string | null;
-  lastChecked: string | null;
-  error: string | null;
-  tunnelStatus: 'off' | 'starting' | 'running' | 'error';
 }
 
 // Additional electron interface for IPC event listeners

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -76,6 +76,14 @@ describe('normalizeCloudVmConfig', () => {
       zone: undefined,
     });
   });
+
+  it('accepts numeric string tunnel ports written by shell tooling', () => {
+    expect(normalizeCloudVmConfig({
+      provider: 'gcp',
+      apiToken: 'legacy-token',
+      tunnelPort: '9000',
+    }).tunnelPort).toBe(9000);
+  });
 });
 
 describe('CloudVmManager', () => {

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -102,6 +102,8 @@ describe('CloudVmManager', () => {
       provider: 'gcp',
       apiToken: 'secret-token',
       serverId: 'pane-user123',
+      projectId: 'pane-project',
+      zone: 'us-central1-a',
       vncPassword: 'vnc-password',
       tunnelPort: 8080,
       daemonStatus: 'ready',
@@ -155,6 +157,61 @@ describe('CloudVmManager', () => {
       preferredAccess: 'daemon',
       allowNoVncFallback: true,
       noVncUrl: null,
+      tunnelStatus: 'off',
+      error: null,
+    });
+  });
+
+  it('surfaces daemon-backed hosted workspace state when lifecycle fields are incomplete', async () => {
+    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      apiToken: 'stale-token',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+    })) as never);
+
+    const fetchVmStatusSpy = vi.spyOn(manager as never, 'fetchVmStatus');
+
+    const state = await manager.getState();
+
+    expect(fetchVmStatusSpy).not.toHaveBeenCalled();
+    expect(state).toMatchObject({
+      status: 'running',
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+      tunnelStatus: 'off',
+      error: null,
+    });
+  });
+
+  it('falls back to daemon-backed hosted workspace state when lifecycle status fetch fails', async () => {
+    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      apiToken: 'stale-token',
+      serverId: 'pane-user123',
+      projectId: 'pane-project',
+      zone: 'us-central1-a',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+    })) as never);
+
+    vi.spyOn(manager as never, 'fetchVmStatus').mockRejectedValue(new Error('401 Unauthorized'));
+
+    const state = await manager.getState();
+
+    expect(state).toMatchObject({
+      status: 'running',
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
       tunnelStatus: 'off',
       error: null,
     });

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -122,4 +122,33 @@ describe('CloudVmManager', () => {
     });
     expect(state.noVncUrl).toContain('http://localhost:8080/novnc/vnc.html');
   });
+
+  it('surfaces daemon-backed hosted workspace state without requiring a local cloud API token', async () => {
+    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+    })) as never);
+
+    const fetchVmStatusSpy = vi.spyOn(manager as never, 'fetchVmStatus');
+
+    const state = await manager.getState();
+
+    expect(fetchVmStatusSpy).not.toHaveBeenCalled();
+    expect(state).toMatchObject({
+      status: 'running',
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+      preferredAccess: 'daemon',
+      allowNoVncFallback: true,
+      noVncUrl: null,
+      tunnelStatus: 'off',
+      error: null,
+    });
+  });
 });

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -1,0 +1,125 @@
+import { EventEmitter } from 'events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createDefaultCloudVmState,
+  normalizeCloudVmConfig,
+  type CloudVmConfig,
+} from '../../../shared/types/cloud';
+import { CloudVmManager } from './cloudVmManager';
+
+class ConfigManagerStub extends EventEmitter {
+  constructor(private readonly cloud?: CloudVmConfig) {
+    super();
+  }
+
+  getConfig(): { cloud?: CloudVmConfig } {
+    return { cloud: this.cloud };
+  }
+}
+
+describe('normalizeCloudVmConfig', () => {
+  it('adds hosted-workspace defaults while preserving existing legacy cloud fields', () => {
+    expect(normalizeCloudVmConfig({
+      provider: 'gcp',
+      apiToken: 'secret-token',
+      serverId: 'pane-user123',
+      projectId: 'pane-cloud-user123',
+      zone: 'us-central1-a',
+      tunnelPort: 9000,
+      linkedRemoteProfileId: 'remote-profile-1',
+      daemonBaseUrl: 'http://127.0.0.1:42137',
+      daemonStatus: 'ready',
+      preferredAccess: 'novnc',
+      allowNoVncFallback: false,
+    })).toEqual({
+      provider: 'gcp',
+      apiToken: 'secret-token',
+      serverId: 'pane-user123',
+      projectId: 'pane-cloud-user123',
+      zone: 'us-central1-a',
+      tunnelPort: 9000,
+      tunnelStatus: 'off',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'http://127.0.0.1:42137',
+      linkedRemoteProfileId: 'remote-profile-1',
+      preferredAccess: 'novnc',
+      allowNoVncFallback: false,
+      serverIp: undefined,
+      vncPassword: undefined,
+      region: undefined,
+    });
+  });
+
+  it('falls back to daemon-first hosted defaults for legacy or invalid values', () => {
+    expect(normalizeCloudVmConfig({
+      provider: 'gcp',
+      apiToken: 'legacy-token',
+      daemonStatus: 'bogus',
+      preferredAccess: 'desktop-stream',
+      daemonBaseUrl: '   ',
+      linkedRemoteProfileId: '',
+    })).toEqual({
+      provider: 'gcp',
+      apiToken: 'legacy-token',
+      tunnelPort: 8080,
+      tunnelStatus: 'off',
+      daemonStatus: 'unknown',
+      daemonBaseUrl: undefined,
+      linkedRemoteProfileId: undefined,
+      preferredAccess: 'daemon',
+      allowNoVncFallback: true,
+      serverId: undefined,
+      serverIp: undefined,
+      vncPassword: undefined,
+      region: undefined,
+      projectId: undefined,
+      zone: undefined,
+    });
+  });
+});
+
+describe('CloudVmManager', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the default hosted workspace state when cloud is not configured', async () => {
+    const manager = new CloudVmManager(new ConfigManagerStub() as never);
+
+    await expect(manager.getState()).resolves.toEqual(createDefaultCloudVmState());
+  });
+
+  it('includes hosted workspace metadata in state snapshots', async () => {
+    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      apiToken: 'secret-token',
+      serverId: 'pane-user123',
+      vncPassword: 'vnc-password',
+      tunnelPort: 8080,
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'http://127.0.0.1:42137',
+      linkedRemoteProfileId: 'remote-profile-1',
+      preferredAccess: 'daemon',
+      allowNoVncFallback: false,
+    })) as never);
+
+    vi.spyOn(manager as never, 'fetchVmStatus').mockResolvedValue('running');
+    vi.spyOn(manager as never, 'checkTunnelHealth').mockResolvedValue(true);
+
+    const state = await manager.getState();
+
+    expect(state).toMatchObject({
+      status: 'running',
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      tunnelStatus: 'running',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'http://127.0.0.1:42137',
+      linkedRemoteProfileId: 'remote-profile-1',
+      preferredAccess: 'daemon',
+      allowNoVncFallback: false,
+      error: null,
+    });
+    expect(state.noVncUrl).toContain('http://localhost:8080/novnc/vnc.html');
+  });
+});

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -58,9 +58,27 @@ export class CloudVmManager extends EventEmitter {
    * Get the current cloud VM state
    */
   async getState(): Promise<CloudVmState> {
-    const config = this.getCloudConfig();
+    const config = this.getCloudStateConfig();
     if (!config) {
       this.cachedState = createDefaultCloudVmState();
+      return { ...this.cachedState };
+    }
+
+    if (!this.canManageVmLifecycle(config)) {
+      if (!this.hasDaemonHostedWorkspaceState(config)) {
+        this.cachedState = createDefaultCloudVmState();
+        return { ...this.cachedState };
+      }
+
+      this.cachedState = {
+        status: this.mapDaemonStatusToVmStatus(config.daemonStatus ?? 'unknown'),
+        ip: null,
+        noVncUrl: null,
+        ...this.getHostedWorkspaceStateFromConfig(config),
+        lastChecked: new Date().toISOString(),
+        error: null,
+        tunnelStatus: 'off',
+      };
       return { ...this.cachedState };
     }
 
@@ -569,6 +587,28 @@ export class CloudVmManager extends EventEmitter {
     return config.cloud;
   }
 
+  private getCloudStateConfig(): CloudVmConfig | null {
+    const config = this.configManager.getConfig();
+    if (!config.cloud?.provider) {
+      return null;
+    }
+
+    return config.cloud;
+  }
+
+  private canManageVmLifecycle(config: CloudVmConfig): boolean {
+    return config.apiToken.trim().length > 0;
+  }
+
+  private hasDaemonHostedWorkspaceState(config: CloudVmConfig): boolean {
+    return Boolean(
+      config.serverId
+      || config.daemonBaseUrl
+      || config.linkedRemoteProfileId
+      || (config.daemonStatus && config.daemonStatus !== 'unknown'),
+    );
+  }
+
   private getHostedWorkspaceStateFromConfig(config: CloudVmConfig): {
     provider: CloudProvider;
     serverId: string | null;
@@ -587,6 +627,19 @@ export class CloudVmManager extends EventEmitter {
       preferredAccess: config.preferredAccess ?? 'daemon',
       allowNoVncFallback: config.allowNoVncFallback ?? true,
     };
+  }
+
+  private mapDaemonStatusToVmStatus(daemonStatus: CloudDaemonStatus): VmStatus {
+    switch (daemonStatus) {
+      case 'ready':
+        return 'running';
+      case 'bootstrapping':
+        return 'initializing';
+      case 'error':
+      case 'unknown':
+      default:
+        return 'unknown';
+    }
   }
 
   /**

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -111,6 +111,20 @@ export class CloudVmManager extends EventEmitter {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger?.error(`[CloudVM] Failed to fetch status: ${message}`);
+
+      if (this.hasDaemonHostedWorkspaceState(config)) {
+        this.cachedState = {
+          status: this.mapDaemonStatusToVmStatus(config.daemonStatus ?? 'unknown'),
+          ip: null,
+          noVncUrl: null,
+          ...this.getHostedWorkspaceStateFromConfig(config),
+          lastChecked: new Date().toISOString(),
+          error: null,
+          tunnelStatus: this.tunnelStatus,
+        };
+        return { ...this.cachedState };
+      }
+
       this.cachedState.error = message;
       this.cachedState.status = 'unknown';
     }
@@ -597,7 +611,12 @@ export class CloudVmManager extends EventEmitter {
   }
 
   private canManageVmLifecycle(config: CloudVmConfig): boolean {
-    return config.apiToken.trim().length > 0;
+    return Boolean(
+      config.apiToken.trim().length > 0
+      && config.serverId
+      && config.projectId
+      && config.zone,
+    );
   }
 
   private hasDaemonHostedWorkspaceState(config: CloudVmConfig): boolean {

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -4,7 +4,15 @@ import https from 'https';
 import http from 'http';
 import type { ConfigManager } from './configManager';
 import type { Logger } from '../utils/logger';
-import type { CloudProvider, VmStatus, TunnelStatus, CloudVmConfig, CloudVmState } from '../../../shared/types/cloud';
+import {
+  createDefaultCloudVmState,
+  type CloudProvider,
+  type CloudDaemonStatus,
+  type CloudVmConfig,
+  type CloudVmState,
+  type TunnelStatus,
+  type VmStatus,
+} from '../../../shared/types/cloud';
 
 export type { CloudProvider, VmStatus, TunnelStatus, CloudVmConfig, CloudVmState };
 
@@ -16,16 +24,7 @@ export class CloudVmManager extends EventEmitter {
   private pollInterval: ReturnType<typeof setTimeout> | null = null;
   private tunnelProcess: ChildProcess | null = null;
   private tunnelStatus: TunnelStatus = 'off';
-  private cachedState: CloudVmState = {
-    status: 'unknown',
-    ip: null,
-    noVncUrl: null,
-    provider: null,
-    serverId: null,
-    lastChecked: null,
-    error: null,
-    tunnelStatus: 'off',
-  };
+  private cachedState: CloudVmState = createDefaultCloudVmState();
   private operationInProgress = false;
   private isRefreshingToken = false;
   private consecutiveErrors = 0;
@@ -61,7 +60,8 @@ export class CloudVmManager extends EventEmitter {
   async getState(): Promise<CloudVmState> {
     const config = this.getCloudConfig();
     if (!config) {
-      return { ...this.cachedState, status: 'not_provisioned' };
+      this.cachedState = createDefaultCloudVmState();
+      return { ...this.cachedState };
     }
 
     try {
@@ -85,8 +85,7 @@ export class CloudVmManager extends EventEmitter {
         status,
         ip: null,
         noVncUrl: this.buildNoVncUrl(tunnelPort, config.vncPassword),
-        provider: config.provider,
-        serverId: config.serverId || null,
+        ...this.getHostedWorkspaceStateFromConfig(config),
         lastChecked: new Date().toISOString(),
         error: null,
         tunnelStatus: effectiveTunnelStatus,
@@ -570,6 +569,26 @@ export class CloudVmManager extends EventEmitter {
     return config.cloud;
   }
 
+  private getHostedWorkspaceStateFromConfig(config: CloudVmConfig): {
+    provider: CloudProvider;
+    serverId: string | null;
+    daemonStatus: CloudDaemonStatus;
+    daemonBaseUrl: string | null;
+    linkedRemoteProfileId: string | null;
+    preferredAccess: CloudVmState['preferredAccess'];
+    allowNoVncFallback: boolean;
+  } {
+    return {
+      provider: config.provider,
+      serverId: config.serverId ?? null,
+      daemonStatus: config.daemonStatus ?? 'unknown',
+      daemonBaseUrl: config.daemonBaseUrl ?? null,
+      linkedRemoteProfileId: config.linkedRemoteProfileId ?? null,
+      preferredAccess: config.preferredAccess ?? 'daemon',
+      allowNoVncFallback: config.allowNoVncFallback ?? true,
+    };
+  }
+
   /**
    * Build noVNC URL with password pre-filled if available
    */
@@ -604,8 +623,7 @@ export class CloudVmManager extends EventEmitter {
         noVncUrl: status === 'running'
           ? this.buildNoVncUrl(tunnelPort, config.vncPassword)
           : null,
-        provider: config.provider,
-        serverId: config.serverId || null,
+        ...this.getHostedWorkspaceStateFromConfig(config),
         lastChecked: new Date().toISOString(),
         error: null,
         tunnelStatus: this.tunnelStatus,

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import type { AnalyticsIdentity, AppConfig } from '../types/config';
+import { normalizeCloudVmConfig } from '../../../shared/types/cloud';
 import { createDefaultRemoteDaemonConfig, normalizeRemoteDaemonConfig } from '../../../shared/types/remoteDaemon';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
 import { DEFAULT_WORKTREE_FILE_SYNC_ENTRIES } from '../../../shared/types/worktreeFileSync';
@@ -135,6 +136,9 @@ export class ConfigManager extends EventEmitter {
           ...this.config.analytics,
           ...loadedConfig.analytics
         },
+        cloud: loadedConfig.cloud !== undefined
+          ? normalizeCloudVmConfig(loadedConfig.cloud)
+          : this.config.cloud,
         remoteDaemon: normalizeRemoteDaemonConfig(loadedConfig.remoteDaemon),
         // Use !== undefined to distinguish "user cleared all entries" (empty array → preserve)
         // from "field absent in config file" (→ use defaults)
@@ -262,6 +266,9 @@ export class ConfigManager extends EventEmitter {
     this.config = {
       ...this.config,
       ...updates,
+      cloud: 'cloud' in updates
+        ? (updates.cloud === undefined ? undefined : normalizeCloudVmConfig(updates.cloud))
+        : this.config.cloud,
       remoteDaemon: 'remoteDaemon' in updates
         ? normalizeRemoteDaemonConfig(updates.remoteDaemon)
         : this.config.remoteDaemon,

--- a/shared/types/cloud.ts
+++ b/shared/types/cloud.ts
@@ -118,6 +118,16 @@ function readOptionalString(value: unknown): string | undefined {
 }
 
 function readPort(value: unknown, fallback: number): number {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (/^\d+$/.test(trimmed)) {
+      const parsed = Number.parseInt(trimmed, 10);
+      if (parsed > 0 && parsed <= 65535) {
+        return parsed;
+      }
+    }
+  }
+
   return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 65535
     ? value
     : fallback;

--- a/shared/types/cloud.ts
+++ b/shared/types/cloud.ts
@@ -2,18 +2,25 @@
 export type CloudProvider = 'gcp';
 export type VmStatus = 'off' | 'starting' | 'running' | 'stopping' | 'unknown' | 'initializing' | 'not_provisioned';
 export type TunnelStatus = 'off' | 'starting' | 'running' | 'error';
+export type CloudWorkspaceAccessMode = 'daemon' | 'novnc';
+export type CloudDaemonStatus = 'unknown' | 'bootstrapping' | 'ready' | 'error';
 
 export interface CloudVmConfig {
   provider: CloudProvider;
   apiToken: string;
   serverId?: string;
-  serverIp?: string;      // Legacy — not used with IAP
+  serverIp?: string; // Legacy - not used with IAP
   vncPassword?: string;
   region?: string;
   projectId?: string;
   zone?: string;
   tunnelPort?: number;
-  tunnelStatus?: TunnelStatus;  // Set by external scripts
+  tunnelStatus?: TunnelStatus; // Set by external scripts
+  daemonStatus?: CloudDaemonStatus; // Set by hosted workspace bootstrap / control plane
+  daemonBaseUrl?: string;
+  linkedRemoteProfileId?: string;
+  preferredAccess?: CloudWorkspaceAccessMode;
+  allowNoVncFallback?: boolean;
 }
 
 export interface CloudVmState {
@@ -25,4 +32,111 @@ export interface CloudVmState {
   lastChecked: string | null;
   error: string | null;
   tunnelStatus: TunnelStatus;
+  daemonStatus: CloudDaemonStatus;
+  daemonBaseUrl: string | null;
+  linkedRemoteProfileId: string | null;
+  preferredAccess: CloudWorkspaceAccessMode;
+  allowNoVncFallback: boolean;
+}
+
+export const DEFAULT_CLOUD_VM_CONFIG: CloudVmConfig = {
+  provider: 'gcp',
+  apiToken: '',
+  tunnelPort: 8080,
+  tunnelStatus: 'off',
+  daemonStatus: 'unknown',
+  preferredAccess: 'daemon',
+  allowNoVncFallback: true,
+};
+
+export function createDefaultCloudVmConfig(): CloudVmConfig {
+  return { ...DEFAULT_CLOUD_VM_CONFIG };
+}
+
+export function createDefaultCloudVmState(): CloudVmState {
+  return {
+    status: 'not_provisioned',
+    ip: null,
+    noVncUrl: null,
+    provider: null,
+    serverId: null,
+    lastChecked: null,
+    error: null,
+    tunnelStatus: DEFAULT_CLOUD_VM_CONFIG.tunnelStatus!,
+    daemonStatus: DEFAULT_CLOUD_VM_CONFIG.daemonStatus!,
+    daemonBaseUrl: null,
+    linkedRemoteProfileId: null,
+    preferredAccess: DEFAULT_CLOUD_VM_CONFIG.preferredAccess!,
+    allowNoVncFallback: DEFAULT_CLOUD_VM_CONFIG.allowNoVncFallback!,
+  };
+}
+
+export function normalizeCloudVmConfig(value: unknown): CloudVmConfig {
+  const defaults = createDefaultCloudVmConfig();
+  if (!isRecord(value)) {
+    return defaults;
+  }
+
+  return {
+    provider: value.provider === 'gcp' ? 'gcp' : defaults.provider,
+    apiToken: readString(value.apiToken, defaults.apiToken),
+    serverId: readOptionalString(value.serverId),
+    serverIp: readOptionalString(value.serverIp),
+    vncPassword: readOptionalString(value.vncPassword),
+    region: readOptionalString(value.region),
+    projectId: readOptionalString(value.projectId),
+    zone: readOptionalString(value.zone),
+    tunnelPort: readPort(value.tunnelPort, defaults.tunnelPort!),
+    tunnelStatus: readTunnelStatus(value.tunnelStatus, defaults.tunnelStatus!),
+    daemonStatus: readDaemonStatus(value.daemonStatus, defaults.daemonStatus!),
+    daemonBaseUrl: readOptionalString(value.daemonBaseUrl),
+    linkedRemoteProfileId: readOptionalString(value.linkedRemoteProfileId),
+    preferredAccess: readWorkspaceAccessMode(value.preferredAccess, defaults.preferredAccess!),
+    allowNoVncFallback: readBoolean(value.allowNoVncFallback, defaults.allowNoVncFallback!),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readPort(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 65535
+    ? value
+    : fallback;
+}
+
+function readTunnelStatus(value: unknown, fallback: TunnelStatus): TunnelStatus {
+  return value === 'off' || value === 'starting' || value === 'running' || value === 'error'
+    ? value
+    : fallback;
+}
+
+function readDaemonStatus(value: unknown, fallback: CloudDaemonStatus): CloudDaemonStatus {
+  return value === 'unknown' || value === 'bootstrapping' || value === 'ready' || value === 'error'
+    ? value
+    : fallback;
+}
+
+function readWorkspaceAccessMode(value: unknown, fallback: CloudWorkspaceAccessMode): CloudWorkspaceAccessMode {
+  return value === 'daemon' || value === 'novnc'
+    ? value
+    : fallback;
 }

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -33,6 +33,21 @@ export async function installElectronApiMock(page: Page) {
       activeBaseUrl: null as string | null,
       lastError: null as string | null,
     };
+    const cloudState = {
+      status: 'not_provisioned' as const,
+      ip: null as string | null,
+      noVncUrl: null as string | null,
+      provider: null as 'gcp' | null,
+      serverId: null as string | null,
+      lastChecked: null as string | null,
+      error: null as string | null,
+      tunnelStatus: 'off' as const,
+      daemonStatus: 'unknown' as const,
+      daemonBaseUrl: null as string | null,
+      linkedRemoteProfileId: null as string | null,
+      preferredAccess: 'daemon' as const,
+      allowNoVncFallback: true,
+    };
     const configState: Record<string, unknown> = {
       remoteDaemon: clone(remoteDaemonConfig),
     };
@@ -123,7 +138,7 @@ export async function installElectronApiMock(page: Page) {
         syncDistinctId: () => undefined,
       }),
       cloud: namespace({
-        getState: () => success({ status: 'idle' }),
+        getState: () => success(clone(cloudState)),
         onStateChanged: subscribe,
         startPolling: () => success(),
         stopPolling: () => success(),

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -139,7 +139,7 @@ export async function installElectronApiMock(page: Page) {
       }),
       cloud: namespace({
         getState: () => success(clone(cloudState)),
-        onStateChanged: subscribe,
+        onStateChanged: (callback: (state: unknown) => void) => subscribe('cloud:state-changed', callback),
         startPolling: () => success(),
         stopPolling: () => success(),
       }),
@@ -341,6 +341,10 @@ export async function installElectronApiMock(page: Page) {
         emitPermissionRequest(request: Record<string, unknown>) {
           pendingPermissions.push(request);
           emit('permission:request', request);
+        },
+        setCloudState(updates: Record<string, unknown>) {
+          Object.assign(cloudState, updates);
+          emit('cloud:state-changed', clone(cloudState));
         },
       },
     });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -222,4 +222,29 @@ test.describe('Smoke Tests', () => {
     await expect(page.locator('button[title="Stop Cloud VM"]')).toHaveCount(0);
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
+
+  test('Cloud widget preserves tunnel controls for legacy noVNC workspaces', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'running',
+        daemonStatus: 'unknown',
+        noVncUrl: 'http://localhost:9000/novnc/vnc.html',
+        preferredAccess: 'daemon',
+      });
+    });
+
+    await expect(page.getByRole('button', { name: 'Cloud', exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button[title="Stop Cloud VM"]')).toBeVisible();
+    await expect(page.getByText('Daemon Ready')).toHaveCount(0);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
 });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -219,6 +219,7 @@ test.describe('Smoke Tests', () => {
 
     await expect(page.getByText('Daemon Ready')).toBeVisible({ timeout: 5000 });
     await expect(page.getByRole('button', { name: 'Reconnect' })).toHaveCount(0);
+    await expect(page.locator('button[title="Stop Cloud VM"]')).toHaveCount(0);
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -247,4 +247,31 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Daemon Ready')).toHaveCount(0);
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
+
+  test('Cloud widget honors noVNC fallback when daemon metadata is unhealthy', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'running',
+        daemonStatus: 'error',
+        daemonBaseUrl: 'https://pane.example.com/daemon/',
+        noVncUrl: 'http://localhost:9000/novnc/vnc.html',
+        preferredAccess: 'daemon',
+        allowNoVncFallback: true,
+      });
+    });
+
+    await expect(page.getByRole('button', { name: 'Cloud', exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button[title="Stop Cloud VM"]')).toBeVisible();
+    await expect(page.getByText('Daemon Ready')).toHaveCount(0);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
 });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -197,4 +197,28 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Permission Required')).toHaveCount(0);
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
+
+  test('Cloud widget treats daemon-backed hosted workspaces as ready, not reconnect-needed', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'off',
+        daemonStatus: 'ready',
+        daemonBaseUrl: 'https://pane.example.com/daemon/',
+        preferredAccess: 'daemon',
+      });
+    });
+
+    await expect(page.getByText('Daemon Ready')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: 'Reconnect' })).toHaveCount(0);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## Summary
- add daemon-first hosted cloud workspace metadata to the shared cloud config/state contract
- normalize persisted cloud config through ConfigManager and surface the new fields from CloudVmManager
- align renderer typings and smoke mocks with the expanded hosted-cloud state
- add focused CloudVmManager coverage for config normalization and hosted-workspace state snapshots

## Testing
- pnpm typecheck
- pnpm lint
- CI=1 pnpm --filter main test -- --run
- PANE_DIR=/tmp/pane-phase4-cloud-state xvfb-run -a pnpm test:ci