### PR TITLE
Slim centered strip rows instead of floating pills in splits

### DIFF
--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1587,6 +1587,7 @@ export const SessionView = memo(() => {
           primaryGroupPanels={primaryGroupPanels}
           primaryGroupActivePanelId={primaryGroupNode?.activePanelId}
           primaryGroupFocused={!primaryGroupNode || primaryGroupNode.id === focusedGroupId}
+          tabsInGroups={sessionLayout?.root.type === 'split'}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
           onStripDrop={primaryGroupNode ? handlePrimaryStripDrop : undefined}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -38,6 +38,7 @@ import {
   findGroupInDirection,
   updateSizes,
   findGroupContainingPanel,
+  subsetInsertIndex,
   type DropZone,
 } from '../utils/panelLayout';
 import { Download, Upload, GitMerge, GitPullRequestArrow, Terminal, ChevronDown, ChevronUp, RefreshCw, Archive, ArchiveRestore, GitCommitHorizontal, TerminalSquare, Undo2, X } from 'lucide-react';
@@ -419,10 +420,47 @@ export const SessionView = memo(() => {
     const panelMap = new Map(tabBarPanels.map(p => [p.id, p]));
     return primaryGroupNode.panelIds.map(id => panelMap.get(id)).filter((p): p is ToolPanel => !!p);
   }, [primaryGroupNode, tabBarPanels]);
+  const isSplitLayout = sessionLayout?.root.type === 'split';
+  /** What the top bar shows: everything when unsplit; only the primary
+      group's permanent tabs once split (working tabs live in group strips). */
+  const topBarPanels = useMemo(() => {
+    if (!primaryGroupPanels) return undefined;
+    if (!isSplitLayout) return primaryGroupPanels;
+    return primaryGroupPanels.filter(p => p.metadata?.permanent === true);
+  }, [primaryGroupPanels, isSplitLayout]);
   // --- Drag & drop state ---
   const [draggedPanelId, setDraggedPanelId] = useState<string | null>(null);
   const [dropZones, setDropZones] = useState<Map<string, DropZone | null>>(new Map());
   const isTabDragging = draggedPanelId !== null;
+
+  // When a split or cross-group move takes a group's ACTIVE panel away, the
+  // pure layer falls back to the first remaining id, which is usually a
+  // permanent tab (Diff). Prefer the first working tab instead: when split,
+  // permanent tabs live in the top bar, so a group flipping to the Diff view
+  // under a terminal strip reads as wrong. Callers gate on the moved panel
+  // having been the group's active so a deliberately-active Diff stays put.
+  const preferWorkingActive = useCallback((
+    root: SessionPanelLayout['root'],
+    sourceGroupId: string | undefined,
+  ): SessionPanelLayout['root'] => {
+    if (!sourceGroupId || !activeSession) return root;
+    const g = findGroup(root, sourceGroupId);
+    if (!g || !g.activePanelId) return root;
+    const panelMap = new Map(
+      (usePanelStore.getState().panels[activeSession.id] || []).map(p => [p.id, p])
+    );
+    if (panelMap.get(g.activePanelId)?.metadata?.permanent !== true) return root;
+    const firstWorking = g.panelIds.find(id => panelMap.get(id)?.metadata?.permanent !== true);
+    if (!firstWorking) return root;
+    const nextActive: string = firstWorking;
+    function fix(node: SessionPanelLayout['root']): SessionPanelLayout['root'] {
+      if (node.type === 'group') {
+        return node.id === sourceGroupId ? { ...node, activePanelId: nextActive } : node;
+      }
+      return { ...node, children: node.children.map(fix) };
+    }
+    return fix(root);
+  }, [activeSession]);
 
   // Track current session/panel in history when they change
   useEffect(() => {
@@ -651,7 +689,10 @@ export const SessionView = memo(() => {
       const sid = activeSession.id;
       const currentLayout = usePanelStore.getState().layouts[sid];
       if (!currentLayout) return;
-      const newRoot = splitGroup(currentLayout.root, focusedGroup.id, focusedGroup.activePanelId, 'row', true);
+      const newRoot = preferWorkingActive(
+        splitGroup(currentLayout.root, focusedGroup.id, focusedGroup.activePanelId, 'row', true),
+        focusedGroup.id,
+      );
       // Find the new group (the one containing the moved panel)
       const newGroup = findGroupContainingPanel(newRoot, focusedGroup.activePanelId);
       const next: SessionPanelLayout = {
@@ -682,7 +723,10 @@ export const SessionView = memo(() => {
       const sid = activeSession.id;
       const currentLayout = usePanelStore.getState().layouts[sid];
       if (!currentLayout) return;
-      const newRoot = splitGroup(currentLayout.root, focusedGroup.id, focusedGroup.activePanelId, 'column', true);
+      const newRoot = preferWorkingActive(
+        splitGroup(currentLayout.root, focusedGroup.id, focusedGroup.activePanelId, 'column', true),
+        focusedGroup.id,
+      );
       const newGroup = findGroupContainingPanel(newRoot, focusedGroup.activePanelId);
       const next: SessionPanelLayout = {
         ...currentLayout,
@@ -957,12 +1001,15 @@ export const SessionView = memo(() => {
     } else {
       newRoot = movePanelInLayout(currentLayout.root, draggedPanelId, { groupId, edge: zone });
     }
+    if (sourceGroup && sourceGroup.activePanelId === draggedPanelId) {
+      newRoot = preferWorkingActive(newRoot, sourceGroup.id);
+    }
 
     const next: SessionPanelLayout = { ...currentLayout, root: newRoot };
     applyLayout(sid, next);
     setDraggedPanelId(null);
     setDropZones(new Map());
-  }, [activeSession, draggedPanelId, applyLayout]);
+  }, [activeSession, draggedPanelId, applyLayout, preferWorkingActive]);
 
   const handleDragStart = useCallback((panelId: string) => {
     setDraggedPanelId(panelId);
@@ -979,18 +1026,28 @@ export const SessionView = memo(() => {
     const currentLayout = usePanelStore.getState().layouts[sid];
     if (!currentLayout) return;
 
-    const newRoot = movePanelInLayout(currentLayout.root, panelId, { groupId, index: insertIndex });
+    const sourceGroup = findGroupContainingPanel(currentLayout.root, panelId);
+    let newRoot = movePanelInLayout(currentLayout.root, panelId, { groupId, index: insertIndex });
+    if (sourceGroup && sourceGroup.id !== groupId && sourceGroup.activePanelId === panelId) {
+      newRoot = preferWorkingActive(newRoot, sourceGroup.id);
+    }
     const next: SessionPanelLayout = { ...currentLayout, root: newRoot };
     applyLayout(sid, next);
     setDraggedPanelId(null);
     setDropZones(new Map());
-  }, [activeSession, applyLayout]);
+  }, [activeSession, applyLayout, preferWorkingActive]);
 
-  // Stable identity for the primary strip's drop handler so memo(PanelTabBar) holds
+  // Stable identity for the primary strip's drop handler so memo(PanelTabBar)
+  // holds. When split, the top bar shows only the permanent subset, so its
+  // drop indexes must translate to the group's full panel order.
   const primaryGroupId = primaryGroupNode?.id;
   const handlePrimaryStripDrop = useCallback((panelId: string, insertIndex: number) => {
-    if (primaryGroupId) handleStripDrop(primaryGroupId, panelId, insertIndex);
-  }, [primaryGroupId, handleStripDrop]);
+    if (!primaryGroupId || !primaryGroupNode) return;
+    const fullIndex = isSplitLayout && topBarPanels
+      ? subsetInsertIndex(primaryGroupNode.panelIds, topBarPanels.map(p => p.id), insertIndex)
+      : insertIndex;
+    handleStripDrop(primaryGroupId, panelId, fullIndex);
+  }, [primaryGroupId, primaryGroupNode, isSplitLayout, topBarPanels, handleStripDrop]);
 
   // --- Editor stage element (shared by both layouts) ---
   const editorStageElement = useMemo(() => {
@@ -1584,10 +1641,10 @@ export const SessionView = memo(() => {
           onPanelCreate={handlePanelCreate}
           onToggleDetailPanel={handleToggleDetailPanel}
           detailPanelVisible={detailVisible}
-          primaryGroupPanels={primaryGroupPanels}
+          primaryGroupPanels={topBarPanels}
           primaryGroupActivePanelId={primaryGroupNode?.activePanelId}
           primaryGroupFocused={!primaryGroupNode || primaryGroupNode.id === focusedGroupId}
-          tabsInGroups={sessionLayout?.root.type === 'split'}
+          tabsInGroups={isSplitLayout}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
           onStripDrop={primaryGroupNode ? handlePrimaryStripDrop : undefined}

--- a/frontend/src/components/panels/PanelGroupView.tsx
+++ b/frontend/src/components/panels/PanelGroupView.tsx
@@ -2,10 +2,11 @@
  * PanelGroupView: renders a single tab group within the split layout.
  *
  * Each group has:
- * - A slim centered tab strip row (compact pill-style tabs) once the pane is
- *   split. It occupies a layout row so it pushes content down instead of
- *   covering it. Single-group panes render no strip here; their tabs live in
- *   PanelTabBar (the pixel-identical rule).
+ * - A slim centered tab strip row (compact tabs) once the pane is split. It
+ *   occupies a layout row so it pushes content down instead of covering it.
+ *   The primary group's permanent tabs (Diff/Explorer/Browser) stay in
+ *   PanelTabBar; only working tabs appear in strips. Single-group panes
+ *   render no strip here at all (the pixel-identical rule).
  * - An absolute-positioned panel stack (the editor-stage pattern: inactive
  *   terminals stay mounted behind display:none so xterm never reflows).
  * - A DropOverlay when a tab drag is in progress.
@@ -16,7 +17,7 @@ import React, { useCallback, useMemo } from 'react';
 import { PanelTabStrip } from './PanelTabStrip';
 import { PanelContainer } from './PanelContainer';
 import type { ToolPanel, PanelGroupNode } from '../../../../shared/types/panels';
-import { dropZoneFor, type DropZone } from '../../utils/panelLayout';
+import { dropZoneFor, subsetInsertIndex, type DropZone } from '../../utils/panelLayout';
 import { cn } from '../../utils/cn';
 
 // ---------------------------------------------------------------------------
@@ -153,6 +154,25 @@ export const PanelGroupView: React.FC<PanelGroupViewProps> = React.memo(({
     return group.panelIds.map(id => panelMap.get(id)).filter((p): p is ToolPanel => !!p);
   }, [group.panelIds, groupPanels]);
 
+  // The primary group's permanent tabs (Diff/Explorer/Browser) stay up in
+  // PanelTabBar; its strip carries only the working tabs. Secondary groups
+  // show their full membership (a permanent tab dragged into one lives there).
+  const stripPanels = useMemo(() => {
+    if (!isPrimary) return orderedPanels;
+    return orderedPanels.filter(p => p.metadata?.permanent !== true);
+  }, [isPrimary, orderedPanels]);
+
+  // Strip drop indexes are relative to the displayed subset; translate to the
+  // group's full panel order before moving.
+  const handleStripDrop = useCallback((panelId: string, subsetIndex: number) => {
+    if (!onStripDrop) return;
+    onStripDrop(panelId, subsetInsertIndex(
+      group.panelIds,
+      stripPanels.map(p => p.id),
+      subsetIndex,
+    ));
+  }, [onStripDrop, group.panelIds, stripPanels]);
+
   return (
     <div
       className={cn(
@@ -161,26 +181,25 @@ export const PanelGroupView: React.FC<PanelGroupViewProps> = React.memo(({
       )}
       onMouseDownCapture={handleMouseDownCapture}
     >
-      {/* Slim centered tab strip row: once the pane is split, every group
-          (primary included) owns its tabs in a compact full-width row that
-          pushes content down so it never covers it. */}
-      {multiGroup && (
+      {/* Slim centered tab strip row: once the pane is split, each group owns
+          its working tabs in a compact full-width row that pushes content
+          down so it never covers it. Hidden when the group has nothing to
+          show (e.g. the primary group holding only permanent tabs). */}
+      {multiGroup && stripPanels.length > 0 && (
         <div
           role="tablist"
           className="flex-shrink-0 flex justify-center bg-bg-chrome border-b border-border-primary px-2 py-0.5"
         >
           <PanelTabStrip
-            panels={orderedPanels}
+            panels={stripPanels}
             activePanelId={group.activePanelId}
             onPanelSelect={onPanelSelect}
             onPanelClose={onPanelClose}
-            isPrimary={isPrimary}
             isFocused={isFocusedGroup}
-            showShortcutHints={isPrimary}
-            variant="pill"
+            variant="compact"
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
-            onStripDrop={onStripDrop}
+            onStripDrop={handleStripDrop}
             isTabDragging={isTabDragging}
             draggedPanelId={draggedPanelId}
           />

--- a/frontend/src/components/panels/PanelGroupView.tsx
+++ b/frontend/src/components/panels/PanelGroupView.tsx
@@ -2,9 +2,10 @@
  * PanelGroupView: renders a single tab group within the split layout.
  *
  * Each group has:
- * - A floating glassmorphic pill (top-center) holding the group's tabs in a
- *   compact PanelTabStrip. The primary group has no pill; its tabs live in
- *   PanelTabBar.
+ * - A slim centered tab strip row (compact pill-style tabs) once the pane is
+ *   split. It occupies a layout row so it pushes content down instead of
+ *   covering it. Single-group panes render no strip here; their tabs live in
+ *   PanelTabBar (the pixel-identical rule).
  * - An absolute-positioned panel stack (the editor-stage pattern: inactive
  *   terminals stay mounted behind display:none so xterm never reflows).
  * - A DropOverlay when a tab drag is in progress.
@@ -160,41 +161,35 @@ export const PanelGroupView: React.FC<PanelGroupViewProps> = React.memo(({
       )}
       onMouseDownCapture={handleMouseDownCapture}
     >
+      {/* Slim centered tab strip row: once the pane is split, every group
+          (primary included) owns its tabs in a compact full-width row that
+          pushes content down so it never covers it. */}
+      {multiGroup && (
+        <div
+          role="tablist"
+          className="flex-shrink-0 flex justify-center bg-bg-chrome border-b border-border-primary px-2 py-0.5"
+        >
+          <PanelTabStrip
+            panels={orderedPanels}
+            activePanelId={group.activePanelId}
+            onPanelSelect={onPanelSelect}
+            onPanelClose={onPanelClose}
+            isPrimary={isPrimary}
+            isFocused={isFocusedGroup}
+            showShortcutHints={isPrimary}
+            variant="pill"
+            onDragStart={onDragStart}
+            onDragEnd={onDragEnd}
+            onStripDrop={onStripDrop}
+            isTabDragging={isTabDragging}
+            draggedPanelId={draggedPanelId}
+          />
+        </div>
+      )}
+
       {/* Panel content stack: only the active tab is displayed; terminals
           stay mounted behind display:none so xterm never reflows */}
       <div className="flex-1 relative min-h-0 overflow-hidden bg-bg-editor">
-        {/* Floating island pill: split groups carry their tabs in a compact
-            glassmorphic pill hovering top-center instead of a second
-            full-size tab bar row. z-30 keeps it interactive above the drop
-            overlay (z-20) so between-tab reorder drops still hit the strip
-            mid-drag. */}
-        {!isPrimary && (
-          <div className="absolute top-1.5 left-1/2 -translate-x-1/2 z-30 max-w-[calc(100%-1rem)]">
-            <div
-              role="tablist"
-              className={cn(
-                "flex items-center rounded-full border bg-[color-mix(in_srgb,var(--color-bg-chrome)_60%,transparent)] backdrop-blur-md shadow-lg shadow-black/20 px-1 py-0.5 transition-colors",
-                isFocusedGroup
-                  ? "border-[color-mix(in_srgb,var(--color-interactive-primary)_40%,transparent)]"
-                  : "border-[color-mix(in_srgb,var(--color-border-primary)_50%,transparent)]",
-              )}
-            >
-              <PanelTabStrip
-                panels={orderedPanels}
-                activePanelId={group.activePanelId}
-                onPanelSelect={onPanelSelect}
-                onPanelClose={onPanelClose}
-                isFocused={isFocusedGroup}
-                variant="pill"
-                onDragStart={onDragStart}
-                onDragEnd={onDragEnd}
-                onStripDrop={onStripDrop}
-                isTabDragging={isTabDragging}
-                draggedPanelId={draggedPanelId}
-              />
-            </div>
-          </div>
-        )}
         {orderedPanels.map(panel => {
           const isActiveTab = panel.id === group.activePanelId;
           const keepAlive = panel.type === 'terminal';

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -71,6 +71,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   primaryGroupPanels,
   primaryGroupActivePanelId,
   primaryGroupFocused,
+  tabsInGroups = false,
   onDragStart,
   onDragEnd,
   onStripDrop,
@@ -480,21 +481,27 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
         role="tablist"
         aria-label="Panel Tabs"
       >
-        {/* Scrollable tab area — delegated to PanelTabStrip */}
-        <PanelTabStrip
-          panels={primaryGroupPanels ?? sortedPanels}
-          activePanelId={primaryGroupActivePanelId !== undefined ? primaryGroupActivePanelId : (activePanel?.id ?? null)}
-          onPanelSelect={handlePanelClick}
-          onPanelClose={handlePanelClose}
-          isPrimary
-          isFocused={primaryGroupFocused ?? true}
-          showShortcutHints
-          onDragStart={onDragStart}
-          onDragEnd={onDragEnd}
-          onStripDrop={onStripDrop}
-          isTabDragging={isTabDragging}
-          draggedPanelId={draggedPanelId}
-        />
+        {/* Scrollable tab area — delegated to PanelTabStrip. When the pane is
+            split, tabs live in the group strips instead and the bar keeps
+            only its controls (a spacer preserves their right alignment). */}
+        {tabsInGroups ? (
+          <div className="flex-1 min-w-0" />
+        ) : (
+          <PanelTabStrip
+            panels={primaryGroupPanels ?? sortedPanels}
+            activePanelId={primaryGroupActivePanelId !== undefined ? primaryGroupActivePanelId : (activePanel?.id ?? null)}
+            onPanelSelect={handlePanelClick}
+            onPanelClose={handlePanelClose}
+            isPrimary
+            isFocused={primaryGroupFocused ?? true}
+            showShortcutHints
+            onDragStart={onDragStart}
+            onDragEnd={onDragEnd}
+            onStripDrop={onStripDrop}
+            isTabDragging={isTabDragging}
+            draggedPanelId={draggedPanelId}
+          />
+        )}
 
         {/* Add Panel dropdown button - outside overflow container so dropdown isn't clipped */}
         <div className="relative h-[var(--panel-tab-height)] flex items-center flex-shrink-0" ref={dropdownRef}>

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -482,26 +482,24 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
         aria-label="Panel Tabs"
       >
         {/* Scrollable tab area — delegated to PanelTabStrip. When the pane is
-            split, tabs live in the group strips instead and the bar keeps
-            only its controls (a spacer preserves their right alignment). */}
-        {tabsInGroups ? (
-          <div className="flex-1 min-w-0" />
-        ) : (
-          <PanelTabStrip
-            panels={primaryGroupPanels ?? sortedPanels}
-            activePanelId={primaryGroupActivePanelId !== undefined ? primaryGroupActivePanelId : (activePanel?.id ?? null)}
-            onPanelSelect={handlePanelClick}
-            onPanelClose={handlePanelClose}
-            isPrimary
-            isFocused={primaryGroupFocused ?? true}
-            showShortcutHints
-            onDragStart={onDragStart}
-            onDragEnd={onDragEnd}
-            onStripDrop={onStripDrop}
-            isTabDragging={isTabDragging}
-            draggedPanelId={draggedPanelId}
-          />
-        )}
+            split, SessionView passes only the primary group's permanent tabs
+            here (working tabs live in the group strips); shortcut hints are
+            disabled then because the strip shows a subset and the 1-9 indexes
+            would lie. */}
+        <PanelTabStrip
+          panels={primaryGroupPanels ?? sortedPanels}
+          activePanelId={primaryGroupActivePanelId !== undefined ? primaryGroupActivePanelId : (activePanel?.id ?? null)}
+          onPanelSelect={handlePanelClick}
+          onPanelClose={handlePanelClose}
+          isPrimary
+          isFocused={primaryGroupFocused ?? true}
+          showShortcutHints={!tabsInGroups}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onStripDrop={onStripDrop}
+          isTabDragging={isTabDragging}
+          draggedPanelId={draggedPanelId}
+        />
 
         {/* Add Panel dropdown button - outside overflow container so dropdown isn't clipped */}
         <div className="relative h-[var(--panel-tab-height)] flex items-center flex-shrink-0" ref={dropdownRef}>

--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -37,10 +37,10 @@ export interface PanelTabStripProps {
   showShortcutHints?: boolean;
   /**
    * Visual variant: 'bar' is the full-size strip used by the primary tab bar;
-   * 'pill' is the compact treatment used by the floating island on split
-   * groups (roughly half height, smaller type, shrink-wrapped tabs).
+   * 'compact' is the slim treatment used by the group strip rows on split
+   * panes (roughly half height, smaller type, shrink-wrapped tabs).
    */
-  variant?: 'bar' | 'pill';
+  variant?: 'bar' | 'compact';
 
   // --- Drag-and-drop ---
   /** Called when a drag starts on a tab. */
@@ -103,7 +103,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
   isTabDragging = false,
   draggedPanelId = null,
 }) => {
-  const pill = variant === 'pill';
+  const compact = variant === 'compact';
   const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const editInputRef = useRef<HTMLInputElement>(null);
@@ -235,7 +235,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
     <div
       className={cn(
         "flex items-center overflow-x-auto scrollbar-none min-w-0",
-        pill ? "rounded-full max-w-full" : "flex-1",
+        compact ? "max-w-full" : "flex-1",
       )}
       onDragLeave={handleStripDragLeave}
     >
@@ -253,9 +253,9 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
           <div
             className={cn(
               "group relative inline-flex items-center justify-center whitespace-nowrap cursor-pointer select-none",
-              pill
+              compact
                 ? cn(
-                    "h-5 rounded-full text-[10px]",
+                    "h-6 text-[11px]",
                     isPermanent ? "px-2" : "px-2 pr-5",
                   )
                 : cn(
@@ -265,9 +265,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
                       : cn("min-w-[8rem] text-sm", isPermanent ? "px-3" : "px-3 pr-7"),
                   ),
               isActive
-                ? pill
-                  ? "text-text-primary bg-[color-mix(in_srgb,var(--color-surface-hover)_80%,transparent)]"
-                  : "text-text-primary"
+                ? "text-text-primary"
                 : "text-text-tertiary hover:text-text-primary hover:bg-surface-hover",
               isDragged && "opacity-50",
             )}
@@ -312,7 +310,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
                 onBlur={handleRenameSubmit}
                 className={cn(
                   "px-1 bg-bg-primary border border-border-primary rounded outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus text-text-primary",
-                  pill ? "text-[10px]" : "text-sm",
+                  compact ? "text-[11px]" : "text-sm",
                 )}
                 onClick={(e) => e.stopPropagation()}
                 style={{ width: `${Math.max(50, editingTitle.length * 8)}px` }}
@@ -320,18 +318,17 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
             ) : (
               <span className={cn(
                 "inline-flex items-center justify-center min-w-0",
-                pill ? "gap-1" : "gap-2",
+                compact ? "gap-1" : "gap-2",
               )}>
                 {panel.type === 'terminal' && (
                   <span className={cn(
-                    "rounded-full flex-shrink-0 transition-all",
-                    pill ? "w-1 h-1" : "w-1.5 h-1.5",
+                    "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
                     getPanelActivityStatus(panel.id) === 'active'
                       ? 'bg-status-info opacity-100 duration-150'
                       : 'bg-text-muted/20 opacity-40 duration-[3s]'
                   )} />
                 )}
-                {getPanelIcon(panel.type, panel, pill ? 'w-3 h-3' : 'w-4 h-4')}
+                {getPanelIcon(panel.type, panel, compact ? 'w-3.5 h-3.5' : 'w-4 h-4')}
                 <span>{displayTitle}</span>
               </span>
             )}
@@ -340,17 +337,17 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
               <button
                 className={cn(
                   "absolute top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity transition-colors text-text-muted hover:bg-surface-hover hover:text-status-error focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle",
-                  pill ? "right-1" : "right-1.5",
+                  compact ? "right-1" : "right-1.5",
                 )}
                 onClick={(e) => handlePanelClose(e, panel)}
               >
-                <X className={pill ? "w-2 h-2" : "w-2.5 h-2.5"} />
+                <X className="w-2.5 h-2.5" />
               </button>
             )}
           </div>
         );
 
-        const showDividerAfter = !pill && panel.type === 'browser';
+        const showDividerAfter = !compact && panel.type === 'browser';
         const divider = showDividerAfter ? (
           <div className="h-4 w-px bg-border-primary mx-1 flex-shrink-0" aria-hidden="true" />
         ) : null;

--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -235,7 +235,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
     <div
       className={cn(
         "flex items-center overflow-x-auto scrollbar-none min-w-0",
-        pill ? "rounded-full" : "flex-1",
+        pill ? "rounded-full max-w-full" : "flex-1",
       )}
       onDragLeave={handleStripDragLeave}
     >

--- a/frontend/src/types/panelComponents.ts
+++ b/frontend/src/types/panelComponents.ts
@@ -24,6 +24,11 @@ export interface PanelTabBarProps {
   primaryGroupActivePanelId?: string | null;
   /** Whether the primary group is the focused group (gates shortcut hints). */
   primaryGroupFocused?: boolean;
+  /**
+   * When the pane is split, every group (primary included) renders its own
+   * strip, so the top bar hides its tab strip and keeps only the controls.
+   */
+  tabsInGroups?: boolean;
   /** Called when a drag starts on a tab. */
   onDragStart?: (panelId: string) => void;
   /** Called when a drag ends. */

--- a/frontend/src/types/panelComponents.ts
+++ b/frontend/src/types/panelComponents.ts
@@ -25,8 +25,10 @@ export interface PanelTabBarProps {
   /** Whether the primary group is the focused group (gates shortcut hints). */
   primaryGroupFocused?: boolean;
   /**
-   * When the pane is split, every group (primary included) renders its own
-   * strip, so the top bar hides its tab strip and keeps only the controls.
+   * When the pane is split, working tabs live in the group strips and the
+   * top bar shows only the primary group's permanent tabs (passed via
+   * primaryGroupPanels). Disables shortcut hints since the bar then shows a
+   * subset and the 1-9 indexes would be wrong.
    */
   tabsInGroups?: boolean;
   /** Called when a drag starts on a tab. */

--- a/frontend/src/utils/panelLayout.test.ts
+++ b/frontend/src/utils/panelLayout.test.ts
@@ -29,6 +29,7 @@ import {
   groupRects,
   findGroupInDirection,
   dropZoneFor,
+  subsetInsertIndex,
 } from './panelLayout';
 
 // ---------------------------------------------------------------------------
@@ -426,6 +427,37 @@ describe('directional focus geometry', () => {
     expect(findGroupInDirection(grid, 'g1', 'left')).toBeNull();
     expect(findGroupInDirection(grid, 'g1', 'up')).toBeNull();
     expect(findGroupInDirection(grid, 'g4', 'right')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subsetInsertIndex
+// ---------------------------------------------------------------------------
+
+describe('subsetInsertIndex', () => {
+  // Full group order: permanent tabs (d, e) interleaved with working tabs
+  const full = ['d', 't1', 'e', 't2', 't3'];
+
+  it('maps a subset index to the position of that panel in the full order', () => {
+    const working = ['t1', 't2', 't3'];
+    expect(subsetInsertIndex(full, working, 0)).toBe(1); // before t1
+    expect(subsetInsertIndex(full, working, 1)).toBe(3); // before t2
+    expect(subsetInsertIndex(full, working, 2)).toBe(4); // before t3
+  });
+
+  it('maps an end-of-subset drop to just after the last subset panel', () => {
+    const working = ['t1', 't2', 't3'];
+    expect(subsetInsertIndex(full, working, 3)).toBe(5);
+    expect(subsetInsertIndex(['d', 't1', 'e'], ['t1'], 1)).toBe(2);
+  });
+
+  it('appends to the full list when the subset is empty', () => {
+    expect(subsetInsertIndex(full, [], 0)).toBe(5);
+  });
+
+  it('falls back to the end for unknown subset ids', () => {
+    expect(subsetInsertIndex(full, ['zzz'], 0)).toBe(5);
+    expect(subsetInsertIndex(full, ['zzz'], 1)).toBe(5);
   });
 });
 

--- a/frontend/src/utils/panelLayout.ts
+++ b/frontend/src/utils/panelLayout.ts
@@ -530,6 +530,31 @@ export function reconcile(
 }
 
 // ---------------------------------------------------------------------------
+// Subset index translation
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate an insertion index within a displayed subset of a group's tabs
+ * (e.g. a strip showing only non-permanent tabs while the permanent ones stay
+ * in the top bar) into an insertion index in the group's full panel order.
+ * The subset must preserve the full order's relative ordering.
+ */
+export function subsetInsertIndex(
+  fullIds: string[],
+  subsetIds: string[],
+  subsetIndex: number,
+): number {
+  if (subsetIndex >= subsetIds.length) {
+    const last = subsetIds[subsetIds.length - 1];
+    if (last === undefined) return fullIds.length;
+    const i = fullIds.indexOf(last);
+    return i === -1 ? fullIds.length : i + 1;
+  }
+  const i = fullIds.indexOf(subsetIds[subsetIndex]);
+  return i === -1 ? fullIds.length : i;
+}
+
+// ---------------------------------------------------------------------------
 // Update sizes
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Feedback on the v2.0.7 pill: it floats over the group content and covers terminal text. This replaces the floating overlay with a slim full-width strip row, keeping the compact pill-style tabs but centered in a real layout row that pushes content down, so nothing is ever covered.

Second change from the same feedback: once a pane is split, **every** group owns its tabs, including the primary group. The primary group renders the same centered strip row as the others, and the top bar hides its tab strip while split, keeping only the controls (Add Tool, resource monitor, run, layout toggles) with a spacer preserving their right alignment. The Mod+Shift+1-9 shortcut hints follow the primary group's strip into its row, still gated on focus.

Unsplit panes are pixel-identical to today: tabs in the top bar, no group strip, no behavior change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run `pnpm typecheck` and `pnpm lint` locally

## Critical Areas Modified

- [x] None of the above (presentation-layer change)