### PR TITLE
Fix split tab groups review follow-ups

### DIFF
--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -275,7 +275,7 @@ export const SessionView = memo(() => {
     return () => {
       flushLayoutPersist();
     };
-  }, [activeSession?.id, setPanels, setActivePanelInStore, setLayoutInStore, setFocusedGroupInStore, flushLayoutPersist]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeSession?.id, setPanels, setActivePanelInStore, setLayoutInStore, setFocusedGroupInStore, flushLayoutPersist]);
   
   // Listen for panel updates from the backend
   useEffect(() => {
@@ -986,6 +986,12 @@ export const SessionView = memo(() => {
     setDropZones(new Map());
   }, [activeSession, applyLayout]);
 
+  // Stable identity for the primary strip's drop handler so memo(PanelTabBar) holds
+  const primaryGroupId = primaryGroupNode?.id;
+  const handlePrimaryStripDrop = useCallback((panelId: string, insertIndex: number) => {
+    if (primaryGroupId) handleStripDrop(primaryGroupId, panelId, insertIndex);
+  }, [primaryGroupId, handleStripDrop]);
+
   // --- Editor stage element (shared by both layouts) ---
   const editorStageElement = useMemo(() => {
     if (!sessionLayout || !activeSession) return null;
@@ -1583,7 +1589,7 @@ export const SessionView = memo(() => {
           primaryGroupFocused={!primaryGroupNode || primaryGroupNode.id === focusedGroupId}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
-          onStripDrop={primaryGroupNode ? (panelId, idx) => handleStripDrop(primaryGroupNode.id, panelId, idx) : undefined}
+          onStripDrop={primaryGroupNode ? handlePrimaryStripDrop : undefined}
           isTabDragging={isTabDragging}
           draggedPanelId={draggedPanelId}
         />

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -11,6 +11,7 @@ import { TerminalPanelProps } from '../../types/panelComponents';
 import { useHotkeyStore } from '../../stores/hotkeyStore';
 import { renderLog, devLog } from '../../utils/console';
 import { getTerminalTheme } from '../../utils/terminalTheme';
+import { isMac } from '../../utils/platformUtils';
 import { FileEdit, FolderOpen } from 'lucide-react';
 import { useTerminalLinks } from '../terminal/hooks/useTerminalLinks';
 import { TerminalLinkTooltip } from '../terminal/TerminalLinkTooltip';
@@ -650,8 +651,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'e') return false;
 
           // Split tab groups: Mod+\ and Mod+Shift+\ (Ctrl+\ is SIGQUIT - must release!)
-          // ISO/international keyboards report the key as IntlBackslash
-          if (ctrlOrMeta && (e.code === 'Backslash' || e.code === 'IntlBackslash')) return false;
+          // ISO/international keyboards report the key as IntlBackslash.
+          // On macOS the app hotkey is Cmd+\, so only release metaKey there
+          // and let Ctrl+\ keep delivering SIGQUIT to the PTY.
+          if ((isMac() ? e.metaKey : e.ctrlKey) && (e.code === 'Backslash' || e.code === 'IntlBackslash')) return false;
           // Zoom toggle: Mod+Shift+Z
           if (ctrlOrMeta && e.shiftKey && e.key.toLowerCase() === 'z') return false;
           // Directional group focus: Mod+Alt+Arrows (all four directions)


### PR DESCRIPTION
## Description

Addresses the three should-fix items from the post-merge review on #224 (https://github.com/dcouple/Pane/pull/224#pullrequestreview-4483457303):

1. Removed the now-unused `eslint-disable` directive on the layout load effect deps in `SessionView.tsx` (it was reporting as a new lint warning).
2. Platform-gated the terminal backslash key release: on macOS the app hotkey is Cmd+\, so Ctrl+\ now keeps delivering SIGQUIT to the PTY instead of being swallowed. Windows/Linux behavior is unchanged (Ctrl+\ is the app hotkey there, as shipped).
3. The primary tab strip's `onStripDrop` handler now has a stable `useCallback` identity, so `memo(PanelTabBar)` is effective again instead of re-rendering on every SessionView render.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (net removes one)
- [x] I have run `pnpm typecheck` and `pnpm lint` locally

## Critical Areas Modified

- [x] None of the above (small targeted fixes)

## Additional Notes

The review's suggestions (background-tab close switching the active tab, allotment defaultSizes divergence after n-ary insert, beforeunload layout flush, missing role="tablist" on secondary strips) are intentionally not included here; they are judgment calls or cosmetic and can ride a later change if wanted.