### PR TITLE
feat: link hosted cloud workspaces to remote profiles

### DIFF
--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -400,13 +400,24 @@ export function CloudWidget() {
       )}
 
       {daemonReady && !daemonConnectAvailable && !daemonConnected && !daemonConnectionUnavailable && !loading && (
-        <div
-          className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
-          title="Hosted workspace daemon is ready"
-        >
-          <Cloud className="w-4 h-4 text-interactive" />
-          <span className="text-xs text-text-primary">Daemon Ready</span>
-        </div>
+        <>
+          {canManageCloudVmLifecycle && (
+            <button
+              onClick={handleStop}
+              className="flex items-center gap-1.5 px-2.5 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
+              title="Stop Cloud VM"
+            >
+              <Square className="w-3.5 h-3.5 text-red-400 fill-red-400" />
+            </button>
+          )}
+          <div
+            className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
+            title="Hosted workspace daemon is ready"
+          >
+            <Cloud className="w-4 h-4 text-interactive" />
+            <span className="text-xs text-text-primary">Daemon Ready</span>
+          </div>
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -194,6 +194,11 @@ export function CloudWidget() {
   const daemonReady = daemonAccess && vmState.daemonStatus === 'ready';
   const daemonConnected = daemonReady && vmState.remoteConnectionStatus === 'connected';
   const daemonConnectAvailable = daemonReady && vmState.remoteConnectionStatus === 'available';
+  const daemonConnectionReconnecting =
+    daemonReady &&
+    (vmState.remoteConnectionStatus === 'connecting' || vmState.remoteConnectionStatus === 'reconnecting');
+  const daemonConnectionError = daemonReady && vmState.remoteConnectionStatus === 'error';
+  const daemonConnectionUnavailable = daemonConnectionReconnecting || daemonConnectionError;
   const daemonError = daemonAccess && vmState.daemonStatus === 'error';
   const canManageCloudVmLifecycle = isRunning && vmState.noVncUrl !== null;
   const tunnelConnecting = isRunning && !daemonAccess && vmState.tunnelStatus === 'starting';
@@ -209,6 +214,11 @@ export function CloudWidget() {
     if (vmState.status === 'stopping') return 'Stopping...';
     if (vmState.status === 'starting' || vmState.status === 'initializing') return 'Starting VM...';
     if (daemonBootstrapping) return 'Starting workspace daemon...';
+    if (daemonConnectionReconnecting) {
+      return vmState.remoteConnectionStatus === 'connecting'
+        ? 'Connecting cloud runtime...'
+        : 'Reconnecting cloud runtime...';
+    }
     if (tunnelConnecting) return 'Connecting tunnel...';
     return 'Loading...';
   };
@@ -226,7 +236,7 @@ export function CloudWidget() {
       )}
 
       {/* Transitioning state (VM starting/stopping or tunnel connecting) */}
-      {(isTransitioning || daemonBootstrapping || tunnelConnecting || loading) && (
+      {(isTransitioning || daemonBootstrapping || daemonConnectionReconnecting || tunnelConnecting || loading) && (
         <div className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg">
           <Loader2 className="w-4 h-4 animate-spin text-yellow-400" />
           <span className="text-xs text-text-secondary">
@@ -363,7 +373,33 @@ export function CloudWidget() {
         </>
       )}
 
-      {daemonReady && !daemonConnectAvailable && !daemonConnected && !loading && (
+      {daemonConnectionUnavailable && !loading && (
+        <>
+          <button
+            onClick={handleDisconnectWorkspace}
+            className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
+            title="Switch back to local runtime"
+          >
+            <Monitor className="w-4 h-4 text-text-primary" />
+            <span className="text-xs text-text-primary">Use Local Runtime</span>
+          </button>
+          <div
+            className={`flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border rounded-xl shadow-lg ${
+              daemonConnectionError ? 'border-red-500/30' : 'border-yellow-500/30'
+            }`}
+            title={daemonConnectionError
+              ? 'Hosted workspace daemon connection failed'
+              : 'Hosted workspace daemon is reconnecting'}
+          >
+            <Cloud className={`w-4 h-4 ${daemonConnectionError ? 'text-red-400' : 'text-yellow-400'}`} />
+            <span className="text-xs text-text-primary">
+              {daemonConnectionError ? 'Cloud Connection Error' : 'Cloud Reconnecting'}
+            </span>
+          </div>
+        </>
+      )}
+
+      {daemonReady && !daemonConnectAvailable && !daemonConnected && !daemonConnectionUnavailable && !loading && (
         <div
           className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
           title="Hosted workspace daemon is ready"

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -87,6 +87,40 @@ export function CloudWidget() {
     }
   }, [setLoading, setShowCloudView, setVmState, vmState]);
 
+  const handleConnectWorkspace = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await window.electronAPI.cloud.connectWorkspace();
+      if (result.success && result.data) {
+        setVmState(result.data);
+      }
+    } catch (err) {
+      setVmState({
+        ...(vmState ?? DEFAULT_CLOUD_STATE),
+        error: err instanceof Error ? err.message : 'Failed to connect to hosted workspace',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [setLoading, setVmState, vmState]);
+
+  const handleDisconnectWorkspace = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await window.electronAPI.cloud.disconnectWorkspace();
+      if (result.success && result.data) {
+        setVmState(result.data);
+      }
+    } catch (err) {
+      setVmState({
+        ...(vmState ?? DEFAULT_CLOUD_STATE),
+        error: err instanceof Error ? err.message : 'Failed to switch back to local runtime',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [setLoading, setVmState, vmState]);
+
   const handleOpenSetupTerminal = useCallback(async () => {
     if (!activeSessionId) {
       setVmState({
@@ -146,6 +180,8 @@ export function CloudWidget() {
     !daemonUnavailableWithFallback;
   const daemonBootstrapping = daemonAccess && vmState.daemonStatus === 'bootstrapping';
   const daemonReady = daemonAccess && vmState.daemonStatus === 'ready';
+  const daemonConnected = daemonReady && vmState.remoteConnectionStatus === 'connected';
+  const daemonConnectAvailable = daemonReady && vmState.remoteConnectionStatus === 'available';
   const daemonError = daemonAccess && vmState.daemonStatus === 'error';
   const canManageCloudVmLifecycle = isRunning && vmState.noVncUrl !== null;
   const tunnelConnecting = isRunning && !daemonAccess && vmState.tunnelStatus === 'starting';
@@ -264,7 +300,7 @@ export function CloudWidget() {
         </>
       )}
 
-      {daemonReady && !loading && (
+      {daemonConnectAvailable && !loading && (
         <>
           {canManageCloudVmLifecycle && (
             <button
@@ -275,14 +311,54 @@ export function CloudWidget() {
               <Square className="w-3.5 h-3.5 text-red-400 fill-red-400" />
             </button>
           )}
-          <div
-            className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
-            title="Hosted workspace daemon is ready"
+          <button
+            onClick={handleConnectWorkspace}
+            className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
+            title="Connect to hosted workspace daemon"
           >
             <Cloud className="w-4 h-4 text-interactive" />
-            <span className="text-xs text-text-primary">Daemon Ready</span>
+            <span className="text-xs text-text-primary">Connect Cloud</span>
+          </button>
+        </>
+      )}
+
+      {daemonConnected && !loading && (
+        <>
+          {canManageCloudVmLifecycle && (
+            <button
+              onClick={handleStop}
+              className="flex items-center gap-1.5 px-2.5 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
+              title="Stop Cloud VM"
+            >
+              <Square className="w-3.5 h-3.5 text-red-400 fill-red-400" />
+            </button>
+          )}
+          <button
+            onClick={handleDisconnectWorkspace}
+            className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg hover:bg-bg-tertiary transition-colors"
+            title="Switch back to local runtime"
+          >
+            <Monitor className="w-4 h-4 text-text-primary" />
+            <span className="text-xs text-text-primary">Use Local Runtime</span>
+          </button>
+          <div
+            className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
+            title="Hosted workspace daemon is connected"
+          >
+            <Cloud className="w-4 h-4 text-interactive" />
+            <span className="text-xs text-text-primary">Cloud Connected</span>
           </div>
         </>
+      )}
+
+      {daemonReady && !daemonConnectAvailable && !daemonConnected && !loading && (
+        <div
+          className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg"
+          title="Hosted workspace daemon is ready"
+        >
+          <Cloud className="w-4 h-4 text-interactive" />
+          <span className="text-xs text-text-primary">Daemon Ready</span>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -116,7 +116,13 @@ export function CloudWidget() {
       const result = await window.electronAPI.cloud.disconnectWorkspace();
       if (result.success && result.data) {
         setVmState(result.data);
+        return;
       }
+
+      setVmState({
+        ...(vmState ?? DEFAULT_CLOUD_STATE),
+        error: result.error ?? 'Failed to switch back to local runtime',
+      });
     } catch (err) {
       setVmState({
         ...(vmState ?? DEFAULT_CLOUD_STATE),

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -93,7 +93,13 @@ export function CloudWidget() {
       const result = await window.electronAPI.cloud.connectWorkspace();
       if (result.success && result.data) {
         setVmState(result.data);
+        return;
       }
+
+      setVmState({
+        ...(vmState ?? DEFAULT_CLOUD_STATE),
+        error: result.error ?? 'Failed to connect to hosted workspace',
+      });
     } catch (err) {
       setVmState({
         ...(vmState ?? DEFAULT_CLOUD_STATE),

--- a/frontend/src/hooks/useIPCEvents.ts
+++ b/frontend/src/hooks/useIPCEvents.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useSessionStore } from '../stores/sessionStore';
 import { useErrorStore } from '../stores/errorStore';
 import { usePanelStore } from '../stores/panelStore';
+import { useConfigStore } from '../stores/configStore';
 import { panelApi } from '../services/panelApi';
 import { API } from '../utils/api';
 import type { Session, SessionOutput, GitStatus } from '../types/session';
@@ -374,6 +375,8 @@ export function useIPCEvents() {
     const unsubscribeRemoteResync = window.electronAPI.events.onRemoteDaemonResyncRequested?.(() => {
       void (async () => {
         try {
+          await useConfigStore.getState().fetchConfig();
+
           const sessionsResponse = await API.sessions.getAll();
           if (sessionsResponse.success && sessionsResponse.data) {
             const sessionsWithJsonMessages = sessionsResponse.data.map((session: Session) => ({

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -437,6 +437,8 @@ interface ElectronAPI {
     stopVm: () => Promise<IPCResponse>;
     startTunnel: () => Promise<IPCResponse>;
     stopTunnel: () => Promise<IPCResponse>;
+    connectWorkspace: () => Promise<IPCResponse>;
+    disconnectWorkspace: () => Promise<IPCResponse>;
     startPolling: () => Promise<IPCResponse>;
     stopPolling: () => Promise<IPCResponse>;
     onStateChanged: (callback: (state: CloudVmState) => void) => () => void;

--- a/main/src/ipc/cloud.test.ts
+++ b/main/src/ipc/cloud.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CloudVmManager } from '../services/cloudVmManager';
+import { registerCloudHandlers } from './cloud';
+
+vi.mock('../services/cloudVmManager', () => ({
+  CloudVmManager: vi.fn(),
+}));
+
+interface IpcMainStub {
+  handlers: Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>;
+  handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
+}
+
+function createIpcMainStub(): IpcMainStub {
+  const handlers = new Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>();
+
+  return {
+    handlers,
+    handle(channel, listener) {
+      handlers.set(channel, listener);
+    },
+  };
+}
+
+describe('cloud IPC', () => {
+  const state = {
+    status: 'running',
+    ip: null,
+    noVncUrl: null,
+    provider: 'gcp',
+    serverId: 'pane-dev',
+    lastChecked: null,
+    error: null,
+    tunnelStatus: 'off',
+    daemonStatus: 'ready',
+    daemonBaseUrl: 'https://pane.example.com/daemon/',
+    linkedRemoteProfileId: 'remote-cloud-1',
+    linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+    remoteConnectionStatus: 'connected',
+    preferredAccess: 'daemon',
+    allowNoVncFallback: true,
+  };
+
+  let connectWorkspace: ReturnType<typeof vi.fn>;
+  let disconnectWorkspace: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectWorkspace = vi.fn().mockResolvedValue(state);
+    disconnectWorkspace = vi.fn().mockResolvedValue({
+      ...state,
+      remoteConnectionStatus: 'available',
+    });
+
+    vi.mocked(CloudVmManager).mockImplementation(() => ({
+      connectWorkspace,
+      disconnectWorkspace,
+      on: vi.fn(),
+    }) as unknown as CloudVmManager);
+  });
+
+  it('requests renderer state resync after hosted workspace mode changes', async () => {
+    const ipcMain = createIpcMainStub();
+    const send = vi.fn();
+
+    registerCloudHandlers(ipcMain, {
+      configManager: {
+        startWatching: vi.fn(),
+      },
+      logger: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+      getMainWindow: () => ({
+        webContents: { send },
+      }),
+    } as never);
+
+    await expect(ipcMain.handlers.get('cloud:connect-workspace')?.({})).resolves.toEqual({
+      success: true,
+      data: state,
+    });
+    expect(send).toHaveBeenCalledWith('remote-daemon:resync-required');
+
+    send.mockClear();
+
+    await expect(ipcMain.handlers.get('cloud:disconnect-workspace')?.({})).resolves.toEqual({
+      success: true,
+      data: {
+        ...state,
+        remoteConnectionStatus: 'available',
+      },
+    });
+    expect(send).toHaveBeenCalledWith('remote-daemon:resync-required');
+  });
+});

--- a/main/src/ipc/cloud.ts
+++ b/main/src/ipc/cloud.ts
@@ -15,6 +15,13 @@ export function getCloudVmManager(): CloudVmManager | null {
 export function registerCloudHandlers(ipcMain: IpcMain, services: AppServices): void {
   const { configManager, logger, getMainWindow } = services;
 
+  function requestRendererRemoteResync(): void {
+    const mainWindow = getMainWindow();
+    if (mainWindow) {
+      mainWindow.webContents.send('remote-daemon:resync-required');
+    }
+  }
+
   // Lazy-initialize the CloudVmManager
   function getManager(): CloudVmManager {
     if (!cloudVmManager) {
@@ -109,6 +116,7 @@ export function registerCloudHandlers(ipcMain: IpcMain, services: AppServices): 
       logger?.info('[Cloud IPC] cloud:connect-workspace requested');
       const manager = getManager();
       const state = await manager.connectWorkspace();
+      requestRendererRemoteResync();
       return { success: true, data: state };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -123,6 +131,7 @@ export function registerCloudHandlers(ipcMain: IpcMain, services: AppServices): 
       logger?.info('[Cloud IPC] cloud:disconnect-workspace requested');
       const manager = getManager();
       const state = await manager.disconnectWorkspace();
+      requestRendererRemoteResync();
       return { success: true, data: state };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/main/src/ipc/cloud.ts
+++ b/main/src/ipc/cloud.ts
@@ -103,6 +103,34 @@ export function registerCloudHandlers(ipcMain: IpcMain, services: AppServices): 
     }
   });
 
+  // Connect the desktop app through the linked hosted workspace remote profile
+  ipcMain.handle('cloud:connect-workspace', async () => {
+    try {
+      logger?.info('[Cloud IPC] cloud:connect-workspace requested');
+      const manager = getManager();
+      const state = await manager.connectWorkspace();
+      return { success: true, data: state };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger?.error('[Cloud IPC] cloud:connect-workspace failed:', err instanceof Error ? err : new Error(message));
+      return { success: false, error: message };
+    }
+  });
+
+  // Disconnect the desktop app from the linked hosted workspace remote profile
+  ipcMain.handle('cloud:disconnect-workspace', async () => {
+    try {
+      logger?.info('[Cloud IPC] cloud:disconnect-workspace requested');
+      const manager = getManager();
+      const state = await manager.disconnectWorkspace();
+      return { success: true, data: state };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger?.error('[Cloud IPC] cloud:disconnect-workspace failed:', err instanceof Error ? err : new Error(message));
+      return { success: false, error: message };
+    }
+  });
+
   // Start polling VM status
   ipcMain.handle('cloud:start-polling', async () => {
     try {

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -1009,6 +1009,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     stopVm: (): Promise<IPCResponse> => invokeIpc('cloud:stop-vm'),
     startTunnel: (): Promise<IPCResponse> => invokeIpc('cloud:start-tunnel'),
     stopTunnel: (): Promise<IPCResponse> => invokeIpc('cloud:stop-tunnel'),
+    connectWorkspace: (): Promise<IPCResponse> => invokeIpc('cloud:connect-workspace'),
+    disconnectWorkspace: (): Promise<IPCResponse> => invokeIpc('cloud:disconnect-workspace'),
     startPolling: (): Promise<IPCResponse> => invokeIpc('cloud:start-polling'),
     stopPolling: (): Promise<IPCResponse> => invokeIpc('cloud:stop-polling'),
     onStateChanged: (callback: (state: unknown) => void): (() => void) => {

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -377,6 +377,37 @@ describe('CloudVmManager', () => {
     });
   });
 
+  it('keeps a hosted workspace connectable when its linked remote profile is missing', async () => {
+    const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
+    remoteDaemonConfig.client.profiles = [];
+    vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+
+    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+    }), remoteDaemonConfig) as never);
+
+    const state = await manager.getState();
+
+    expect(state).toMatchObject({
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+      linkedRemoteProfileLabel: null,
+      remoteConnectionStatus: 'available',
+    });
+  });
+
   it('disconnects the hosted workspace when its linked remote profile is active', async () => {
     const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
     remoteDaemonConfig.client.profiles = [{

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -338,6 +338,45 @@ describe('CloudVmManager', () => {
     });
   });
 
+  it('requires the active hosted remote profile to match the current daemon endpoint', async () => {
+    const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
+    remoteDaemonConfig.client.profiles = [{
+      id: 'remote-profile-1',
+      label: 'Pane Cloud Workspace',
+      baseUrl: 'https://old.example.com/daemon/',
+      token: 'secret-token',
+      transport: 'http+sse',
+    }];
+    remoteDaemonConfig.client.activeProfileId = 'remote-profile-1';
+    remoteDaemonConfig.client.mode = 'remote';
+
+    vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'remote-profile-1',
+      activeProfileLabel: 'Pane Cloud Workspace',
+      activeBaseUrl: 'https://old.example.com/daemon/',
+      lastError: null,
+    });
+
+    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://new.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+    }), remoteDaemonConfig) as never);
+
+    const state = await manager.getState();
+
+    expect(state).toMatchObject({
+      daemonBaseUrl: 'https://new.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+      linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+      remoteConnectionStatus: 'available',
+    });
+  });
+
   it('disconnects the hosted workspace when its linked remote profile is active', async () => {
     const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
     remoteDaemonConfig.client.profiles = [{

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -5,15 +5,36 @@ import {
   normalizeCloudVmConfig,
   type CloudVmConfig,
 } from '../../../shared/types/cloud';
+import {
+  createDefaultRemoteDaemonConfig,
+  type RemoteDaemonConfig,
+} from '../../../shared/types/remoteDaemon';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import { CloudVmManager } from './cloudVmManager';
 
 class ConfigManagerStub extends EventEmitter {
-  constructor(private readonly cloud?: CloudVmConfig) {
+  constructor(
+    private cloud?: CloudVmConfig,
+    private remoteDaemon: RemoteDaemonConfig = createDefaultRemoteDaemonConfig(),
+  ) {
     super();
   }
 
-  getConfig(): { cloud?: CloudVmConfig } {
-    return { cloud: this.cloud };
+  getConfig(): { cloud?: CloudVmConfig; remoteDaemon?: RemoteDaemonConfig } {
+    return { cloud: this.cloud, remoteDaemon: this.remoteDaemon };
+  }
+
+  async updateConfig(
+    updates: { cloud?: CloudVmConfig; remoteDaemon?: RemoteDaemonConfig },
+  ): Promise<{ cloud?: CloudVmConfig; remoteDaemon?: RemoteDaemonConfig }> {
+    if ('cloud' in updates) {
+      this.cloud = updates.cloud;
+    }
+    if ('remoteDaemon' in updates && updates.remoteDaemon) {
+      this.remoteDaemon = updates.remoteDaemon;
+    }
+    this.emit('config-updated', this.getConfig());
+    return this.getConfig();
   }
 }
 
@@ -98,6 +119,23 @@ describe('CloudVmManager', () => {
   });
 
   it('includes hosted workspace metadata in state snapshots', async () => {
+    const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
+    remoteDaemonConfig.client.profiles = [{
+      id: 'remote-profile-1',
+      label: 'Pane Cloud Workspace',
+      baseUrl: 'http://127.0.0.1:42137',
+      token: 'secret-token',
+      transport: 'http+sse',
+    }];
+    vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+
     const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       apiToken: 'secret-token',
@@ -111,7 +149,7 @@ describe('CloudVmManager', () => {
       linkedRemoteProfileId: 'remote-profile-1',
       preferredAccess: 'daemon',
       allowNoVncFallback: false,
-    })) as never);
+    }), remoteDaemonConfig) as never);
 
     vi.spyOn(manager as never, 'fetchVmStatus').mockResolvedValue('running');
     vi.spyOn(manager as never, 'checkTunnelHealth').mockResolvedValue(true);
@@ -126,6 +164,8 @@ describe('CloudVmManager', () => {
       daemonStatus: 'ready',
       daemonBaseUrl: 'http://127.0.0.1:42137',
       linkedRemoteProfileId: 'remote-profile-1',
+      linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+      remoteConnectionStatus: 'available',
       preferredAccess: 'daemon',
       allowNoVncFallback: false,
       error: null,
@@ -134,13 +174,30 @@ describe('CloudVmManager', () => {
   });
 
   it('surfaces daemon-backed hosted workspace state without requiring a local cloud API token', async () => {
+    const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
+    remoteDaemonConfig.client.profiles = [{
+      id: 'remote-profile-1',
+      label: 'Pane Cloud Workspace',
+      baseUrl: 'https://pane.example.com/daemon/',
+      token: 'secret-token',
+      transport: 'http+sse',
+    }];
+    vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+
     const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       serverId: 'pane-user123',
       daemonStatus: 'ready',
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
-    })) as never);
+    }), remoteDaemonConfig) as never);
 
     const fetchVmStatusSpy = vi.spyOn(manager as never, 'fetchVmStatus');
 
@@ -154,6 +211,8 @@ describe('CloudVmManager', () => {
       daemonStatus: 'ready',
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
+      linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+      remoteConnectionStatus: 'available',
       preferredAccess: 'daemon',
       allowNoVncFallback: true,
       noVncUrl: null,
@@ -214,6 +273,120 @@ describe('CloudVmManager', () => {
       linkedRemoteProfileId: 'remote-profile-1',
       tunnelStatus: 'off',
       error: null,
+    });
+  });
+
+  it('connects the hosted workspace through the linked remote profile and syncs its endpoint', async () => {
+    const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
+    remoteDaemonConfig.client.profiles = [{
+      id: 'remote-profile-1',
+      label: 'Pane Cloud Workspace',
+      baseUrl: 'https://old.example.com/pane/',
+      token: 'secret-token',
+      transport: 'http+sse',
+    }];
+    vi.spyOn(remotePaneClientController, 'activateProfile').mockResolvedValue({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'remote-profile-1',
+      activeProfileLabel: 'Pane Cloud Workspace',
+      activeBaseUrl: 'https://pane.example.com/daemon/',
+      lastError: null,
+    });
+    vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
+      mode: 'remote',
+      status: 'connected',
+      activeProfileId: 'remote-profile-1',
+      activeProfileLabel: 'Pane Cloud Workspace',
+      activeBaseUrl: 'https://pane.example.com/daemon/',
+      lastError: null,
+    });
+
+    const configManager = new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+    }), remoteDaemonConfig);
+    const manager = new CloudVmManager(configManager as never);
+
+    const state = await manager.connectWorkspace();
+
+    expect(remotePaneClientController.activateProfile).toHaveBeenCalledWith({
+      id: 'remote-profile-1',
+      label: 'Pane Cloud Workspace',
+      baseUrl: 'https://pane.example.com/daemon/',
+      token: 'secret-token',
+      transport: 'http+sse',
+    });
+    expect(configManager.getConfig().remoteDaemon?.client).toMatchObject({
+      activeProfileId: 'remote-profile-1',
+      mode: 'remote',
+    });
+    expect(configManager.getConfig().remoteDaemon?.client.profiles).toContainEqual({
+      id: 'remote-profile-1',
+      label: 'Pane Cloud Workspace',
+      baseUrl: 'https://pane.example.com/daemon/',
+      token: 'secret-token',
+      transport: 'http+sse',
+    });
+    expect(state).toMatchObject({
+      linkedRemoteProfileId: 'remote-profile-1',
+      linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+      remoteConnectionStatus: 'connected',
+    });
+  });
+
+  it('disconnects the hosted workspace when its linked remote profile is active', async () => {
+    const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
+    remoteDaemonConfig.client.profiles = [{
+      id: 'remote-profile-1',
+      label: 'Pane Cloud Workspace',
+      baseUrl: 'https://pane.example.com/daemon/',
+      token: 'secret-token',
+      transport: 'http+sse',
+    }];
+    remoteDaemonConfig.client.activeProfileId = 'remote-profile-1';
+    remoteDaemonConfig.client.mode = 'remote';
+
+    vi.spyOn(remotePaneClientController, 'switchToLocalMode').mockResolvedValue({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+    vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+    });
+
+    const configManager = new ConfigManagerStub(normalizeCloudVmConfig({
+      provider: 'gcp',
+      serverId: 'pane-user123',
+      daemonStatus: 'ready',
+      daemonBaseUrl: 'https://pane.example.com/daemon/',
+      linkedRemoteProfileId: 'remote-profile-1',
+    }), remoteDaemonConfig);
+    const manager = new CloudVmManager(configManager as never);
+
+    const state = await manager.disconnectWorkspace();
+
+    expect(remotePaneClientController.switchToLocalMode).toHaveBeenCalledOnce();
+    expect(configManager.getConfig().remoteDaemon?.client).toMatchObject({
+      activeProfileId: null,
+      mode: 'local',
+    });
+    expect(state).toMatchObject({
+      linkedRemoteProfileId: 'remote-profile-1',
+      linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+      remoteConnectionStatus: 'available',
     });
   });
 });

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -377,7 +377,7 @@ describe('CloudVmManager', () => {
     });
   });
 
-  it('keeps a hosted workspace connectable when its linked remote profile is missing', async () => {
+  it('reports an error when a hosted workspace linked remote profile is missing', async () => {
     const remoteDaemonConfig = createDefaultRemoteDaemonConfig();
     remoteDaemonConfig.client.profiles = [];
     vi.spyOn(remotePaneClientController, 'getConnectionState').mockReturnValue({
@@ -404,7 +404,7 @@ describe('CloudVmManager', () => {
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
       linkedRemoteProfileLabel: null,
-      remoteConnectionStatus: 'available',
+      remoteConnectionStatus: 'error',
     });
   });
 

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -761,9 +761,11 @@ export class CloudVmManager extends EventEmitter {
     }
 
     const connectionState = remotePaneClientController.getConnectionState();
+    const expectedBaseUrl = config.daemonBaseUrl ?? linkedProfile.baseUrl;
     if (
       connectionState.mode === 'remote' &&
-      connectionState.activeProfileId === linkedProfile.id
+      connectionState.activeProfileId === linkedProfile.id &&
+      connectionState.activeBaseUrl === expectedBaseUrl
     ) {
       return connectionState.status;
     }

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -756,8 +756,12 @@ export class CloudVmManager extends EventEmitter {
     config: CloudVmConfig,
     linkedProfile: RemotePaneConnectionProfile | null,
   ): CloudRemoteConnectionStatus {
-    if (!config.linkedRemoteProfileId || !linkedProfile) {
+    if (!config.linkedRemoteProfileId) {
       return 'unlinked';
+    }
+
+    if (!linkedProfile) {
+      return 'available';
     }
 
     const connectionState = remotePaneClientController.getConnectionState();

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -5,6 +5,7 @@ import http from 'http';
 import type { ConfigManager } from './configManager';
 import type { Logger } from '../utils/logger';
 import {
+  type CloudRemoteConnectionStatus,
   createDefaultCloudVmState,
   type CloudProvider,
   type CloudDaemonStatus,
@@ -13,6 +14,13 @@ import {
   type TunnelStatus,
   type VmStatus,
 } from '../../../shared/types/cloud';
+import {
+  createDefaultRemoteDaemonConfig,
+  normalizeRemoteDaemonConfig,
+  type RemoteDaemonConfig,
+  type RemotePaneConnectionProfile,
+} from '../../../shared/types/remoteDaemon';
+import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 
 export type { CloudProvider, VmStatus, TunnelStatus, CloudVmConfig, CloudVmState };
 
@@ -225,6 +233,80 @@ export class CloudVmManager extends EventEmitter {
     } finally {
       this.operationInProgress = false;
     }
+  }
+
+  async connectWorkspace(): Promise<CloudVmState> {
+    const cloudConfig = this.getCloudStateConfig();
+    if (!cloudConfig) {
+      throw new Error('Hosted cloud workspace is not configured');
+    }
+
+    if (!cloudConfig.linkedRemoteProfileId) {
+      throw new Error('Hosted cloud workspace does not have a linked remote profile');
+    }
+
+    const remoteConfig = this.getRemoteDaemonConfig();
+    const profile = remoteConfig.client.profiles.find((candidate) => candidate.id === cloudConfig.linkedRemoteProfileId);
+    if (!profile) {
+      throw new Error(`Hosted cloud workspace linked profile "${cloudConfig.linkedRemoteProfileId}" does not exist`);
+    }
+
+    const nextProfile = cloudConfig.daemonBaseUrl && profile.baseUrl !== cloudConfig.daemonBaseUrl
+      ? { ...profile, baseUrl: cloudConfig.daemonBaseUrl }
+      : profile;
+
+    const nextRemoteConfig = normalizeRemoteDaemonConfig({
+      ...remoteConfig,
+      client: {
+        ...remoteConfig.client,
+        profiles: upsertById(remoteConfig.client.profiles, nextProfile),
+        activeProfileId: nextProfile.id,
+        mode: 'remote',
+      },
+    });
+
+    await remotePaneClientController.activateProfile(nextProfile);
+    await this.configManager.updateConfig({ remoteDaemon: nextRemoteConfig });
+
+    const state = await this.getState();
+    this.emit('state-changed', state);
+    return state;
+  }
+
+  async disconnectWorkspace(): Promise<CloudVmState> {
+    const cloudConfig = this.getCloudStateConfig();
+    if (!cloudConfig?.linkedRemoteProfileId) {
+      const state = await this.getState();
+      this.emit('state-changed', state);
+      return state;
+    }
+
+    const remoteConfig = this.getRemoteDaemonConfig();
+    const linkedProfileIsActive =
+      remoteConfig.client.mode === 'remote' &&
+      remoteConfig.client.activeProfileId === cloudConfig.linkedRemoteProfileId;
+
+    if (!linkedProfileIsActive) {
+      const state = await this.getState();
+      this.emit('state-changed', state);
+      return state;
+    }
+
+    const nextRemoteConfig = normalizeRemoteDaemonConfig({
+      ...remoteConfig,
+      client: {
+        ...remoteConfig.client,
+        activeProfileId: null,
+        mode: 'local',
+      },
+    });
+
+    await remotePaneClientController.switchToLocalMode();
+    await this.configManager.updateConfig({ remoteDaemon: nextRemoteConfig });
+
+    const state = await this.getState();
+    this.emit('state-changed', state);
+    return state;
   }
 
   /**
@@ -619,6 +701,10 @@ export class CloudVmManager extends EventEmitter {
     );
   }
 
+  private getRemoteDaemonConfig(): RemoteDaemonConfig {
+    return normalizeRemoteDaemonConfig(this.configManager.getConfig().remoteDaemon ?? createDefaultRemoteDaemonConfig());
+  }
+
   private hasDaemonHostedWorkspaceState(config: CloudVmConfig): boolean {
     return Boolean(
       config.serverId
@@ -634,18 +720,55 @@ export class CloudVmManager extends EventEmitter {
     daemonStatus: CloudDaemonStatus;
     daemonBaseUrl: string | null;
     linkedRemoteProfileId: string | null;
+    linkedRemoteProfileLabel: string | null;
+    remoteConnectionStatus: CloudRemoteConnectionStatus;
     preferredAccess: CloudVmState['preferredAccess'];
     allowNoVncFallback: boolean;
   } {
+    const remoteConfig = this.getRemoteDaemonConfig();
+    const linkedProfile = this.getLinkedRemoteProfile(config, remoteConfig);
+
     return {
       provider: config.provider,
       serverId: config.serverId ?? null,
       daemonStatus: config.daemonStatus ?? 'unknown',
       daemonBaseUrl: config.daemonBaseUrl ?? null,
       linkedRemoteProfileId: config.linkedRemoteProfileId ?? null,
+      linkedRemoteProfileLabel: linkedProfile?.label ?? null,
+      remoteConnectionStatus: this.getHostedWorkspaceRemoteConnectionStatus(config, linkedProfile),
       preferredAccess: config.preferredAccess ?? 'daemon',
       allowNoVncFallback: config.allowNoVncFallback ?? true,
     };
+  }
+
+  private getLinkedRemoteProfile(
+    config: CloudVmConfig,
+    remoteConfig: RemoteDaemonConfig,
+  ): RemotePaneConnectionProfile | null {
+    if (!config.linkedRemoteProfileId) {
+      return null;
+    }
+
+    return remoteConfig.client.profiles.find((profile) => profile.id === config.linkedRemoteProfileId) ?? null;
+  }
+
+  private getHostedWorkspaceRemoteConnectionStatus(
+    config: CloudVmConfig,
+    linkedProfile: RemotePaneConnectionProfile | null,
+  ): CloudRemoteConnectionStatus {
+    if (!config.linkedRemoteProfileId || !linkedProfile) {
+      return 'unlinked';
+    }
+
+    const connectionState = remotePaneClientController.getConnectionState();
+    if (
+      connectionState.mode === 'remote' &&
+      connectionState.activeProfileId === linkedProfile.id
+    ) {
+      return connectionState.status;
+    }
+
+    return 'available';
   }
 
   private mapDaemonStatusToVmStatus(daemonStatus: CloudDaemonStatus): VmStatus {
@@ -752,4 +875,13 @@ export class CloudVmManager extends EventEmitter {
       req.end();
     });
   }
+}
+
+function upsertById<T extends { id: string }>(items: T[], nextItem: T): T[] {
+  const existingIndex = items.findIndex((item) => item.id === nextItem.id);
+  if (existingIndex === -1) {
+    return [...items, nextItem];
+  }
+
+  return items.map((item, index) => (index === existingIndex ? nextItem : item));
 }

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -761,7 +761,7 @@ export class CloudVmManager extends EventEmitter {
     }
 
     if (!linkedProfile) {
-      return 'available';
+      return 'error';
     }
 
     const connectionState = remotePaneClientController.getConnectionState();

--- a/shared/types/cloud.ts
+++ b/shared/types/cloud.ts
@@ -1,9 +1,12 @@
+import type { RemotePaneConnectionStatus } from './remoteDaemon';
+
 // Cloud VM types — shared between main process and frontend
 export type CloudProvider = 'gcp';
 export type VmStatus = 'off' | 'starting' | 'running' | 'stopping' | 'unknown' | 'initializing' | 'not_provisioned';
 export type TunnelStatus = 'off' | 'starting' | 'running' | 'error';
 export type CloudWorkspaceAccessMode = 'daemon' | 'novnc';
 export type CloudDaemonStatus = 'unknown' | 'bootstrapping' | 'ready' | 'error';
+export type CloudRemoteConnectionStatus = RemotePaneConnectionStatus | 'available' | 'unlinked';
 
 export interface CloudVmConfig {
   provider: CloudProvider;
@@ -35,6 +38,8 @@ export interface CloudVmState {
   daemonStatus: CloudDaemonStatus;
   daemonBaseUrl: string | null;
   linkedRemoteProfileId: string | null;
+  linkedRemoteProfileLabel: string | null;
+  remoteConnectionStatus: CloudRemoteConnectionStatus;
   preferredAccess: CloudWorkspaceAccessMode;
   allowNoVncFallback: boolean;
 }
@@ -66,6 +71,8 @@ export function createDefaultCloudVmState(): CloudVmState {
     daemonStatus: DEFAULT_CLOUD_VM_CONFIG.daemonStatus!,
     daemonBaseUrl: null,
     linkedRemoteProfileId: null,
+    linkedRemoteProfileLabel: null,
+    remoteConnectionStatus: 'unlinked',
     preferredAccess: DEFAULT_CLOUD_VM_CONFIG.preferredAccess!,
     allowNoVncFallback: DEFAULT_CLOUD_VM_CONFIG.allowNoVncFallback!,
   };

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -53,6 +53,7 @@ export async function installElectronApiMock(page: Page) {
     const configState: Record<string, unknown> = {
       remoteDaemon: clone(remoteDaemonConfig),
     };
+    let cloudDisconnectError: string | null = null;
 
     const subscribe = (channel: string, callback: (...args: unknown[]) => void) => {
       const callbacks = listeners.get(channel) ?? new Set<(...args: unknown[]) => void>();
@@ -169,6 +170,10 @@ export async function installElectronApiMock(page: Page) {
           return success(clone(cloudState));
         },
         disconnectWorkspace: () => {
+          if (cloudDisconnectError) {
+            return Promise.resolve({ success: false, error: cloudDisconnectError });
+          }
+
           remoteDaemonConfig.client.activeProfileId = null;
           remoteDaemonConfig.client.mode = 'local';
           syncRemoteDaemonConfig();
@@ -389,6 +394,9 @@ export async function installElectronApiMock(page: Page) {
         setCloudState(updates: Record<string, unknown>) {
           Object.assign(cloudState, updates);
           emit('cloud:state-changed', clone(cloudState));
+        },
+        setCloudDisconnectError(error: string | null) {
+          cloudDisconnectError = error;
         },
       },
     });

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -54,6 +54,7 @@ export async function installElectronApiMock(page: Page) {
       remoteDaemon: clone(remoteDaemonConfig),
     };
     let cloudDisconnectError: string | null = null;
+    let configGetCount = 0;
 
     const subscribe = (channel: string, callback: (...args: unknown[]) => void) => {
       const callbacks = listeners.get(channel) ?? new Set<(...args: unknown[]) => void>();
@@ -104,6 +105,9 @@ export async function installElectronApiMock(page: Page) {
         }
         if (prop === 'onPermissionResolved') {
           return (callback: (event: unknown) => void) => subscribe('permission:resolved', callback);
+        }
+        if (prop === 'onRemoteDaemonResyncRequested') {
+          return (callback: () => void) => subscribe('remote-daemon:resync-required', callback);
         }
         return () => unsubscribe;
       },
@@ -193,7 +197,10 @@ export async function installElectronApiMock(page: Page) {
         stopPolling: () => success(),
       }),
       config: namespace({
-        get: () => success(clone(configState)),
+        get: () => {
+          configGetCount += 1;
+          return success(clone(configState));
+        },
         update: (updates: Record<string, unknown>) => {
           Object.assign(configState, updates);
           return success();
@@ -397,6 +404,12 @@ export async function installElectronApiMock(page: Page) {
         },
         setCloudDisconnectError(error: string | null) {
           cloudDisconnectError = error;
+        },
+        emitRemoteDaemonResyncRequested() {
+          emit('remote-daemon:resync-required');
+        },
+        getConfigReadCount() {
+          return configGetCount;
         },
       },
     });

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -45,6 +45,8 @@ export async function installElectronApiMock(page: Page) {
       daemonStatus: 'unknown' as const,
       daemonBaseUrl: null as string | null,
       linkedRemoteProfileId: null as string | null,
+      linkedRemoteProfileLabel: null as string | null,
+      remoteConnectionStatus: 'unlinked' as const,
       preferredAccess: 'daemon' as const,
       allowNoVncFallback: true,
     };
@@ -140,6 +142,48 @@ export async function installElectronApiMock(page: Page) {
       cloud: namespace({
         getState: () => success(clone(cloudState)),
         onStateChanged: (callback: (state: unknown) => void) => subscribe('cloud:state-changed', callback),
+        connectWorkspace: () => {
+          if (!cloudState.linkedRemoteProfileId) {
+            return Promise.resolve({ success: false, error: 'Hosted cloud workspace does not have a linked remote profile' });
+          }
+          const profile = remoteDaemonConfig.client.profiles.find(
+            (candidate) => candidate.id === cloudState.linkedRemoteProfileId,
+          );
+          if (!profile) {
+            return Promise.resolve({ success: false, error: `Hosted cloud workspace linked profile "${cloudState.linkedRemoteProfileId}" does not exist` });
+          }
+          remoteDaemonConfig.client.activeProfileId = profile.id;
+          remoteDaemonConfig.client.mode = 'remote';
+          syncRemoteDaemonConfig();
+          cloudState.linkedRemoteProfileLabel = String(profile.label);
+          cloudState.remoteConnectionStatus = 'connected';
+          setRemoteConnectionState({
+            mode: 'remote',
+            status: 'connected',
+            activeProfileId: String(profile.id),
+            activeProfileLabel: String(profile.label),
+            activeBaseUrl: String(profile.baseUrl),
+            lastError: null,
+          });
+          emit('cloud:state-changed', clone(cloudState));
+          return success(clone(cloudState));
+        },
+        disconnectWorkspace: () => {
+          remoteDaemonConfig.client.activeProfileId = null;
+          remoteDaemonConfig.client.mode = 'local';
+          syncRemoteDaemonConfig();
+          cloudState.remoteConnectionStatus = cloudState.linkedRemoteProfileId ? 'available' : 'unlinked';
+          setRemoteConnectionState({
+            mode: 'local',
+            status: 'local',
+            activeProfileId: null,
+            activeProfileLabel: null,
+            activeBaseUrl: null,
+            lastError: null,
+          });
+          emit('cloud:state-changed', clone(cloudState));
+          return success(clone(cloudState));
+        },
         startPolling: () => success(),
         stopPolling: () => success(),
       }),

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -198,10 +198,20 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 
-  test('Cloud widget treats daemon-backed hosted workspaces as ready, not reconnect-needed', async ({ page }) => {
+  test('Cloud widget treats connected daemon-backed hosted workspaces as ready, not reconnect-needed', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 
     await dismissStartupDialogs(page);
+
+    await page.evaluate(async () => {
+      await window.electronAPI.remoteDaemon.upsertConnectionProfile({
+        id: 'remote-cloud-1',
+        label: 'Pane Cloud Workspace',
+        baseUrl: 'https://pane.example.com/daemon/',
+        token: 'secret-token',
+        transport: 'http+sse',
+      });
+    });
 
     await page.evaluate(() => {
       const mock = (window as typeof window & {
@@ -213,11 +223,14 @@ test.describe('Smoke Tests', () => {
         tunnelStatus: 'off',
         daemonStatus: 'ready',
         daemonBaseUrl: 'https://pane.example.com/daemon/',
+        linkedRemoteProfileId: 'remote-cloud-1',
+        remoteConnectionStatus: 'connected',
         preferredAccess: 'daemon',
       });
     });
 
-    await expect(page.getByText('Daemon Ready')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Cloud Connected')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: 'Use Local Runtime' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Reconnect' })).toHaveCount(0);
     await expect(page.locator('button[title="Stop Cloud VM"]')).toHaveCount(0);
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
@@ -272,6 +285,48 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByRole('button', { name: 'Cloud', exact: true })).toBeVisible({ timeout: 5000 });
     await expect(page.locator('button[title="Stop Cloud VM"]')).toBeVisible();
     await expect(page.getByText('Daemon Ready')).toHaveCount(0);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
+  test('Cloud widget offers connect for available daemon-backed hosted workspaces', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(async () => {
+      await window.electronAPI.remoteDaemon.upsertConnectionProfile({
+        id: 'remote-cloud-1',
+        label: 'Pane Cloud Workspace',
+        baseUrl: 'https://pane.example.com/daemon/',
+        token: 'secret-token',
+        transport: 'http+sse',
+      });
+    });
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'off',
+        daemonStatus: 'ready',
+        daemonBaseUrl: 'https://pane.example.com/daemon/',
+        linkedRemoteProfileId: 'remote-cloud-1',
+        remoteConnectionStatus: 'available',
+        preferredAccess: 'daemon',
+      });
+    });
+
+    await expect(page.getByRole('button', { name: 'Connect Cloud' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Cloud Connected')).toHaveCount(0);
+    await expect(page.locator('button[title="Stop Cloud VM"]')).toHaveCount(0);
+
+    await clickDomNode(page.getByRole('button', { name: 'Connect Cloud' }));
+
+    await expect(page.getByText('Cloud Connected')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: 'Use Local Runtime' })).toBeVisible();
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -330,31 +330,6 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 
-  test('Cloud widget preserves tunnel controls for legacy noVNC workspaces', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
-
-    await dismissStartupDialogs(page);
-
-    await page.evaluate(() => {
-      const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
-      }).__paneTestElectronMock;
-
-      mock?.setCloudState({
-        status: 'running',
-        tunnelStatus: 'running',
-        daemonStatus: 'unknown',
-        noVncUrl: 'http://localhost:9000/novnc/vnc.html',
-        preferredAccess: 'daemon',
-      });
-    });
-
-    await expect(page.getByRole('button', { name: 'Cloud', exact: true })).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('button[title="Stop Cloud VM"]')).toBeVisible();
-    await expect(page.getByText('Daemon Ready')).toHaveCount(0);
-    await expect(page.getByText('Something went wrong')).toHaveCount(0);
-  });
-
   test('Cloud widget surfaces hosted workspace connection failures', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -329,4 +329,56 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByRole('button', { name: 'Use Local Runtime' })).toBeVisible();
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
+
+  test('Cloud widget preserves tunnel controls for legacy noVNC workspaces', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'running',
+        daemonStatus: 'unknown',
+        noVncUrl: 'http://localhost:9000/novnc/vnc.html',
+        preferredAccess: 'daemon',
+      });
+    });
+
+    await expect(page.getByRole('button', { name: 'Cloud', exact: true })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button[title="Stop Cloud VM"]')).toBeVisible();
+    await expect(page.getByText('Daemon Ready')).toHaveCount(0);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
+  test('Cloud widget surfaces hosted workspace connection failures', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'off',
+        daemonStatus: 'ready',
+        daemonBaseUrl: 'https://pane.example.com/daemon/',
+        linkedRemoteProfileId: 'missing-profile',
+        remoteConnectionStatus: 'available',
+        preferredAccess: 'daemon',
+      });
+    });
+
+    await clickDomNode(page.getByRole('button', { name: 'Connect Cloud' }));
+
+    await expect(page.getByText(/does not exist/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
 });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -356,4 +356,36 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText(/does not exist/i)).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
+
+  test('Cloud widget surfaces hosted workspace disconnect failures', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: {
+          setCloudState: (updates: Record<string, unknown>) => void;
+          setCloudDisconnectError: (error: string | null) => void;
+        };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'off',
+        daemonStatus: 'ready',
+        daemonBaseUrl: 'https://pane.example.com/daemon/',
+        linkedRemoteProfileId: 'remote-cloud-1',
+        linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+        remoteConnectionStatus: 'connected',
+        preferredAccess: 'daemon',
+      });
+      mock?.setCloudDisconnectError('Unable to switch back to local runtime');
+    });
+
+    await clickDomNode(page.getByRole('button', { name: 'Use Local Runtime' }));
+
+    await expect(page.getByText('Unable to switch back to local runtime')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
 });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -236,6 +236,38 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 
+  test('Cloud widget keeps local runtime switch available when hosted daemon connection fails', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'off',
+        daemonStatus: 'ready',
+        daemonBaseUrl: 'https://pane.example.com/daemon/',
+        linkedRemoteProfileId: 'remote-cloud-1',
+        linkedRemoteProfileLabel: 'Pane Cloud Workspace',
+        remoteConnectionStatus: 'error',
+        preferredAccess: 'daemon',
+      });
+    });
+
+    await expect(page.getByText('Cloud Connection Error')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: 'Use Local Runtime' })).toBeVisible();
+    await expect(page.getByText('Daemon Ready')).toHaveCount(0);
+
+    await clickDomNode(page.getByRole('button', { name: 'Use Local Runtime' }));
+
+    await expect(page.getByRole('button', { name: 'Connect Cloud' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
   test('Cloud widget preserves tunnel controls for legacy noVNC workspaces', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -198,6 +198,35 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 
+  test('Remote daemon resync refreshes renderer config', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.waitForTimeout(250);
+
+    const beforeCount = await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: {
+          emitRemoteDaemonResyncRequested: () => void;
+          getConfigReadCount: () => number;
+        };
+      }).__paneTestElectronMock;
+
+      const count = mock?.getConfigReadCount() ?? 0;
+      mock?.emitRemoteDaemonResyncRequested();
+      return count;
+    });
+
+    await expect.poll(async () => page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { getConfigReadCount: () => number };
+      }).__paneTestElectronMock;
+
+      return mock?.getConfigReadCount() ?? 0;
+    })).toBeGreaterThan(beforeCount);
+  });
+
   test('Cloud widget treats connected daemon-backed hosted workspaces as ready, not reconnect-needed', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 
@@ -233,6 +262,34 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByRole('button', { name: 'Use Local Runtime' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Reconnect' })).toHaveCount(0);
     await expect(page.locator('button[title="Stop Cloud VM"]')).toHaveCount(0);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
+  test('Cloud widget preserves VM stop control for daemon-ready managed VMs', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+      }).__paneTestElectronMock;
+
+      mock?.setCloudState({
+        status: 'running',
+        tunnelStatus: 'off',
+        daemonStatus: 'ready',
+        daemonBaseUrl: 'https://pane.example.com/daemon/',
+        noVncUrl: 'http://localhost:9000/novnc/vnc.html',
+        linkedRemoteProfileId: null,
+        linkedRemoteProfileLabel: null,
+        remoteConnectionStatus: 'unlinked',
+        preferredAccess: 'daemon',
+      });
+    });
+
+    await expect(page.getByText('Daemon Ready')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button[title="Stop Cloud VM"]')).toBeVisible();
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Summary
- link hosted cloud workspace state to remote daemon connection profiles
- add cloud IPC/preload endpoints to connect and disconnect the linked hosted workspace
- extend CloudVmManager, tests, and the maintained Electron mock so Phase 4 can route through the existing remote client path

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `CI=1 pnpm --filter main exec vitest run`
- `PANE_DIR=/tmp/pane-phase4-task2-cloud-link xvfb-run -a pnpm test:ci`
