### PR TITLE
Add native mac explorer trash shortcut

### DIFF
--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -319,15 +319,14 @@ function HeadlessFileTree({
     setContextMenu(null);
   }, [contextMenu, isRemoteMode, sessionId]);
 
-  // Delete handler
-  const handleDelete = useCallback(async (file: FileItem) => {
+  const handleDelete = useCallback(async (file: FileItem, options: { skipConfirm?: boolean } = {}) => {
     const files = getSelectedFilesForAction(file);
     const confirmMessage = files.length > 1
       ? `Move ${files.length} items to trash?`
       : files[0]?.isDirectory
         ? `Move folder "${files[0].name}" and all its contents to trash?`
         : `Move file "${files[0]?.name}" to trash?`;
-    if (!confirm(confirmMessage)) return;
+    if (!options.skipConfirm && !confirm(confirmMessage)) return;
 
     try {
       for (const target of files) {
@@ -335,6 +334,7 @@ function HeadlessFileTree({
           sessionId,
           filePath: target.path,
           useTrash: true,
+          allowPermanentFallback: !options.skipConfirm,
         });
 
         if (!result.success) {
@@ -732,7 +732,7 @@ function HeadlessFileTree({
         const item = tree.getItemInstance(selectedItems[0])?.getItemData();
         if (item) {
           e.preventDefault();
-          handleDelete(item);
+          handleDelete(item, { skipConfirm: isMac() && e.metaKey });
         }
       }
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'c' && selectedItems.length > 0) {

--- a/main/src/ipc/file.ts
+++ b/main/src/ipc/file.ts
@@ -43,6 +43,7 @@ interface FileDeleteRequest {
   sessionId: string;
   filePath: string;
   useTrash?: boolean;
+  allowPermanentFallback?: boolean;
 }
 
 interface FileRenameRequest {
@@ -738,6 +739,12 @@ export function registerFileHandlers(
           await shell.trashItem(fullPath);
           return { success: true };
         } catch (trashError) {
+          if (request.allowPermanentFallback === false) {
+            return {
+              success: false,
+              error: trashError instanceof Error ? trashError.message : 'Failed to move item to trash'
+            };
+          }
           console.warn('Failed to move item to trash, permanently deleting instead:', trashError);
         }
       }


### PR DESCRIPTION
## Summary
- Add macOS `Cmd+Delete` / `Cmd+Backspace` support in the explorer to move selected items to Trash without a confirmation popup.
- Preserve confirmation prompts for plain `Delete` / `Backspace`, the inline trash button, and context-menu delete.
- Guard the no-confirm IPC path so Trash failures return an error instead of falling through to permanent deletion.

## Validation
- `pnpm typecheck` passed
- `pnpm lint` passed with existing warnings
- Pre-commit hook reran typecheck and lint successfully

## Notes
Manual macOS UI verification is still expected: select multiple explorer files, use `Cmd+Delete` / `Cmd+Backspace`, and confirm they move to Trash without a popup.