### PR TITLE
Prevent nested worktree sync traversal

### DIFF
--- a/main/src/services/__tests__/worktreeFileSyncService.test.ts
+++ b/main/src/services/__tests__/worktreeFileSyncService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { worktreeFileSyncService } from '../worktreeFileSyncService';
 import type { WorktreeFileSyncEntry } from '../../../../shared/types/worktreeFileSync';
 import type { CommandRunner } from '../../utils/commandRunner';
@@ -85,6 +85,12 @@ const nodeModulesEntry: WorktreeFileSyncEntry = {
 const claudeEntry: WorktreeFileSyncEntry = {
   id: 'claude',
   path: '.claude',
+  enabled: true,
+  recursive: false,
+};
+const codexEntry: WorktreeFileSyncEntry = {
+  id: 'codex',
+  path: '.codex',
   enabled: true,
   recursive: false,
 };
@@ -294,6 +300,25 @@ describe('worktreeFileSyncService', () => {
         'cp "/home/user/repo/.env" "/home/user/worktree/.env"',
       );
     });
+
+    it('prunes generated worktrees directories before recursive discovery', async () => {
+      const cpCommands: string[] = [];
+      const runner = makeMockCommandRunner('/home/user/repo/.env', new Set(), cpCommands);
+
+      await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [envEntry],
+      );
+
+      const execAsync = runner.execAsync as ReturnType<typeof vi.fn>;
+      const matchCall = execAsync.mock.calls.find((call) => isMatchCommand(String(call[0])));
+      expect(matchCall).toBeDefined();
+      expect(String(matchCall?.[0])).toContain('-type d -name worktrees');
+      expect(String(matchCall?.[0])).toContain('-prune -o -print');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -354,28 +379,102 @@ describe('worktreeFileSyncService', () => {
     const mainRepoPath = '/home/user/repo';
     const worktreePath = '/home/user/worktree';
 
-    it('copies .claude directory as a root-level entry', async () => {
-      const cpCommands: string[] = [];
-
-      // For non-recursive entries the runner is called with existsAt checks,
-      // not find. Simulate: src exists, dest does not exist, src is a directory.
+    function makeRootDirectoryRunner(rootPath: string, copyCommands: string[]): CommandRunner {
       const execAsync = vi.fn().mockImplementation((cmd: string) => {
-        if (cmd === 'test -e "/home/user/repo/.claude"') {
-          // source exists
+        if (cmd.startsWith('test -e ')) {
+          return cmd.includes(`/repo/${rootPath}`)
+            ? Promise.resolve({ stdout: '', stderr: '' })
+            : Promise.reject(new Error('not exists'));
+        }
+        if (cmd.startsWith('test -f ')) {
+          return Promise.reject(new Error('not a file'));
+        }
+        if (cmd.includes('for item in')) {
+          copyCommands.push(cmd);
           return Promise.resolve({ stdout: '', stderr: '' });
         }
-        if (cmd === 'test -e "/home/user/worktree/.claude"') {
-          // destination does not exist
+        return Promise.resolve({ stdout: '', stderr: '' });
+      });
+
+      return { execAsync } as unknown as CommandRunner;
+    }
+
+    it('copies .claude contents without entering nested worktrees', async () => {
+      const copyCommands: string[] = [];
+      const runner = makeRootDirectoryRunner('.claude', copyCommands);
+
+      const result = await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [claudeEntry],
+      );
+
+      expect(result.failures).toHaveLength(0);
+      expect(copyCommands).toHaveLength(1);
+      expect(copyCommands[0]).toContain('/home/user/repo/.claude');
+      expect(copyCommands[0]).toContain('case "$base" in worktrees) continue ;; esac');
+      expect(copyCommands[0]).toContain('cp -rp "$item"');
+      expect(copyCommands[0]).not.toBe('cp -rp "/home/user/repo/.claude" "/home/user/worktree/.claude"');
+    });
+
+    it('applies the generated worktrees exclusion to other agent config roots', async () => {
+      const copyCommands: string[] = [];
+      const runner = makeRootDirectoryRunner('.codex', copyCommands);
+
+      await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [codexEntry],
+      );
+
+      expect(copyCommands).toHaveLength(1);
+      expect(copyCommands[0]).toContain('/home/user/repo/.codex');
+      expect(copyCommands[0]).toContain('case "$base" in worktrees) continue ;; esac');
+    });
+
+    it('applies the generated worktrees exclusion to custom config roots', async () => {
+      const copyCommands: string[] = [];
+      const runner = makeRootDirectoryRunner('.agent', copyCommands);
+
+      await worktreeFileSyncService.syncWorktree(
+        mainRepoPath,
+        worktreePath,
+        runner,
+        environment,
+        [{
+          id: 'agent',
+          path: '.agent',
+          enabled: true,
+          recursive: false,
+        }],
+      );
+
+      expect(copyCommands).toHaveLength(1);
+      expect(copyCommands[0]).toContain('/home/user/repo/.agent');
+      expect(copyCommands[0]).toContain('case "$base" in worktrees) continue ;; esac');
+    });
+
+    it('honors an explicit nested worktrees entry', async () => {
+      const cpCommands: string[] = [];
+
+      const execAsync = vi.fn().mockImplementation((cmd: string) => {
+        if (cmd === 'test -e "/home/user/repo/.agent/worktrees"') {
+          return Promise.resolve({ stdout: '', stderr: '' });
+        }
+        if (cmd === 'test -e "/home/user/worktree/.agent/worktrees"') {
           return Promise.reject(new Error('not exists'));
         }
         if (cmd.startsWith('test -f ')) {
-          // .claude is a directory — test -f fails
           return Promise.reject(new Error('not a file'));
         }
         if (cmd.startsWith('mkdir ')) {
           return Promise.resolve({ stdout: '', stderr: '' });
         }
-        if (cmd.startsWith('cp ')) {
+        if (cmd.includes('for item in') || cmd.startsWith('cp ')) {
           cpCommands.push(cmd);
           return Promise.resolve({ stdout: '', stderr: '' });
         }
@@ -389,12 +488,17 @@ describe('worktreeFileSyncService', () => {
         worktreePath,
         runner,
         environment,
-        [claudeEntry],
+        [{
+          id: 'agent-worktrees',
+          path: '.agent/worktrees',
+          enabled: true,
+          recursive: true,
+        }],
       );
 
       expect(cpCommands).toHaveLength(1);
       expect(cpCommands[0]).toBe(
-        'cp -rp "/home/user/repo/.claude" "/home/user/worktree/.claude"',
+        'cp -rp "/home/user/repo/.agent/worktrees" "/home/user/worktree/.agent/worktrees"',
       );
     });
 
@@ -518,11 +622,11 @@ describe('worktreeFileSyncService', () => {
             ? Promise.reject(new Error('not a file'))
             : Promise.resolve({ stdout: '', stderr: '' });
         }
-        if (cmd.startsWith('mkdir ')) {
+        if (cmd.includes('for item in') || cmd.startsWith('cp ')) {
+          cpCommands.push(cmd);
           return Promise.resolve({ stdout: '', stderr: '' });
         }
-        if (cmd.startsWith('cp ')) {
-          cpCommands.push(cmd);
+        if (cmd.startsWith('mkdir ')) {
           return Promise.resolve({ stdout: '', stderr: '' });
         }
         return Promise.resolve({ stdout: '', stderr: '' });
@@ -568,11 +672,11 @@ describe('worktreeFileSyncService', () => {
             ? Promise.reject(new Error('not a file'))
             : Promise.resolve({ stdout: '', stderr: '' });
         }
-        if (cmd.startsWith('mkdir ')) {
+        if (cmd.includes('for item in') || cmd.startsWith('cp ')) {
+          cpCommands.push(cmd);
           return Promise.resolve({ stdout: '', stderr: '' });
         }
-        if (cmd.startsWith('cp ')) {
-          cpCommands.push(cmd);
+        if (cmd.startsWith('mkdir ')) {
           return Promise.resolve({ stdout: '', stderr: '' });
         }
         return Promise.resolve({ stdout: '', stderr: '' });

--- a/main/src/services/worktreeFileSyncService.ts
+++ b/main/src/services/worktreeFileSyncService.ts
@@ -20,6 +20,7 @@ export interface WorktreeFileSyncResult {
 // 60s default exec timeout; give copy commands a generous ceiling instead of
 // killing them midway and leaving a partial node_modules behind.
 const COPY_TIMEOUT_MS = 600_000;
+const GENERATED_WORKSPACE_DIR_NAMES = new Set(['worktrees']);
 
 /**
  * Joins path segments correctly for the target environment.
@@ -70,6 +71,16 @@ function entryHasGlobPattern(entryPath: string): boolean {
   return hasMagic(entryPath);
 }
 
+function isGeneratedWorkspaceSegment(segment: string): boolean {
+  return GENERATED_WORKSPACE_DIR_NAMES.has(segment);
+}
+
+function isExplicitGeneratedWorkspaceEntry(entryPath: string): boolean {
+  const segments = entryPath.split('/').filter(Boolean);
+  const lastSegment = segments[segments.length - 1];
+  return lastSegment !== undefined && isGeneratedWorkspaceSegment(lastSegment);
+}
+
 function buildMatchPatterns(entryPath: string, recursive: boolean): string[] {
   if (!recursive || entryPath.includes('/')) {
     return [entryPath];
@@ -85,13 +96,12 @@ function buildMatchPatterns(entryPath: string, recursive: boolean): string[] {
 
 function shouldSkipMatch(relativePath: string): boolean {
   const normalized = relativePath.replace(/\\/g, '/');
+  const segments = normalized.split('/').filter(Boolean);
   if (
     normalized === '.git'
     || normalized.startsWith('.git/')
     || normalized.includes('/.git/')
-    || normalized === 'worktrees'
-    || normalized.startsWith('worktrees/')
-    || normalized.includes('/worktrees/')
+    || segments.some(isGeneratedWorkspaceSegment)
   ) {
     return true;
   }
@@ -332,7 +342,7 @@ async function findRecursiveMatchesUnix(
 ): Promise<string[]> {
   const script = [
     'repo=$1',
-    'find "$repo" -maxdepth 5 \\( -path "$repo/.git" -o -path "$repo/.git/*" -o -path "$repo/worktrees" -o -path "$repo/worktrees/*" \\) -prune -o -print | while IFS= read -r abs; do',
+    'find "$repo" -maxdepth 5 \\( -path "$repo/.git" -o \\( -type d -name worktrees ! -path "$repo" \\) \\) -prune -o -print | while IFS= read -r abs; do',
     '  printf "%s\\n" "$abs"',
     'done',
   ].join('\n');
@@ -361,7 +371,9 @@ async function findRecursiveMatchesWindows(
     absolute: true,
     follow: false,
     ignore: [
+      '**/.git',
       '**/.git/**',
+      '**/worktrees',
       '**/worktrees/**',
     ],
   });
@@ -391,6 +403,43 @@ async function execCopyCommand(
   }
 }
 
+async function copyRootDirectoryExcludingGeneratedChildren(
+  srcPath: string,
+  destPath: string,
+  commandRunner: CommandRunner,
+  environment: ProjectEnvironment,
+): Promise<void> {
+  if (environment === 'windows') {
+    await fs.promises.mkdir(destPath, { recursive: true });
+    const children = await fs.promises.readdir(srcPath, { withFileTypes: true });
+    for (const child of children) {
+      if (isGeneratedWorkspaceSegment(child.name)) continue;
+      await fs.promises.cp(
+        path.join(srcPath, child.name),
+        path.join(destPath, child.name),
+        { recursive: true, force: false, errorOnExist: false, preserveTimestamps: true },
+      );
+    }
+    return;
+  }
+
+  const copyCommand = environment === 'macos' ? 'cp -c -R' : 'cp -rp';
+  const excludedCasePatterns = Array.from(GENERATED_WORKSPACE_DIR_NAMES).join('|');
+  const escapedSrc = escapeForBash(srcPath);
+  const escapedDest = escapeForBash(destPath);
+  const command = [
+    `mkdir -p ${escapedDest}`,
+    `for item in ${escapedSrc}/* ${escapedSrc}/.[!.]* ${escapedSrc}/..?*; do`,
+    '  [ -e "$item" ] || continue',
+    '  base="$(basename "$item")"',
+    `  case "$base" in ${excludedCasePatterns}) continue ;; esac`,
+    `  ${copyCommand} "$item" ${escapedDest}/`,
+    'done',
+  ].join('; ');
+
+  await commandRunner.execAsync(command, srcPath, { timeout: COPY_TIMEOUT_MS });
+}
+
 /**
  * Copies a single root-level entry from main repo into the worktree.
  * Only copies if the source exists AND the destination is missing.
@@ -415,6 +464,11 @@ async function copyRootEntry(
   if (destExists) return;
 
   const isFile = await isFilePath(srcPath, commandRunner, environment, mainRepoPath);
+  if (!isFile && !isExplicitGeneratedWorkspaceEntry(entryPath)) {
+    await copyRootDirectoryExcludingGeneratedChildren(srcPath, destPath, commandRunner, environment);
+    return;
+  }
+
   await ensureParentDir(destPath, commandRunner, worktreePath, environment);
   const cmd = getFastCopyCommand(srcPath, destPath, environment, isFile);
   await execCopyCommand(cmd, mainRepoPath, commandRunner, environment);
@@ -577,7 +631,9 @@ export const worktreeFileSyncService = {
       for (const entry of orderedEntries) {
         try {
           const normalizedPath = normalizeSyncPath(entry.path);
-          if (entry.recursive || entryHasGlobPattern(normalizedPath)) {
+          const hasGlobPattern = entryHasGlobPattern(normalizedPath);
+          const isExplicitGeneratedWorkspacePath = !hasGlobPattern && isExplicitGeneratedWorkspaceEntry(normalizedPath);
+          if ((entry.recursive || hasGlobPattern) && !isExplicitGeneratedWorkspacePath) {
             const matchFailures = await copyRecursiveMatches(
               mainRepoPath,
               worktreePath,


### PR DESCRIPTION
## Why this matters
- Some agents keep their own native workspace/worktree state under agent config directories such as `.claude/worktrees` or `.codex/worktrees`.
- Pane's worktree file sync copies gitignored config directories into new Pane worktrees. If that parent directory contains generated `worktrees` state, a single recursive copy or recursive scan can enter a 5-10 GB tree and saturate disk bandwidth.
- The fix needs to be agent-agnostic: lightweight config should sync, but generated worktree forests should be treated as a boundary unless the user explicitly opts into that exact path.

## Summary
- skip direct `worktrees` children when syncing root config directories such as `.claude`, `.codex`, or custom `.agent` entries
- prune any directory named `worktrees` during Unix recursive/glob discovery before traversal
- tighten Windows glob ignores to exclude both `worktrees` directories and their contents
- preserve explicit user opt-ins like `.agent/worktrees` or `worktrees` as exact sync entries
- add regression coverage for Claude, Codex, custom agent roots, explicit opt-in, and recursive prune behavior

## Visual Overview

`worktrees` is now a traversal boundary for default/parent sync. Pane can copy config beside it, but does not cross into generated workspace state unless the user explicitly syncs that exact path.

```mermaid
flowchart LR
  subgraph Before[Before: parent directory copy]
    A[Pane syncs .agent] --> B[recursive copy / recursive scan]
    B --> C[.agent/settings.json copied]
    B --> D[.agent/worktrees/... entered]
    D --> E[huge generated workspace
GBs + high file count
app or machine stalls]
  end

  subgraph After[After: generated workspace boundary]
    F[Pane syncs .agent] --> G[enumerate direct children]
    G --> H[copy .agent/settings.json]
    G --> I{child name is worktrees?}
    I -->|yes| J[skip before traversal]
    I -->|explicit exact entry| K[copy only when user opted in]
    L[recursive discovery] --> M[find/glob prunes worktrees dirs]
  end
```

Excalidraw source saved locally at `/tmp/codex-pr-diagrams/pr-236/worktree-sync-no-traverse.excalidraw`.

## Verification
- `pnpm --filter main exec vitest run src/services/__tests__/worktreeFileSyncService.test.ts`
- `pnpm --filter main typecheck`
- `pnpm --filter main lint` (passes with existing warnings)
- pre-commit hook also ran workspace `pnpm run -r typecheck` and `pnpm run -r lint`

Note: this shell uses Node `v20.19.3`, so pnpm emitted the existing engine warning because the repo asks for Node `>=22.14.0`. The commands still exited successfully.