### PR TITLE
fix: guard terminal renderer grid and replay against mid-layout container sizes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preload" href="/fonts/SymbolsNerdFontMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
     <title>Pane</title>
     <script>
       // Apply theme class before React loads to prevent flash

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -1473,9 +1473,13 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
   // Performance mode keeps mounted terminals live, so returning to a panel only
   // needs layout/paint work. Do not reset and replay scrollback here.
+  // The overlay masks the font-swap flash (xterm renders one frame with fallback
+  // monospace before the real terminal font is rasterized after display:none→block).
   useEffect(() => {
     if (useBatterySaverTerminalVisibility) return;
     if (!panelVisible || !isInitialized || !fitAddonRef.current || !xtermRef.current) return;
+
+    setIsRefreshing(true);
 
     let lastWidth = 0;
     let retries = 0;
@@ -1483,6 +1487,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let hideOverlayTimer: ReturnType<typeof setTimeout> | null = null;
 
     const fitAndPaint = () => {
       if (cancelled || !fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
@@ -1495,21 +1500,27 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         return;
       }
 
-      // Never settled at a viable size — bail; the ResizeObserver finishes the job once layout settles
       if (containerWidth < MIN_VIABLE_RECT_PX) {
         console.warn(`[TerminalPanel] Activation fit bailed for panel ${panel.id}: container ${containerWidth}px`);
+        setIsRefreshing(false);
         if (autoFocus) xtermRef.current?.focus();
         return;
       }
 
-      resizePtyToFit();
-      const terminal = xtermRef.current;
-      if (terminal && terminal.rows > 0) {
-        terminal.refresh(0, terminal.rows - 1);
-      }
-      if (autoFocus) {
-        terminal?.focus();
-      }
+      void document.fonts.ready.then(() => {
+        if (cancelled || !fitAddonRef.current || !xtermRef.current) return;
+        resizePtyToFit();
+        const terminal = xtermRef.current;
+        if (terminal && terminal.rows > 0) {
+          terminal.refresh(0, terminal.rows - 1);
+        }
+        if (autoFocus) {
+          terminal?.focus();
+        }
+        hideOverlayTimer = setTimeout(() => {
+          if (!cancelled) setIsRefreshing(false);
+        }, 32);
+      });
     };
 
     const animationFrame = requestAnimationFrame(fitAndPaint);
@@ -1518,6 +1529,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       cancelled = true;
       cancelAnimationFrame(animationFrame);
       if (retryTimer) clearTimeout(retryTimer);
+      if (hideOverlayTimer) clearTimeout(hideOverlayTimer);
+      setIsRefreshing(false);
     };
   }, [useBatterySaverTerminalVisibility, panelVisible, isInitialized, autoFocus, resizePtyToFit]);
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -59,6 +59,9 @@ const DEFAULT_TERMINAL_FONT_SIZE = 14;
 const WEBGL_APP_BLUR_DETACH_DELAY_MS = 10_000;
 const REFOCUS_DELAYED_REFRESH_MS = 300;
 const TERMINAL_VISIBILITY_REFRESH_MS = 60_000;
+const MIN_VIABLE_RECT_PX = 100; // below this the container is hidden or mid-layout (Allotment minSize is 120)
+const MIN_PTY_COLS = 20;        // mirrors main-process floor
+const MIN_PTY_ROWS = 5;
 const TERMINAL_VISIBILITY_VIEWER_ID = getTerminalVisibilityViewerId();
 
 function getTerminalVisibilityViewerId(): string {
@@ -381,10 +384,19 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   } = useTerminalSearch(xtermRef);
 
   const resizePtyToFit = useCallback(() => {
-    if (!fitAddonRef.current) return;
+    if (!fitAddonRef.current || !terminalRef.current) return;
+    // Guard before fit(): the renderer grid is the damage point, not just the IPC.
+    // Width only: wrap junk is a cols problem, and a stacked pane at Allotment's
+    // 120px minSize minus tab-bar chrome leaves a legitimately <100px-tall container.
+    const rect = terminalRef.current.getBoundingClientRect();
+    if (rect.width < MIN_VIABLE_RECT_PX) return;
     fitAddonRef.current.fit();
     const dimensions = fitAddonRef.current.proposeDimensions();
-    if (dimensions) {
+    if (
+      dimensions &&
+      Number.isInteger(dimensions.cols) && Number.isInteger(dimensions.rows) &&
+      dimensions.cols >= MIN_PTY_COLS && dimensions.rows >= MIN_PTY_ROWS
+    ) {
       window.electronAPI.invoke('terminal:resize', panel.id, dimensions.cols, dimensions.rows);
     }
   }, [panel.id]);
@@ -393,6 +405,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   const handleRefreshTerminal = useCallback(async () => {
     const terminal = xtermRef.current;
     if (!terminal) return;
+    // Entry guard: never reset+replay into a tiny/unsettled container (width only,
+    // matching resizePtyToFit: height-constrained panes are legitimate layouts)
+    const rect = terminalRef.current?.getBoundingClientRect();
+    if (!rect || rect.width < MIN_VIABLE_RECT_PX) return;
     try {
       const state = await window.electronAPI.invoke('terminal:getState', panel.id);
       if (state?.isAlternateScreen) {
@@ -403,6 +419,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         return;
       }
 
+      // Fit first so reset+replay lands at the settled width, not a stale/tiny grid
+      resizePtyToFit();
       terminal.reset();
       if (state?.scrollbackBuffer) {
         const content = typeof state.scrollbackBuffer === 'string'
@@ -412,7 +430,9 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             : '';
         if (content) terminal.write(content);
       }
-      resizePtyToFit();
+      // The old post-replay fit() invalidated WebGL via a dims change; after reordering
+      // that fit is a same-size no-op, so an explicit refresh is needed for WebGL redraw
+      if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
     } catch (e) {
       console.warn('[TerminalPanel] Failed to refresh terminal:', e);
     }
@@ -1256,25 +1276,13 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             }
           });
 
-          // Handle resize
-          // Debounce resize so fit() only fires after transitions settle (300ms sidebar animations)
+          // Handle resize — delegates to the guarded resizePtyToFit (single resize path)
+          // Debounce so fit() only fires after transitions settle (300ms sidebar animations)
           let resizeTimer: ReturnType<typeof setTimeout> | null = null;
           const debouncedResize = () => {
             if (resizeTimer) clearTimeout(resizeTimer);
             resizeTimer = setTimeout(() => {
-              if (fitAddon && !disposed && terminalRef.current) {
-                // Skip resize if container is too small (likely hidden via display:none or mid-collapse)
-                const rect = terminalRef.current.getBoundingClientRect();
-                if (rect.width < 100 || rect.height < 100) {
-                  return;
-                }
-
-                fitAddon.fit();
-                const dimensions = fitAddon.proposeDimensions();
-                if (dimensions) {
-                  window.electronAPI.invoke('terminal:resize', panel.id, dimensions.cols, dimensions.rows);
-                }
-              }
+              if (!disposed) resizePtyToFit();
             }, 150);
           };
 
@@ -1411,11 +1419,19 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
       const containerWidth = terminalRef.current.clientWidth;
 
-      // If width is still changing or zero, the reflow isn't done — retry
-      if ((containerWidth === 0 || containerWidth !== lastWidth) && retries < MAX_RETRIES) {
+      // If width is still changing or below viable threshold, the reflow isn't done — retry
+      if ((containerWidth < MIN_VIABLE_RECT_PX || containerWidth !== lastWidth) && retries < MAX_RETRIES) {
         lastWidth = containerWidth;
         retries++;
         retryTimer = setTimeout(fitAndRefresh, 50);
+        return;
+      }
+
+      // Never settled at a viable size — bail; the ResizeObserver finishes the job once layout settles
+      if (containerWidth < MIN_VIABLE_RECT_PX) {
+        forwardToMainLog('warn', `[TerminalPanel] Activation refresh bailed for panel ${panel.id}: container ${containerWidth}px`);
+        setIsRefreshing(false);
+        if (autoFocus) xtermRef.current?.focus();
         return;
       }
 
@@ -1472,10 +1488,17 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       if (cancelled || !fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
 
       const containerWidth = terminalRef.current.clientWidth;
-      if ((containerWidth === 0 || containerWidth !== lastWidth) && retries < MAX_RETRIES) {
+      if ((containerWidth < MIN_VIABLE_RECT_PX || containerWidth !== lastWidth) && retries < MAX_RETRIES) {
         lastWidth = containerWidth;
         retries++;
         retryTimer = setTimeout(fitAndPaint, 50);
+        return;
+      }
+
+      // Never settled at a viable size — bail; the ResizeObserver finishes the job once layout settles
+      if (containerWidth < MIN_VIABLE_RECT_PX) {
+        console.warn(`[TerminalPanel] Activation fit bailed for panel ${panel.id}: container ${containerWidth}px`);
+        if (autoFocus) xtermRef.current?.focus();
         return;
       }
 

--- a/frontend/src/styles/tokens/typography.css
+++ b/frontend/src/styles/tokens/typography.css
@@ -1,7 +1,7 @@
 /* Typography Design Tokens for Pane */
 
 @import url('https://fonts.googleapis.com/css2?family=Sora:wght@100;200;300;400;500;600;700;800&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100;200;300;400;500;600;700;800;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100;200;300;400;500;600;700;800;900&display=block');
 
 /*
  * Symbols Nerd Font Mono — SIL Open Font License 1.1 (Ryan L McIntyre / Nerd Fonts)

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -49,6 +49,8 @@ class PtyHandleShim implements pty.IPty {
   handleFlowControl = false;
   readonly ptyId: string;
   private readonly handle: PtyHandleLike;
+  /** Monotonic resize ordinal; only the latest call may confirm cols/rows. */
+  private resizeSeq = 0;
 
   constructor(handle: PtyHandleLike, cols: number, rows: number) {
     this.handle = handle;
@@ -74,9 +76,17 @@ class PtyHandleShim implements pty.IPty {
   };
 
   resize(columns: number, rows: number): void {
-    this.cols = columns;
-    this.rows = rows;
-    this.handle.resize(columns, rows).catch((err: unknown) => {
+    // Confirm dims only after the async host resize succeeds so dedupe never
+    // compares against an unconfirmed size. The sequence check stops an older
+    // in-flight resize from overwriting a newer confirmed size when promises
+    // resolve out of order.
+    const seq = ++this.resizeSeq;
+    this.handle.resize(columns, rows).then(() => {
+      if (seq === this.resizeSeq) {
+        this.cols = columns;
+        this.rows = rows;
+      }
+    }).catch((err: unknown) => {
       console.warn('[ptyHost] resize failed', err);
     });
   }
@@ -1142,22 +1152,25 @@ export class TerminalPanelManager {
       return;
     }
 
-    // Reject unreasonably small dimensions (likely from hidden container)
-    if (cols < 20 || rows < 5) {
+    // Reject non-integers (NaN/Infinity/floats) and mid-layout garbage
+    if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols < 20 || rows < 5) {
       console.warn(`[TerminalPanelManager] Rejecting invalid resize ${cols}x${rows} for ${panelId}`);
+      return;
+    }
+
+    // Dedupe: avoids ConPTY repaints and redundant WINCH redraws
+    if (terminal.pty.cols === cols && terminal.pty.rows === rows) {
       return;
     }
 
     try {
       terminal.pty.resize(cols, rows);
     } catch (err) {
-      // PTY may have exited between the map lookup and the resize call
+      // A resize failure does not mean the pty died; onExit owns cleanup
       console.warn(`[TerminalPanelManager] Failed to resize terminal ${panelId}:`, err);
-      this.terminals.delete(panelId);
-      this.visibleViewersByPanel.delete(panelId);
       return;
     }
-    
+
     // Update panel state with new dimensions
     const panel = panelManager.getPanel(panelId);
     if (panel) {


### PR DESCRIPTION
closes #230, though the mechanism turned out different than the issue describes.

went digging before implementing and the pty was never the victim. \`resizeTerminal\` has floored cols<20/rows<5 since the initial commit, and my real db (1239 terminal panels) shows the minimum pty width ever persisted is 29. i also scanned 315 saved raw recordings containing my prompt: zero stair-step junk in the byte stream. the 7-8 col garbage is manufactured in the renderer at replay time, not recorded.

actual chain: the activation effects only wait for the container width to be *stable*, not sane. a split pane sitting at 60px for 100ms passes, \`fit()\` happily shrinks the xterm grid to 7 cols (fit addon's own minimum is 2), then refresh-on-activate resets and replays the whole raw history into that tiny grid. plain text soft-wraps and heals on widen, but CR overwrites / erase-line / cursor moves in the recording mangle into hard rows that reflow can never merge back. every activation during split churn regenerates it, which is why refresh never seemed to help.

bonus bug found on the way: \`proposeDimensions()\` can return NaN (Math.max propagates parseInt of "auto"), \`NaN < 20\` is false so the floor passed it, node-pty throws on NaN, and the catch evicted the live terminal from the map. panel permanently dead after one bad measurement.

changes:
- \`resizePtyToFit\` guards the container rect before \`fit()\` (width only: wrap junk is a cols problem, and a stacked pane at allotment's 120px minSize minus tab chrome is legitimately under 100px tall) and validates integer dims >= 20x5 before the ipc send
- \`handleRefreshTerminal\` gets an entry guard and reorders to fit -> reset -> replay -> explicit \`terminal.refresh\` (the old post-replay fit invalidated webgl via a dims change; after reordering it would be a same-size no-op)
- both activation effects bail instead of force-fitting after 10 retries; battery saver bail clears the overlay so it can't stick
- the resize observer path delegates to \`resizePtyToFit\` instead of duplicating fit/propose/invoke
- main: \`Number.isInteger\` validation, same-size dedupe against the pty's confirmed dims (the ptyHost shim now confirms cols/rows only when the async resize succeeds, seq-guarded against out-of-order resolution), and a resize failure no longer evicts the terminal

existing poisoned scrollback won't heal, same as the issue says. #231 stays the architectural follow-up for the wider recorded-junk class (legit narrow redraws during drags still enter recordings; the dedupe just cuts the redundant ones).

typecheck and lint clean. not yet manually tested in the running app; the repro to verify is split/drag with a prompt visible, widen back, refresh, plus checking vim/htop still resize and that macos webgl doesn't show a stale canvas after refresh.