### PR TITLE
Improve onboarding support flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,6 +69,7 @@ function App() {
   const [hasCheckedWelcome, setHasCheckedWelcome] = useState(false);
   const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
   const [hasCheckedOnboarding, setHasCheckedOnboarding] = useState(false);
+  const [completedOnboardingThisSession, setCompletedOnboardingThisSession] = useState(false);
   const analyticsCheckStarted = useRef(false);
   const onboardingCheckStarted = useRef(false);
 
@@ -409,7 +410,7 @@ function App() {
       let welcomeScreenShown = false;
       
       // If user explicitly said "don't show again", respect that preference
-      if (hideWelcome) {
+      if (hideWelcome || completedOnboardingThisSession) {
         welcomeScreenShown = false;
       } else {
         try {
@@ -485,7 +486,7 @@ function App() {
     // Set the flag first to prevent re-runs
     setHasCheckedWelcome(true);
     checkInitialState();
-  }, [isLoaded, isAnalyticsConsentOpen, hasCheckedOnboarding, isOnboardingOpen]);
+  }, [isLoaded, isAnalyticsConsentOpen, hasCheckedOnboarding, isOnboardingOpen, completedOnboardingThisSession]);
 
   // Discord popup logic is now combined with welcome screen logic above
 
@@ -640,6 +641,7 @@ function App() {
         <OnboardingDialog
           isOpen={isOnboardingOpen}
           onClose={() => {
+            setCompletedOnboardingThisSession(true);
             setIsOnboardingOpen(false);
             window.dispatchEvent(new Event('project-changed'));
           }}

--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -1,12 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
-import { GitFork, Download, AlertCircle, Star, ExternalLink, CheckCircle2, Loader2 } from 'lucide-react';
+import { GitFork, Download, AlertCircle, Star, ExternalLink, Loader2 } from 'lucide-react';
 import { usePaneLogo } from '../hooks/usePaneLogo';
 import { Modal, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
-import { Tooltip } from './ui/Tooltip';
 import { capture } from '../services/posthog';
 
-type DialogStep = 'detecting' | 'ready' | 'cloning' | 'success' | 'error';
+type DialogStep = 'detecting' | 'ready';
 
 interface EnvironmentInfo {
   gitInstalled: boolean;
@@ -23,9 +22,19 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
   const paneLogo = usePaneLogo();
   const [step, setStep] = useState<DialogStep>('detecting');
   const [env, setEnv] = useState<EnvironmentInfo | null>(null);
-  const [errorMessage, setErrorMessage] = useState('');
-  const [hasStarred, setHasStarred] = useState(false);
-  const [shouldStarOnSetup, setShouldStarOnSetup] = useState(true);
+  const [shouldSupportOnSetup, setShouldSupportOnSetup] = useState(true);
+  const [showSupportPopover, setShowSupportPopover] = useState(false);
+  const [showOptOutConfirm, setShowOptOutConfirm] = useState(false);
+
+  const markOnboardingComplete = async () => {
+    try {
+      if (window.electron?.invoke) {
+        await window.electron.invoke('preferences:set', 'onboarding_repo_setup', 'true');
+      }
+    } catch {
+      // Ensure dialog closes even if preference write fails
+    }
+  };
 
   const detectEnvironment = useCallback(async () => {
     setStep('detecting');
@@ -52,80 +61,58 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
   }, [isOpen, detectEnvironment]);
 
   const handleSetup = async () => {
-    setStep('cloning');
-    try {
-      const result = await window.electronAPI.onboarding.setupDefaultRepo();
-      if (result.success) {
-        // Best-effort star during setup when the user opted in and gh is authed.
-        // Fire-and-forget: star failure or latency must not block or delay the
-        // transition to the success screen. When the promise later resolves,
-        // setHasStarred will flip the success-screen copy to "Thanks!".
-        if (shouldStarOnSetup && env?.ghAuthenticated) {
-          void window.electronAPI.onboarding.starRepo()
-            .then((starResult) => {
-              if (starResult?.success) {
-                setHasStarred(true);
-                capture('onboarding_repo_starred_during_setup');
-              }
-            })
-            .catch(() => {
-              // swallow: star failure is non-fatal
-            });
-        }
-        setStep('success');
-      } else {
-        setErrorMessage(result.error || 'Failed to set up project');
-        setStep('error');
-      }
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : 'An unexpected error occurred');
-      setStep('error');
-    }
-  };
+    await markOnboardingComplete();
+    onClose();
 
-  const handleStar = async () => {
-    try {
-      const result = await window.electronAPI.onboarding.starRepo();
-      if (result.success) {
-        setHasStarred(true);
-      } else {
-        // Fall back to opening in browser
-        window.electronAPI.openExternal('https://github.com/dcouple/Pane');
-        setHasStarred(true);
-      }
-    } catch {
-      window.electronAPI.openExternal('https://github.com/dcouple/Pane');
-      setHasStarred(true);
+    if (shouldSupportOnSetup && env?.ghAuthenticated) {
+      void window.electronAPI.onboarding.supportProject()
+        .then((supportResult) => {
+          if (supportResult?.success) {
+            capture('onboarding_project_supported_during_setup');
+          }
+        })
+        .catch(() => {
+          // swallow: support failure is non-fatal
+        });
     }
+
+    void window.electronAPI.onboarding.setupDefaultRepo()
+      .then((result) => {
+        if (result.success) {
+          window.dispatchEvent(new Event('project-changed'));
+        } else {
+          console.error('[Onboarding] Background setup failed:', result.error || 'Failed to set up project');
+        }
+      })
+      .catch((error) => {
+        console.error('[Onboarding] Background setup failed:', error);
+      });
   };
 
   const handleSkip = async () => {
     capture('onboarding_skipped');
-    try {
-      if (window.electron?.invoke) {
-        await window.electron.invoke('preferences:set', 'onboarding_repo_setup', 'true');
-      }
-    } catch {
-      // Ensure dialog closes even if preference write fails
-    }
+    await markOnboardingComplete();
     onClose();
   };
 
-  const handleFinish = async () => {
-    try {
-      if (window.electron?.invoke) {
-        await window.electron.invoke('preferences:set', 'onboarding_repo_setup', 'true');
-      }
-    } catch {
-      // Ensure dialog closes even if preference write fails
+  const handleSupportCheckboxChange = (checked: boolean) => {
+    if (!checked && shouldSupportOnSetup) {
+      setShowSupportPopover(false);
+      setShowOptOutConfirm(true);
+      return;
     }
-    // Parent onClose handler dispatches 'project-changed', so no need to dispatch here
-    onClose();
+
+    setShouldSupportOnSetup(checked);
   };
 
-  const handleRetry = () => {
-    setErrorMessage('');
-    detectEnvironment();
+  const handleKeepSupporting = () => {
+    setShouldSupportOnSetup(true);
+    setShowOptOutConfirm(false);
+  };
+
+  const handleConfirmOptOut = () => {
+    setShouldSupportOnSetup(false);
+    setShowOptOutConfirm(false);
   };
 
   const handleOpenGitGuide = () => {
@@ -151,7 +138,7 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
         </div>
       </div>
 
-      <ModalBody>
+      <ModalBody className={step === 'ready' && env?.ghAuthenticated ? 'overflow-visible' : undefined}>
         {step === 'detecting' && (
           <div className="flex flex-col items-center py-8 gap-4">
             <Loader2 className="h-8 w-8 text-interactive animate-spin" />
@@ -174,28 +161,63 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
                     </p>
                   </div>
                 </div>
-                <label className="flex items-center gap-2 cursor-pointer w-fit">
-                  <input
-                    type="checkbox"
-                    checked={shouldStarOnSetup}
-                    onChange={(e) => setShouldStarOnSetup(e.target.checked)}
-                    className="rounded border-border-primary text-interactive focus:ring-interactive"
-                  />
-                  <Star className="h-3.5 w-3.5 text-text-secondary flex-shrink-0" />
-                  <Tooltip
-                    side="top"
-                    interactive
-                    content={
-                      <div className="max-w-xs whitespace-normal">
-                        Stars are the cheapest form of support, and they help this project reach more developers. Pane is built by Dcouple, a self-funded two-person studio.
-                      </div>
+                <div
+                  className="relative w-fit ml-9"
+                  onMouseEnter={() => {
+                    if (!showOptOutConfirm) setShowSupportPopover(true);
+                  }}
+                  onMouseLeave={() => setShowSupportPopover(false)}
+                  onFocus={() => {
+                    if (!showOptOutConfirm) setShowSupportPopover(true);
+                  }}
+                  onBlur={(event) => {
+                    if (!event.currentTarget.contains(event.relatedTarget)) {
+                      setShowSupportPopover(false);
                     }
-                  >
+                  }}
+                >
+                  {(showSupportPopover || showOptOutConfirm) && (
+                    <div className="absolute left-0 bottom-full mb-3 w-80 z-30 rounded-lg border border-border-primary bg-surface-primary shadow-lg p-4">
+                      {showOptOutConfirm ? (
+                        <div className="space-y-3">
+                          <div className="space-y-1">
+                            <p className="text-sm font-semibold text-text-primary">Keep supporting independent development?</p>
+                            <p className="text-xs leading-relaxed text-text-secondary">
+                              Pane is built by Parsa, a self-funded developer, not a large corporation. A GitHub star for Pane and a follow are the easiest free way to support the project so it can keep growing.
+                            </p>
+                          </div>
+                          <div className="flex items-center justify-end gap-2">
+                            <Button variant="ghost" size="sm" onClick={handleConfirmOptOut}>
+                              Uncheck anyway
+                            </Button>
+                            <Button variant="primary" size="sm" onClick={handleKeepSupporting}>
+                              Keep supporting
+                            </Button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="space-y-1">
+                          <p className="text-sm font-semibold text-text-primary">Support Pane with a star and follow</p>
+                          <p className="text-xs leading-relaxed text-text-secondary">
+                            Pane is built by Parsa, a self-funded developer. A GitHub star for Pane and a follow are the easiest free way to support the project so it can keep growing.
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  <label className="flex items-center gap-2 cursor-pointer w-fit">
+                    <input
+                      type="checkbox"
+                      checked={shouldSupportOnSetup}
+                      onChange={(e) => handleSupportCheckboxChange(e.target.checked)}
+                      className="rounded border-border-primary text-interactive focus:ring-interactive"
+                    />
+                    <Star className="h-3.5 w-3.5 text-text-secondary flex-shrink-0" />
                     <span className="text-text-secondary text-xs underline decoration-dotted underline-offset-2">
                       Help us keep building Pane independently
                     </span>
-                  </Tooltip>
-                </label>
+                  </label>
+                </div>
               </>
             ) : env.gitInstalled ? (
               <div className="flex items-start gap-3">
@@ -226,63 +248,6 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
           </div>
         )}
 
-        {step === 'cloning' && (
-          <div className="flex flex-col items-center py-8 gap-4">
-            <Loader2 className="h-8 w-8 text-interactive animate-spin" />
-            <p className="text-text-primary font-medium">Setting up your project...</p>
-            <p className="text-text-secondary text-sm">This may take a moment</p>
-          </div>
-        )}
-
-        {step === 'success' && (
-          <div className="space-y-5">
-            <div className="flex items-start gap-3">
-              <CheckCircle2 className="h-6 w-6 text-status-success flex-shrink-0 mt-0.5" />
-              <div className="space-y-1">
-                <p className="text-text-primary font-medium">Pane is ready!</p>
-                <p className="text-text-secondary text-sm">
-                  The Pane repository has been set up as your first project.
-                </p>
-              </div>
-            </div>
-
-            {/* Star prompt */}
-            <div className="p-4 bg-surface-secondary border border-border-secondary rounded-lg">
-              <div className="flex items-start gap-3">
-                <Star className={`h-5 w-5 flex-shrink-0 mt-0.5 ${hasStarred ? 'text-yellow-500 fill-yellow-500' : 'text-text-secondary'}`} />
-                <div className="space-y-2 flex-1">
-                  <p className="text-text-primary text-sm">
-                    {hasStarred
-                      ? 'Thanks for your support!'
-                      : 'If you like Pane, consider starring us on GitHub!'}
-                  </p>
-                  {!hasStarred && (
-                    <button
-                      onClick={handleStar}
-                      className="inline-flex items-center gap-1.5 text-sm text-interactive hover:text-interactive-hover transition-colors"
-                    >
-                      <Star className="h-4 w-4" />
-                      Star on GitHub
-                      <ExternalLink className="h-3 w-3" />
-                    </button>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {step === 'error' && (
-          <div className="space-y-4">
-            <div className="flex items-start gap-3">
-              <AlertCircle className="h-6 w-6 text-status-error flex-shrink-0 mt-0.5" />
-              <div className="space-y-2">
-                <p className="text-text-primary font-medium">Setup Failed</p>
-                <p className="text-text-secondary text-sm">{errorMessage}</p>
-              </div>
-            </div>
-          </div>
-        )}
       </ModalBody>
 
       <ModalFooter className="flex justify-between items-center">
@@ -312,32 +277,6 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
           </>
         )}
 
-        {step === 'cloning' && (
-          <>
-            <div />
-            <Button variant="primary" disabled loading loadingText="Setting up...">
-              Setting up...
-            </Button>
-          </>
-        )}
-
-        {step === 'success' && (
-          <>
-            <div />
-            <Button onClick={handleFinish} variant="primary">
-              Get Started
-            </Button>
-          </>
-        )}
-
-        {step === 'error' && (
-          <>
-            <Button onClick={handleSkip} variant="ghost">Skip</Button>
-            <Button onClick={handleRetry} variant="primary">
-              Try Again
-            </Button>
-          </>
-        )}
       </ModalFooter>
     </Modal>
   );

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -437,7 +437,7 @@ interface ElectronAPI {
   onboarding: {
     detectEnvironment: () => Promise<IPCResponse>;
     setupDefaultRepo: () => Promise<IPCResponse>;
-    starRepo: () => Promise<IPCResponse>;
+    supportProject: () => Promise<IPCResponse>;
   };
 
   // Spotlight

--- a/main/src/ipc/onboarding.ts
+++ b/main/src/ipc/onboarding.ts
@@ -15,6 +15,7 @@ function shellExecOpts(extra?: Record<string, unknown>): Record<string, unknown>
 
 const PANE_REPO = 'dcouple/Pane';
 const PANE_REPO_URL = `https://github.com/${PANE_REPO}.git`;
+const SUPPORT_GITHUB_USER = 'parsakhaz';
 
 interface EnvironmentInfo {
   gitInstalled: boolean;
@@ -50,6 +51,24 @@ function detectEnvironment(): EnvironmentInfo {
   }
 
   return result;
+}
+
+function starPaneRepo(): boolean {
+  try {
+    execSync(`gh api -X PUT /user/starred/${PANE_REPO}`, shellExecOpts({ stdio: 'ignore', timeout: 15000 }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function followSupportUser(): boolean {
+  try {
+    execSync(`gh api -X PUT /user/following/${SUPPORT_GITHUB_USER}`, shellExecOpts({ stdio: 'ignore', timeout: 15000 }));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Checks that the path is a git repo related to dcouple/Pane (canonical or a fork cloned via `gh repo clone`). */
@@ -254,19 +273,21 @@ export function registerOnboardingHandlers(ipcMain: IpcMain, services: AppServic
     }
   });
 
-  // Star the Pane repo via gh API
-  ipcMain.handle('onboarding:star-repo', async () => {
-    try {
-      execSync(`gh api -X PUT /user/starred/${PANE_REPO}`, shellExecOpts({ stdio: 'ignore', timeout: 15000 }));
+  // Support Pane via gh API: star the repo and follow the maintainer.
+  ipcMain.handle('onboarding:support-project', async () => {
+    const results = {
+      starred: starPaneRepo(),
+      followed: followSupportUser(),
+    };
 
+    if (results.starred || results.followed) {
       if (analyticsManager) {
-        analyticsManager.track('onboarding_repo_starred');
+        analyticsManager.track('onboarding_project_supported', results);
       }
 
-      return { success: true, data: { method: 'api' } };
-    } catch {
-      // gh api failed — frontend should fall back to opening browser
-      return { success: false, error: 'gh_api_failed' };
+      return { success: true, data: results };
     }
+
+    return { success: false, error: 'gh_api_failed', data: results };
   });
 }

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -709,7 +709,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onboarding: {
     detectEnvironment: (): Promise<IPCResponse> => invokeIpc('onboarding:detect-environment'),
     setupDefaultRepo: (): Promise<IPCResponse> => invokeIpc('onboarding:setup-default-repo'),
-    starRepo: (): Promise<IPCResponse> => invokeIpc('onboarding:star-repo'),
+    supportProject: (): Promise<IPCResponse> => invokeIpc('onboarding:support-project'),
   },
 
   // UI State management

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -231,7 +231,7 @@ export async function installElectronApiMock(page: Page) {
       onboarding: namespace({
         detectEnvironment: () => success({}),
         setupDefaultRepo: () => success({}),
-        starRepo: () => success({}),
+        supportProject: () => success({}),
       }),
       panels: namespace({
         getSessionPanels: () => success([]),


### PR DESCRIPTION
## Summary
- replace the old star-only onboarding API with a single support action that stars Pane and best-effort follows the maintainer
- add explicit hover/focus and opt-out support copy to the onboarding checkbox
- remove the blocking setup/success onboarding screens so repo setup runs in the background after the primary click

## Testing
- pnpm typecheck
- pnpm lint
- local onboarding run with isolated PANE_DIR=/tmp/pane-onboarding-test