### PR TITLE
Floating glassmorphic pill strips for split groups

### DIFF
--- a/frontend/src/components/panels/PanelGroupView.tsx
+++ b/frontend/src/components/panels/PanelGroupView.tsx
@@ -2,7 +2,9 @@
  * PanelGroupView: renders a single tab group within the split layout.
  *
  * Each group has:
- * - A PanelTabStrip (hidden for the primary group, whose tabs live in PanelTabBar).
+ * - A floating glassmorphic pill (top-center) holding the group's tabs in a
+ *   compact PanelTabStrip. The primary group has no pill; its tabs live in
+ *   PanelTabBar.
  * - An absolute-positioned panel stack (the editor-stage pattern: inactive
  *   terminals stay mounted behind display:none so xterm never reflows).
  * - A DropOverlay when a tab drag is in progress.
@@ -54,19 +56,19 @@ const DropOverlay: React.FC<DropOverlayProps> = React.memo(({ onZoneChange, onDr
     >
       {/* Zone highlight overlays */}
       {activeZone === 'center' && (
-        <div className="absolute inset-4 border-2 border-interactive/40 bg-interactive/10 rounded pointer-events-none" />
+        <div className="absolute inset-4 border-2 border-[color-mix(in_srgb,var(--color-interactive-primary)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-interactive-primary)_10%,transparent)] rounded pointer-events-none" />
       )}
       {activeZone === 'left' && (
-        <div className="absolute inset-y-0 left-0 w-1/4 border-2 border-interactive/40 bg-interactive/10 pointer-events-none" />
+        <div className="absolute inset-y-0 left-0 w-1/4 border-2 border-[color-mix(in_srgb,var(--color-interactive-primary)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-interactive-primary)_10%,transparent)] pointer-events-none" />
       )}
       {activeZone === 'right' && (
-        <div className="absolute inset-y-0 right-0 w-1/4 border-2 border-interactive/40 bg-interactive/10 pointer-events-none" />
+        <div className="absolute inset-y-0 right-0 w-1/4 border-2 border-[color-mix(in_srgb,var(--color-interactive-primary)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-interactive-primary)_10%,transparent)] pointer-events-none" />
       )}
       {activeZone === 'top' && (
-        <div className="absolute inset-x-0 top-0 h-1/4 border-2 border-interactive/40 bg-interactive/10 pointer-events-none" />
+        <div className="absolute inset-x-0 top-0 h-1/4 border-2 border-[color-mix(in_srgb,var(--color-interactive-primary)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-interactive-primary)_10%,transparent)] pointer-events-none" />
       )}
       {activeZone === 'bottom' && (
-        <div className="absolute inset-x-0 bottom-0 h-1/4 border-2 border-interactive/40 bg-interactive/10 pointer-events-none" />
+        <div className="absolute inset-x-0 bottom-0 h-1/4 border-2 border-[color-mix(in_srgb,var(--color-interactive-primary)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-interactive-primary)_10%,transparent)] pointer-events-none" />
       )}
     </div>
   );
@@ -154,31 +156,45 @@ export const PanelGroupView: React.FC<PanelGroupViewProps> = React.memo(({
     <div
       className={cn(
         "h-full flex flex-col",
-        multiGroup && isFocusedGroup && "ring-1 ring-inset ring-interactive/30",
+        multiGroup && isFocusedGroup && "ring-1 ring-inset ring-[color-mix(in_srgb,var(--color-interactive-primary)_30%,transparent)]",
       )}
       onMouseDownCapture={handleMouseDownCapture}
     >
-      {/* Tab strip for secondary groups */}
-      {!isPrimary && (
-        <div className="flex-shrink-0 bg-bg-chrome border-b border-border-primary" role="tablist">
-          <PanelTabStrip
-            panels={orderedPanels}
-            activePanelId={group.activePanelId}
-            onPanelSelect={onPanelSelect}
-            onPanelClose={onPanelClose}
-            isFocused={isFocusedGroup}
-            onDragStart={onDragStart}
-            onDragEnd={onDragEnd}
-            onStripDrop={onStripDrop}
-            isTabDragging={isTabDragging}
-            draggedPanelId={draggedPanelId}
-          />
-        </div>
-      )}
-
       {/* Panel content stack: only the active tab is displayed; terminals
           stay mounted behind display:none so xterm never reflows */}
       <div className="flex-1 relative min-h-0 overflow-hidden bg-bg-editor">
+        {/* Floating island pill: split groups carry their tabs in a compact
+            glassmorphic pill hovering top-center instead of a second
+            full-size tab bar row. z-30 keeps it interactive above the drop
+            overlay (z-20) so between-tab reorder drops still hit the strip
+            mid-drag. */}
+        {!isPrimary && (
+          <div className="absolute top-1.5 left-1/2 -translate-x-1/2 z-30 max-w-[calc(100%-1rem)]">
+            <div
+              role="tablist"
+              className={cn(
+                "flex items-center rounded-full border bg-[color-mix(in_srgb,var(--color-bg-chrome)_60%,transparent)] backdrop-blur-md shadow-lg shadow-black/20 px-1 py-0.5 transition-colors",
+                isFocusedGroup
+                  ? "border-[color-mix(in_srgb,var(--color-interactive-primary)_40%,transparent)]"
+                  : "border-[color-mix(in_srgb,var(--color-border-primary)_50%,transparent)]",
+              )}
+            >
+              <PanelTabStrip
+                panels={orderedPanels}
+                activePanelId={group.activePanelId}
+                onPanelSelect={onPanelSelect}
+                onPanelClose={onPanelClose}
+                isFocused={isFocusedGroup}
+                variant="pill"
+                onDragStart={onDragStart}
+                onDragEnd={onDragEnd}
+                onStripDrop={onStripDrop}
+                isTabDragging={isTabDragging}
+                draggedPanelId={draggedPanelId}
+              />
+            </div>
+          </div>
+        )}
         {orderedPanels.map(panel => {
           const isActiveTab = panel.id === group.activePanelId;
           const keepAlive = panel.type === 'terminal';

--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -35,6 +35,12 @@ export interface PanelTabStripProps {
   isFocused?: boolean;
   /** Show shortcut hints (only for primary group in PanelTabBar). */
   showShortcutHints?: boolean;
+  /**
+   * Visual variant: 'bar' is the full-size strip used by the primary tab bar;
+   * 'pill' is the compact treatment used by the floating island on split
+   * groups (roughly half height, smaller type, shrink-wrapped tabs).
+   */
+  variant?: 'bar' | 'pill';
 
   // --- Drag-and-drop ---
   /** Called when a drag starts on a tab. */
@@ -53,26 +59,26 @@ export interface PanelTabStripProps {
 // Icon helper (existing icons from PanelTabBar)
 // ---------------------------------------------------------------------------
 
-function getPanelIcon(type: ToolPanelType, panel?: ToolPanel): React.ReactNode {
+function getPanelIcon(type: ToolPanelType, panel?: ToolPanel, iconClass = 'w-4 h-4'): React.ReactNode {
   switch (type) {
     case 'terminal': {
       if (panel?.title) {
         const lowerTitle = panel.title.toLowerCase();
-        if (lowerTitle.includes('claude')) return <ClaudeIcon className="w-4 h-4" />;
-        if (lowerTitle.includes('codex')) return <OpenAIIcon className="w-4 h-4" />;
+        if (lowerTitle.includes('claude')) return <ClaudeIcon className={iconClass} />;
+        if (lowerTitle.includes('codex')) return <OpenAIIcon className={iconClass} />;
       }
-      return <Terminal className="w-4 h-4" />;
+      return <Terminal className={iconClass} />;
     }
     case 'diff':
-      return <GitBranch className="w-4 h-4" />;
+      return <GitBranch className={iconClass} />;
     case 'explorer':
-      return <FolderTree className="w-4 h-4" />;
+      return <FolderTree className={iconClass} />;
     case 'logs':
-      return <FileCode className="w-4 h-4" />;
+      return <FileCode className={iconClass} />;
     case 'dashboard':
-      return <BarChart3 className="w-4 h-4" />;
+      return <BarChart3 className={iconClass} />;
     case 'browser':
-      return <Globe className="w-4 h-4" />;
+      return <Globe className={iconClass} />;
     default:
       return null;
   }
@@ -90,12 +96,14 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
   isPrimary = false,
   isFocused = false,
   showShortcutHints = false,
+  variant = 'bar',
   onDragStart,
   onDragEnd,
   onStripDrop,
   isTabDragging = false,
   draggedPanelId = null,
 }) => {
+  const pill = variant === 'pill';
   const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const editInputRef = useRef<HTMLInputElement>(null);
@@ -225,7 +233,10 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
 
   return (
     <div
-      className="flex items-center overflow-x-auto scrollbar-none min-w-0 flex-1"
+      className={cn(
+        "flex items-center overflow-x-auto scrollbar-none min-w-0",
+        pill ? "rounded-full" : "flex-1",
+      )}
       onDragLeave={handleStripDragLeave}
     >
       {panels.map((panel, index) => {
@@ -241,12 +252,22 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
         const tab = (
           <div
             className={cn(
-              "group relative inline-flex items-center h-[var(--panel-tab-height)] justify-center whitespace-nowrap cursor-pointer select-none",
-              isCompactTab
-                ? cn("min-w-[5rem] text-xs", isPermanent ? "px-2" : "px-2 pr-6")
-                : cn("min-w-[8rem] text-sm", isPermanent ? "px-3" : "px-3 pr-7"),
+              "group relative inline-flex items-center justify-center whitespace-nowrap cursor-pointer select-none",
+              pill
+                ? cn(
+                    "h-5 rounded-full text-[10px]",
+                    isPermanent ? "px-2" : "px-2 pr-5",
+                  )
+                : cn(
+                    "h-[var(--panel-tab-height)]",
+                    isCompactTab
+                      ? cn("min-w-[5rem] text-xs", isPermanent ? "px-2" : "px-2 pr-6")
+                      : cn("min-w-[8rem] text-sm", isPermanent ? "px-3" : "px-3 pr-7"),
+                  ),
               isActive
-                ? "text-text-primary"
+                ? pill
+                  ? "text-text-primary bg-[color-mix(in_srgb,var(--color-surface-hover)_80%,transparent)]"
+                  : "text-text-primary"
                 : "text-text-tertiary hover:text-text-primary hover:bg-surface-hover",
               isDragged && "opacity-50",
             )}
@@ -289,37 +310,47 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
                 onChange={(e) => setEditingTitle(e.target.value)}
                 onKeyDown={handleRenameKeyDown}
                 onBlur={handleRenameSubmit}
-                className="px-1 text-sm bg-bg-primary border border-border-primary rounded outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus text-text-primary"
+                className={cn(
+                  "px-1 bg-bg-primary border border-border-primary rounded outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus text-text-primary",
+                  pill ? "text-[10px]" : "text-sm",
+                )}
                 onClick={(e) => e.stopPropagation()}
                 style={{ width: `${Math.max(50, editingTitle.length * 8)}px` }}
               />
             ) : (
-              <span className="inline-flex items-center justify-center gap-2 min-w-0">
+              <span className={cn(
+                "inline-flex items-center justify-center min-w-0",
+                pill ? "gap-1" : "gap-2",
+              )}>
                 {panel.type === 'terminal' && (
                   <span className={cn(
-                    "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
+                    "rounded-full flex-shrink-0 transition-all",
+                    pill ? "w-1 h-1" : "w-1.5 h-1.5",
                     getPanelActivityStatus(panel.id) === 'active'
                       ? 'bg-status-info opacity-100 duration-150'
                       : 'bg-text-muted/20 opacity-40 duration-[3s]'
                   )} />
                 )}
-                {getPanelIcon(panel.type, panel)}
+                {getPanelIcon(panel.type, panel, pill ? 'w-3 h-3' : 'w-4 h-4')}
                 <span>{displayTitle}</span>
               </span>
             )}
 
             {!isPermanent && !isEditing && (
               <button
-                className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity transition-colors text-text-muted hover:bg-surface-hover hover:text-status-error focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle"
+                className={cn(
+                  "absolute top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity transition-colors text-text-muted hover:bg-surface-hover hover:text-status-error focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle",
+                  pill ? "right-1" : "right-1.5",
+                )}
                 onClick={(e) => handlePanelClose(e, panel)}
               >
-                <X className="w-2.5 h-2.5" />
+                <X className={pill ? "w-2 h-2" : "w-2.5 h-2.5"} />
               </button>
             )}
           </div>
         );
 
-        const showDividerAfter = panel.type === 'browser';
+        const showDividerAfter = !pill && panel.type === 'browser';
         const divider = showDividerAfter ? (
           <div className="h-4 w-px bg-border-primary mx-1 flex-shrink-0" aria-hidden="true" />
         ) : null;


### PR DESCRIPTION
## Description

Split groups no longer render a second full-size tab bar row stacked against the primary bar. Each split group now carries its tabs in a floating island pill, centered at the top of the group, hovering over the content: glassmorphic (translucent chrome background, backdrop blur, soft shadow), rounded-full, roughly half the tab bar height with 10px type and scaled-down icons, close buttons, and activity dots. The pill border brightens subtly when the group has focus.

- `PanelTabStrip` gains a `variant` prop (`'bar' | 'pill'`). The primary tab bar keeps the existing full-size `bar` variant pixel-identical.
- All strip mechanics carry over: drag to reorder with the midpoint indicator, trailing append zone, center/edge drops, close, double-click rename, activity dot.
- The pill renders at z-30, above the drop overlay (z-20), so between-tab reorder drops stay interactive mid-drag.
- Since the pill floats instead of occupying a layout row, split group content gets the full group height.

**Also fixes a shipped styling bug found while building this:** Tailwind opacity modifiers on the var()-based design tokens (`bg-interactive/10`, `border-interactive/40`, `ring-interactive/30`) silently compile to nothing because the tokens are plain `var()` strings without `<alpha-value>`. In practice the 5-zone drop highlights and the focused-group ring never rendered at all. Replaced with `color-mix()` arbitrary values (verified they compile; Electron's Chromium supports color-mix).

**Stacked PR:** this branch includes #226 and #227; merge those first and this PR reduces to the single pill commit.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (the token-opacity rendering fix)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run `pnpm typecheck` and `pnpm lint` locally

## Critical Areas Modified

- [x] None of the above (presentation-layer change in two components)