### PR TITLE
fix: address QoL bugs found in README feature audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Other tools build custom chat UIs that only work with agents they've explicitly 
 |----------|--------|
 | `⌘⇧P` / `Ctrl+Shift+P` | Open command palette |
 | `⌘K` / `Ctrl+K` | Clear terminal scrollback |
-| `⌘Enter` / `Ctrl+Enter` | Send message to AI agent |
 | `⌘N` / `Ctrl+N` | New pane |
 | `⌘⇧W` / `Ctrl+Shift+W` | Archive pane |
 | `⌘1-9` / `Ctrl+1-9` | Switch pane |

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
-import { useHotkeyStore } from '../stores/hotkeyStore';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { AddProjectDialog } from './AddProjectDialog';
 import { Dropdown } from './ui/Dropdown';
@@ -31,7 +30,6 @@ export function ProjectSessionList({
   remoteDesktopTooltip,
 }: ProjectSessionListProps) {
   const [projects, setProjects] = useState<Project[]>([]);
-  const [expandedProjects, setExpandedProjects] = useState<Set<number>>(new Set());
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [createForProject, setCreateForProject] = useState<Project | null>(null);
 
@@ -47,12 +45,13 @@ export function ProjectSessionList({
   const setActiveSession = useSessionStore(s => s.setActiveSession);
   const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
   const navigateToProject = useNavigationStore(s => s.navigateToProject);
+  // Expansion state lives in the navigation store so the always-mounted
+  // session hotkeys (useSessionNavigationHotkeys) see the same visible ordering
+  const expandedProjects = useNavigationStore(s => s.expandedProjects);
+  const toggleProjectExpanded = useNavigationStore(s => s.toggleProjectExpanded);
+  const expandProject = useNavigationStore(s => s.expandProject);
   const panelPanels = usePanelStore(s => s.panels);
   const panelActivityStatus = usePanelStore(s => s.activityStatus);
-
-  // Hotkey registration
-  const register = useHotkeyStore(s => s.register);
-  const unregister = useHotkeyStore(s => s.unregister);
 
   // Load projects
   const loadProjects = useCallback(async () => {
@@ -120,80 +119,8 @@ export function ProjectSessionList({
       .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
   }, [sessions, getPinnedSessionLabel]);
 
-  // Flat list of all visible sessions (for hotkey mapping)
-  const allVisibleSessions = useMemo(() => {
-    const result: Session[] = [];
-    projects.forEach(p => {
-      if (expandedProjects.has(p.id)) {
-        const list = sessionsByProject.get(p.id) || [];
-        result.push(...list);
-      }
-    });
-    return result;
-  }, [projects, expandedProjects, sessionsByProject]);
-
-  // Register ⌘1-⌘9 hotkeys with dynamic session name labels
-  const allVisibleSessionsRef = useRef(allVisibleSessions);
-  allVisibleSessionsRef.current = allVisibleSessions;
-  const setActiveSessionRef = useRef(setActiveSession);
-  setActiveSessionRef.current = setActiveSession;
-  const navigateToSessionsRef = useRef(navigateToSessions);
-  navigateToSessionsRef.current = navigateToSessions;
-
-  // Build stable label key so we re-register when session names/projects change
-  const sessionLabelKey = allVisibleSessions.slice(0, 9).map(s => `${s.name}:${s.projectId}`).join('|');
-  const projectsRef = useRef(projects);
-  projectsRef.current = projects;
-
-  useEffect(() => {
-    const ids: string[] = [];
-    for (let i = 1; i <= 9; i++) {
-      const id = `switch-session-${i}`;
-      ids.push(id);
-      const session = allVisibleSessionsRef.current[i - 1];
-      let label = `Switch to pane ${i}`;
-      if (session) {
-        const project = projectsRef.current.find(p => p.id === session.projectId);
-        label = project
-          ? `Switch to ${session.name} (${project.name})`
-          : `Switch to ${session.name}`;
-      }
-      const idx = i - 1;
-      register({
-        id,
-        label,
-        keys: `mod+${i}`,
-        category: 'session',
-        enabled: () => !!allVisibleSessionsRef.current[idx],
-        action: () => {
-          const s = allVisibleSessionsRef.current[idx];
-          if (s) {
-            setActiveSessionRef.current(s.id);
-            navigateToSessionsRef.current();
-          }
-        },
-      });
-    }
-    return () => ids.forEach(id => unregister(id));
-  }, [register, unregister, sessionLabelKey]);
-
-  // Track known project IDs so we only auto-expand newly added ones
-  const knownProjectIds = useRef<Set<number>>(new Set());
-  const projectIds = useMemo(() => projects.map(p => p.id).join(','), [projects]);
-
-  // Auto-expand newly added projects (preserves user-collapsed state for existing ones)
-  useEffect(() => {
-    const newIds = projects.filter(p => !knownProjectIds.current.has(p.id)).map(p => p.id);
-    knownProjectIds.current = new Set(projects.map(p => p.id));
-    if (newIds.length > 0) {
-      setExpandedProjects(prev => {
-        const next = new Set(prev);
-        newIds.forEach(id => next.add(id));
-        return next;
-      });
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [projectIds]);
+  // mod+1-9 session switch hotkeys are registered in useSessionNavigationHotkeys
+  // (always mounted in Sidebar), and new-project auto-expansion lives there too.
 
   // Auto-expand the project that contains the active session
   // (e.g., when a new session is created and auto-activated)
@@ -202,23 +129,11 @@ export function ProjectSessionList({
     const currentSessions = useSessionStore.getState().sessions;
     const session = currentSessions.find(s => s.id === activeSessionId);
     if (!session?.projectId) return;
-    if (!expandedProjects.has(session.projectId)) {
-      setExpandedProjects(prev => {
-        const next = new Set(prev);
-        next.add(session.projectId!);
-        return next;
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeSessionId]);
+    expandProject(session.projectId);
+  }, [activeSessionId, expandProject]);
 
   const toggleProject = (id: number) => {
-    setExpandedProjects(prev => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+    toggleProjectExpanded(id);
   };
 
   const handleSessionClick = (sessionId: string) => {

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -40,7 +40,7 @@ Each worktree needs its own dev server on a unique port.
 
 Create scripts/pane-run-script.js (Node.js, cross-platform) that:
 1. Auto-detects git worktrees vs main repo
-2. Assigns unique ports using hash(cwd) % 1000 + base_port, with separate ranges for main vs worktrees
+2. Assigns ports from the PANE_PORT environment variable that Pane injects into every pane terminal: each pane gets its own block of 10 ports starting at PANE_PORT, so PANE_PORT, PANE_PORT+1, ... PANE_PORT+9 are safe to use. Falls back to hash(cwd) % 1000 + base_port (separate ranges for main vs worktrees) only if PANE_PORT is unset
 ${depsStep}
 4. Auto-detects if build is stale (src mtime > dist mtime)
 5. Clean Ctrl+C termination (taskkill on Windows, SIGTERM on Unix)

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -608,7 +608,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             }
           }
           // Ctrl/Cmd+Alt+/: open shortcut settings
-          if (ctrlOrMeta && e.altKey && e.key === '/') return false;
+          // Check e.code too: macOS Option modifies e.key (e.g. '/' becomes '÷')
+          if (ctrlOrMeta && e.altKey && (e.key === '/' || (!e.getModifierState('AltGraph') && e.code === 'Slash'))) return false;
           // Ctrl/Cmd+W or Ctrl/Cmd+Q: close active tab
           if (ctrlOrMeta && (e.key.toLowerCase() === 'w' || e.key.toLowerCase() === 'q')) return false;
           // Ctrl/Cmd+T: open Add Tool dropdown
@@ -874,10 +875,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
                   const file = items[i].getAsFile();
                   if (!file) return;
 
-                  if (file.size > 10 * 1024 * 1024) {
+                  if (file.size > 50 * 1024 * 1024) {
                     const sizeMB = (file.size / (1024 * 1024)).toFixed(1);
                     if (terminal && !disposed) {
-                      terminal.paste(`[Image paste failed] File too large (${sizeMB} MB), max 10 MB\n`);
+                      terminal.paste(`[Image paste failed] File too large (${sizeMB} MB), max 50 MB\n`);
                     }
                     return;
                   }
@@ -1018,6 +1019,12 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
                   }
                 } catch (err) {
                   console.error('[TerminalPanel] Failed to drop file:', err);
+                  if (!disposed && terminal) {
+                    // Strip Electron's IPC wrapper so the user sees the backend reason
+                    const raw = err instanceof Error ? err.message : String(err);
+                    const reason = raw.replace(/^Error invoking remote method '[^']*':\s*(?:Error:\s*)?/, '');
+                    terminal.paste(`[Drop failed] ${reason || 'Unknown error'}\n`);
+                  }
                 }
               }
             })();

--- a/frontend/src/components/panels/browser/BrowserPanel.tsx
+++ b/frontend/src/components/panels/browser/BrowserPanel.tsx
@@ -12,16 +12,12 @@ interface BrowserPanelProps {
   isActive: boolean;
 }
 
-const LOCALHOST_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/.*)?$/;
-
-function isLocalhostUrl(url: string): boolean {
-  return LOCALHOST_PATTERN.test(url);
-}
-
 function normalizeUrl(input: string): string {
   let url = input.trim();
-  if (url.startsWith('localhost') || url.startsWith('127.0.0.1') || url.startsWith('[::1]')) {
-    url = 'http://' + url;
+  if (!/^https?:\/\//i.test(url)) {
+    // Local hosts default to http, everything else to https
+    const isLocalHost = url.startsWith('localhost') || url.startsWith('127.0.0.1') || url.startsWith('[::1]');
+    url = (isLocalHost ? 'http://' : 'https://') + url;
   }
   return url;
 }
@@ -104,8 +100,14 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
 
   const navigateTo = useCallback((rawUrl: string) => {
     const normalized = normalizeUrl(rawUrl);
-    if (!isLocalhostUrl(normalized)) {
-      setUrlError('Only localhost and 127.0.0.1 URLs are supported');
+    let parsed: URL | null = null;
+    try {
+      parsed = new URL(normalized);
+    } catch {
+      parsed = null;
+    }
+    if (!parsed || (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')) {
+      setUrlError('Enter a valid http or https URL');
       return;
     }
     setUrlError('');
@@ -388,7 +390,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
             type="text"
             value={inputUrl}
             onChange={(e) => { setInputUrl(e.target.value); setUrlError(''); }}
-            placeholder="localhost:3000"
+            placeholder="Enter a URL (e.g. localhost:3000)"
             className={cn(
               'w-full px-2.5 py-1 text-sm rounded bg-bg-primary border border-border-primary',
               'text-text-primary placeholder-text-tertiary',
@@ -412,7 +414,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
           <Globe className="w-12 h-12 mb-4 opacity-20" />
           <p className="text-sm">No URL loaded</p>
           <p className="text-xs text-text-tertiary mt-1">
-            Enter a localhost URL above or select one from terminal output
+            Enter a URL above or select one from terminal output
           </p>
         </div>
       ) : (

--- a/frontend/src/components/terminal/SelectionPopover.tsx
+++ b/frontend/src/components/terminal/SelectionPopover.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Copy, ExternalLink, FolderOpen, Globe } from 'lucide-react';
 import { TerminalPopover, PopoverButton } from './TerminalPopover';
+import { InterceptorToast } from './InterceptorToast';
 import { isWindows } from '../../utils/platformUtils';
 
 export interface SelectionPopoverProps {
@@ -16,7 +18,6 @@ export interface SelectionPopoverProps {
 }
 
 const URL_PATTERN = /https?:\/\/[^\s<>"{}|\\^`[\]]+/;
-const LOCALHOST_URL_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/.*)?$/;
 
 // File path patterns - detect Unix paths, Windows paths, and relative paths with extensions
 const FILE_PATH_PATTERNS = [
@@ -63,14 +64,14 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
   onOpenInBrowser,
   onClose,
 }) => {
-  // Early return when not visible to avoid unnecessary computation
-  if (!visible) return null;
+  // Stays mounted while hidden so the error toast can outlive the popover
+  const [errorToast, setErrorToast] = useState<string | null>(null);
 
-  const trimmedText = text.trim();
-  const urlMatch = trimmedText.match(URL_PATTERN);
+  // Skip computation when not visible
+  const trimmedText = visible ? text.trim() : '';
+  const urlMatch = visible ? trimmedText.match(URL_PATTERN) : null;
   const isUrl = urlMatch !== null;
-  const isLocalhostUrl = urlMatch ? LOCALHOST_URL_PATTERN.test(urlMatch[0]) : false;
-  const isFile = !isUrl && isFilePath(trimmedText);
+  const isFile = visible && !isUrl && isFilePath(trimmedText);
 
   const handleCopy = async () => {
     try {
@@ -117,15 +118,24 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
 
       const resolvedPath = resolveFilePath(trimmedText, workingDirectory);
       try {
-        await window.electronAPI.invoke('app:showItemInFolder', resolvedPath);
+        const result: { success: boolean; error?: string } = await window.electronAPI.invoke(
+          'app:showItemInFolder',
+          resolvedPath,
+          sessionId
+        );
+        if (!result?.success) {
+          setErrorToast(result?.error || 'Failed to show in file manager');
+        }
       } catch (error) {
         console.error('Failed to show in explorer:', error);
+        setErrorToast('Failed to show in file manager');
       }
       onClose();
     }
   };
 
   return (
+    <>
     <TerminalPopover visible={visible} x={x} y={y} onClose={onClose}>
       <PopoverButton onClick={handleCopy}>
         <span className="flex items-center gap-2">
@@ -133,7 +143,7 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
           Copy
         </span>
       </PopoverButton>
-      {isLocalhostUrl && sessionId && (
+      {isUrl && sessionId && (
         <PopoverButton onClick={handleOpenInBrowser}>
           <span className="flex items-center gap-2">
             <Globe className="w-4 h-4" />
@@ -162,5 +172,16 @@ export const SelectionPopover: React.FC<SelectionPopoverProps> = ({
         </PopoverButton>
       )}
     </TerminalPopover>
+    {errorToast && createPortal(
+      <div className="fixed inset-0 z-[10002] pointer-events-none">
+        <InterceptorToast
+          visible={!!errorToast}
+          message={errorToast}
+          onHide={() => setErrorToast(null)}
+        />
+      </div>,
+      document.body
+    )}
+    </>
   );
 };

--- a/frontend/src/components/terminal/hooks/useTerminalLinks.ts
+++ b/frontend/src/components/terminal/hooks/useTerminalLinks.ts
@@ -187,13 +187,20 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
     }
 
     try {
-      await window.electronAPI.invoke('app:showItemInFolder', path);
+      const result: { success: boolean; error?: string } = await window.electronAPI.invoke(
+        'app:showItemInFolder',
+        path,
+        config.sessionId
+      );
+      if (!result?.success) {
+        console.error('Failed to show item in folder:', result?.error);
+      }
     } catch (error) {
       console.error('Failed to show item in folder:', error);
     }
 
     setFilePopover((prev) => ({ ...prev, visible: false }));
-  }, [filePopover, isRemoteMode]);
+  }, [filePopover, isRemoteMode, config.sessionId]);
 
   const handleOpenInBrowser = useCallback(async (url: string) => {
     const panels = usePanelStore.getState().getSessionPanels(config.sessionId);

--- a/frontend/src/hooks/useSessionNavigationHotkeys.ts
+++ b/frontend/src/hooks/useSessionNavigationHotkeys.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useHotkey } from './useHotkey';
+import { useHotkeyStore } from '../stores/hotkeyStore';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
 import { cycleIndex } from '../utils/arrayUtils';
@@ -68,6 +69,30 @@ export function useSessionNavigationHotkeys({
       })
       .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
   }, [sessions, projectById]);
+
+  const expandedProjects = useNavigationStore(s => s.expandedProjects);
+  const registerProjectIds = useNavigationStore(s => s.registerProjectIds);
+
+  // Auto-expand newly added projects. Lives here (not in ProjectSessionList)
+  // because this hook stays mounted when the sidebar is collapsed or immersive
+  // mode hides it, keeping mod+1-9 numbering alive and consistent.
+  useEffect(() => {
+    registerProjectIds(projects.map(p => p.id));
+  }, [projects, registerProjectIds]);
+
+  // Sessions in the exact order ProjectSessionList renders them: projects in
+  // display order, collapsed projects skipped, sessions sorted by createdAt.
+  // Pinned rows are excluded, matching the list's hotkey numbering.
+  const visibleSessions = useMemo(() => {
+    const result: Session[] = [];
+    projects.forEach(project => {
+      if (expandedProjects.has(project.id)) {
+        const list = sessionsByProject.get(project.id) || [];
+        result.push(...list);
+      }
+    });
+    return result;
+  }, [projects, expandedProjects, sessionsByProject]);
 
   const allActiveSessionsRef = useRef(allActiveSessions);
   allActiveSessionsRef.current = allActiveSessions;
@@ -148,4 +173,48 @@ export function useSessionNavigationHotkeys({
     },
     action: () => cyclePinnedOrAllSessions('prev'),
   });
+
+  const visibleSessionsRef = useRef(visibleSessions);
+  visibleSessionsRef.current = visibleSessions;
+  const projectByIdRef = useRef(projectById);
+  projectByIdRef.current = projectById;
+
+  const register = useHotkeyStore(s => s.register);
+  const unregister = useHotkeyStore(s => s.unregister);
+
+  // Register mod+1-9 with dynamic session name labels. Build a stable label key
+  // so we re-register when session names/projects change.
+  const sessionLabelKey = visibleSessions.slice(0, 9).map(s => `${s.name}:${s.projectId}`).join('|');
+
+  useEffect(() => {
+    const ids: string[] = [];
+    for (let i = 1; i <= 9; i++) {
+      const id = `switch-session-${i}`;
+      ids.push(id);
+      const session = visibleSessionsRef.current[i - 1];
+      let label = `Switch to pane ${i}`;
+      if (session) {
+        const project = session.projectId != null ? projectByIdRef.current.get(session.projectId) : undefined;
+        label = project
+          ? `Switch to ${session.name} (${project.name})`
+          : `Switch to ${session.name}`;
+      }
+      const idx = i - 1;
+      register({
+        id,
+        label,
+        keys: `mod+${i}`,
+        category: 'session',
+        enabled: () => !!visibleSessionsRef.current[idx],
+        action: () => {
+          const s = visibleSessionsRef.current[idx];
+          if (s) {
+            setActiveSessionRef.current(s.id);
+            navigateToSessionsRef.current();
+          }
+        },
+      });
+    }
+    return () => ids.forEach(id => unregister(id));
+  }, [register, unregister, sessionLabelKey]);
 }

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -69,23 +69,49 @@ interface HotkeyStore {
 // Canonical modifier order — MUST be identical in both normalize functions
 const MODIFIER_ORDER = ['mod', 'alt', 'shift'] as const;
 
+// Punctuation codes resolved via e.code when Alt is held; macOS Option modifies
+// e.key for these too (e.g. Option+/ produces '÷' on some layouts)
+const ALT_PUNCTUATION_CODES: Record<string, string> = {
+  Slash: '/',
+  Comma: ',',
+  Period: '.',
+  Semicolon: ';',
+  Quote: "'",
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backquote: '`',
+  Minus: '-',
+  Equal: '=',
+};
+
+/**
+ * Resolve the logical key from e.code for Alt-held combos, where macOS Option
+ * translates e.key into a special character (e.g. Option+A produces 'å',
+ * Option+1 produces '¡', Option+/ produces '÷' on some layouts).
+ * Covers letters, digits, and common punctuation. Returns null when the code
+ * isn't one we normalize.
+ */
+function altKeyFromCode(code: string): string | null {
+  const letterMatch = code.match(/^Key([A-Z])$/);
+  if (letterMatch) return letterMatch[1].toLowerCase();
+  const digitMatch = code.match(/^Digit(\d)$/);
+  if (digitMatch) return digitMatch[1];
+  return ALT_PUNCTUATION_CODES[code] ?? null;
+}
+
 function normalizeKeyEvent(e: KeyboardEvent): string {
   const parts: string[] = [];
   if (e.metaKey || e.ctrlKey) parts.push('mod');
   if (e.altKey) parts.push('alt');
   if (e.shiftKey) parts.push('shift');
   // parts is already in canonical order because we push in that order
-  // Use e.code for letters when alt is held — macOS Option key modifies e.key
-  // (e.g. Option+A produces 'å' instead of 'a')
-  // Skip AltGr — on Windows/Linux international layouts AltGr sets both ctrlKey+altKey
+  // Use e.code for letters/digits/punctuation when alt is held; macOS Option
+  // key modifies e.key (e.g. Option+A produces 'å' instead of 'a')
+  // Skip AltGr: on Windows/Linux international layouts AltGr sets both ctrlKey+altKey
   // but is used for character input (e.g. AltGr+Q = '@' on German keyboards)
   const isAltGr = e.getModifierState('AltGraph');
-  const altLetterMatch = e.altKey && !isAltGr && e.code.match(/^Key([A-Z])$/);
-  let key = altLetterMatch
-    ? altLetterMatch[1].toLowerCase()
-    : e.key.length === 1
-      ? e.key.toLowerCase()
-      : e.key;
+  const altCodeKey = e.altKey && !isAltGr ? altKeyFromCode(e.code) : null;
+  let key = altCodeKey ?? (e.key.length === 1 ? e.key.toLowerCase() : e.key);
   // Use e.code for digits when shift is held — e.key is layout-dependent
   // (e.g. Shift+2 produces '@' on US, '"' on UK, different on AZERTY)
   const digitMatch = e.shiftKey && e.code.match(/^Digit(\d)$/);

--- a/frontend/src/stores/navigationStore.ts
+++ b/frontend/src/stores/navigationStore.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand';
 
+// Tracks which project ids have already been seen so registerProjectIds only
+// auto-expands genuinely new projects (preserves user-collapsed state)
+let knownProjectIds = new Set<number>();
+
 interface NavigationState {
   activeView: 'sessions' | 'project';
   activeProjectId: number | null;
@@ -12,6 +16,13 @@ interface NavigationState {
   // Immersive mode — all sidebars hide in sync
   immersiveMode: boolean;
   setImmersiveMode: (immersive: boolean) => void;
+
+  // Sidebar project expansion, shared between ProjectSessionList and the
+  // always-mounted session hotkeys so mod+1-9 numbering matches the visible list
+  expandedProjects: Set<number>;
+  toggleProjectExpanded: (projectId: number) => void;
+  expandProject: (projectId: number) => void;
+  registerProjectIds: (projectIds: number[]) => void;
 
   // Actions
   setActiveView: (view: 'sessions' | 'project') => void;
@@ -37,6 +48,28 @@ export const useNavigationStore = create<NavigationState>((set) => ({
 
   immersiveMode: false,
   setImmersiveMode: (immersive) => set({ immersiveMode: immersive }),
+
+  expandedProjects: new Set<number>(),
+  toggleProjectExpanded: (projectId) => set((state) => {
+    const next = new Set(state.expandedProjects);
+    if (next.has(projectId)) next.delete(projectId);
+    else next.add(projectId);
+    return { expandedProjects: next };
+  }),
+  expandProject: (projectId) => set((state) => {
+    if (state.expandedProjects.has(projectId)) return state;
+    const next = new Set(state.expandedProjects);
+    next.add(projectId);
+    return { expandedProjects: next };
+  }),
+  registerProjectIds: (projectIds) => set((state) => {
+    const newIds = projectIds.filter(id => !knownProjectIds.has(id));
+    knownProjectIds = new Set(projectIds);
+    if (newIds.length === 0) return state;
+    const next = new Set(state.expandedProjects);
+    newIds.forEach(id => next.add(id));
+    return { expandedProjects: next };
+  }),
 
   setActiveView: (view) => set({ activeView: view }),
 

--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -254,6 +254,12 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
   resourceMonitorService.initialize({
     app: options.app,
     getSessionById: (sessionId) => sessionManager.getSession(sessionId),
+    getSessionWslDistro: (sessionId) => {
+      const projectId = sessionManager.getSession(sessionId)?.projectId;
+      if (!projectId) return null;
+      const project = databaseService.getProject(projectId);
+      return project?.wsl_enabled && project.wsl_distribution ? project.wsl_distribution : null;
+    },
   });
 
   if (options.restoreSpotlights !== false) {

--- a/main/src/events.ts
+++ b/main/src/events.ts
@@ -147,7 +147,7 @@ export function setupEventListeners(services: AppServices): void {
   });
 
   // Listen to claudeCodeManager events
-  claudeCodeManager.on('output', async (output: {
+  claudeCodeManager.on('output', (output: {
     panelId: string;
     sessionId: string;
     type: 'json' | 'stdout' | 'stderr';
@@ -173,19 +173,6 @@ export function setupEventListeners(services: AppServices): void {
         data: output.data,
         timestamp: output.timestamp
       });
-    }
-
-    // In interactive Claude mode, the process stays alive between turns. Flip
-    // session status to 'waiting' when Claude emits a prompt so the UI
-    // re-enables git actions (SessionView gates on status === 'running').
-    if (
-      output.type === 'json' &&
-      typeof output.data === 'object' &&
-      output.data &&
-      'type' in output.data &&
-      (output.data as { type?: string }).type === 'prompt'
-    ) {
-      await sessionManager.updateSession(output.sessionId, { status: 'waiting' });
     }
 
     // Send real-time updates to renderer

--- a/main/src/ipc/app.ts
+++ b/main/src/ipc/app.ts
@@ -1,6 +1,7 @@
 import { IpcMain, shell } from 'electron';
 import { execFile } from 'child_process';
 import type { AppServices } from './types';
+import { revealInFileManager } from '../utils/revealInFileManager';
 
 export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): void {
   const { app } = services;
@@ -40,28 +41,32 @@ export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): vo
     }
   });
 
-  ipcMain.handle('app:showItemInFolder', async (_event, filePath: string) => {
+  ipcMain.handle('app:showItemInFolder', async (_event, filePath: string, sessionId?: string) => {
     try {
+      let targetPath = filePath;
+
+      // When the caller knows the session, convert stored paths (e.g. in-distro
+      // POSIX paths for WSL projects) to ones this process's fs can reach.
+      if (sessionId) {
+        try {
+          const ctx = services.sessionManager.getProjectContext(sessionId);
+          if (ctx) {
+            targetPath = ctx.pathResolver.toFileSystem(filePath);
+          }
+        } catch {
+          // Fall back to the raw path
+        }
+      }
+
       // Validate path exists before showing
       const fs = await import('fs/promises');
-      const exists = await fs.access(filePath).then(() => true).catch(() => false);
+      const exists = await fs.access(targetPath).then(() => true).catch(() => false);
 
       if (!exists) {
         return { success: false, error: 'File does not exist' };
       }
 
-      if (process.platform === 'darwin') {
-        // On macOS, shell.showItemInFolder can fail silently.
-        // Use `open -R` which reveals the file in Finder reliably.
-        await new Promise<void>((resolve, reject) => {
-          execFile('open', ['-R', filePath], (error) => {
-            if (error) reject(error);
-            else resolve();
-          });
-        });
-      } else {
-        shell.showItemInFolder(filePath);
-      }
+      await revealInFileManager(targetPath);
       return { success: true };
     } catch (error) {
       console.error('Failed to show item in folder:', error);

--- a/main/src/ipc/file.ts
+++ b/main/src/ipc/file.ts
@@ -1,9 +1,7 @@
 import type { IpcMain } from 'electron';
 import { shell } from 'electron';
 import * as fs from 'fs/promises';
-import * as fsSync from 'fs';
 import * as path from 'path';
-import { execFileSync } from 'child_process';
 import { glob } from 'glob';
 import type { PaneCommandRegistry } from '../daemon/commandRegistry';
 import type { AppServices } from './types';
@@ -11,19 +9,7 @@ import type { Session } from '../types/session';
 import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
 import { commandExecutor } from '../utils/commandExecutor';
 import { buildGitCommitCommand } from '../utils/shellEscape';
-
-/** Detect if the Electron process is running inside WSL (e.g. via WSLg). */
-let _isWSL: boolean | null = null;
-function isRunningInWSL(): boolean {
-  if (_isWSL !== null) return _isWSL;
-  try {
-    const version = fsSync.readFileSync('/proc/version', 'utf-8');
-    _isWSL = /microsoft/i.test(version);
-  } catch {
-    _isWSL = false;
-  }
-  return _isWSL;
-}
+import { revealInFileManager } from '../utils/revealInFileManager';
 
 interface FileReadRequest {
   sessionId: string;
@@ -1232,15 +1218,7 @@ export function registerFileHandlers(
       const basePath = ctx.pathResolver.toFileSystem(session.worktreePath);
       const targetPath = relativePath ? path.join(basePath, relativePath) : basePath;
 
-      if (isRunningInWSL()) {
-        // Inside WSL, shell.showItemInFolder has no file manager.
-        // Convert to a Windows path and open with explorer.exe.
-        // Use execFileSync with argument arrays to avoid shell injection.
-        const winPath = execFileSync('wslpath', ['-w', targetPath], { encoding: 'utf-8' }).trim();
-        execFileSync('explorer.exe', [`/select,${winPath}`]);
-      } else {
-        shell.showItemInFolder(targetPath);
-      }
+      await revealInFileManager(targetPath);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : 'Failed to show in folder' };

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -678,9 +678,10 @@ export function registerPanelHandlers(
     }
     const buffer = Buffer.from(base64Data, 'base64');
 
-    // Backend size validation (10MB limit)
-    if (buffer.length > 10 * 1024 * 1024) {
-      throw new Error('Image too large');
+    // Backend size validation: same 50MB cap as terminal:paste-file, since this
+    // handler also just saves the bytes to disk and returns the resolved path
+    if (buffer.length > 50 * 1024 * 1024) {
+      throw new Error('Image too large (max 50 MB)');
     }
 
     const resolvedPath = await saveFileForSession(sessionId, 'images', filename, buffer);

--- a/main/src/services/__tests__/gitStatusManager.test.ts
+++ b/main/src/services/__tests__/gitStatusManager.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import { GitStatusManager } from '../gitStatusManager';
 import { execSync } from '../../utils/commandExecutor';
-import { existsSync } from 'fs';
 import { fastCheckWorkingDirectory, fastGetAheadBehind, fastGetDiffStats } from '../gitPlumbingCommands';
 import type { SessionManager } from '../sessionManager';
 import type { WorktreeManager } from '../worktreeManager';
@@ -56,7 +55,7 @@ const mockProject = {
 const mockProjectContext = {
   project: mockProject,
   pathResolver: {},
-  commandRunner: { execAsync: vi.fn() },
+  commandRunner: { execAsync: vi.fn(), exec: vi.fn(), wslContext: null },
 };
 
 const cleanIndexStatus: GitIndexStatus = {
@@ -105,9 +104,6 @@ describe('GitStatusManager', () => {
       mockLogger
     );
 
-    // Default mocks: no rebase in progress
-    (existsSync as Mock).mockReturnValue(false);
-
     // Default: no uncommitted changes, no ahead/behind
     (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
     (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 0, behind: 0 });
@@ -115,6 +111,9 @@ describe('GitStatusManager', () => {
 
     // Default execSync returns empty buffer
     (execSync as Mock).mockReturnValue(Buffer.from(''));
+
+    // Default commandRunner.exec returns empty string
+    (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('');
   });
 
   describe('fetchGitStatus via getGitStatus (cache miss scenarios)', () => {
@@ -154,14 +153,14 @@ describe('GitStatusManager', () => {
     it('returns ahead state when commits ahead of main', async () => {
       (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
       (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 3, behind: 0 });
-      (execSync as Mock).mockImplementation((cmd: string) => {
-        if ((cmd as string).includes('diff --shortstat')) {
-          return Buffer.from(' 5 files changed, 20 insertions(+), 10 deletions(-)');
+      (mockProjectContext.commandRunner.exec as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('diff --shortstat')) {
+          return ' 5 files changed, 20 insertions(+), 10 deletions(-)';
         }
-        if ((cmd as string).includes('rev-list --count')) {
-          return Buffer.from('3');
+        if (cmd.includes('rev-list --count')) {
+          return '3';
         }
-        return Buffer.from('');
+        return '';
       });
 
       const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
@@ -189,14 +188,14 @@ describe('GitStatusManager', () => {
     it('returns diverged state when both ahead and behind', async () => {
       (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
       (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 2, behind: 3 });
-      (execSync as Mock).mockImplementation((cmd: string) => {
-        if ((cmd as string).includes('diff --shortstat')) {
-          return Buffer.from(' 4 files changed, 15 insertions(+), 8 deletions(-)');
+      (mockProjectContext.commandRunner.exec as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('diff --shortstat')) {
+          return ' 4 files changed, 15 insertions(+), 8 deletions(-)';
         }
-        if ((cmd as string).includes('rev-list --count')) {
-          return Buffer.from('2');
+        if (cmd.includes('rev-list --count')) {
+          return '2';
         }
-        return Buffer.from('');
+        return '';
       });
 
       const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
@@ -252,14 +251,14 @@ describe('GitStatusManager', () => {
       });
       (fastGetDiffStats as Mock).mockReturnValue({ additions: 5, deletions: 2, filesChanged: 2 });
       (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 2, behind: 0 });
-      (execSync as Mock).mockImplementation((cmd: string) => {
-        if ((cmd as string).includes('diff --shortstat')) {
-          return Buffer.from(' 3 files changed, 10 insertions(+), 5 deletions(-)');
+      (mockProjectContext.commandRunner.exec as Mock).mockImplementation((cmd: string) => {
+        if (cmd.includes('diff --shortstat')) {
+          return ' 3 files changed, 10 insertions(+), 5 deletions(-)';
         }
-        if ((cmd as string).includes('rev-list --count')) {
-          return Buffer.from('2');
+        if (cmd.includes('rev-list --count')) {
+          return '2';
         }
-        return Buffer.from('');
+        return '';
       });
 
       const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');

--- a/main/src/services/__tests__/worktreeFileSyncService.test.ts
+++ b/main/src/services/__tests__/worktreeFileSyncService.test.ts
@@ -424,6 +424,239 @@ describe('worktreeFileSyncService', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Entry ordering: small/critical entries before heavyweight directories
+  // -------------------------------------------------------------------------
+
+  describe('entry ordering', () => {
+    const environment: ProjectEnvironment = 'linux';
+    const mainRepoPath = '/home/user/repo';
+    const worktreePath = '/home/user/worktree';
+
+    function makeOrderingRunner(cpCommands: string[]): CommandRunner {
+      const execAsync = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.startsWith('find ')) {
+          if (cmd.includes('-name "node_modules"')) {
+            return Promise.resolve({ stdout: '/home/user/repo/node_modules', stderr: '' });
+          }
+          return Promise.resolve({ stdout: '/home/user/repo/.env', stderr: '' });
+        }
+        if (cmd.startsWith('test -e ')) {
+          return Promise.reject(new Error('not exists'));
+        }
+        if (cmd.startsWith('test -f ')) {
+          return cmd.includes('node_modules')
+            ? Promise.reject(new Error('not a file'))
+            : Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd.startsWith('mkdir ')) {
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd.startsWith('cp ')) {
+          cpCommands.push(cmd);
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      return { execAsync } as unknown as CommandRunner;
+    }
+
+    it('copies .env entries before node_modules even when node_modules is listed first', async () => {
+      const cpCommands: string[] = [];
+      const runner = makeOrderingRunner(cpCommands);
+
+      await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [nodeModulesEntry, envEntry],
+      );
+
+      expect(cpCommands).toHaveLength(2);
+      expect(cpCommands[0]).toBe(
+        'cp "/home/user/repo/.env" "/home/user/worktree/.env"',
+      );
+      expect(cpCommands[1]).toBe(
+        'cp -rp "/home/user/repo/node_modules" "/home/user/worktree/node_modules"',
+      );
+    });
+
+    it('keeps non-heavyweight entries in config order', async () => {
+      const cpCommands: string[] = [];
+      const execAsync = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.startsWith('find ')) {
+          return Promise.resolve({ stdout: '/home/user/repo/.env', stderr: '' });
+        }
+        if (cmd === 'test -e "/home/user/repo/.claude"') {
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd.startsWith('test -e ')) {
+          return Promise.reject(new Error('not exists'));
+        }
+        if (cmd.startsWith('test -f ')) {
+          return cmd.includes('.claude')
+            ? Promise.reject(new Error('not a file'))
+            : Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd.startsWith('mkdir ')) {
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd.startsWith('cp ')) {
+          cpCommands.push(cmd);
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      const runner = { execAsync } as unknown as CommandRunner;
+
+      await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [envEntry, claudeEntry],
+      );
+
+      expect(cpCommands).toHaveLength(2);
+      expect(cpCommands[0]).toContain('.env');
+      expect(cpCommands[1]).toContain('.claude');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Copy timeout
+  // -------------------------------------------------------------------------
+
+  describe('copy timeout', () => {
+    it('passes a generous per-call timeout to copy commands', async () => {
+      const cpCommands: string[] = [];
+      const runner = makeMockCommandRunner(
+        '/home/user/repo/node_modules',
+        new Set(),
+        cpCommands,
+      );
+
+      await worktreeFileSyncService.syncWorktree(
+        '/home/user/repo',
+        '/home/user/worktree',
+        runner,
+        'linux',
+        [nodeModulesEntry],
+      );
+
+      const execAsync = runner.execAsync as ReturnType<typeof vi.fn>;
+      const cpCall = execAsync.mock.calls.find((call) => String(call[0]).startsWith('cp '));
+      expect(cpCall).toBeDefined();
+      expect(cpCall?.[2]).toMatchObject({ timeout: 600_000 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Result summary: install command and failures
+  // -------------------------------------------------------------------------
+
+  describe('sync result', () => {
+    const environment: ProjectEnvironment = 'linux';
+    const mainRepoPath = '/home/user/repo';
+    const worktreePath = '/home/user/worktree';
+
+    it('returns the detected install command and no failures on success', async () => {
+      const cpCommands: string[] = [];
+      const existingDests = new Set(['/home/user/repo/pnpm-lock.yaml']);
+      const runner = makeMockCommandRunner(
+        '/home/user/repo/.env',
+        existingDests,
+        cpCommands,
+      );
+
+      const result = await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [envEntry],
+      );
+
+      expect(cpCommands).toHaveLength(1);
+      expect(result.installCommand).toBe('pnpm install');
+      expect(result.failures).toHaveLength(0);
+    });
+
+    it('reports per-match copy failures without aborting the sync', async () => {
+      const execAsync = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.startsWith('find ')) {
+          return Promise.resolve({ stdout: '/home/user/repo/node_modules', stderr: '' });
+        }
+        if (cmd.startsWith('test -e ')) {
+          return Promise.reject(new Error('not exists'));
+        }
+        if (cmd.startsWith('mkdir ')) {
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd.startsWith('cp ')) {
+          return Promise.reject(new Error('cp blew up'));
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      const runner = { execAsync } as unknown as CommandRunner;
+
+      const result = await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [nodeModulesEntry],
+      );
+
+      expect(result.installCommand).toBeNull();
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0].path).toBe('node_modules');
+      expect(result.failures[0].reason).toContain('cp blew up');
+    });
+
+    it('continues to later entries after an earlier entry fails', async () => {
+      const cpCommands: string[] = [];
+      const execAsync = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd.startsWith('find ')) {
+          if (cmd.includes('-name "node_modules"')) {
+            return Promise.resolve({ stdout: '/home/user/repo/node_modules', stderr: '' });
+          }
+          return Promise.resolve({ stdout: '/home/user/repo/.env', stderr: '' });
+        }
+        if (cmd.startsWith('test -e ')) {
+          return Promise.reject(new Error('not exists'));
+        }
+        if (cmd.startsWith('mkdir ')) {
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd.startsWith('cp ')) {
+          if (cmd.includes('.env')) {
+            return Promise.reject(new Error('env copy failed'));
+          }
+          cpCommands.push(cmd);
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+      const runner = { execAsync } as unknown as CommandRunner;
+
+      const result = await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [envEntry, nodeModulesEntry],
+      );
+
+      expect(cpCommands).toHaveLength(1);
+      expect(cpCommands[0]).toContain('node_modules');
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0].path).toBe('.env');
+      expect(result.failures[0].reason).toContain('env copy failed');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Disabled entries
   // -------------------------------------------------------------------------
 

--- a/main/src/services/gitPlumbingCommands.ts
+++ b/main/src/services/gitPlumbingCommands.ts
@@ -1,5 +1,6 @@
-import { execSync, ExtendedExecSyncOptions } from '../utils/commandExecutor';
+import { execSync } from '../utils/commandExecutor';
 import * as fs from 'fs';
+import { WSLContext, linuxToUNCPath } from '../utils/wslUtils';
 
 /**
  * Optimized git commands using plumbing (low-level) commands
@@ -14,10 +15,25 @@ export interface GitIndexStatus {
 }
 
 /**
+ * Check the directory exists before attempting git operations.
+ * This prevents ENOENT errors when worktrees have been deleted (e.g., /tmp cleanup).
+ * WSL paths are not visible to Windows fs APIs directly, so check via the UNC mount.
+ */
+function directoryExists(cwd: string, wslContext?: WSLContext | null): boolean {
+  const fsPath = wslContext ? linuxToUNCPath(cwd, wslContext.distribution) : cwd;
+  try {
+    fs.accessSync(fsPath, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Fast check if working directory has any changes using git plumbing commands
  * Much faster than running full `git status --porcelain`
  */
-export function fastCheckWorkingDirectory(cwd: string): GitIndexStatus {
+export function fastCheckWorkingDirectory(cwd: string, wslContext?: WSLContext | null): GitIndexStatus {
   const result: GitIndexStatus = {
     hasModified: false,
     hasStaged: false,
@@ -25,11 +41,7 @@ export function fastCheckWorkingDirectory(cwd: string): GitIndexStatus {
     hasConflicts: false
   };
 
-  // Check if the directory exists before attempting git operations
-  // This prevents ENOENT errors when worktrees have been deleted (e.g., /tmp cleanup)
-  try {
-    fs.accessSync(cwd, fs.constants.F_OK);
-  } catch {
+  if (!directoryExists(cwd, wslContext)) {
     // Directory doesn't exist - return safe defaults
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return {
@@ -43,45 +55,46 @@ export function fastCheckWorkingDirectory(cwd: string): GitIndexStatus {
   try {
     // 1. Refresh the index first (very fast, updates git's cache)
     try {
-      execSync('git update-index --refresh --ignore-submodules', { cwd, encoding: 'utf8', silent: true });
+      execSync('git update-index --refresh --ignore-submodules', { cwd, encoding: 'utf8', silent: true }, wslContext);
     } catch {
       // Some files may have been modified, that's ok
     }
 
     // 2. Check for unstaged changes (modified files in working directory)
     try {
-      execSync('git diff-files --quiet --ignore-submodules', { cwd, encoding: 'utf8', silent: true });
+      execSync('git diff-files --quiet --ignore-submodules', { cwd, encoding: 'utf8', silent: true }, wslContext);
     } catch {
       result.hasModified = true;
     }
 
     // 3. Check for staged changes (in index)
     try {
-      execSync('git diff-index --cached --quiet HEAD --ignore-submodules', { cwd, encoding: 'utf8', silent: true });
+      execSync('git diff-index --cached --quiet HEAD --ignore-submodules', { cwd, encoding: 'utf8', silent: true }, wslContext);
     } catch {
       result.hasStaged = true;
     }
 
     // 4. Check for untracked files (more efficient than ls-files for just checking existence)
     const untrackedCheck = execSync(
-      'git ls-files --others --exclude-standard --directory --no-empty-directory', 
-      { cwd }
+      'git ls-files --others --exclude-standard --directory --no-empty-directory',
+      { cwd },
+      wslContext
     ).toString().trim();
-    
+
     if (untrackedCheck) {
       result.hasUntracked = true;
     }
 
     // 5. Check for merge conflicts
-    const conflictCheck = execSync('git diff --name-only --diff-filter=U', { cwd })
+    const conflictCheck = execSync('git diff --name-only --diff-filter=U', { cwd }, wslContext)
       .toString().trim();
-    
+
     if (conflictCheck) {
       result.hasConflicts = true;
     }
 
     return result;
-  } catch (error) {
+  } catch {
     // If any unexpected error, return safe defaults
     return {
       hasModified: true,
@@ -95,17 +108,14 @@ export function fastCheckWorkingDirectory(cwd: string): GitIndexStatus {
 /**
  * Get count of commits ahead/behind using rev-list (faster than rev-parse)
  */
-export function fastGetAheadBehind(cwd: string, baseBranch: string): { ahead: number; behind: number } {
-  // Check if the directory exists before attempting git operations
-  try {
-    fs.accessSync(cwd, fs.constants.F_OK);
-  } catch {
+export function fastGetAheadBehind(cwd: string, baseBranch: string, wslContext?: WSLContext | null): { ahead: number; behind: number } {
+  if (!directoryExists(cwd, wslContext)) {
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return { ahead: 0, behind: 0 };
   }
 
   try {
-    const result = execSync(`git rev-list --left-right --count ${baseBranch}...HEAD`, { cwd })
+    const result = execSync(`git rev-list --left-right --count ${baseBranch}...HEAD`, { cwd }, wslContext)
       .toString().trim();
 
     const [behind, ahead] = result.split('\t').map(n => parseInt(n, 10));
@@ -121,18 +131,15 @@ export function fastGetAheadBehind(cwd: string, baseBranch: string): { ahead: nu
 /**
  * Get statistics about changes (additions/deletions) efficiently
  */
-export function fastGetDiffStats(cwd: string): { additions: number; deletions: number; filesChanged: number } {
-  // Check if the directory exists before attempting git operations
-  try {
-    fs.accessSync(cwd, fs.constants.F_OK);
-  } catch {
+export function fastGetDiffStats(cwd: string, wslContext?: WSLContext | null): { additions: number; deletions: number; filesChanged: number } {
+  if (!directoryExists(cwd, wslContext)) {
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return { additions: 0, deletions: 0, filesChanged: 0 };
   }
 
   try {
     // Use numstat for machine-readable output (faster to parse)
-    const result = execSync('git diff --numstat', { cwd }).toString().trim();
+    const result = execSync('git diff --numstat', { cwd }, wslContext).toString().trim();
 
     if (!result) {
       return { additions: 0, deletions: 0, filesChanged: 0 };
@@ -157,4 +164,3 @@ export function fastGetDiffStats(cwd: string): { additions: number; deletions: n
     return { additions: 0, deletions: 0, filesChanged: 0 };
   }
 }
-

--- a/main/src/services/gitStatusManager.ts
+++ b/main/src/services/gitStatusManager.ts
@@ -1,7 +1,4 @@
 import { EventEmitter } from 'events';
-import { execSync } from '../utils/commandExecutor';
-import { existsSync } from 'fs';
-import { join } from 'path';
 import type { Logger } from '../utils/logger';
 import type { GitStatus } from '../types/session';
 import type { SessionManager } from './sessionManager';
@@ -258,7 +255,7 @@ export class GitStatusManager extends EventEmitter {
               const ctx = this.sessionManager.getProjectContext(session.id);
               if (ctx) {
                 const comparisonBranch = await this.worktreeManager.getSessionComparisonBranch(session, ctx);
-                const { ahead, behind } = fastGetAheadBehind(session.worktreePath, comparisonBranch);
+                const { ahead, behind } = fastGetAheadBehind(session.worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
                 
                 const updatedStatus = { ...cached.status };
                 updatedStatus.ahead = ahead;
@@ -321,17 +318,17 @@ export class GitStatusManager extends EventEmitter {
         // hasUncommittedChanges might be true if there were conflicts
         // We'll do a quick check for uncommitted changes
         try {
-          const quickStatus = fastCheckWorkingDirectory(session.worktreePath);
+          const quickStatus = fastCheckWorkingDirectory(session.worktreePath, ctx.commandRunner.wslContext);
           updatedStatus.hasUncommittedChanges = quickStatus.hasModified || quickStatus.hasStaged;
           updatedStatus.hasUntrackedFiles = quickStatus.hasUntracked;
           // Update state based on conflicts
           if (quickStatus.hasConflicts) {
             updatedStatus.state = 'conflict';
           }
-          
+
           if (updatedStatus.hasUncommittedChanges) {
             // Get updated diff stats
-            const quickStats = fastGetDiffStats(session.worktreePath);
+            const quickStats = fastGetDiffStats(session.worktreePath, ctx.commandRunner.wslContext);
             updatedStatus.additions = quickStats.additions;
             updatedStatus.deletions = quickStats.deletions;
             updatedStatus.filesChanged = quickStats.filesChanged;
@@ -677,27 +674,28 @@ export class GitStatusManager extends EventEmitter {
     if (!cached) return true;
     
     try {
+      const ctx = this.sessionManager.getProjectContext(sessionId);
+
       // Quick check using plumbing commands
-      const quickStatus = fastCheckWorkingDirectory(worktreePath);
-      
+      const quickStatus = fastCheckWorkingDirectory(worktreePath, ctx?.commandRunner.wslContext);
+
       // Compare with cached status
       const cachedHasChanges = cached.status.hasUncommittedChanges || cached.status.hasUntrackedFiles;
       const currentHasChanges = quickStatus.hasModified || quickStatus.hasStaged || quickStatus.hasUntracked;
-      
+
       // If the basic state differs, we need to refresh
       if (cachedHasChanges !== currentHasChanges) {
         return true;
       }
-      
+
       // If both have no changes, check if ahead/behind changed
       if (!currentHasChanges) {
-        const ctx = this.sessionManager.getProjectContext(sessionId);
         if (ctx) {
           const session = await this.sessionManager.getSession(sessionId);
           const comparisonBranch = session
             ? await this.worktreeManager.getSessionComparisonBranch(session, ctx)
             : await this.worktreeManager.getProjectMainBranch(ctx.project.path, ctx.commandRunner);
-          const { ahead, behind } = fastGetAheadBehind(worktreePath, comparisonBranch);
+          const { ahead, behind } = fastGetAheadBehind(worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
 
           if ((cached.status.ahead || 0) !== ahead || (cached.status.behind || 0) !== behind) {
             return true;
@@ -741,7 +739,7 @@ export class GitStatusManager extends EventEmitter {
       }
 
       // Use fast plumbing commands for initial checks
-      const quickStatus = fastCheckWorkingDirectory(session.worktreePath);
+      const quickStatus = fastCheckWorkingDirectory(session.worktreePath, ctx.commandRunner.wslContext);
       const hasUncommittedChanges = quickStatus.hasModified || quickStatus.hasStaged;
       const hasUntrackedFiles = quickStatus.hasUntracked;
       const hasMergeConflicts = quickStatus.hasConflicts;
@@ -750,7 +748,7 @@ export class GitStatusManager extends EventEmitter {
       let uncommittedDiff = { stats: { filesChanged: 0, additions: 0, deletions: 0 } };
       if (hasUncommittedChanges) {
         // Use fast diff stats instead of full diff capture when possible
-        const quickStats = fastGetDiffStats(session.worktreePath);
+        const quickStats = fastGetDiffStats(session.worktreePath, ctx.commandRunner.wslContext);
         uncommittedDiff = {
           stats: {
             filesChanged: quickStats.filesChanged,
@@ -762,7 +760,7 @@ export class GitStatusManager extends EventEmitter {
 
       // Get ahead/behind status using fast plumbing command
       const comparisonBranch = await this.worktreeManager.getSessionComparisonBranch(session, ctx);
-      const { ahead, behind } = fastGetAheadBehind(session.worktreePath, comparisonBranch);
+      const { ahead, behind } = fastGetAheadBehind(session.worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
 
       // Get total additions/deletions for all commits in the branch (compared to comparison branch)
       let totalCommitAdditions = 0;
@@ -771,7 +769,7 @@ export class GitStatusManager extends EventEmitter {
       if (ahead > 0) {
         // Use git diff --shortstat for commit statistics
         try {
-          const statLine = execSync(`git diff --shortstat ${comparisonBranch}...HEAD`, { cwd: session.worktreePath }).toString().trim();
+          const statLine = ctx.commandRunner.exec(`git diff --shortstat ${comparisonBranch}...HEAD`, session.worktreePath, { silent: true }).trim();
           if (statLine) {
             const filesMatch = statLine.match(/(\d+) files? changed/);
             const additionsMatch = statLine.match(/(\d+) insertions?\(\+\)/);
@@ -785,14 +783,6 @@ export class GitStatusManager extends EventEmitter {
           // Keep defaults of 0 if command fails
         }
       }
-
-      // Check for rebase in progress
-      let isRebasing = false;
-      
-      // Check for rebase in progress using filesystem APIs
-      const rebaseMergeExists = existsSync(join(session.worktreePath, '.git', 'rebase-merge'));
-      const rebaseApplyExists = existsSync(join(session.worktreePath, '.git', 'rebase-apply'));
-      isRebasing = rebaseMergeExists || rebaseApplyExists;
 
       // Determine the overall state and secondary states
       let state: GitStatus['state'] = 'clean';
@@ -827,7 +817,7 @@ export class GitStatusManager extends EventEmitter {
       // Get total number of commits in the branch
       let totalCommits = ahead;
       try {
-        const countStr = execSync(`git rev-list --count ${comparisonBranch}..HEAD`, { cwd: session.worktreePath }).toString().trim();
+        const countStr = ctx.commandRunner.exec(`git rev-list --count ${comparisonBranch}..HEAD`, session.worktreePath, { silent: true }).trim();
         totalCommits = parseInt(countStr, 10) || ahead;
       } catch {
         // Keep default of ahead if command fails

--- a/main/src/services/panelManager.ts
+++ b/main/src/services/panelManager.ts
@@ -430,8 +430,6 @@ export class PanelManager {
     
     // Also emit to frontend via IPC
     this.sendRendererEvent('panel:event', event);
-    
-    console.log(`[PanelManager] Emitted event ${eventType} from panel ${panelId}`);
   }
   
   private generatePanelTitle(sessionId: string, type: string): string {

--- a/main/src/services/panels/logPanel/logsManager.ts
+++ b/main/src/services/panels/logPanel/logsManager.ts
@@ -6,7 +6,7 @@ import { panelManager } from '../../panelManager';
 import { addSessionLog, cleanupSessionLogs } from '../../../ipc/logs';
 import { getShellPath } from '../../../utils/shellPath';
 import type { AnalyticsManager } from '../../analyticsManager';
-import { WSLContext } from '../../../utils/wslUtils';
+import { WSLContext, buildWSLENV } from '../../../utils/wslUtils';
 
 export class LogsManager {
   private static instance: LogsManager;
@@ -156,8 +156,16 @@ export class LogsManager {
     let childProcess: ChildProcess;
 
     if (wslContext) {
+      // Env vars set on the wsl.exe Windows process do not cross into the distro shell;
+      // WSLENV tells WSL to copy the listed vars into the Linux env (see buildWSLENV docs)
       childProcess = spawn('wsl.exe', ['-d', wslContext.distribution, '--', 'bash', '-c', `cd '${cwd}' && ${command}`], {
-        env: { ...process.env, PATH: shellPath, PANE_PORT: panePort, PANE_WORKSPACE_PATH: cwd }
+        env: {
+          ...process.env,
+          PATH: shellPath,
+          PANE_PORT: panePort,
+          PANE_WORKSPACE_PATH: cwd,
+          WSLENV: buildWSLENV(['PANE_PORT', 'PANE_WORKSPACE_PATH'])
+        }
       });
     } else {
       childProcess = spawn(command, [], {

--- a/main/src/services/resourceMonitorService.test.ts
+++ b/main/src/services/resourceMonitorService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ResourceMonitorService } from './resourceMonitorService';
+import { ResourceMonitorService, parseWslEnvironScan } from './resourceMonitorService';
 
 describe('ResourceMonitorService', () => {
   it('returns no Electron metrics when initialized without an app', () => {
@@ -7,5 +7,50 @@ describe('ResourceMonitorService', () => {
     service.initialize();
 
     expect((service as { getElectronMetrics(): unknown[] }).getElectronMetrics()).toEqual([]);
+  });
+});
+
+describe('parseWslEnvironScan', () => {
+  it('parses well-formed scan lines', () => {
+    const stdout = 'sess-1|412|7|524288|node\nsess-1|413|0|1024|bash\nsess-2|99|3661|2048|claude\n';
+
+    expect(parseWslEnvironScan(stdout)).toEqual([
+      { sessionId: 'sess-1', pid: 412, name: 'node', cpuTimeSeconds: 7, memoryMB: 512 },
+      { sessionId: 'sess-1', pid: 413, name: 'bash', cpuTimeSeconds: 0, memoryMB: 1 },
+      { sessionId: 'sess-2', pid: 99, name: 'claude', cpuTimeSeconds: 3661, memoryMB: 2 },
+    ]);
+  });
+
+  it('keeps pipes inside comm by joining trailing fields', () => {
+    const samples = parseWslEnvironScan('sess-1|10|1|1024|odd|comm|name\n');
+
+    expect(samples).toHaveLength(1);
+    expect(samples[0].name).toBe('odd|comm|name');
+  });
+
+  it('skips malformed, partial, and empty lines', () => {
+    const stdout = [
+      '',
+      '   ',
+      'not-a-scan-line',
+      'sess-1|abc|7|1024|node',
+      'sess-1|10|x|1024|node',
+      'sess-1|10|7|y|node',
+      '|10|7|1024|node',
+      'sess-1|10|7|1024',
+      'sess-1|11|7|2048|node',
+    ].join('\n');
+
+    expect(parseWslEnvironScan(stdout)).toEqual([
+      { sessionId: 'sess-1', pid: 11, name: 'node', cpuTimeSeconds: 7, memoryMB: 2 },
+    ]);
+  });
+
+  it('falls back to unknown when comm is empty', () => {
+    const samples = parseWslEnvironScan('sess-1|10|7|1024|\n');
+
+    expect(samples).toEqual([
+      { sessionId: 'sess-1', pid: 10, name: 'unknown', cpuTimeSeconds: 7, memoryMB: 1 },
+    ]);
   });
 });

--- a/main/src/services/resourceMonitorService.ts
+++ b/main/src/services/resourceMonitorService.ts
@@ -30,25 +30,85 @@ interface WindowsBatchItem {
   MemoryMB: number;
 }
 
+export interface WslProcessSample {
+  sessionId: string;
+  pid: number;
+  name: string;
+  cpuTimeSeconds: number;
+  memoryMB: number;
+}
+
+/**
+ * Shell script run inside a WSL distro (one wsl.exe invocation per distro per
+ * poll). Scans /proc/<pid>/environ for processes carrying PANE_SESSION_ID
+ * (injected into every pane terminal and propagated via WSLENV) and emits one
+ * line per process: sessionId|pid|cpuSeconds|rssKB|comm
+ * Uses only POSIX sh + grep/tr/sed so it works on busybox-based distros too.
+ */
+const WSL_ENVIRON_SCAN_SCRIPT = [
+  'clk=$(getconf CLK_TCK 2>/dev/null); case "$clk" in ""|0|*[!0-9]*) clk=100;; esac',
+  'pg=$(getconf PAGESIZE 2>/dev/null); case "$pg" in ""|0|*[!0-9]*) pg=4096;; esac',
+  'for e in $(grep -slz PANE_SESSION_ID= /proc/[0-9]*/environ 2>/dev/null); do ' +
+    'p=${e#/proc/}; p=${p%/environ}; ' +
+    's=$({ tr "\\0" "\\n" < "$e" | sed -n "s/^PANE_SESSION_ID=//p" | head -n 1; } 2>/dev/null); ' +
+    '[ -n "$s" ] || continue; ' +
+    'st=$(cat "/proc/$p/stat" 2>/dev/null) || continue; ' +
+    '[ -n "$st" ] || continue; ' +
+    'c=${st#*(}; c=${c%%)*}; ' +
+    'rest=${st##*) }; ' +
+    'set -- $rest; ' +
+    '[ $# -ge 22 ] || continue; ' +
+    'cpu=$(( (${12} + ${13}) / clk )); ' +
+    'rss=$(( ${22} * (pg / 1024) )); ' +
+    'printf "%s|%s|%s|%s|%s\\n" "$s" "$p" "$cpu" "$rss" "$c"; ' +
+  'done',
+].join('; ');
+
+/**
+ * Parse the output of WSL_ENVIRON_SCAN_SCRIPT. Pure function, exported for tests.
+ * Lines are sessionId|pid|cpuSeconds|rssKB|comm; comm may itself contain pipes.
+ */
+export function parseWslEnvironScan(stdout: string): WslProcessSample[] {
+  const samples: WslProcessSample[] = [];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split('|');
+    if (parts.length < 5) continue;
+    const sessionId = parts[0];
+    const pid = parseInt(parts[1], 10);
+    const cpuTimeSeconds = parseInt(parts[2], 10);
+    const rssKB = parseInt(parts[3], 10);
+    if (!sessionId || isNaN(pid) || isNaN(cpuTimeSeconds) || isNaN(rssKB)) continue;
+    const name = parts.slice(4).join('|').trim() || 'unknown';
+    samples.push({ sessionId, pid, name, cpuTimeSeconds, memoryMB: rssKB / 1024 });
+  }
+  return samples;
+}
+
 interface ResourceMonitorInitializationOptions {
   app?: App | null;
   getSessionById?: (sessionId: string) => { name?: string; initial_prompt?: string } | undefined;
+  getSessionWslDistro?: (sessionId: string) => string | null;
 }
 
 export class ResourceMonitorService extends EventEmitter {
   private app: App | null = null;
   private getSessionById: ((sessionId: string) => { name?: string; initial_prompt?: string } | undefined) | null = null;
+  private getSessionWslDistro: ((sessionId: string) => string | null) | null = null;
   private idleTimer: ReturnType<typeof setInterval> | null = null;
   private activeTimer: ReturnType<typeof setInterval> | null = null;
   private isActivePolling = false;
   private pollInProgress = false;
-  private previousCpuSamples = new Map<number, CpuSample>();
+  private previousCpuSamples = new Map<string, CpuSample>();
   private isHidden = false;
   private needsCpuWarmup = false;
+  private wslScanFailedDistros = new Set<string>();
 
   initialize(options: ResourceMonitorInitializationOptions = {}): void {
     this.app = options.app ?? null;
     this.getSessionById = options.getSessionById ?? null;
+    this.getSessionWslDistro = options.getSessionWslDistro ?? null;
   }
 
   private getElectronMetrics(): ElectronProcessInfo[] {
@@ -127,12 +187,14 @@ export class ResourceMonitorService extends EventEmitter {
   }
 
   /**
-   * Compute delta-based CPU percentage for a PID using cached previous samples.
+   * Compute delta-based CPU percentage for a process using cached previous samples.
+   * Keys are String(pid) for native processes and wsl:<distro>:<pid> for WSL
+   * processes so Linux pids cannot collide with Windows pids.
    * Returns 0 on first observation (no previous sample to compare against).
    */
-  private computeDeltaCpu(pid: number, currentCpuTimeSeconds: number, currentTimestamp: number): number {
-    const prev = this.previousCpuSamples.get(pid);
-    this.previousCpuSamples.set(pid, { cpuTimeSeconds: currentCpuTimeSeconds, timestamp: currentTimestamp });
+  private computeDeltaCpu(key: string, currentCpuTimeSeconds: number, currentTimestamp: number): number {
+    const prev = this.previousCpuSamples.get(key);
+    this.previousCpuSamples.set(key, { cpuTimeSeconds: currentCpuTimeSeconds, timestamp: currentTimestamp });
 
     if (!prev) return 0;
 
@@ -146,12 +208,12 @@ export class ResourceMonitorService extends EventEmitter {
   }
 
   /**
-   * Remove stale entries from the CPU sample cache for PIDs no longer being tracked.
+   * Remove stale entries from the CPU sample cache for keys no longer being tracked.
    */
-  private cleanupCpuSampleCache(activePids: Set<number>): void {
-    for (const pid of this.previousCpuSamples.keys()) {
-      if (!activePids.has(pid)) {
-        this.previousCpuSamples.delete(pid);
+  private cleanupCpuSampleCache(activeKeys: Set<string>): void {
+    for (const key of this.previousCpuSamples.keys()) {
+      if (!activeKeys.has(key)) {
+        this.previousCpuSamples.delete(key);
       }
     }
   }
@@ -234,10 +296,59 @@ export class ResourceMonitorService extends EventEmitter {
     return pids
       .map(pid => {
         const raw = rawStats.get(pid) || { name: 'unknown', cpuTimeSeconds: 0, memoryMB: 0 };
-        const cpuPercent = this.computeDeltaCpu(pid, raw.cpuTimeSeconds, now);
+        const cpuPercent = this.computeDeltaCpu(String(pid), raw.cpuTimeSeconds, now);
         return { pid, name: raw.name, cpuPercent, memoryMB: raw.memoryMB };
       })
       .filter(c => c.cpuPercent > 0 || c.memoryMB > 0.1);
+  }
+
+  /**
+   * On Windows hosts, sessions running inside WSL hide behind a single wsl.exe
+   * relay pid; the Windows process-tree walk cannot see into the distro. This
+   * runs one batched environ scan per distro that has live WSL sessions and
+   * groups the resulting samples by sessionId. Any failure (wsl.exe missing,
+   * distro stopped, parse error) is swallowed so native polling is unaffected.
+   */
+  private async getWslSamplesBySession(sessionIds: string[]): Promise<Map<string, { distro: string; sample: WslProcessSample }[]>> {
+    const result = new Map<string, { distro: string; sample: WslProcessSample }[]>();
+    if (os.platform() !== 'win32' || !this.getSessionWslDistro) return result;
+
+    const sessionDistro = new Map<string, string>();
+    for (const sessionId of sessionIds) {
+      try {
+        const distro = this.getSessionWslDistro(sessionId);
+        if (distro) sessionDistro.set(sessionId, distro);
+      } catch {
+        // Resolver failure: treat session as non-WSL
+      }
+    }
+    if (sessionDistro.size === 0) return result;
+
+    const distros = [...new Set(sessionDistro.values())];
+    await Promise.all(distros.map(async distro => {
+      let stdout: string;
+      try {
+        ({ stdout } = await execFileAsync(
+          'wsl.exe',
+          ['-d', distro, '--', 'sh', '-c', WSL_ENVIRON_SCAN_SCRIPT],
+          { encoding: 'utf8', timeout: 4000 }
+        ));
+        this.wslScanFailedDistros.delete(distro);
+      } catch (error) {
+        if (!this.wslScanFailedDistros.has(distro)) {
+          this.wslScanFailedDistros.add(distro);
+          console.warn(`[ResourceMonitor] WSL process scan failed for distro ${distro}, skipping:`, error instanceof Error ? error.message : error);
+        }
+        return;
+      }
+      for (const sample of parseWslEnvironScan(stdout)) {
+        if (sessionDistro.get(sample.sessionId) !== distro) continue;
+        const list = result.get(sample.sessionId) || [];
+        list.push({ distro, sample });
+        result.set(sample.sessionId, list);
+      }
+    }));
+    return result;
   }
 
   private async getSessionMetrics(): Promise<SessionResourceInfo[]> {
@@ -272,7 +383,10 @@ export class ResourceMonitorService extends EventEmitter {
     }
 
     const sessions: SessionResourceInfo[] = [];
-    const allTrackedPids = new Set<number>();
+    const allTrackedKeys = new Set<string>();
+
+    // WSL sessions on Windows: one batched in-distro scan per distro
+    const wslSamplesBySession = await this.getWslSamplesBySession([...sessionPids.keys()]);
 
     for (const [sessionId, ptyPids] of sessionPids) {
       const session = this.getSessionById?.(sessionId);
@@ -285,7 +399,7 @@ export class ResourceMonitorService extends EventEmitter {
       }
 
       // Track all PIDs for cache cleanup
-      for (const pid of allPids) allTrackedPids.add(pid);
+      for (const pid of allPids) allTrackedKeys.add(String(pid));
 
       let children: ChildProcessInfo[];
       if (os.platform() === 'win32') {
@@ -294,6 +408,19 @@ export class ResourceMonitorService extends EventEmitter {
       } else {
         const rawStats = await this.getUnixBatchRawStats(allPids);
         children = this.resolveProcessStats(allPids, rawStats, now);
+      }
+
+      // WSL processes appear alongside the wsl.exe relay already attributed above
+      const wslEntries = wslSamplesBySession.get(sessionId);
+      if (wslEntries) {
+        for (const { distro, sample } of wslEntries) {
+          const key = `wsl:${distro}:${sample.pid}`;
+          allTrackedKeys.add(key);
+          const cpuPercent = this.computeDeltaCpu(key, sample.cpuTimeSeconds, now);
+          if (cpuPercent > 0 || sample.memoryMB > 0.1) {
+            children.push({ pid: sample.pid, name: `${sample.name} (${distro})`, cpuPercent, memoryMB: sample.memoryMB });
+          }
+        }
       }
 
       const totalCpu = children.reduce((sum, c) => sum + c.cpuPercent, 0);
@@ -309,7 +436,7 @@ export class ResourceMonitorService extends EventEmitter {
     }
 
     // Clean up stale CPU samples for processes that no longer exist
-    this.cleanupCpuSampleCache(allTrackedPids);
+    this.cleanupCpuSampleCache(allTrackedKeys);
 
     return sessions;
   }

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -14,7 +14,7 @@ import { panelManager } from './panelManager';
 import { PathResolver } from '../utils/pathResolver';
 import type { DatabaseService } from '../database/database';
 import type { Project } from '../database/models';
-import { worktreeFileSyncService } from './worktreeFileSyncService';
+import { worktreeFileSyncService, type WorktreeFileSyncFailure } from './worktreeFileSyncService';
 import { terminalPanelManager } from './terminalPanelManager';
 import { detectProjectConfig } from './projectConfigDetector';
 import { emitFolderCreatedEvent } from './folderEvents';
@@ -44,6 +44,21 @@ interface CreateSessionJob {
 interface ContinueSessionJob {
   sessionId: string;
   prompt: string;
+}
+
+/**
+ * Builds a single shell-safe `echo` line summarizing worktree file sync
+ * failures, or null when nothing failed. Kept to one line even when many
+ * entries fail.
+ */
+function buildFileSyncWarningCommand(failures: WorktreeFileSyncFailure[]): string | null {
+  if (failures.length === 0) return null;
+  const sanitize = (text: string): string =>
+    text.split('\n')[0].replace(/["`$\\]/g, '').trim();
+  const first = failures[0];
+  const reason = sanitize(first.reason).slice(0, 120);
+  const rest = failures.length > 1 ? `; ${failures.length - 1} more failed` : '';
+  return `echo "[Pane] file sync: failed to copy ${sanitize(first.path)} (${reason})${rest}"`;
 }
 
 interface SendInputJob {
@@ -272,8 +287,14 @@ export class TaskQueue {
           ctx.commandRunner,
           ctx.pathResolver.environment,
           getRuntimeConfigManager().getWorktreeFileSyncEntries()
-        ).then(async (installCommand) => {
-          if (!installCommand) return;
+        ).then(async (syncResult) => {
+          const installCommand = syncResult.installCommand;
+          const warningCommand = buildFileSyncWarningCommand(syncResult.failures);
+          if (!installCommand && !warningCommand) return;
+          const commandsToWrite = [warningCommand, installCommand]
+            .filter((c): c is string => !!c)
+            .map(c => c + '\r')
+            .join('');
           // Find the default terminal panel — may not exist yet if sync finished before
           // the session-created event handler in events.ts created it. Retry briefly.
           let terminalPanel = panelManager.getPanelsForSession(capturedSessionId).find(p => p.type === 'terminal');
@@ -285,15 +306,15 @@ export class TaskQueue {
               if (terminalPanel) break;
             }
             if (!terminalPanel) {
-              console.warn(`[TaskQueue] No terminal panel found for session ${capturedSessionId}, skipping install command`);
+              console.warn(`[TaskQueue] No terminal panel found for session ${capturedSessionId}, skipping sync warning/install command`);
               return;
             }
           }
 
           if (terminalPanelManager.isTerminalInitialized(terminalPanel.id)) {
             // Terminal already running — write directly
-            terminalPanelManager.writeToTerminal(terminalPanel.id, installCommand + '\r');
-            console.log(`[TaskQueue] Wrote install command to terminal: ${installCommand}`);
+            terminalPanelManager.writeToTerminal(terminalPanel.id, commandsToWrite);
+            console.log(`[TaskQueue] Wrote to terminal: ${[warningCommand, installCommand].filter(Boolean).join(' | ')}`);
           } else {
             // Terminal not yet initialized — eagerly init it, then write the command
             // We don't store as initialCommand to avoid polluting panel state
@@ -301,8 +322,8 @@ export class TaskQueue {
             await terminalPanelManager.initializeTerminal(terminalPanel, worktreePath, wslContext);
             // Small delay for shell prompt to appear before writing
             await new Promise(resolve => setTimeout(resolve, 1000));
-            terminalPanelManager.writeToTerminal(terminalPanel.id, installCommand + '\r');
-            console.log(`[TaskQueue] Eagerly initialized terminal and wrote install command: ${installCommand}`);
+            terminalPanelManager.writeToTerminal(terminalPanel.id, commandsToWrite);
+            console.log(`[TaskQueue] Eagerly initialized terminal and wrote: ${[warningCommand, installCommand].filter(Boolean).join(' | ')}`);
           }
         }).catch((err) => {
           console.error('[TaskQueue] Worktree file sync failed (non-fatal):', err);

--- a/main/src/services/worktreeFileSyncService.ts
+++ b/main/src/services/worktreeFileSyncService.ts
@@ -5,6 +5,21 @@ import type { ProjectEnvironment } from '../utils/pathResolver';
 import { posixJoin } from '../utils/wslUtils';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
 
+export interface WorktreeFileSyncFailure {
+  path: string;
+  reason: string;
+}
+
+export interface WorktreeFileSyncResult {
+  installCommand: string | null;
+  failures: WorktreeFileSyncFailure[];
+}
+
+// Recursive node_modules copies on large repos can take far longer than the
+// 60s default exec timeout; give copy commands a generous ceiling instead of
+// killing them midway and leaving a partial node_modules behind.
+const COPY_TIMEOUT_MS = 600_000;
+
 /**
  * Joins path segments correctly for the target environment.
  * On WSL, Node's path.join uses backslashes (Windows host), but commands
@@ -261,7 +276,7 @@ async function execCopyCommand(
   environment: ProjectEnvironment,
 ): Promise<void> {
   try {
-    await commandRunner.execAsync(cmd, cwd);
+    await commandRunner.execAsync(cmd, cwd, { timeout: COPY_TIMEOUT_MS });
   } catch (err: unknown) {
     if (environment === 'windows' && err !== null && typeof err === 'object' && 'code' in err) {
       const code = (err as { code: unknown }).code;
@@ -302,9 +317,14 @@ async function copyRootEntry(
   await execCopyCommand(cmd, mainRepoPath, commandRunner, environment);
 }
 
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /**
  * Finds all recursive matches of `entry.path` in the main repo and copies any
- * that are missing from the worktree.
+ * that are missing from the worktree. Returns the failures encountered so the
+ * caller can surface them; individual failures never abort remaining matches.
  */
 async function copyRecursiveMatches(
   mainRepoPath: string,
@@ -312,7 +332,7 @@ async function copyRecursiveMatches(
   entry: WorktreeFileSyncEntry,
   commandRunner: CommandRunner,
   environment: ProjectEnvironment,
-): Promise<void> {
+): Promise<WorktreeFileSyncFailure[]> {
   const matches = await findRecursiveMatches(
     mainRepoPath,
     entry.path,
@@ -320,9 +340,10 @@ async function copyRecursiveMatches(
     environment,
   );
 
+  const failures: WorktreeFileSyncFailure[] = [];
   for (const match of matches) {
+    const relativePath = envRelative(environment, mainRepoPath, match.path);
     try {
-      const relativePath = envRelative(environment, mainRepoPath, match.path);
       const destPath = envJoin(environment, worktreePath, relativePath);
 
       const destExists = await existsAt(destPath, commandRunner, environment, worktreePath);
@@ -333,9 +354,11 @@ async function copyRecursiveMatches(
       await execCopyCommand(cmd, mainRepoPath, commandRunner, environment);
     } catch (err) {
       console.error(`[WorktreeFileSync] Failed to copy match "${match.path}":`, err);
-      // Continue with remaining matches — best effort
+      failures.push({ path: relativePath, reason: describeError(err) });
+      // Continue with remaining matches, best effort
     }
   }
+  return failures;
 }
 
 /**
@@ -404,17 +427,27 @@ export function detectInstallCommandSync(cwd: string): string | null {
   return null;
 }
 
+/**
+ * Heavyweight entries (node_modules) can take tens of seconds to copy, so
+ * they must never delay small/critical entries like .env files.
+ */
+function isHeavyweightEntry(entry: WorktreeFileSyncEntry): boolean {
+  const name = entry.path.trim();
+  return name === 'node_modules' || name.endsWith('/node_modules');
+}
+
 export const worktreeFileSyncService = {
   /**
    * Copies all enabled sync entries from `mainRepoPath` into `worktreePath`,
    * then detects the package manager and returns its install command.
    *
-   * This method is best-effort: individual copy failures are caught and logged
-   * without aborting the rest of the sync. The method itself never throws — it
-   * returns `null` on any top-level failure.
+   * Small/critical entries (.env*, config dirs) are always copied before
+   * heavyweight directories like node_modules, regardless of the order in the
+   * persisted config, so credentials land quickly even on large repos.
    *
-   * @returns The detected install command (e.g. `"pnpm install"`) or `null`
-   *          if no lock file was found or the sync itself failed.
+   * This method is best-effort: individual copy failures are caught, logged,
+   * and reported in the returned `failures` array without aborting the rest
+   * of the sync. The method itself never throws.
    */
   async syncWorktree(
     mainRepoPath: string,
@@ -422,20 +455,26 @@ export const worktreeFileSyncService = {
     commandRunner: CommandRunner,
     environment: ProjectEnvironment,
     entries: WorktreeFileSyncEntry[],
-  ): Promise<string | null> {
+  ): Promise<WorktreeFileSyncResult> {
+    const failures: WorktreeFileSyncFailure[] = [];
     try {
       const enabledEntries = entries.filter((e) => e.enabled && e.path.trim().length > 0);
+      const orderedEntries = [
+        ...enabledEntries.filter((e) => !isHeavyweightEntry(e)),
+        ...enabledEntries.filter(isHeavyweightEntry),
+      ];
 
-      for (const entry of enabledEntries) {
+      for (const entry of orderedEntries) {
         try {
           if (entry.recursive) {
-            await copyRecursiveMatches(
+            const matchFailures = await copyRecursiveMatches(
               mainRepoPath,
               worktreePath,
               entry,
               commandRunner,
               environment,
             );
+            failures.push(...matchFailures);
           } else {
             await copyRootEntry(
               mainRepoPath,
@@ -447,14 +486,17 @@ export const worktreeFileSyncService = {
           }
         } catch (err) {
           console.error(`[WorktreeFileSync] Failed to sync entry "${entry.path}":`, err);
-          // Continue with next entry — best effort
+          failures.push({ path: entry.path, reason: describeError(err) });
+          // Continue with next entry, best effort
         }
       }
 
-      return await detectInstallCommand(mainRepoPath, commandRunner, environment);
+      const installCommand = await detectInstallCommand(mainRepoPath, commandRunner, environment);
+      return { installCommand, failures };
     } catch (err) {
       console.error('[WorktreeFileSync] syncWorktree failed:', err);
-      return null;
+      failures.push({ path: 'worktree files', reason: describeError(err) });
+      return { installCommand: null, failures };
     }
   },
 };

--- a/main/src/utils/revealInFileManager.ts
+++ b/main/src/utils/revealInFileManager.ts
@@ -1,0 +1,41 @@
+import { shell } from 'electron';
+import * as fsSync from 'fs';
+import { execFile, execFileSync } from 'child_process';
+
+/** Detect if the Electron process is running inside WSL (e.g. via WSLg). */
+let _isWSL: boolean | null = null;
+export function isRunningInWSL(): boolean {
+  if (_isWSL !== null) return _isWSL;
+  try {
+    const version = fsSync.readFileSync('/proc/version', 'utf-8');
+    _isWSL = /microsoft/i.test(version);
+  } catch {
+    _isWSL = false;
+  }
+  return _isWSL;
+}
+
+/**
+ * Reveal a file or folder in the OS file manager.
+ * Handles macOS (`open -R`, since shell.showItemInFolder can fail silently),
+ * WSL-hosted apps (convert via wslpath and select in explorer.exe), and
+ * everything else via shell.showItemInFolder.
+ */
+export async function revealInFileManager(targetPath: string): Promise<void> {
+  if (process.platform === 'darwin') {
+    await new Promise<void>((resolve, reject) => {
+      execFile('open', ['-R', targetPath], (error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  } else if (isRunningInWSL()) {
+    // Inside WSL, shell.showItemInFolder has no file manager.
+    // Convert to a Windows path and open with explorer.exe.
+    // Use execFileSync with argument arrays to avoid shell injection.
+    const winPath = execFileSync('wslpath', ['-w', targetPath], { encoding: 'utf-8' }).trim();
+    execFileSync('explorer.exe', [`/select,${winPath}`]);
+  } else {
+    shell.showItemInFolder(targetPath);
+  }
+}

--- a/shared/types/worktreeFileSync.ts
+++ b/shared/types/worktreeFileSync.ts
@@ -5,8 +5,9 @@ export interface WorktreeFileSyncEntry {
   recursive: boolean;
 }
 
+// Small/critical entries come first; heavyweight directories (node_modules)
+// last so credentials and config land before slow recursive copies.
 export const DEFAULT_WORKTREE_FILE_SYNC_ENTRIES: WorktreeFileSyncEntry[] = [
-  { id: 'node_modules', path: 'node_modules', enabled: true, recursive: true },
   { id: 'env', path: '.env*', enabled: true, recursive: true },
   { id: 'claude', path: '.claude', enabled: true, recursive: false },
   { id: 'codex', path: '.codex', enabled: true, recursive: false },
@@ -19,4 +20,5 @@ export const DEFAULT_WORKTREE_FILE_SYNC_ENTRIES: WorktreeFileSyncEntry[] = [
   { id: 'gemini', path: '.gemini', enabled: true, recursive: false },
   { id: 'junie', path: '.junie', enabled: true, recursive: false },
   { id: 'aider-conf', path: '.aider.conf.yml', enabled: true, recursive: false },
+  { id: 'node_modules', path: 'node_modules', enabled: true, recursive: true },
 ];


### PR DESCRIPTION
went through the readme's qol feature list and fixed everything that didn't hold up:

- env files now copy before node_modules in worktree sync, copy timeout raised to 10min, and sync failures print into the session terminal instead of being swallowed
- git status plumbing (rev-list, shortstat, dirty checks) now routes through wsl.exe for wsl sessions, existence checks go through the unc mount. fixes ahead/behind silently failing for every wsl pane
- resource manager now attributes processes inside wsl distros on windows hosts (scans /proc for PANE_SESSION_ID, one wsl.exe call per distro per poll)
- ctrl/cmd+1-9 pane switching no longer dies when the sidebar is collapsed or immersive mode is on
- alt-held punctuation/digit hotkeys normalized via e.code so cmd+opt+/ works on mac layouts
- image drops up to 50mb now work (backend cap was 10mb for no reason), and drop failures show in the terminal instead of console-only
- show in explorer unified into one helper, works on wsl-hosted apps and converts in-distro paths via the session's path resolver
- browser panel accepts any http/https url, not just localhost
- PANE_PORT now propagates into wsl run scripts (missing WSLENV), and the setup run script prompt teaches PANE_PORT instead of the old hash scheme
- removed: dead 'waiting' status writer, the panel event log line that was 80-90% of production log volume, unused isRebasing code, and the ctrl+enter readme row that was never implemented