### PR TITLE
Fix tab drop after the last tab in the strip

### DIFF
--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -173,20 +173,32 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
     setStripDropIndex(null);
   }, [onDragEnd]);
 
+  // VS Code midpoint rule: the cursor's half of the hovered tab decides
+  // whether the drop inserts before (left half) or after (right half) it.
   const handleStripDragOver = useCallback((e: React.DragEvent, index: number) => {
     if (!isTabDragging) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
-    setStripDropIndex(index);
+    const rect = e.currentTarget.getBoundingClientRect();
+    const after = e.clientX > rect.left + rect.width / 2;
+    setStripDropIndex(index + (after ? 1 : 0));
   }, [isTabDragging]);
 
-  const handleStripDrop = useCallback((e: React.DragEvent, index: number) => {
+  // The empty space after the last tab appends to the strip.
+  const handleTrailingDragOver = useCallback((e: React.DragEvent) => {
+    if (!isTabDragging) return;
     e.preventDefault();
-    if (draggedPanelId && onStripDrop) {
-      onStripDrop(draggedPanelId, index);
+    e.dataTransfer.dropEffect = 'move';
+    setStripDropIndex(panels.length);
+  }, [isTabDragging, panels.length]);
+
+  const handleStripDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    if (draggedPanelId && onStripDrop && stripDropIndex !== null) {
+      onStripDrop(draggedPanelId, stripDropIndex);
     }
     setStripDropIndex(null);
-  }, [draggedPanelId, onStripDrop]);
+  }, [draggedPanelId, onStripDrop, stripDropIndex]);
 
   const handleStripDragLeave = useCallback(() => {
     setStripDropIndex(null);
@@ -242,7 +254,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
             onDragStart={(e) => handleDragStart(e, panel.id)}
             onDragEnd={handleDragEnd}
             onDragOver={(e) => handleStripDragOver(e, index)}
-            onDrop={(e) => handleStripDrop(e, index)}
+            onDrop={handleStripDrop}
             onClick={() => !isEditing && onPanelSelect(panel)}
             onDoubleClick={(e) => {
               if (!isEditing && !isPermanent && !isDiffPanel) {
@@ -260,9 +272,13 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
               }
             }}
           >
-            {/* Strip drop indicator line */}
+            {/* Strip drop indicator line. Between-tab boundaries render as the
+                next tab's left edge; only the strip's end renders a right edge. */}
             {isTabDragging && stripDropIndex === index && (
               <div className="absolute left-0 top-1 bottom-1 w-0.5 bg-interactive z-10" />
+            )}
+            {isTabDragging && stripDropIndex === index + 1 && index === panels.length - 1 && (
+              <div className="absolute right-0 top-1 bottom-1 w-0.5 bg-interactive z-10" />
             )}
 
             {isEditing ? (
@@ -325,6 +341,14 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
           </React.Fragment>
         ) : <React.Fragment key={panel.id}>{tab}{divider}</React.Fragment>;
       })}
+      {/* Trailing drop target: the strip's empty space appends after the last tab */}
+      {isTabDragging && (
+        <div
+          className="flex-1 self-stretch min-w-8"
+          onDragOver={handleTrailingDragOver}
+          onDrop={handleStripDrop}
+        />
+      )}
     </div>
   );
 });


### PR DESCRIPTION
## Description

Dragging a tab to the right of the last tab in a strip (e.g. after Diff/Explorer/Browser in the top bar) was impossible: the drop indicator always meant insert-before-the-hovered-tab, and the strip's trailing empty space was not a drop target, so drops there silently did nothing. This was flagged as a UX gap in the #224 review.

Now the strip follows the VS Code midpoint rule:

- Hovering the left half of a tab inserts before it; the right half inserts after it.
- The empty space after the last tab is a drop target that appends.
- The end-of-strip position shows a right-edge indicator on the last tab; between-tab boundaries keep showing the next tab's left edge, so there is always exactly one indicator.
- Drops commit the midpoint-adjusted index, which composes with the same-group reorder index adjustment in `movePanel` (dropping a tab on its own right half is a no-op, as expected).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run `pnpm typecheck` and `pnpm lint` locally

## Critical Areas Modified

- [x] None of the above (single component, drag/drop handlers only)