### PR TITLE
[codex] Fix PostHog app attribution

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,14 @@ import { CloudWidget } from './components/CloudWidget';
 import { CreateSessionDialog } from './components/CreateSessionDialog';
 import { AddProjectDialog } from './components/AddProjectDialog';
 import { useNavigationStore } from './stores/navigationStore';
-import { initPostHog, capture, captureUnconditionally, posthog } from './services/posthog';
+import {
+  aliasWebVisitor,
+  capture,
+  captureUnconditionally,
+  initPostHog,
+  posthog,
+  queuePendingEvent,
+} from './services/posthog';
 import type { VersionUpdateInfo } from './types/session';
 import type { AnalyticsIdentity, TerminalShortcut } from './types/config';
 import type { ResumableSession } from '../../shared/types/panels';
@@ -279,6 +286,14 @@ function App() {
     const initializeAnalytics = async () => {
       let identity: AnalyticsIdentity | undefined;
       const analyticsEnabled = appConfig.analytics?.enabled ?? false;
+      let consentDecided = false;
+
+      try {
+        const consentResult = await window.electron?.invoke?.('preferences:get', 'analytics_consent_shown') as IPCResponse<string> | undefined;
+        consentDecided = consentResult?.data === 'true';
+      } catch (error) {
+        console.error('[App] Error resolving analytics consent state:', error);
+      }
 
       if (analyticsEnabled) {
         try {
@@ -300,6 +315,11 @@ function App() {
         identity,
       });
 
+      if (analyticsEnabled && identity?.webDistinctId) {
+        aliasWebVisitor(identity.webDistinctId);
+        void window.electronAPI?.analytics?.redeemAttribution?.();
+      }
+
       // Sync distinct ID to main process so shutdown analytics use the same identity
       const distinctId = identity?.distinctId || posthog.get_distinct_id();
       if (distinctId) {
@@ -310,7 +330,11 @@ function App() {
       // The preload buffers any events that arrived before this point and replays them.
       if (!window.electronAPI?.analytics?.onMainEvent) return;
       cleanup = window.electronAPI.analytics.onMainEvent((event) => {
-        capture(event.eventName, event.properties);
+        if (analyticsEnabled) {
+          capture(event.eventName, event.properties);
+        } else if (!consentDecided) {
+          queuePendingEvent(event);
+        }
       });
     };
 

--- a/frontend/src/components/AnalyticsConsentDialog.tsx
+++ b/frontend/src/components/AnalyticsConsentDialog.tsx
@@ -4,7 +4,7 @@ import { usePaneLogo } from '../hooks/usePaneLogo';
 import { Modal, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import { useConfigStore } from '../stores/configStore';
-import { optIn, capture, captureAndOptOut } from '../services/posthog';
+import { optIn, capture, captureAndOptOut, discardPendingEvents, flushPendingEvents } from '../services/posthog';
 
 interface AnalyticsConsentDialogProps {
   isOpen: boolean;
@@ -29,6 +29,7 @@ export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsCon
 
       // Track opt-in event
       optIn();
+      flushPendingEvents();
       capture('analytics_opted_in');
 
       // Mark consent as shown
@@ -50,6 +51,12 @@ export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsCon
       // Track opt-out event FIRST (before disabling analytics)
       // Uses captureAndOptOut to ensure the event is flushed before disabling
       captureAndOptOut('analytics_opted_out');
+      discardPendingEvents();
+
+      // Mark consent as shown before the config update re-registers analytics listeners.
+      if (window.electron?.invoke) {
+        await window.electron.invoke('preferences:set', 'analytics_consent_shown', 'true');
+      }
 
       // Disable analytics (keep it disabled since it's opt-in)
       await updateConfig({
@@ -58,11 +65,6 @@ export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsCon
           enabled: false,
         },
       });
-
-      // Mark consent as shown
-      if (window.electron?.invoke) {
-        await window.electron.invoke('preferences:set', 'analytics_consent_shown', 'true');
-      }
 
       onClose(false);
     } catch (error) {

--- a/frontend/src/services/posthog.ts
+++ b/frontend/src/services/posthog.ts
@@ -39,6 +39,19 @@ function identifyUser(config: PostHogConfig): void {
   ));
 }
 
+function directCaptureTarget(): { token: string; host: string; distinctId: string } {
+  const distinctId = posthog.get_distinct_id?.();
+
+  return {
+    token: currentApiKey || DEFAULT_API_KEY,
+    host: currentHost || DEFAULT_HOST,
+    distinctId:
+      typeof distinctId === 'string' && distinctId.length > 0
+        ? distinctId
+        : `anon_${crypto.randomUUID()}`,
+  };
+}
+
 export function initPostHog(config: PostHogConfig): void {
   const apiKey = config.posthogApiKey || DEFAULT_API_KEY;
   const host = config.posthogHost || DEFAULT_HOST;
@@ -132,11 +145,7 @@ export function aliasWebVisitor(webDistinctId: string): void {
  * during the flush window.
  */
 export function captureAndOptOut(eventName: string, properties?: Record<string, unknown>): void {
-  const token = posthog.get_property?.('$token') as string | undefined
-    || posthog.config?.token
-    || DEFAULT_API_KEY;
-  const host = posthog.config?.api_host || DEFAULT_HOST;
-  const distinctId = posthog.get_distinct_id();
+  const { token, host, distinctId } = directCaptureTarget();
 
   const payload = {
     api_key: token,
@@ -191,11 +200,7 @@ export function capture(eventName: string, properties?: Record<string, unknown>)
  * opted_in + opted_out lower bound).
  */
 export function captureUnconditionally(eventName: string, properties?: Record<string, unknown>): void {
-  const token = (posthog.get_property?.('$token') as string | undefined)
-    || posthog.config?.token
-    || DEFAULT_API_KEY;
-  const host = posthog.config?.api_host || DEFAULT_HOST;
-  const distinctId = posthog.get_distinct_id();
+  const { token, host, distinctId } = directCaptureTarget();
 
   const payload = {
     api_key: token,

--- a/frontend/src/services/posthog.ts
+++ b/frontend/src/services/posthog.ts
@@ -1,25 +1,25 @@
 import posthog from 'posthog-js';
+import type { AnalyticsIdentity } from '../types/config';
 
 const DEFAULT_API_KEY = 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1';
-const DEFAULT_HOST = 'https://us.i.posthog.com';
+const DEFAULT_HOST = 'https://runpane.com/api/c';
 
 let currentApiKey: string | undefined;
 let currentHost: string | undefined;
 let currentEnabled: boolean | undefined;
 
+export interface PendingAnalyticsEvent {
+  eventName: string;
+  properties?: Record<string, unknown>;
+}
+
+let pendingEvents: PendingAnalyticsEvent[] = [];
+
 export interface PostHogConfig {
   enabled: boolean;
   posthogApiKey?: string;
   posthogHost?: string;
-  identity?: {
-    distinctId: string;
-    identitySource: string;
-    githubUsername?: string;
-    githubEmail?: string;
-    gitEmail?: string;
-    gitEmailHash?: string;
-    gitUserName?: string;
-  };
+  identity?: AnalyticsIdentity;
 }
 
 function identifyUser(config: PostHogConfig): void {
@@ -82,6 +82,10 @@ export function initPostHog(config: PostHogConfig): void {
   }
 
   identifyUser(config);
+
+  if (config.enabled) {
+    flushPendingEvents();
+  }
 }
 
 export function optIn(): void {
@@ -90,6 +94,34 @@ export function optIn(): void {
 
 export function optOut(): void {
   posthog.opt_out_capturing();
+}
+
+export function queuePendingEvent(event: PendingAnalyticsEvent): void {
+  pendingEvents.push({
+    eventName: event.eventName,
+    properties: event.properties,
+  });
+}
+
+export function flushPendingEvents(): void {
+  const eventsToSend = pendingEvents;
+  pendingEvents = [];
+
+  for (const event of eventsToSend) {
+    capture(event.eventName, event.properties);
+  }
+}
+
+export function discardPendingEvents(): void {
+  pendingEvents = [];
+}
+
+export function aliasWebVisitor(webDistinctId: string): void {
+  try {
+    posthog.alias(webDistinctId);
+  } catch (error) {
+    console.error('[PostHog] Failed to alias web visitor:', error);
+  }
 }
 
 /**
@@ -114,6 +146,7 @@ export function captureAndOptOut(eventName: string, properties?: Record<string, 
       distinct_id: distinctId,
       token,
       $lib: 'posthog-js',
+      $process_person_profile: false,
     },
     timestamp: new Date().toISOString(),
   };
@@ -172,6 +205,7 @@ export function captureUnconditionally(eventName: string, properties?: Record<st
       distinct_id: distinctId,
       token,
       $lib: 'posthog-js',
+      $process_person_profile: false,
     },
     timestamp: new Date().toISOString(),
   };

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -26,6 +26,7 @@ export interface AnalyticsIdentity {
   gitEmail?: string;
   gitEmailHash?: string;
   gitUserName?: string;
+  webDistinctId?: string;
 }
 
 export interface AnalyticsConfig {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -432,6 +432,7 @@ interface ElectronAPI {
     getIdentity: () => Promise<IPCResponse<import('./config').AnalyticsIdentity>>;
     onMainEvent: (callback: (event: { eventName: string; properties: Record<string, unknown> }) => void) => () => void;
     syncDistinctId: (distinctId: string) => void;
+    redeemAttribution: () => Promise<IPCResponse<void>>;
   };
 
   // Onboarding

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -44,7 +44,7 @@ import type { VersionChecker } from './services/versionChecker';
 import type { Logger } from './utils/logger';
 import type { ArchiveProgressManager } from './services/archiveProgressManager';
 import type { AnalyticsManager } from './services/analyticsManager';
-import { resolveAnalyticsIdentity } from './services/analyticsIdentity';
+import { readWebAttribution, resolveAnalyticsIdentity } from './services/analyticsIdentity';
 import { resourceMonitorService } from './services/resourceMonitorService';
 import { applyAppDirectoryOverrideFromArgs, migrateDataDirectory, getAppDirectory } from './utils/appDirectory';
 import { getCurrentWorktreeName } from './utils/worktreeUtils';
@@ -958,11 +958,29 @@ async function initializeServices() {
   ipcMain.handle('analytics:get-identity', async () => {
     try {
       const identity = resolveAnalyticsIdentity(configManager.getAnalyticsDistinctId());
+      const webDistinctId = readWebAttribution(getAppDirectory());
+      if (webDistinctId) {
+        identity.webDistinctId = webDistinctId;
+      }
       await configManager.setAnalyticsIdentity(identity);
       return { success: true, data: identity };
     } catch (error) {
       console.error('[Analytics] Failed to resolve identity:', error);
       return { success: false, error: 'Failed to resolve analytics identity' };
+    }
+  });
+
+  ipcMain.handle('analytics:redeem-attribution', async () => {
+    try {
+      await fs.promises.unlink(path.join(getAppDirectory(), 'attribution_ref')).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+      });
+      return { success: true };
+    } catch (error) {
+      console.error('[Analytics] Failed to redeem attribution:', error);
+      return { success: false, error: 'Failed to redeem analytics attribution' };
     }
   });
 

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -1049,6 +1049,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     syncDistinctId: (distinctId: string): void => {
       ipcRenderer.send('analytics:sync-distinct-id', distinctId);
     },
+    redeemAttribution: (): Promise<IPCResponse<void>> => invokeIpc('analytics:redeem-attribution'),
   },
 
   // Spotlight

--- a/main/src/services/analyticsIdentity.ts
+++ b/main/src/services/analyticsIdentity.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from 'child_process';
 import * as crypto from 'crypto';
+import * as fsSync from 'fs';
 import * as os from 'os';
+import * as path from 'path';
 import { getShellPath } from '../utils/shellPath';
 import type { AnalyticsIdentity } from '../types/config';
 
@@ -58,4 +60,23 @@ export function resolveAnalyticsIdentity(existingDistinctId?: string): Analytics
     gitEmailHash,
     gitUserName,
   };
+}
+
+export function readWebAttribution(appDir: string): string | undefined {
+  try {
+    const token = fsSync.readFileSync(path.join(appDir, 'attribution_ref'), 'utf8').trim();
+    if (!token) return undefined;
+
+    const decoded = Buffer.from(token, 'base64url').toString('utf8');
+    const separatorIndex = decoded.lastIndexOf('|');
+    if (separatorIndex <= 0) return undefined;
+
+    const distinctId = decoded.slice(0, separatorIndex);
+    const issuedAt = decoded.slice(separatorIndex + 1);
+    if (!/^\d+$/.test(issuedAt)) return undefined;
+
+    return distinctId.length > 0 && distinctId.length <= 64 ? distinctId : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -11,6 +11,10 @@ import os from 'os';
 import { getAppDirectory } from '../utils/appDirectory';
 import { clearShellPathCache } from '../utils/shellPath';
 
+const DEFAULT_POSTHOG_API_KEY = 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1';
+const LEGACY_POSTHOG_HOST = 'https://us.i.posthog.com';
+const DEFAULT_POSTHOG_HOST = 'https://runpane.com/api/c';
+
 export class ConfigManager extends EventEmitter {
   private config: AppConfig;
   private configPath: string;
@@ -60,8 +64,8 @@ export class ConfigManager extends EventEmitter {
       },
       analytics: {
         enabled: false, // Opt-in: disabled by default until user consents
-        posthogApiKey: 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1',
-        posthogHost: 'https://us.i.posthog.com'
+        posthogApiKey: DEFAULT_POSTHOG_API_KEY,
+        posthogHost: DEFAULT_POSTHOG_HOST
       },
       remoteDaemon: createDefaultRemoteDaemonConfig(),
       terminalShortcuts: [
@@ -151,6 +155,11 @@ export class ConfigManager extends EventEmitter {
           ? loadedConfig.worktreeFileSync
           : DEFAULT_WORKTREE_FILE_SYNC_ENTRIES
       };
+
+      if (this.config.analytics?.posthogHost === LEGACY_POSTHOG_HOST) {
+        this.config.analytics.posthogHost = DEFAULT_POSTHOG_HOST;
+        await this.saveConfig();
+      }
     } catch (error: unknown) {
       const isNotFound = error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
       if (isNotFound) {
@@ -355,8 +364,8 @@ export class ConfigManager extends EventEmitter {
   getAnalyticsSettings() {
     return this.config.analytics || {
       enabled: false, // Opt-in: disabled by default until user consents
-      posthogApiKey: 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1',
-      posthogHost: 'https://us.i.posthog.com'
+      posthogApiKey: DEFAULT_POSTHOG_API_KEY,
+      posthogHost: DEFAULT_POSTHOG_HOST
     };
   }
 
@@ -372,8 +381,8 @@ export class ConfigManager extends EventEmitter {
     if (!this.config.analytics) {
       this.config.analytics = {
         enabled: false,
-        posthogApiKey: 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1',
-        posthogHost: 'https://us.i.posthog.com'
+        posthogApiKey: DEFAULT_POSTHOG_API_KEY,
+        posthogHost: DEFAULT_POSTHOG_HOST
       };
     }
     this.config.analytics.distinctId = distinctId;
@@ -384,8 +393,8 @@ export class ConfigManager extends EventEmitter {
     if (!this.config.analytics) {
       this.config.analytics = {
         enabled: false,
-        posthogApiKey: 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1',
-        posthogHost: 'https://us.i.posthog.com'
+        posthogApiKey: DEFAULT_POSTHOG_API_KEY,
+        posthogHost: DEFAULT_POSTHOG_HOST
       };
     }
     this.config.analytics.distinctId = identity.distinctId;

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -26,6 +26,7 @@ export interface AnalyticsIdentity {
   gitEmail?: string;
   gitEmailHash?: string;
   gitUserName?: string;
+  webDistinctId?: string;
 }
 
 export interface AnalyticsConfig {


### PR DESCRIPTION
## Summary

Fixes the app side of the PostHog attribution path:

- queues main-process analytics events while consent is undecided, then flushes on opt-in before `analytics_opted_in`
- migrates the app PostHog host from `https://us.i.posthog.com` to `https://runpane.com/api/c` for existing default-config installs
- adds one-shot install attribution redemption via `attribution_ref` and `posthog.alias(webDistinctId)` after identify
- marks raw pre-consent captures with `$process_person_profile: false`

## Why

First-launch `app_opened` was being replayed into an opted-out PostHog SDK and silently dropped, breaking `app_opened -> onboarding_started` and removing the `is_first_launch` install signal. The app also needed to consume the website install ref token so copied install commands can stitch anonymous web visitors to opted-in app users.

Companion website PR: https://github.com/parsakhaz/runpane-website/pull/85

## Validation

- `pnpm typecheck` passed after rebase
- `pnpm lint` passed after rebase with existing warnings only

Note: local Node is `v20.19.3`; the repo declares `>=22.14.0`, so pnpm emits an engine warning during checks.