### PR TITLE
Add Remote Pane PWA onboarding and docs

### DIFF
--- a/.github/workflows/deploy-remote-pwa-preview.yml
+++ b/.github/workflows/deploy-remote-pwa-preview.yml
@@ -2,8 +2,12 @@ name: Deploy Remote PWA Preview
 
 on:
   push:
-    branches: [nightly]
+    branches: [main, nightly]
   workflow_dispatch:
+
+concurrency:
+  group: remote-pwa-preview-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 </div>
 
-> **Experimental:** Remote Pane is now available for running Pane against a remote workstation or VM while keeping the local desktop UI. This is a large runtime split and still experimental; see the [Remote Daemon docs](https://runpane.com/docs/remote-daemon) before using it for critical work.
+> **Experimental:** Remote Pane is now available for running Pane against a remote workstation or VM from the desktop app or the browser app at [runpane.com/app](https://runpane.com/app/). This is a large runtime split and still experimental; see the [Remote Daemon docs](https://runpane.com/docs/remote-daemon) before using it for critical work.
 
 ---
 
@@ -91,7 +91,7 @@ Each of these is a small thing. Together they compound fast.
 | **Resource Manager** | Built-in CPU and memory monitor broken down per pane and per process, so you can catch a runaway agent before it eats your laptop. | <img src="images/qol-resource-manager.png" alt="Built-in resource manager" width="420"> |
 | **Status Dots** | Activity indicators at the tab, pane, and project level tell you which agent is idle, working, or waiting without you having to look. | <img src="images/qol-status-dots.png" alt="Session activity status dots" width="280"> |
 | **Jump + Refresh** | Jump to top, jump to bottom, or hard-refresh any terminal from the toolbar to unstick a frozen state in one click. | <img src="images/qol-jump-refresh.png" alt="Terminal jump and refresh controls" width="120"> |
-| **Remote Pane** | Experimental remote daemon support lets your local Pane desktop connect to a remote workstation or VM. See the [Remote Daemon docs](https://runpane.com/docs/remote-daemon) for setup and current limits. | |
+| **Remote Pane** | Experimental remote daemon support lets desktop Pane or the browser app at [runpane.com/app](https://runpane.com/app/) connect to a remote workstation or VM. See the [Remote Daemon docs](https://runpane.com/docs/remote-daemon) for setup and current limits. | |
 | **Auto Secrets Copy** | Every pane automatically mirrors `.env` files and secrets from your root project so your worktree is runnable the moment it's created. | |
 | **Isolated Ports** | Each pane runs on its own port range automatically, so you can spin up five dev servers in parallel without a single conflict. | |
 | **Terminal Rendering Patches** | Claude Code's scroll-jump bug (long conversations snapping to top when you scroll up) is fixed here, even though it's still broken in Claude Code itself. | |

--- a/docs/SELF_HOSTED_REMOTE_DAEMON.md
+++ b/docs/SELF_HOSTED_REMOTE_DAEMON.md
@@ -1,12 +1,12 @@
 # Self-Hosted Remote Daemon
 
-This guide covers running Pane on your own workstation, Mac mini, Linux box, or VM and connecting to it from the local Pane desktop app.
+This guide covers running Pane on your own workstation, Mac mini, Linux box, or VM and connecting to it from the local Pane desktop app or the Remote Pane browser app.
 
 The intended flow is:
 
 1. Run one setup command on the remote machine.
 2. Copy the generated `pane-remote://...` connection code.
-3. Paste it into local Pane under `Settings > Self-Hosted Remote Daemon > Import Remote Connection`.
+3. Paste it into desktop Pane under `Settings > Remote Pane`, or open `https://runpane.com/app/` and paste it there.
 
 Pane saves the profile and attempts to connect immediately. Local desktop mode is unchanged until a remote profile is imported and activated.
 
@@ -18,16 +18,28 @@ From a source checkout:
 pnpm remote:setup -- --label "VM"
 ```
 
+SSH tunnel mode:
+
+```bash
+pnpm remote:setup -- --label "VM" --prefer-tunnel ssh
+```
+
 For validation against a separate data directory:
 
 ```bash
-PANE_DIR=/tmp/pane-remote-vm pnpm remote:setup -- --label "VM" --print-only
+PANE_DIR=/tmp/pane-remote-vm pnpm remote:setup -- --label "VM" --prefer-tunnel ssh --print-only
 ```
 
 Packaged Pane builds can run the same setup path without opening a window:
 
 ```bash
 pane --remote-setup --label "VM"
+```
+
+If Pane is already installed on the host, this is the most direct command:
+
+```bash
+pane --remote-setup --label "VM" --prefer-tunnel tailscale
 ```
 
 The setup command:
@@ -57,11 +69,31 @@ pnpm remote:setup -- --no-tailscale-serve
 On your local desktop machine:
 
 1. Open Pane.
-2. Go to `Settings > Self-Hosted Remote Daemon`.
+2. Go to `Settings > Remote Pane`.
 3. Paste the full `pane-remote://...` code into `Import Remote Connection`.
 4. Click `Import & Connect`.
 
 If the tunnel is not reachable yet, Pane still saves the profile and shows the connection error. Start the printed SSH/Tailscale tunnel and click `Connect` on the saved profile.
+
+## Use the Mobile / Browser App
+
+The same connection code works in the Remote Pane PWA:
+
+```text
+https://runpane.com/app/
+```
+
+Use the PWA for phone or tablet access to terminal-backed remote sessions:
+
+1. Set up the remote host with Tailscale or a trusted HTTPS tunnel.
+2. Copy the full `pane-remote://...` code printed by setup.
+3. Open `https://runpane.com/app/` on the client device.
+4. Paste the code and connect.
+
+For iPhone or iPad, open the URL in Safari, tap Share, then tap `Add to Home Screen`.
+For Android, open the URL in Chrome, open the browser menu, then tap `Add to Home screen` or `Install app`.
+
+SSH tunnel mode is mainly useful from desktop clients. For mobile browser access, prefer Tailscale or Manual HTTPS so the phone can reach the daemon URL directly.
 
 ## Security Model
 
@@ -103,7 +135,7 @@ Launch Pane on the host against that directory:
 PANE_DIR="$HOME/.pane_remote" pnpm dev
 ```
 
-In `Settings > Self-Hosted Remote Daemon`:
+In `Settings > Remote Pane`:
 
 1. Enable `Enable remote daemon listener`.
 2. Keep `Listen Host` on `127.0.0.1`.
@@ -186,6 +218,5 @@ Some actions operate on the local desktop client machine rather than the remote 
 ## Current Limitations
 
 - No hosted relay, NAT traversal, or account-based multi-tenant auth
-- No web/mobile client in this phase
 - No direct non-loopback listener support
 - No full live remote end-to-end CI harness yet

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1381,18 +1381,18 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                     <div className="space-y-1">
                       <p className="text-[11px] font-medium text-text-secondary">macOS / Linux</p>
                       <code className="block rounded-md bg-surface-primary border border-border-secondary px-3 py-2 text-xs text-text-primary overflow-x-auto">
-                        curl -fsSL https://runpane.com/install-remote.sh | sh
+                        curl -fsSL https://runpane.com/install-remote.sh | sh -s -- --label "My Server"
                       </code>
                     </div>
                     <div className="space-y-1">
                       <p className="text-[11px] font-medium text-text-secondary">Windows PowerShell</p>
                       <code className="block rounded-md bg-surface-primary border border-border-secondary px-3 py-2 text-xs text-text-primary overflow-x-auto">
-                        irm https://runpane.com/install-remote.ps1 | iex
+                        &amp; ([scriptblock]::Create((irm https://runpane.com/install-remote.ps1))) -Label "My Server"
                       </code>
                     </div>
                   </div>
                   <p className="text-xs text-text-tertiary">
-                    Install Codex, Claude Code, or your preferred CLI agent on the remote host before starting agent panels.
+                    Install Codex, Claude Code, or your preferred CLI agent on the remote host before starting agent panels. For phone access, keep the default Tailscale setup and open runpane.com/app on the phone.
                   </p>
                 </div>
 

--- a/frontend/src/remote/components/RemoteConnectionScreen.tsx
+++ b/frontend/src/remote/components/RemoteConnectionScreen.tsx
@@ -1,6 +1,9 @@
-import { useState } from 'react';
-import { ArrowRight, ClipboardPaste, Monitor, Trash2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ArrowLeft, ArrowRight, BookOpen, ClipboardPaste, Download, Monitor, Smartphone, Trash2 } from 'lucide-react';
 import type { RemotePaneConnectionProfile } from '../../../../shared/types/remoteDaemon';
+
+type ConnectionScreenMode = 'menu' | 'connect';
+type MobileInstallPlatform = 'ios' | 'android' | 'mobile';
 
 interface RemoteConnectionScreenProps {
   savedProfiles: RemotePaneConnectionProfile[];
@@ -20,7 +23,17 @@ export function RemoteConnectionScreen({
   const [code, setCode] = useState('');
   const [isConnecting, setIsConnecting] = useState(false);
   const [clipboardError, setClipboardError] = useState<string | null>(null);
+  const [mode, setMode] = useState<ConnectionScreenMode>(() => (
+    savedProfiles.length > 0 ? 'connect' : 'menu'
+  ));
   const canReadClipboard = typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.readText);
+  const mobileInstallPlatform = getMobileInstallPlatform();
+
+  useEffect(() => {
+    if (savedProfiles.length > 0) {
+      setMode('connect');
+    }
+  }, [savedProfiles.length]);
 
   const handleSubmit = async () => {
     let connectionCode = code.trim();
@@ -48,86 +61,223 @@ export function RemoteConnectionScreen({
     }
   };
 
+  const showFirstRunMenu = savedProfiles.length === 0 && mode === 'menu';
+  const showBackToMenu = savedProfiles.length === 0 && mode === 'connect';
+
   return (
     <main className="flex min-h-dvh w-full items-center justify-center overflow-y-auto bg-bg-primary px-4 py-6 text-text-primary sm:p-6">
-      <section className="w-full max-w-sm rounded-lg border border-border-primary bg-surface-primary p-5 shadow-lg sm:max-w-lg sm:p-6">
+      <section className="w-full max-w-sm sm:max-w-2xl">
         <div className="mb-6 flex items-start gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-surface-secondary text-interactive">
             <Monitor className="h-5 w-5" />
           </div>
           <div className="min-w-0">
             <h1 className="text-xl font-semibold text-text-primary">Remote Pane</h1>
-            <p className="text-sm text-text-secondary">Connect to a Pane host using a connection code from Settings &gt; Remote Pane.</p>
+            <p className="text-sm text-text-secondary">Connect to a Pane host from desktop or mobile.</p>
           </div>
         </div>
 
-        <label className="mb-2 block text-sm font-medium text-text-secondary" htmlFor="connection-code">
-          Connection Code
-        </label>
-        <textarea
-          id="connection-code"
-          value={code}
-          onChange={event => setCode(event.target.value)}
-          placeholder="pane-remote://..."
-          className="min-h-32 max-h-52 w-full resize-y rounded-md border border-border-primary bg-bg-secondary p-3 font-mono text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-border-focus"
-        />
-
-        {(error || clipboardError) && (
-          <div className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-600">
-            <p>{error || clipboardError}</p>
-            {error && (
-              <p className="mt-2 text-xs text-red-500/90">
-                If this profile uses Tailscale, install or open Tailscale on this device, sign in to the same tailnet as the host, then retry.
-              </p>
+        {showFirstRunMenu ? (
+          <div className="space-y-4">
+            {mobileInstallPlatform && (
+              <MobileInstallPrompt platform={mobileInstallPlatform} />
             )}
-          </div>
-        )}
 
-        <div className="mt-4 flex justify-stretch sm:justify-end">
-          <button
-            type="button"
-            onClick={handleSubmit}
-            disabled={isConnecting || (!code.trim() && !canReadClipboard)}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-interactive px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:py-2"
-          >
-            {code.trim() ? <ArrowRight className="h-4 w-4" /> : <ClipboardPaste className="h-4 w-4" />}
-            {isConnecting ? 'Connecting...' : code.trim() ? 'Import & Connect' : 'Paste & Connect'}
-          </button>
-        </div>
-
-        {savedProfiles.length > 0 && (
-          <div className="mt-7 border-t border-border-primary pt-5">
-            <h2 className="mb-3 text-sm font-semibold text-text-secondary">Saved profiles</h2>
-            <div className="space-y-2">
-              {savedProfiles.map(profile => (
-                <div key={profile.id} className="flex flex-col gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-text-primary">{profile.label}</p>
-                    <p className="truncate text-xs text-text-tertiary">{profile.baseUrl}</p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => setMode('connect')}
+                className="group flex min-h-36 flex-col items-start justify-between rounded-lg border border-border-primary bg-surface-primary p-4 text-left shadow-lg transition-colors hover:border-border-focus hover:bg-surface-hover"
+              >
+                <div>
+                  <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md bg-surface-secondary text-interactive">
+                    <ClipboardPaste className="h-5 w-5" />
                   </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => { void onConnectProfile(profile).catch(() => {}); }}
-                      className="min-w-0 flex-1 rounded-md bg-interactive px-3 py-2 text-sm font-semibold text-white hover:opacity-90 sm:flex-none sm:py-1.5"
-                    >
-                      Connect
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onForgetProfile(profile.id)}
-                      className="rounded-md p-2 text-text-tertiary hover:bg-surface-hover hover:text-text-primary"
-                      aria-label={`Forget ${profile.label}`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
-                  </div>
+                  <h2 className="text-base font-semibold text-text-primary">Connect with a code</h2>
+                  <p className="mt-2 text-sm leading-5 text-text-secondary">Paste a pane-remote:// code from an existing remote host.</p>
                 </div>
-              ))}
+                <span className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-interactive">
+                  Open connection form
+                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </span>
+              </button>
+
+              <a
+                href="https://runpane.com/docs/remote-daemon"
+                target="_blank"
+                rel="noreferrer"
+                className="group flex min-h-36 flex-col items-start justify-between rounded-lg border border-border-primary bg-surface-primary p-4 text-left shadow-lg transition-colors hover:border-border-focus hover:bg-surface-hover"
+              >
+                <div>
+                  <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md bg-surface-secondary text-interactive">
+                    <BookOpen className="h-5 w-5" />
+                  </div>
+                  <h2 className="text-base font-semibold text-text-primary">Set up a remote host</h2>
+                  <p className="mt-2 text-sm leading-5 text-text-secondary">Run Pane on a VM, WSL box, server, or desktop and create a connection code.</p>
+                </div>
+                <span className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-interactive">
+                  Open setup guide
+                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                </span>
+              </a>
             </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-border-primary bg-surface-primary p-5 shadow-lg sm:p-6">
+            {showBackToMenu && (
+              <button
+                type="button"
+                onClick={() => setMode('menu')}
+                className="mb-4 inline-flex items-center gap-2 text-sm font-medium text-text-secondary hover:text-text-primary"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back
+              </button>
+            )}
+
+            <label className="mb-2 block text-sm font-medium text-text-secondary" htmlFor="connection-code">
+              Connection Code
+            </label>
+            <textarea
+              id="connection-code"
+              value={code}
+              onChange={event => setCode(event.target.value)}
+              placeholder="pane-remote://..."
+              className="min-h-32 max-h-52 w-full resize-y rounded-md border border-border-primary bg-bg-secondary p-3 font-mono text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-border-focus"
+            />
+
+            {(error || clipboardError) && (
+              <div className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-600">
+                <p>{error || clipboardError}</p>
+                {error && (
+                  <p className="mt-2 text-xs text-red-500/90">
+                    If this profile uses Tailscale, install or open Tailscale on this device, sign in to the same tailnet as the host, then retry.
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="mt-4 flex justify-stretch sm:justify-end">
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isConnecting || (!code.trim() && !canReadClipboard)}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-interactive px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:py-2"
+              >
+                {code.trim() ? <ArrowRight className="h-4 w-4" /> : <ClipboardPaste className="h-4 w-4" />}
+                {isConnecting ? 'Connecting...' : code.trim() ? 'Import & Connect' : 'Paste & Connect'}
+              </button>
+            </div>
+
+            {savedProfiles.length > 0 && (
+              <div className="mt-7 border-t border-border-primary pt-5">
+                <h2 className="mb-3 text-sm font-semibold text-text-secondary">Saved profiles</h2>
+                <div className="space-y-2">
+                  {savedProfiles.map(profile => (
+                    <div key={profile.id} className="flex flex-col gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-text-primary">{profile.label}</p>
+                        <p className="truncate text-xs text-text-tertiary">{profile.baseUrl}</p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => { void onConnectProfile(profile).catch(() => {}); }}
+                          className="min-w-0 flex-1 rounded-md bg-interactive px-3 py-2 text-sm font-semibold text-white hover:opacity-90 sm:flex-none sm:py-1.5"
+                        >
+                          Connect
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onForgetProfile(profile.id)}
+                          className="rounded-md p-2 text-text-tertiary hover:bg-surface-hover hover:text-text-primary"
+                          aria-label={`Forget ${profile.label}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
       </section>
     </main>
   );
+}
+
+function MobileInstallPrompt({ platform }: { platform: MobileInstallPlatform }) {
+  const steps = getMobileInstallSteps(platform);
+
+  return (
+    <div className="rounded-lg border border-border-primary bg-surface-primary p-4 shadow-lg">
+      <div className="flex gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-surface-secondary text-interactive">
+          <Smartphone className="h-5 w-5" />
+        </div>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold text-text-primary">Install Remote Pane</h2>
+            <Download className="h-4 w-4 text-interactive" />
+          </div>
+          <ol className="mt-2 list-inside list-decimal space-y-1 text-sm leading-5 text-text-secondary">
+            {steps.map(step => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getMobileInstallSteps(platform: MobileInstallPlatform): string[] {
+  if (platform === 'ios') {
+    return [
+      'Open this page in Safari.',
+      'Tap Share.',
+      'Tap Add to Home Screen.',
+    ];
+  }
+
+  if (platform === 'android') {
+    return [
+      'Open this page in Chrome.',
+      'Open the browser menu.',
+      'Tap Install app or Add to Home screen.',
+    ];
+  }
+
+  return [
+    'Open this page in your mobile browser.',
+    'Use the browser menu or share sheet.',
+    'Choose the home-screen install option.',
+  ];
+}
+
+function getMobileInstallPlatform(): MobileInstallPlatform | null {
+  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+    return null;
+  }
+
+  const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
+  const isStandalone = window.matchMedia('(display-mode: standalone)').matches || navigatorWithStandalone.standalone === true;
+  if (isStandalone) {
+    return null;
+  }
+
+  const userAgent = navigator.userAgent.toLowerCase();
+  const touchMac = /macintosh/.test(userAgent) && navigator.maxTouchPoints > 1;
+  if (/iphone|ipad|ipod/.test(userAgent) || touchMac) {
+    return 'ios';
+  }
+
+  if (/android/.test(userAgent)) {
+    return 'android';
+  }
+
+  const isNarrowTouch = window.matchMedia('(max-width: 767px)').matches && navigator.maxTouchPoints > 0;
+  return isNarrowTouch ? 'mobile' : null;
 }

--- a/main/src/daemon/setupRemoteHost.ts
+++ b/main/src/daemon/setupRemoteHost.ts
@@ -178,7 +178,7 @@ export function formatSetupRemoteHostResult(result: SetupRemoteHostResult): stri
     lines.push('');
   }
 
-  lines.push('Paste the full pane-remote:// code into Pane Settings > Self-Hosted Remote Daemon > Import Remote Connection.');
+  lines.push('Paste the full pane-remote:// code into Settings > Remote Pane in desktop Pane, or into https://runpane.com/app/.');
   return lines.join('\n');
 }
 


### PR DESCRIPTION
## Summary
- Adds a first-run Remote Pane PWA onboarding screen with separate paths for connecting with a code or setting up a host.
- Adds mobile PWA install guidance with iOS/Android detection, while saved profiles still open the profile connection flow directly.
- Updates Pane README, in-app setup snippets, CLI setup output, and self-hosted remote daemon docs to mention runpane.com/app and exact setup commands.
- Updates the Remote PWA Cloud Run workflow to deploy on main as well as nightly, with concurrency protection.

## Validation
- `pnpm typecheck` passed.
- `pnpm lint` passed with existing warnings only.
- `pnpm --filter main exec vitest run src/daemon/setupRemoteHostCli.test.ts src/daemon/setupRemoteHost.test.ts` passed.
- `pnpm run build:frontend` passed.
- Playwright smoke-tested built `/remote.html` for first-run desktop, mobile install prompt, and saved-profile bypass.

## Notes
- Local Node is v20.19.3, while this repo declares Node >=22.14.0; commands still completed successfully.
