### PR TITLE
ci: opt all workflows into Node 24 actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
         type: boolean
         default: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   metadata:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -5,6 +5,9 @@ on:
   # Manual trigger for validation
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   quality-checks:
     name: Quality Checks + Smoke


### PR DESCRIPTION
opts build, quality, nightly-release, and notify-website into node 24 actions via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24, same pattern as the remote pwa deploy (012705b) which has run green under it twice. traffic-snapshot uses no actions so it's untouched.

this is the stopgap before github flips the default on june 16. the flag only changes the runtime executing the actions' own js; app builds still use the pinned node 22.15.1 from setup-node. proper action major bumps tracked in #222.

verification: the quality run on this pr exercises the flag; after merge i'll dispatch a full no-publish build of build.yml to dry-run the release path.