### PR TITLE
Add terminal power mode setting

### DIFF
--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -3,7 +3,7 @@ import { NotificationSettings } from './NotificationSettings';
 import { useNotifications } from '../hooks/useNotifications';
 import { API } from '../utils/api';
 import { optIn, capture, captureAndOptOut } from '../services/posthog';
-import type { PreferredShell, TerminalShortcut } from '../types/config';
+import type { PreferredShell, PreferredTerminalPowerMode, TerminalShortcut } from '../types/config';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
 import { DEFAULT_WORKTREE_FILE_SYNC_ENTRIES } from '../../../shared/types/worktreeFileSync';
 import {
@@ -138,6 +138,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [devMode, setDevMode] = useState(false);
   const [usePtyHost, setUsePtyHost] = useState(false);
   const [initialUsePtyHost, setInitialUsePtyHost] = useState(false);
+  const [terminalPowerMode, setTerminalPowerMode] = useState<PreferredTerminalPowerMode>('performance');
   const [additionalPathsText, setAdditionalPathsText] = useState('');
   const [platform, setPlatform] = useState<string>('darwin');
   const [enableCommitFooter, setEnableCommitFooter] = useState(true);
@@ -263,6 +264,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
       setDevMode(data.devMode || false);
       setUsePtyHost(data.usePtyHost === true);
       setInitialUsePtyHost(data.usePtyHost === true);
+      setTerminalPowerMode(data.terminalPowerMode === 'batterySaver' ? 'batterySaver' : 'performance');
       setClaudeExecutablePath(data.claudeExecutablePath || '');
       setEnableCommitFooter(data.enableCommitFooter !== false); // Default to true
       setUiScale(data.uiScale || 1.0);
@@ -786,6 +788,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
         autoCheckUpdates,
         devMode,
         usePtyHost,
+        terminalPowerMode,
         claudeExecutablePath,
         enableCommitFooter,
         uiScale,
@@ -2653,6 +2656,42 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                       Restart Pane for this change to take effect.
                     </p>
                   )}
+                </div>
+
+                <div className="mt-4">
+                  <label className="block text-sm font-medium text-text-primary mb-2">
+                    Terminal power mode
+                  </label>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setTerminalPowerMode('performance')}
+                      className={`text-left p-3 rounded-lg border transition-colors ${
+                        terminalPowerMode === 'performance'
+                          ? 'border-interactive bg-surface-interactive text-text-primary'
+                          : 'border-border-secondary bg-surface-secondary hover:bg-surface-hover text-text-secondary'
+                      }`}
+                    >
+                      <div className="text-sm font-medium">Performance</div>
+                      <div className="text-xs text-text-tertiary mt-1">
+                        Keep mounted terminals live for best scrollback and instant resume. Uses more battery.
+                      </div>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setTerminalPowerMode('batterySaver')}
+                      className={`text-left p-3 rounded-lg border transition-colors ${
+                        terminalPowerMode === 'batterySaver'
+                          ? 'border-interactive bg-surface-interactive text-text-primary'
+                          : 'border-border-secondary bg-surface-secondary hover:bg-surface-hover text-text-secondary'
+                      }`}
+                    >
+                      <div className="text-sm font-medium">Battery Saver</div>
+                      <div className="text-xs text-text-tertiary mt-1">
+                        Suspend inactive or unfocused terminal rendering. May replay scrollback when shown.
+                      </div>
+                    </button>
+                  </div>
                 </div>
               </SettingsSection>
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -106,8 +106,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   const [windowFocused, setWindowFocused] = useState(true);
   const interceptorRef = useRef<TerminalInterceptor | null>(null);
   const skipNextInterceptRef = useRef(false); // set by AltGr @ detection
+  const terminalPowerMode = useConfigStore((state) => state.config?.terminalPowerMode ?? 'performance');
+  const useBatterySaverTerminalVisibility = terminalPowerMode === 'batterySaver';
   const panelVisible = isActive;
-  const effectiveVisible = panelVisible && windowFocused;
+  const effectiveVisible = useBatterySaverTerminalVisibility ? panelVisible && windowFocused : true;
   const [webglAllowed, setWebglAllowed] = useState(panelVisible);
   const blurDetachTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -356,6 +358,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     filePopover,
     selectionPopover,
     handleOpenInEditor,
+    handleOpenInBrowser,
     handleShowInExplorer,
     closeFilePopover,
     closeSelectionPopover,
@@ -539,6 +542,13 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           rescaleOverlappingGlyphs: true,
           minimumContrastRatio: 1,
           macOptionIsMeta: false,
+          linkHandler: {
+            activate: (_event, uri) => {
+              void window.electronAPI.openExternal(uri).catch((error: unknown) => {
+                console.error('[TerminalPanel] Failed to open terminal link:', error);
+              });
+            },
+          },
         });
         console.log('[TerminalPanel] XTerm instance created:', !!terminal);
 
@@ -1359,9 +1369,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     };
   }, [panel.id]); // Only depend on panel.id to prevent re-initialization on session switch
 
-  // Handle visibility changes (resize and full refresh when becoming visible)
+  // Handle Battery Saver visibility changes (resize and full refresh when becoming visible)
   // Include isInitialized so this effect re-runs after terminal initialization completes
   useEffect(() => {
+    if (!useBatterySaverTerminalVisibility) return;
     if (!effectiveVisible || !isInitialized || !fitAddonRef.current || !xtermRef.current) return;
 
     // Show overlay immediately to mask the terminal.reset()+rewrite flicker
@@ -1421,8 +1432,52 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       if (retryTimer) clearTimeout(retryTimer);
       if (delayedRefreshTimer) clearTimeout(delayedRefreshTimer);
       if (hideOverlayTimer) clearTimeout(hideOverlayTimer);
+      setIsRefreshing(false);
     };
-  }, [effectiveVisible, panel.id, isInitialized, autoFocus, handleRefreshTerminal, forwardToMainLog]);
+  }, [useBatterySaverTerminalVisibility, effectiveVisible, panel.id, isInitialized, autoFocus, handleRefreshTerminal, forwardToMainLog]);
+
+  // Performance mode keeps mounted terminals live, so returning to a panel only
+  // needs layout/paint work. Do not reset and replay scrollback here.
+  useEffect(() => {
+    if (useBatterySaverTerminalVisibility) return;
+    if (!panelVisible || !isInitialized || !fitAddonRef.current || !xtermRef.current) return;
+
+    let lastWidth = 0;
+    let retries = 0;
+    const MAX_RETRIES = 10;
+
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const fitAndPaint = () => {
+      if (cancelled || !fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
+
+      const containerWidth = terminalRef.current.clientWidth;
+      if ((containerWidth === 0 || containerWidth !== lastWidth) && retries < MAX_RETRIES) {
+        lastWidth = containerWidth;
+        retries++;
+        retryTimer = setTimeout(fitAndPaint, 50);
+        return;
+      }
+
+      resizePtyToFit();
+      const terminal = xtermRef.current;
+      if (terminal && terminal.rows > 0) {
+        terminal.refresh(0, terminal.rows - 1);
+      }
+      if (autoFocus) {
+        terminal?.focus();
+      }
+    };
+
+    const animationFrame = requestAnimationFrame(fitAndPaint);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(animationFrame);
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [useBatterySaverTerminalVisibility, panelVisible, isInitialized, autoFocus, resizePtyToFit]);
 
   useEffect(() => {
     if (!xtermRef.current) {
@@ -1580,6 +1635,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         workingDirectory={workingDirectory}
         sessionId={panel.sessionId}
         isRemoteMode={isRemoteMode}
+        onOpenInBrowser={handleOpenInBrowser}
         onClose={closeSelectionPopover}
       />
 

--- a/frontend/src/components/panels/browser/BrowserPanel.tsx
+++ b/frontend/src/components/panels/browser/BrowserPanel.tsx
@@ -35,6 +35,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const [devToolsOpen, setDevToolsOpen] = useState(false);
+  const currentUrlFromPanelState = (panel.state.customState as BrowserPanelState | undefined)?.currentUrl;
 
   const webviewRef = useRef<Electron.WebviewTag>(null);
   const devToolsPlaceholderRef = useRef<HTMLDivElement>(null);
@@ -101,7 +102,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
     }, 2000);
   }, []);
 
-  const navigateTo = (rawUrl: string) => {
+  const navigateTo = useCallback((rawUrl: string) => {
     const normalized = normalizeUrl(rawUrl);
     if (!isLocalhostUrl(normalized)) {
       setUrlError('Only localhost and 127.0.0.1 URLs are supported');
@@ -112,7 +113,12 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
     setUrl(normalized);
     setInputUrl(normalized);
     persistState(normalized);
-  };
+  }, [persistState]);
+
+  useEffect(() => {
+    if (!currentUrlFromPanelState || currentUrlFromPanelState === url) return;
+    navigateTo(currentUrlFromPanelState);
+  }, [currentUrlFromPanelState, navigateTo, url]);
 
   const handleBack = () => {
     webviewRef.current?.goBack();

--- a/frontend/src/components/terminal/SelectionPopover.tsx
+++ b/frontend/src/components/terminal/SelectionPopover.tsx
@@ -11,6 +11,7 @@ export interface SelectionPopoverProps {
   workingDirectory?: string;
   sessionId?: string;
   isRemoteMode?: boolean;
+  onOpenInBrowser?: (url: string) => void | Promise<void>;
   onClose: () => void;
 }
 
@@ -59,6 +60,7 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
   workingDirectory,
   sessionId,
   isRemoteMode = false,
+  onOpenInBrowser,
   onClose,
 }) => {
   // Early return when not visible to avoid unnecessary computation
@@ -87,12 +89,21 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
     }
   };
 
-  const handleOpenInBrowser = () => {
+  const handleOpenInBrowser = async () => {
     if (urlMatch && sessionId) {
-      window.dispatchEvent(new CustomEvent('browser-panel:navigate', {
-        detail: { url: urlMatch[0], sessionId }
-      }));
-      onClose();
+      try {
+        if (onOpenInBrowser) {
+          await onOpenInBrowser(urlMatch[0]);
+        } else {
+          window.dispatchEvent(new CustomEvent('browser-panel:navigate', {
+            detail: { url: urlMatch[0], sessionId }
+          }));
+        }
+      } catch (error) {
+        console.error('Failed to open URL in browser panel:', error);
+      } finally {
+        onClose();
+      }
     }
   };
 

--- a/frontend/src/components/terminal/hooks/useTerminalLinks.ts
+++ b/frontend/src/components/terminal/hooks/useTerminalLinks.ts
@@ -5,6 +5,7 @@ import { registerAllLinkProviders } from '../linkProviders';
 import { panelApi } from '../../../services/panelApi';
 import { usePanelStore } from '../../../stores/panelStore';
 import { useConfigStore } from '../../../stores/configStore';
+import type { BrowserPanelState, ToolPanel } from '../../../../../shared/types/panels';
 
 export interface UseTerminalLinksConfig {
   workingDirectory: string;
@@ -32,6 +33,14 @@ interface SelectionPopoverState {
   x: number;
   y: number;
   text: string;
+}
+
+function getBrowserPanelTitle(url: string): string {
+  try {
+    return new URL(url).host || 'Browser';
+  } catch {
+    return 'Browser';
+  }
 }
 
 export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalLinksConfig) {
@@ -132,6 +141,7 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
   // Get panel store methods
   const addPanel = usePanelStore((state) => state.addPanel);
   const setActivePanelInStore = usePanelStore((state) => state.setActivePanel);
+  const updatePanelState = usePanelStore((state) => state.updatePanelState);
 
   // File popover action handlers
   const handleOpenInEditor = useCallback(async () => {
@@ -185,6 +195,47 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
     setFilePopover((prev) => ({ ...prev, visible: false }));
   }, [filePopover, isRemoteMode]);
 
+  const handleOpenInBrowser = useCallback(async (url: string) => {
+    const panels = usePanelStore.getState().getSessionPanels(config.sessionId);
+    const existingPanel = panels.find((candidate) => candidate.type === 'browser');
+
+    let browserPanel: ToolPanel;
+    if (existingPanel) {
+      const existingCustomState = (existingPanel.state.customState ?? {}) as BrowserPanelState & Record<string, unknown>;
+      browserPanel = {
+        ...existingPanel,
+        state: {
+          ...existingPanel.state,
+          customState: {
+            ...existingCustomState,
+            currentUrl: url,
+          },
+        },
+      };
+      await panelApi.updatePanel(browserPanel.id, { state: browserPanel.state });
+      updatePanelState(browserPanel);
+    } else {
+      browserPanel = await panelApi.createPanel({
+        sessionId: config.sessionId,
+        type: 'browser',
+        title: getBrowserPanelTitle(url),
+        initialState: {
+          customState: {
+            currentUrl: url,
+          },
+        },
+      });
+      addPanel(browserPanel);
+    }
+
+    setActivePanelInStore(config.sessionId, browserPanel.id);
+    await panelApi.setActivePanel(config.sessionId, browserPanel.id);
+
+    window.dispatchEvent(new CustomEvent('browser-panel:navigate', {
+      detail: { url, sessionId: config.sessionId },
+    }));
+  }, [config.sessionId, addPanel, setActivePanelInStore, updatePanelState]);
+
   const closeTooltip = useCallback(() => {
     setTooltip((prev) => ({ ...prev, visible: false }));
   }, []);
@@ -204,6 +255,7 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
     isRemoteMode,
     selectionPopover,
     handleOpenInEditor,
+    handleOpenInBrowser,
     handleShowInExplorer,
     closeTooltip,
     closeFilePopover,

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -16,6 +16,8 @@ export interface CustomCommand {
   command: string;
 }
 
+export type TerminalPowerMode = 'performance' | 'batterySaver';
+
 export interface AnalyticsIdentity {
   distinctId: string;
   identitySource: 'email' | 'github' | 'git_name' | 'posthog' | 'anonymous';
@@ -108,6 +110,8 @@ export interface AppConfig {
   worktreeFileSync?: WorktreeFileSyncEntry[];
   // Preferred shell for Windows terminals
   preferredShell?: 'auto' | 'gitbash' | 'powershell' | 'pwsh' | 'cmd';
+  // Terminal rendering/power behavior
+  terminalPowerMode?: TerminalPowerMode;
   // Cloud VM settings
   cloud?: CloudVmConfig;
   // Self-hosted remote daemon settings and saved client profiles
@@ -117,6 +121,7 @@ export interface AppConfig {
 }
 
 export type PreferredShell = NonNullable<AppConfig['preferredShell']>;
+export type PreferredTerminalPowerMode = NonNullable<AppConfig['terminalPowerMode']>;
 
 export interface UpdateConfigRequest {
   verbose?: boolean;
@@ -147,6 +152,7 @@ export interface UpdateConfigRequest {
   terminalShortcuts?: TerminalShortcut[];
   worktreeFileSync?: WorktreeFileSyncEntry[];
   preferredShell?: PreferredShell;
+  terminalPowerMode?: PreferredTerminalPowerMode;
   cloud?: CloudVmConfig;
   terminalFontFamily?: string;
   terminalFontSize?: number;

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -562,7 +562,13 @@ async function createWindow() {
   }
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (url.startsWith('about:')) {
+      return { action: 'deny' };
+    }
+
+    void shell.openExternal(url).catch((error) => {
+      console.error('Failed to open external URL from window.open:', error);
+    });
     return { action: 'deny' };
   });
 

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -36,6 +36,7 @@ export class ConfigManager extends EventEmitter {
       theme: 'light-rounded',
       terminalFontFamily: 'Geist Mono',
       terminalFontSize: 14,
+      terminalPowerMode: 'performance',
       defaultPermissionMode: 'ignore',
       defaultModel: 'sonnet',
       stravuApiKey: undefined,

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -16,6 +16,8 @@ export interface CustomCommand {
   command: string;
 }
 
+export type TerminalPowerMode = 'performance' | 'batterySaver';
+
 export interface AnalyticsIdentity {
   distinctId: string;
   identitySource: 'email' | 'github' | 'git_name' | 'posthog' | 'anonymous';
@@ -107,6 +109,8 @@ export interface AppConfig {
   worktreeFileSync?: WorktreeFileSyncEntry[];
   // Preferred shell for Windows terminals
   preferredShell?: 'auto' | 'gitbash' | 'powershell' | 'pwsh' | 'cmd';
+  // Terminal rendering/power behavior
+  terminalPowerMode?: TerminalPowerMode;
   // Cloud VM settings
   cloud?: CloudVmConfig;
   // Self-hosted remote daemon settings and saved client profiles
@@ -168,6 +172,8 @@ export interface UpdateConfigRequest {
   worktreeFileSync?: WorktreeFileSyncEntry[];
   // Preferred shell for Windows terminals
   preferredShell?: 'auto' | 'gitbash' | 'powershell' | 'pwsh' | 'cmd';
+  // Terminal rendering/power behavior
+  terminalPowerMode?: TerminalPowerMode;
   // Cloud VM settings
   cloud?: CloudVmConfig;
   // Self-hosted remote daemon settings and saved client profiles


### PR DESCRIPTION
## Summary
- add a terminal power mode setting that defaults to Performance and keeps Battery Saver as the opt-in aggressive suspend/replay behavior
- keep mounted terminals live in Performance mode so scrollback is preserved across blur and inactive panel switches
- make terminal selection Open in Browser create/activate/update the browser panel before navigation so unmounted browser panels still open localhost URLs

## Testing
- pnpm typecheck (pass; Node engine warning because local Node is v20.19.3 and repo expects >=22.14.0)
- pnpm lint (pass; 0 errors, existing warnings)
- pnpm build (fails in Electron native rebuild: msgpackr-extract is rebuilt with target_arch x64 on this linux arm64 environment, and g++ rejects -m64)