### PR TITLE
Fix analytics identity stitching before consent

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,9 @@ import { useNavigationStore } from './stores/navigationStore';
 import {
   aliasWebVisitor,
   capture,
+  captureAppFirstOpened,
   captureUnconditionally,
+  flushPendingEvents,
   initPostHog,
   posthog,
   queuePendingEvent,
@@ -77,7 +79,11 @@ function App() {
   const [isOnboardingOpen, setIsOnboardingOpen] = useState(false);
   const [hasCheckedOnboarding, setHasCheckedOnboarding] = useState(false);
   const [completedOnboardingThisSession, setCompletedOnboardingThisSession] = useState(false);
+  const [analyticsIdentity, setAnalyticsIdentity] = useState<AnalyticsIdentity | undefined>();
   const analyticsCheckStarted = useRef(false);
+  const analyticsIdentityPromise = useRef<Promise<AnalyticsIdentity | undefined> | null>(null);
+  const analyticsConsentOpenRef = useRef(false);
+  const appFirstOpenedCaptured = useRef(false);
   const onboardingCheckStarted = useRef(false);
 
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
@@ -125,6 +131,10 @@ function App() {
   
   useIPCEvents();
   const { showNotification } = useNotifications();
+
+  useEffect(() => {
+    analyticsConsentOpenRef.current = isAnalyticsConsentOpen;
+  }, [isAnalyticsConsentOpen]);
 
   // Global panel activity status listener
   useEffect(() => {
@@ -240,9 +250,38 @@ function App() {
     return projects.find(p => p.active) || projects[0];
   }, [projects, activeProjectId]);
 
+  const resolveAnalyticsIdentity = useCallback(async (): Promise<AnalyticsIdentity | undefined> => {
+    if (!analyticsIdentityPromise.current) {
+      analyticsIdentityPromise.current = (async () => {
+        try {
+          const identityResult = await window.electronAPI?.analytics?.getIdentity?.();
+          if (identityResult?.success && identityResult.data) {
+            setAnalyticsIdentity(identityResult.data);
+            return identityResult.data;
+          }
+        } catch (error) {
+          console.error('[App] Error resolving analytics identity:', error);
+        }
+        return undefined;
+      })();
+    }
+
+    const identity = await analyticsIdentityPromise.current;
+    if (!identity) {
+      analyticsIdentityPromise.current = null;
+    }
+    return identity;
+  }, []);
+
+  const captureFirstOpenOnce = useCallback(async (identity?: AnalyticsIdentity): Promise<void> => {
+    if (!identity || appFirstOpenedCaptured.current) return;
+    appFirstOpenedCaptured.current = true;
+    await captureAppFirstOpened(identity);
+  }, []);
+
   // Check if analytics consent dialog should be shown (before other dialogs)
   useEffect(() => {
-    if (hasCheckedAnalyticsConsent || analyticsCheckStarted.current) return;
+    if (!appConfig || hasCheckedAnalyticsConsent || analyticsCheckStarted.current) return;
     analyticsCheckStarted.current = true;
 
     const checkAnalyticsConsent = async () => {
@@ -256,13 +295,21 @@ function App() {
         const hasShownConsent = consentResult?.data === 'true';
 
         if (!hasShownConsent) {
+          const identity = await resolveAnalyticsIdentity();
+          initPostHog({
+            enabled: false,
+            posthogApiKey: appConfig.analytics?.posthogApiKey,
+            posthogHost: appConfig.analytics?.posthogHost,
+            identity,
+          }, { flushPendingEvents: false });
           // Fire consent_dialog_shown BEFORE the user can opt in/out, so we
           // have a true "saw the dialog" denominator for funnel math instead
           // of the conservative opted_in + opted_out lower bound. Uses direct
           // HTTP via captureUnconditionally so it bypasses the opt-in gate.
           // See docs/analytics-attribution.md in runpane-website repo for
           // the funnel formula this event enables.
-          captureUnconditionally('consent_dialog_shown');
+          await captureUnconditionally('consent_dialog_shown', undefined, identity);
+          await captureFirstOpenOnce(identity);
           setIsAnalyticsConsentOpen(true);
         }
       } catch (error) {
@@ -273,7 +320,7 @@ function App() {
     };
 
     checkAnalyticsConsent();
-  }, [hasCheckedAnalyticsConsent]);
+  }, [appConfig, captureFirstOpenOnce, hasCheckedAnalyticsConsent, resolveAnalyticsIdentity]);
 
   // Initialize PostHog after config loads, then start forwarding main-process events.
   // Both must live in the same effect so buffered events aren't replayed before init.
@@ -284,7 +331,6 @@ function App() {
     let cancelled = false;
 
     const initializeAnalytics = async () => {
-      let identity: AnalyticsIdentity | undefined;
       const analyticsEnabled = appConfig.analytics?.enabled ?? false;
       let consentDecided = false;
 
@@ -295,16 +341,7 @@ function App() {
         console.error('[App] Error resolving analytics consent state:', error);
       }
 
-      if (analyticsEnabled) {
-        try {
-          const identityResult = await window.electronAPI?.analytics?.getIdentity?.();
-          if (identityResult?.success) {
-            identity = identityResult.data;
-          }
-        } catch (error) {
-          console.error('[App] Error resolving analytics identity:', error);
-        }
-      }
+      const identity = await resolveAnalyticsIdentity();
 
       if (cancelled) return;
 
@@ -313,10 +350,10 @@ function App() {
         posthogApiKey: appConfig.analytics?.posthogApiKey,
         posthogHost: appConfig.analytics?.posthogHost,
         identity,
-      });
+      }, { flushPendingEvents: false });
 
       if (analyticsEnabled && identity?.webDistinctId) {
-        aliasWebVisitor(identity.webDistinctId);
+        aliasWebVisitor(identity.webDistinctId, identity.distinctId);
         void window.electronAPI?.analytics?.redeemAttribution?.();
       }
 
@@ -336,6 +373,11 @@ function App() {
           queuePendingEvent(event);
         }
       });
+
+      if (analyticsEnabled && !analyticsConsentOpenRef.current) {
+        await captureFirstOpenOnce(identity);
+        flushPendingEvents();
+      }
     };
 
     void initializeAnalytics();
@@ -344,7 +386,7 @@ function App() {
       cancelled = true;
       cleanup?.();
     };
-  }, [appConfig]);
+  }, [appConfig, captureFirstOpenOnce, resolveAnalyticsIdentity]);
 
   // CRITICAL PERFORMANCE FIX: Cleanup to prevent V8 array iteration issues
   // Uses visibility-aware interval: 60s when active, 600s when hidden
@@ -661,6 +703,9 @@ function App() {
         <AnalyticsConsentDialog
           isOpen={isAnalyticsConsentOpen}
           onClose={() => setIsAnalyticsConsentOpen(false)}
+          analyticsIdentity={analyticsIdentity}
+          onResolveAnalyticsIdentity={resolveAnalyticsIdentity}
+          onCaptureFirstOpen={captureFirstOpenOnce}
         />
         <OnboardingDialog
           isOpen={isOnboardingOpen}

--- a/frontend/src/components/AnalyticsConsentDialog.tsx
+++ b/frontend/src/components/AnalyticsConsentDialog.tsx
@@ -4,14 +4,32 @@ import { usePaneLogo } from '../hooks/usePaneLogo';
 import { Modal, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import { useConfigStore } from '../stores/configStore';
-import { optIn, capture, captureAndOptOut, discardPendingEvents, flushPendingEvents } from '../services/posthog';
+import {
+  aliasWebVisitor,
+  aliasWebVisitorDirect,
+  captureAndOptOut,
+  captureUnconditionally,
+  discardPendingEvents,
+  flushPendingEvents,
+  initPostHog,
+} from '../services/posthog';
+import type { AnalyticsIdentity } from '../types/config';
 
 interface AnalyticsConsentDialogProps {
   isOpen: boolean;
   onClose: (accepted: boolean) => void;
+  analyticsIdentity?: AnalyticsIdentity;
+  onResolveAnalyticsIdentity: () => Promise<AnalyticsIdentity | undefined>;
+  onCaptureFirstOpen: (identity?: AnalyticsIdentity) => Promise<void>;
 }
 
-export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsConsentDialogProps) {
+export default function AnalyticsConsentDialog({
+  isOpen,
+  onClose,
+  analyticsIdentity,
+  onResolveAnalyticsIdentity,
+  onCaptureFirstOpen,
+}: AnalyticsConsentDialogProps) {
   const paneLogo = usePaneLogo();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const { config, updateConfig } = useConfigStore();
@@ -19,7 +37,8 @@ export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsCon
   const handleAccept = async () => {
     setIsSubmitting(true);
     try {
-      // Enable analytics
+      const identity = analyticsIdentity ?? await onResolveAnalyticsIdentity();
+
       await updateConfig({
         analytics: {
           ...config?.analytics,
@@ -27,10 +46,21 @@ export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsCon
         },
       });
 
-      // Track opt-in event
-      optIn();
+      initPostHog({
+        enabled: true,
+        posthogApiKey: config?.analytics?.posthogApiKey,
+        posthogHost: config?.analytics?.posthogHost,
+        identity,
+      }, { flushPendingEvents: false });
+
+      if (identity?.webDistinctId) {
+        aliasWebVisitor(identity.webDistinctId, identity.distinctId);
+        void window.electronAPI?.analytics?.redeemAttribution?.();
+      }
+
+      await captureUnconditionally('analytics_opted_in', undefined, identity);
+      await onCaptureFirstOpen(identity);
       flushPendingEvents();
-      capture('analytics_opted_in');
 
       // Mark consent as shown
       if (window.electron?.invoke) {
@@ -48,9 +78,22 @@ export default function AnalyticsConsentDialog({ isOpen, onClose }: AnalyticsCon
   const handleDecline = async () => {
     setIsSubmitting(true);
     try {
-      // Track opt-out event FIRST (before disabling analytics)
-      // Uses captureAndOptOut to ensure the event is flushed before disabling
-      captureAndOptOut('analytics_opted_out');
+      const identity = analyticsIdentity ?? await onResolveAnalyticsIdentity();
+
+      initPostHog({
+        enabled: false,
+        posthogApiKey: config?.analytics?.posthogApiKey,
+        posthogHost: config?.analytics?.posthogHost,
+        identity,
+      }, { flushPendingEvents: false });
+
+      if (identity?.webDistinctId) {
+        await aliasWebVisitorDirect(identity);
+        void window.electronAPI?.analytics?.redeemAttribution?.();
+      }
+
+      await onCaptureFirstOpen(identity);
+      await captureAndOptOut('analytics_opted_out', undefined, identity);
       discardPendingEvents();
 
       // Mark consent as shown before the config update re-registers analytics listeners.

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -2,8 +2,22 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { NotificationSettings } from './NotificationSettings';
 import { useNotifications } from '../hooks/useNotifications';
 import { API } from '../utils/api';
-import { optIn, capture, captureAndOptOut } from '../services/posthog';
-import type { PreferredShell, PreferredTerminalPowerMode, TerminalShortcut } from '../types/config';
+import {
+  aliasWebVisitor,
+  aliasWebVisitorDirect,
+  captureAndOptOut,
+  captureUnconditionally,
+  discardPendingEvents,
+  flushPendingEvents,
+  initPostHog,
+} from '../services/posthog';
+import type {
+  AnalyticsConfig,
+  AnalyticsIdentity,
+  PreferredShell,
+  PreferredTerminalPowerMode,
+  TerminalShortcut,
+} from '../types/config';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
 import { DEFAULT_WORKTREE_FILE_SYNC_ENTRIES } from '../../../shared/types/worktreeFileSync';
 import {
@@ -158,8 +172,9 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<'general' | 'notifications' | 'shortcuts'>('general');
-  const [analyticsEnabled, setAnalyticsEnabled] = useState(true);
-  const [previousAnalyticsEnabled, setPreviousAnalyticsEnabled] = useState(true);
+  const [analyticsEnabled, setAnalyticsEnabled] = useState(false);
+  const [previousAnalyticsEnabled, setPreviousAnalyticsEnabled] = useState(false);
+  const [analyticsConfig, setAnalyticsConfig] = useState<AnalyticsConfig | undefined>();
   const [preferredShell, setPreferredShell] = useState<PreferredShell>('auto');
   const [availableShells, setAvailableShells] = useState<AvailableShell[]>([]);
   const [terminalShortcuts, setTerminalShortcuts] = useState<TerminalShortcut[]>([]);
@@ -284,9 +299,14 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
 
       // Load analytics settings
       if (data.analytics) {
-        const enabled = data.analytics.enabled !== false; // Default to true
+        const enabled = data.analytics.enabled === true;
         setAnalyticsEnabled(enabled);
         setPreviousAnalyticsEnabled(enabled);
+        setAnalyticsConfig(data.analytics);
+      } else {
+        setAnalyticsEnabled(false);
+        setPreviousAnalyticsEnabled(false);
+        setAnalyticsConfig(undefined);
       }
 
       // Fetch available shells on Windows
@@ -765,6 +785,46 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
     }
   };
 
+  const resolveAnalyticsIdentity = async (): Promise<AnalyticsIdentity | undefined> => {
+    try {
+      const identityResult = await window.electronAPI?.analytics?.getIdentity?.();
+      if (identityResult?.success) {
+        return identityResult.data;
+      }
+    } catch (error) {
+      console.error('[Settings] Error resolving analytics identity:', error);
+    }
+    return undefined;
+  };
+
+  const syncAnalyticsToggle = async (enabled: boolean) => {
+    const identity = await resolveAnalyticsIdentity();
+
+    initPostHog({
+      enabled,
+      posthogApiKey: analyticsConfig?.posthogApiKey,
+      posthogHost: analyticsConfig?.posthogHost,
+      identity,
+    }, { flushPendingEvents: false });
+
+    if (enabled) {
+      if (identity?.webDistinctId) {
+        aliasWebVisitor(identity.webDistinctId, identity.distinctId);
+        void window.electronAPI?.analytics?.redeemAttribution?.();
+      }
+      await captureUnconditionally('analytics_opted_in', undefined, identity);
+      flushPendingEvents();
+      return;
+    }
+
+    if (identity?.webDistinctId) {
+      await aliasWebVisitorDirect(identity);
+      void window.electronAPI?.analytics?.redeemAttribution?.();
+    }
+    await captureAndOptOut('analytics_opted_out', undefined, identity);
+    discardPendingEvents();
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
@@ -795,6 +855,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
         additionalPaths: parsedPaths,
         notifications: notificationSettings,
         analytics: {
+          ...analyticsConfig,
           enabled: analyticsEnabled
         },
         preferredShell,
@@ -808,12 +869,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
 
       // Only toggle PostHog opt-in/opt-out after config save succeeds
       if (previousAnalyticsEnabled !== analyticsEnabled) {
-        if (analyticsEnabled) {
-          optIn();
-          capture('analytics_opted_in');
-        } else {
-          captureAndOptOut('analytics_opted_out');
-        }
+        await syncAnalyticsToggle(analyticsEnabled);
       }
 
       // Update the useNotifications hook with new settings

--- a/frontend/src/services/posthog.ts
+++ b/frontend/src/services/posthog.ts
@@ -7,6 +7,7 @@ const DEFAULT_HOST = 'https://runpane.com/api/c';
 let currentApiKey: string | undefined;
 let currentHost: string | undefined;
 let currentEnabled: boolean | undefined;
+let currentIdentity: AnalyticsIdentity | undefined;
 
 export interface PendingAnalyticsEvent {
   eventName: string;
@@ -22,37 +23,110 @@ export interface PostHogConfig {
   identity?: AnalyticsIdentity;
 }
 
-function identifyUser(config: PostHogConfig): void {
-  if (!config.enabled || !config.identity) return;
-
-  const properties = {
-    identity_source: config.identity.identitySource,
-    github_username: config.identity.githubUsername,
-    github_email: config.identity.githubEmail,
-    git_email: config.identity.gitEmail,
-    git_email_sha256: config.identity.gitEmailHash,
-    git_user_name: config.identity.gitUserName,
-  };
-
-  posthog.identify(config.identity.distinctId, Object.fromEntries(
-    Object.entries(properties).filter(([, value]) => value !== undefined)
-  ));
+export interface PostHogInitOptions {
+  flushPendingEvents?: boolean;
 }
 
-function directCaptureTarget(): { token: string; host: string; distinctId: string } {
-  const distinctId = posthog.get_distinct_id?.();
+function compactProperties(properties: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([, value]) => value !== undefined)
+  );
+}
+
+function personProperties(identity?: AnalyticsIdentity): Record<string, unknown> {
+  if (!identity) return {};
+
+  return compactProperties({
+    install_id: identity.installId,
+    identity_source: identity.identitySource,
+    github_username: identity.githubUsername,
+    github_email: identity.githubEmail,
+    git_email: identity.gitEmail,
+    git_email_sha256: identity.gitEmailHash,
+    git_user_name: identity.gitUserName,
+    app_version: identity.appVersion,
+    platform: identity.platform,
+  });
+}
+
+function contextProperties(identity = currentIdentity): Record<string, unknown> {
+  if (!identity) return {};
+
+  return compactProperties({
+    install_id: identity.installId,
+    identity_source: identity.identitySource,
+    github_username: identity.githubUsername,
+    git_email_sha256: identity.gitEmailHash,
+    app_version: identity.appVersion,
+    platform: identity.platform,
+    electron_version: identity.electronVersion,
+    web_attributed: Boolean(identity.webDistinctId || identity.webAttributionPresent),
+    web_attribution_present: identity.webAttributionPresent,
+    is_first_launch: identity.isFirstLaunch,
+    previous_version: identity.previousVersion,
+  });
+}
+
+function identifyUser(config: PostHogConfig): void {
+  currentIdentity = config.identity;
+  if (!config.enabled || !config.identity) return;
+
+  posthog.identify(config.identity.distinctId, personProperties(config.identity));
+}
+
+function directCaptureTarget(identity = currentIdentity): { token: string; host: string; distinctId: string } {
+  const posthogDistinctId = posthog.get_distinct_id?.();
 
   return {
     token: currentApiKey || DEFAULT_API_KEY,
     host: currentHost || DEFAULT_HOST,
     distinctId:
-      typeof distinctId === 'string' && distinctId.length > 0
-        ? distinctId
+      typeof identity?.distinctId === 'string' && identity.distinctId.length > 0
+        ? identity.distinctId
+        : typeof posthogDistinctId === 'string' && posthogDistinctId.length > 0
+        ? posthogDistinctId
         : `anon_${crypto.randomUUID()}`,
   };
 }
 
-export function initPostHog(config: PostHogConfig): void {
+async function directCapture(
+  eventName: string,
+  properties?: Record<string, unknown>,
+  identity = currentIdentity,
+  options: { processPersonProfile?: boolean } = {}
+): Promise<void> {
+  const { token, host, distinctId } = directCaptureTarget(identity);
+  const shouldProcessPersonProfile = Boolean(options.processPersonProfile && identity);
+
+  const payload = {
+    api_key: token,
+    event: eventName,
+    properties: compactProperties({
+      ...contextProperties(identity),
+      ...properties,
+      distinct_id: distinctId,
+      token,
+      $lib: 'posthog-js',
+      ...(shouldProcessPersonProfile
+        ? { $set: personProperties(identity) }
+        : { $process_person_profile: false }),
+    }),
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    await fetch(`${host.replace(/\/$/, '')}/capture/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch (error) {
+    console.error(`[PostHog] Failed to capture ${eventName}:`, error);
+  }
+}
+
+export function initPostHog(config: PostHogConfig, options: PostHogInitOptions = {}): void {
   const apiKey = config.posthogApiKey || DEFAULT_API_KEY;
   const host = config.posthogHost || DEFAULT_HOST;
 
@@ -96,7 +170,7 @@ export function initPostHog(config: PostHogConfig): void {
 
   identifyUser(config);
 
-  if (config.enabled) {
+  if (config.enabled && options.flushPendingEvents !== false) {
     flushPendingEvents();
   }
 }
@@ -129,12 +203,25 @@ export function discardPendingEvents(): void {
   pendingEvents = [];
 }
 
-export function aliasWebVisitor(webDistinctId: string): void {
+export function aliasWebVisitor(webDistinctId?: string, distinctId = currentIdentity?.distinctId): void {
+  if (!webDistinctId || !distinctId || webDistinctId === distinctId) return;
+
   try {
-    posthog.alias(webDistinctId);
+    posthog.alias(webDistinctId, distinctId);
   } catch (error) {
     console.error('[PostHog] Failed to alias web visitor:', error);
   }
+}
+
+export async function aliasWebVisitorDirect(identity = currentIdentity): Promise<void> {
+  if (!identity?.webDistinctId || identity.webDistinctId === identity.distinctId) return;
+
+  await directCapture(
+    '$create_alias',
+    { alias: identity.webDistinctId },
+    identity,
+    { processPersonProfile: true }
+  );
 }
 
 /**
@@ -144,89 +231,59 @@ export function aliasWebVisitor(webDistinctId: string): void {
  * opt-in state, so no other events (autocapture, pageviews, etc.) can leak
  * during the flush window.
  */
-export function captureAndOptOut(eventName: string, properties?: Record<string, unknown>): void {
-  const { token, host, distinctId } = directCaptureTarget();
-
-  const payload = {
-    api_key: token,
-    event: eventName,
-    properties: {
-      ...properties,
-      distinct_id: distinctId,
-      token,
-      $lib: 'posthog-js',
-      $process_person_profile: false,
-    },
-    timestamp: new Date().toISOString(),
-  };
-
-  try {
-    fetch(`${host}/capture/`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      keepalive: true,
-    }).catch((err) => {
-      console.error('[PostHog] Failed to send opt-out event:', err);
-    });
-  } catch (error) {
-    console.error('[PostHog] Failed to capture event:', error);
-  }
-
+export async function captureAndOptOut(
+  eventName: string,
+  properties?: Record<string, unknown>,
+  identity = currentIdentity
+): Promise<void> {
+  currentIdentity = identity;
+  await directCapture(eventName, properties, identity, {
+    processPersonProfile: Boolean(identity),
+  });
   posthog.opt_out_capturing();
+  currentEnabled = false;
 }
 
 export function capture(eventName: string, properties?: Record<string, unknown>): void {
   try {
-    posthog.capture(eventName, properties);
+    posthog.capture(eventName, compactProperties({
+      ...contextProperties(),
+      ...properties,
+    }));
   } catch (error) {
     console.error('[PostHog] Failed to capture event:', error);
   }
 }
 
 /**
- * Capture a single event regardless of opt-in state, without toggling
- * opt-in afterward. Counterpart to captureAndOptOut: that one is for the
- * decline click; this one is for measurement events that need to fire
- * BEFORE the user has consented (e.g. consent_dialog_shown).
+ * Capture a single event directly, regardless of SDK opt-in state, without
+ * toggling opt-in afterward. Counterpart to captureAndOptOut: that one is for
+ * the decline click; this one is for deterministic consent/funnel markers.
  *
  * Sends the event directly via HTTP so it bypasses the SDK's opt-in gate.
  * Same network path as captureAndOptOut, just without the opt-out flip.
  *
- * Use this sparingly. The only legitimate case is funnel-completeness
- * events that must be captured before the user can opt in or out —
- * specifically, "the user saw the consent dialog." It establishes the
- * real denominator for opt-in rate (versus the conservative
- * opted_in + opted_out lower bound).
+ * Use this sparingly. The legitimate cases are funnel-completeness and
+ * consent-decision events that must be captured in a strict order:
+ * consent_dialog_shown, analytics_opted_in, and app_first_opened.
  */
-export function captureUnconditionally(eventName: string, properties?: Record<string, unknown>): void {
-  const { token, host, distinctId } = directCaptureTarget();
+export async function captureUnconditionally(
+  eventName: string,
+  properties?: Record<string, unknown>,
+  identity = currentIdentity
+): Promise<void> {
+  currentIdentity = identity;
+  await directCapture(eventName, properties, identity, {
+    processPersonProfile: Boolean(identity),
+  });
+}
 
-  const payload = {
-    api_key: token,
-    event: eventName,
-    properties: {
-      ...properties,
-      distinct_id: distinctId,
-      token,
-      $lib: 'posthog-js',
-      $process_person_profile: false,
-    },
-    timestamp: new Date().toISOString(),
-  };
+export async function captureAppFirstOpened(identity = currentIdentity): Promise<void> {
+  if (!identity?.isFirstLaunch && !identity?.webAttributionPresent) return;
 
-  try {
-    fetch(`${host}/capture/`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-      keepalive: true,
-    }).catch((err) => {
-      console.error('[PostHog] Failed to send unconditional event:', err);
-    });
-  } catch (error) {
-    console.error('[PostHog] Failed to capture event:', error);
-  }
+  await captureUnconditionally('app_first_opened', {
+    source: identity.webAttributionPresent ? 'web_attribution' : 'first_launch',
+  }, identity);
 }
 
 export { posthog };

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -21,18 +21,26 @@ export type TerminalPowerMode = 'performance' | 'batterySaver';
 export interface AnalyticsIdentity {
   distinctId: string;
   identitySource: 'email' | 'github' | 'git_name' | 'posthog' | 'anonymous';
+  installId?: string;
+  appVersion?: string;
+  platform?: string;
+  electronVersion?: string;
+  webDistinctId?: string;
+  webAttributionPresent?: boolean;
+  isFirstLaunch?: boolean;
+  previousVersion?: string | null;
   githubUsername?: string;
   githubEmail?: string;
   gitEmail?: string;
   gitEmailHash?: string;
   gitUserName?: string;
-  webDistinctId?: string;
 }
 
 export interface AnalyticsConfig {
   enabled: boolean;
   posthogApiKey?: string;
   posthogHost?: string;
+  installId?: string;
   distinctId?: string;
   identitySource?: AnalyticsIdentity['identitySource'];
   githubUsername?: string;

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -79,6 +79,11 @@ const registeredPartitions = new Set<string>();
 
 // Module-level shutdown guard to prevent multiple shutdown attempts
 let shutdownInProgress = false;
+let analyticsLaunchContext: {
+  appVersion?: string;
+  previousVersion?: string | null;
+  isFirstLaunch?: boolean;
+} = {};
 
 type RendererDiagnosticPayload = {
   kind?: string;
@@ -957,11 +962,24 @@ async function initializeServices() {
 
   ipcMain.handle('analytics:get-identity', async () => {
     try {
-      const identity = resolveAnalyticsIdentity(configManager.getAnalyticsDistinctId());
+      const installId = await configManager.getOrCreateAnalyticsInstallId();
+      const currentVersion = analyticsLaunchContext.appVersion || app.getVersion();
+      const previousVersion =
+        analyticsLaunchContext.previousVersion !== undefined
+          ? analyticsLaunchContext.previousVersion
+          : databaseService.getLastAppVersion();
+      const isFirstLaunch = analyticsLaunchContext.isFirstLaunch ?? previousVersion === null;
+      const identity = resolveAnalyticsIdentity(configManager.getAnalyticsDistinctId(), installId);
       const webDistinctId = readWebAttribution(getAppDirectory());
       if (webDistinctId) {
         identity.webDistinctId = webDistinctId;
       }
+      identity.appVersion = currentVersion;
+      identity.platform = os.platform();
+      identity.electronVersion = process.versions.electron;
+      identity.webAttributionPresent = webDistinctId !== undefined;
+      identity.isFirstLaunch = isFirstLaunch;
+      identity.previousVersion = previousVersion;
       await configManager.setAnalyticsIdentity(identity);
       return { success: true, data: identity };
     } catch (error) {
@@ -1125,6 +1143,11 @@ if (launchRemoteSetup) {
     const currentVersion = app.getVersion();
     const lastVersion = databaseService.getLastAppVersion();
     const isFirstLaunch = lastVersion === null;
+    analyticsLaunchContext = {
+      appVersion: currentVersion,
+      previousVersion: lastVersion,
+      isFirstLaunch,
+    };
 
     if (lastVersion && lastVersion !== currentVersion) {
       analyticsManager.track('app_updated', {
@@ -1381,7 +1404,7 @@ if (launchRemoteSetup) {
       try {
         const settings = configManager.getAnalyticsSettings();
         const apiKey = settings.posthogApiKey || 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1';
-        const host = settings.posthogHost || 'https://us.i.posthog.com';
+        const host = settings.posthogHost || 'https://runpane.com/api/c';
         const distinctId = configManager.getAnalyticsDistinctId() || `anon-${Date.now().toString(36)}`;
         const sessionDurationSeconds = Math.floor((Date.now() - appStartTime) / 1000);
 
@@ -1395,6 +1418,7 @@ if (launchRemoteSetup) {
             properties: {
               distinct_id: distinctId,
               token: apiKey,
+              install_id: settings.installId,
               session_duration_seconds: sessionDurationSeconds,
               app_version: app.getVersion(),
               platform: os.platform(),

--- a/main/src/services/analyticsIdentity.test.ts
+++ b/main/src/services/analyticsIdentity.test.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from 'child_process';
+import * as fsSync from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { readWebAttribution, resolveAnalyticsIdentity } from './analyticsIdentity';
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock('../utils/shellPath', () => ({
+  getShellPath: () => '/usr/bin',
+}));
+
+const execFileSyncMock = vi.mocked(execFileSync);
+
+function mockCommandOutput(outputs: Record<string, string>): void {
+  execFileSyncMock.mockImplementation(((command: string, args: string[]) => {
+    const key = `${command} ${args.join(' ')}`;
+    if (key in outputs) {
+      return outputs[key];
+    }
+    throw new Error(`Unexpected command: ${key}`);
+  }) as never);
+}
+
+describe('resolveAnalyticsIdentity', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('uses the stable install ID when no git or GitHub identity is available', () => {
+    mockCommandOutput({});
+
+    expect(resolveAnalyticsIdentity(undefined, 'install_123')).toEqual({
+      distinctId: 'install:install_123',
+      identitySource: 'anonymous',
+      installId: 'install_123',
+      githubUsername: undefined,
+      githubEmail: undefined,
+      gitEmail: undefined,
+      gitEmailHash: undefined,
+      gitUserName: undefined,
+    });
+  });
+
+  it('keeps an existing PostHog ID until a stronger identity is available', () => {
+    mockCommandOutput({});
+
+    expect(resolveAnalyticsIdentity('existing_distinct', 'install_123')).toMatchObject({
+      distinctId: 'existing_distinct',
+      identitySource: 'posthog',
+      installId: 'install_123',
+    });
+  });
+
+  it('keeps the install-ID fallback classified as anonymous on later launches', () => {
+    mockCommandOutput({});
+
+    expect(resolveAnalyticsIdentity('install:install_123', 'install_123')).toMatchObject({
+      distinctId: 'install:install_123',
+      identitySource: 'anonymous',
+      installId: 'install_123',
+    });
+  });
+
+  it('prefers email identity and hashes the normalized email', () => {
+    mockCommandOutput({
+      'gh api user --jq .login': 'octocat\n',
+      'git config --global user.email': 'Dev@Example.COM\n',
+      'git config --global user.name': 'Dev User\n',
+    });
+
+    const identity = resolveAnalyticsIdentity(undefined, 'install_123');
+
+    expect(identity).toMatchObject({
+      distinctId: 'email:dev@example.com',
+      identitySource: 'email',
+      installId: 'install_123',
+      githubUsername: 'octocat',
+      gitEmail: 'Dev@Example.COM',
+      gitUserName: 'Dev User',
+    });
+    expect(identity.gitEmailHash).toBe('eb2b6c0d061bbd5caa545b6d1184a1887b11dba0b1d7fd8ca5b42ebf0ad7d3a8');
+  });
+});
+
+describe('readWebAttribution', () => {
+  it('reads a valid web distinct ID token', () => {
+    const appDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'pane-attribution-'));
+    const token = Buffer.from('web_distinct|1710000000000').toString('base64url');
+
+    try {
+      fsSync.writeFileSync(path.join(appDir, 'attribution_ref'), token);
+
+      expect(readWebAttribution(appDir)).toBe('web_distinct');
+    } finally {
+      fsSync.rmSync(appDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/main/src/services/analyticsIdentity.ts
+++ b/main/src/services/analyticsIdentity.ts
@@ -29,7 +29,7 @@ function sha256(value: string): string {
   return crypto.createHash('sha256').update(value.trim().toLowerCase()).digest('hex');
 }
 
-export function resolveAnalyticsIdentity(existingDistinctId?: string): AnalyticsIdentity {
+export function resolveAnalyticsIdentity(existingDistinctId?: string, installId?: string): AnalyticsIdentity {
   const githubUsername = runCommand('gh', ['api', 'user', '--jq', '.login']);
   const githubEmail = runCommand('gh', ['api', 'user', '--jq', '.email // empty']);
   const gitEmail = runCommand('git', ['config', '--global', 'user.email']);
@@ -37,8 +37,9 @@ export function resolveAnalyticsIdentity(existingDistinctId?: string): Analytics
   const email = githubEmail || gitEmail;
   const gitEmailHash = email ? sha256(email) : undefined;
 
-  let distinctId = existingDistinctId || `anon-${Date.now().toString(36)}`;
-  let identitySource: AnalyticsIdentity['identitySource'] = existingDistinctId ? 'posthog' : 'anonymous';
+  let distinctId = existingDistinctId || (installId ? `install:${installId}` : `anon-${Date.now().toString(36)}`);
+  let identitySource: AnalyticsIdentity['identitySource'] =
+    existingDistinctId && existingDistinctId !== `install:${installId}` ? 'posthog' : 'anonymous';
 
   if (email) {
     distinctId = `email:${email.trim().toLowerCase()}`;
@@ -54,6 +55,7 @@ export function resolveAnalyticsIdentity(existingDistinctId?: string): Analytics
   return {
     distinctId,
     identitySource,
+    installId,
     githubUsername,
     githubEmail,
     gitEmail,

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -8,12 +8,21 @@ import fs from 'fs/promises';
 import { watch, type FSWatcher } from 'fs';
 import path from 'path';
 import os from 'os';
+import { randomUUID } from 'crypto';
 import { getAppDirectory } from '../utils/appDirectory';
 import { clearShellPathCache } from '../utils/shellPath';
 
 const DEFAULT_POSTHOG_API_KEY = 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1';
 const LEGACY_POSTHOG_HOST = 'https://us.i.posthog.com';
 const DEFAULT_POSTHOG_HOST = 'https://runpane.com/api/c';
+
+function defaultAnalyticsConfig(): NonNullable<AppConfig['analytics']> {
+  return {
+    enabled: false,
+    posthogApiKey: DEFAULT_POSTHOG_API_KEY,
+    posthogHost: DEFAULT_POSTHOG_HOST
+  };
+}
 
 export class ConfigManager extends EventEmitter {
   private config: AppConfig;
@@ -62,11 +71,7 @@ export class ConfigManager extends EventEmitter {
         },
         showAdvanced: false
       },
-      analytics: {
-        enabled: false, // Opt-in: disabled by default until user consents
-        posthogApiKey: DEFAULT_POSTHOG_API_KEY,
-        posthogHost: DEFAULT_POSTHOG_HOST
-      },
+      analytics: defaultAnalyticsConfig(),
       remoteDaemon: createDefaultRemoteDaemonConfig(),
       terminalShortcuts: [
         {
@@ -277,9 +282,19 @@ export class ConfigManager extends EventEmitter {
   }
 
   async updateConfig(updates: Partial<AppConfig>): Promise<AppConfig> {
+    const analytics =
+      updates.analytics !== undefined
+        ? {
+            ...defaultAnalyticsConfig(),
+            ...this.config.analytics,
+            ...updates.analytics
+          }
+        : this.config.analytics;
+
     this.config = {
       ...this.config,
       ...updates,
+      analytics,
       cloud: 'cloud' in updates
         ? (updates.cloud === undefined ? undefined : normalizeCloudVmConfig(updates.cloud))
         : this.config.cloud,
@@ -362,11 +377,7 @@ export class ConfigManager extends EventEmitter {
   }
 
   getAnalyticsSettings() {
-    return this.config.analytics || {
-      enabled: false, // Opt-in: disabled by default until user consents
-      posthogApiKey: DEFAULT_POSTHOG_API_KEY,
-      posthogHost: DEFAULT_POSTHOG_HOST
-    };
+    return this.config.analytics || defaultAnalyticsConfig();
   }
 
   isAnalyticsEnabled(): boolean {
@@ -377,33 +388,38 @@ export class ConfigManager extends EventEmitter {
     return this.config.analytics?.distinctId;
   }
 
-  async setAnalyticsDistinctId(distinctId: string): Promise<void> {
+  private ensureAnalyticsConfig(): NonNullable<AppConfig['analytics']> {
     if (!this.config.analytics) {
-      this.config.analytics = {
-        enabled: false,
-        posthogApiKey: DEFAULT_POSTHOG_API_KEY,
-        posthogHost: DEFAULT_POSTHOG_HOST
-      };
+      this.config.analytics = defaultAnalyticsConfig();
     }
-    this.config.analytics.distinctId = distinctId;
+    return this.config.analytics;
+  }
+
+  async getOrCreateAnalyticsInstallId(): Promise<string> {
+    const analytics = this.ensureAnalyticsConfig();
+    if (!analytics.installId) {
+      analytics.installId = `install_${randomUUID()}`;
+      await this.saveConfig();
+    }
+    return analytics.installId;
+  }
+
+  async setAnalyticsDistinctId(distinctId: string): Promise<void> {
+    const analytics = this.ensureAnalyticsConfig();
+    analytics.distinctId = distinctId;
     await this.saveConfig();
   }
 
   async setAnalyticsIdentity(identity: AnalyticsIdentity): Promise<void> {
-    if (!this.config.analytics) {
-      this.config.analytics = {
-        enabled: false,
-        posthogApiKey: DEFAULT_POSTHOG_API_KEY,
-        posthogHost: DEFAULT_POSTHOG_HOST
-      };
-    }
-    this.config.analytics.distinctId = identity.distinctId;
-    this.config.analytics.identitySource = identity.identitySource;
-    this.config.analytics.githubUsername = identity.githubUsername;
-    this.config.analytics.githubEmail = identity.githubEmail;
-    this.config.analytics.gitEmail = identity.gitEmail;
-    this.config.analytics.gitEmailHash = identity.gitEmailHash;
-    this.config.analytics.gitUserName = identity.gitUserName;
+    const analytics = this.ensureAnalyticsConfig();
+    analytics.distinctId = identity.distinctId;
+    analytics.identitySource = identity.identitySource;
+    analytics.installId = identity.installId ?? analytics.installId;
+    analytics.githubUsername = identity.githubUsername;
+    analytics.githubEmail = identity.githubEmail;
+    analytics.gitEmail = identity.gitEmail;
+    analytics.gitEmailHash = identity.gitEmailHash;
+    analytics.gitUserName = identity.gitUserName;
     await this.saveConfig();
   }
 

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -21,18 +21,26 @@ export type TerminalPowerMode = 'performance' | 'batterySaver';
 export interface AnalyticsIdentity {
   distinctId: string;
   identitySource: 'email' | 'github' | 'git_name' | 'posthog' | 'anonymous';
+  installId?: string;
+  appVersion?: string;
+  platform?: string;
+  electronVersion?: string;
+  webDistinctId?: string;
+  webAttributionPresent?: boolean;
+  isFirstLaunch?: boolean;
+  previousVersion?: string | null;
   githubUsername?: string;
   githubEmail?: string;
   gitEmail?: string;
   gitEmailHash?: string;
   gitUserName?: string;
-  webDistinctId?: string;
 }
 
 export interface AnalyticsConfig {
   enabled: boolean;
   posthogApiKey?: string;
   posthogHost?: string;
+  installId?: string;
   distinctId?: string;
   identitySource?: AnalyticsIdentity['identitySource'];
   githubUsername?: string;

--- a/tests/analytics-consent.spec.ts
+++ b/tests/analytics-consent.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+type CapturedPostHogRequest = {
+  url: string;
+  body: string;
+};
+
+type CapturedPostHogEvent = {
+  event?: string;
+  properties?: Record<string, unknown>;
+};
+
+function parseCapturedEvents(requests: CapturedPostHogRequest[]): CapturedPostHogEvent[] {
+  return requests.flatMap((request) => {
+    try {
+      const body = parsePostHogBody(request.body);
+      if (Array.isArray(body.batch)) {
+        return body.batch;
+      }
+      return [body];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function parsePostHogBody(bodyText: string): CapturedPostHogEvent & { batch?: CapturedPostHogEvent[] } {
+  try {
+    return JSON.parse(bodyText) as CapturedPostHogEvent & { batch?: CapturedPostHogEvent[] };
+  } catch {
+    const data = new URLSearchParams(bodyText).get('data');
+    return data
+      ? JSON.parse(data) as CapturedPostHogEvent & { batch?: CapturedPostHogEvent[] }
+      : {};
+  }
+}
+
+test('declining analytics sends identified consent events and discards queued usage', async ({ page }) => {
+  const identity = {
+    distinctId: 'install:install_decline_e2e',
+    installId: 'install_decline_e2e',
+    identitySource: 'anonymous',
+    appVersion: '2.1.2-test',
+    platform: 'linux',
+    electronVersion: 'test-electron',
+    webDistinctId: 'web_decline_e2e',
+    webAttributionPresent: true,
+    isFirstLaunch: true,
+    previousVersion: null,
+  };
+  const requests: CapturedPostHogRequest[] = [];
+
+  await page.route('http://posthog.test/**', async (route) => {
+    requests.push({
+      url: route.request().url(),
+      body: route.request().postData() ?? '',
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{}',
+    });
+  });
+
+  await installElectronApiMock(page, {
+    analyticsConsentShown: false,
+    analyticsIdentity: identity,
+    initialConfig: {
+      analytics: {
+        enabled: false,
+        posthogApiKey: 'phc_test',
+        posthogHost: 'http://posthog.test',
+        installId: identity.installId,
+        distinctId: identity.distinctId,
+        identitySource: identity.identitySource,
+      },
+    },
+    mainAnalyticsEvents: [
+      {
+        eventName: 'app_opened',
+        properties: { is_first_launch: true },
+      },
+    ],
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  await expect(page.getByText('Help Improve Pane')).toBeVisible({ timeout: 10000 });
+  await expect.poll(() => parseCapturedEvents(requests).map((event) => event.event)).toEqual(
+    expect.arrayContaining(['consent_dialog_shown', 'app_first_opened'])
+  );
+
+  await page.getByRole('button', { name: 'No thanks' }).click();
+
+  await expect.poll(() => parseCapturedEvents(requests).map((event) => event.event)).toEqual(
+    expect.arrayContaining(['consent_dialog_shown', 'app_first_opened', '$create_alias', 'analytics_opted_out'])
+  );
+
+  const events = parseCapturedEvents(requests);
+  const consentShown = events.find((event) => event.event === 'consent_dialog_shown');
+  const firstOpened = events.find((event) => event.event === 'app_first_opened');
+  const optedOut = events.find((event) => event.event === 'analytics_opted_out');
+  const alias = events.find((event) => event.event === '$create_alias');
+
+  for (const event of [consentShown, firstOpened, optedOut]) {
+    expect(event?.properties).toMatchObject({
+      distinct_id: identity.distinctId,
+      install_id: identity.installId,
+      identity_source: identity.identitySource,
+      app_version: identity.appVersion,
+      platform: identity.platform,
+    });
+    expect(event?.properties?.$set).toMatchObject({
+      install_id: identity.installId,
+      app_version: identity.appVersion,
+      platform: identity.platform,
+    });
+  }
+
+  expect(firstOpened?.properties).toMatchObject({
+    source: 'web_attribution',
+    web_attributed: true,
+    web_attribution_present: true,
+    is_first_launch: true,
+  });
+  expect(alias?.properties).toMatchObject({
+    distinct_id: identity.distinctId,
+    alias: identity.webDistinctId,
+    install_id: identity.installId,
+  });
+  expect(events.some((event) => event.event === 'app_opened')).toBe(false);
+});
+
+test('accepting analytics captures opt-in before any queued usage event can flush', async ({ page }) => {
+  const identity = {
+    distinctId: 'install:install_accept_e2e',
+    installId: 'install_accept_e2e',
+    identitySource: 'anonymous',
+    appVersion: '2.1.2-test',
+    platform: 'linux',
+    electronVersion: 'test-electron',
+    webAttributionPresent: false,
+    isFirstLaunch: false,
+    previousVersion: '2.1.1-test',
+  };
+  const requests: CapturedPostHogRequest[] = [];
+
+  await page.route('http://posthog.test/**', async (route) => {
+    requests.push({
+      url: route.request().url(),
+      body: route.request().postData() ?? '',
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{}',
+    });
+  });
+
+  await installElectronApiMock(page, {
+    analyticsConsentShown: false,
+    analyticsIdentity: identity,
+    initialConfig: {
+      analytics: {
+        enabled: false,
+        posthogApiKey: 'phc_test',
+        posthogHost: 'http://posthog.test',
+        installId: identity.installId,
+        distinctId: identity.distinctId,
+        identitySource: identity.identitySource,
+      },
+    },
+    mainAnalyticsEvents: [
+      {
+        eventName: 'app_opened',
+        properties: { is_first_launch: false },
+      },
+    ],
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+  await expect(page.getByText('Help Improve Pane')).toBeVisible({ timeout: 10000 });
+  await page.getByRole('button', { name: 'Enable analytics' }).click();
+
+  await expect.poll(() => parseCapturedEvents(requests).map((event) => event.event)).toContain('analytics_opted_in');
+
+  const events = parseCapturedEvents(requests);
+  const optInIndex = events.findIndex((event) => event.event === 'analytics_opted_in');
+  const appOpenedIndex = events.findIndex((event) => event.event === 'app_opened');
+  const optedIn = events[optInIndex];
+
+  expect(optInIndex).toBeGreaterThanOrEqual(0);
+  if (appOpenedIndex >= 0) {
+    expect(appOpenedIndex).toBeGreaterThan(optInIndex);
+  }
+  expect(optedIn.properties).toMatchObject({
+    distinct_id: identity.distinctId,
+    install_id: identity.installId,
+    identity_source: identity.identitySource,
+    app_version: identity.appVersion,
+    platform: identity.platform,
+  });
+});

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -1,12 +1,38 @@
 import type { Page } from '@playwright/test';
 
-export async function installElectronApiMock(page: Page) {
-  await page.addInitScript(() => {
+type AnalyticsMainEvent = {
+  eventName: string;
+  properties?: Record<string, unknown>;
+};
+
+type ElectronApiMockOptions = {
+  analyticsConsentShown?: boolean;
+  analyticsIdentity?: Record<string, unknown>;
+  initialConfig?: Record<string, unknown>;
+  mainAnalyticsEvents?: AnalyticsMainEvent[];
+};
+
+export async function installElectronApiMock(page: Page, options: ElectronApiMockOptions = {}) {
+  await page.addInitScript((mockOptions: ElectronApiMockOptions) => {
     const success = (data: unknown = null) => Promise.resolve({ success: true, data });
     const unsubscribe = () => undefined;
     const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
     const pendingPermissions: Array<Record<string, unknown>> = [];
     const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+    const preferences: Record<string, string> = {
+      analytics_consent_shown: mockOptions.analyticsConsentShown === false ? 'false' : 'true',
+    };
+    const defaultAnalyticsIdentity = {
+      distinctId: 'test',
+      installId: 'install_test',
+      identitySource: 'anonymous',
+      appVersion: 'test',
+      platform: 'linux',
+      electronVersion: 'test',
+      webAttributionPresent: false,
+      isFirstLaunch: false,
+      previousVersion: 'test',
+    };
     let nextRemoteConnectionId = 1;
     const remoteDaemonConfig = {
       host: {
@@ -61,6 +87,7 @@ export async function installElectronApiMock(page: Page) {
     };
     const configState: Record<string, unknown> = {
       remoteDaemon: clone(remoteDaemonConfig),
+      ...clone(mockOptions.initialConfig ?? {}),
     };
     let mockSessions: Array<Record<string, unknown>> = [];
     let cloudDisconnectError: string | null = null;
@@ -129,9 +156,15 @@ export async function installElectronApiMock(page: Page) {
       },
     });
 
-    const invoke = (channel: string) => {
+    const invoke = (channel: string, key?: string, value?: string) => {
       if (channel === 'preferences:get') {
-        return success('true');
+        return success(key ? preferences[key] ?? 'true' : 'true');
+      }
+      if (channel === 'preferences:set') {
+        if (key) {
+          preferences[key] = value ?? '';
+        }
+        return success();
       }
       if (channel === 'archive:get-progress') {
         return success(null);
@@ -156,9 +189,16 @@ export async function installElectronApiMock(page: Page) {
       checkForUpdates: () => success({ hasUpdate: false }),
       openExternal: () => undefined,
       analytics: namespace({
-        getIdentity: () => success({ distinctId: 'test', hasConsent: false }),
-        onMainEvent: subscribe,
+        getIdentity: () => success(clone(mockOptions.analyticsIdentity ?? defaultAnalyticsIdentity)),
+        onMainEvent: (callback: (event: AnalyticsMainEvent) => void) => {
+          const remove = subscribe('analytics:main-event', callback as (...args: unknown[]) => void);
+          for (const event of mockOptions.mainAnalyticsEvents ?? []) {
+            callback(clone(event));
+          }
+          return remove;
+        },
         syncDistinctId: () => undefined,
+        redeemAttribution: () => success(undefined),
       }),
       cloud: namespace({
         getState: () => success(clone(cloudState)),
@@ -493,6 +533,12 @@ export async function installElectronApiMock(page: Page) {
     Object.defineProperty(window, '__paneTestElectronMock', {
       configurable: true,
       value: {
+        getConfig() {
+          return clone(configState);
+        },
+        getPreferences() {
+          return clone(preferences);
+        },
         emitPermissionRequest(request: Record<string, unknown>) {
           pendingPermissions.push(request);
           emit('permission:request', request);
@@ -518,5 +564,5 @@ export async function installElectronApiMock(page: Page) {
         },
       },
     });
-  });
+  }, options);
 }


### PR DESCRIPTION
## Description
Fixes analytics identity stitching around the first-run consent funnel so consent, opt-in/opt-out, first-open, attribution, version, platform, and install context can be read together in PostHog.

Key changes:
- Resolve and persist a stable analytics identity before the consent dialog records shown/enable/disable events.
- Capture opt-out with identity context before disabling analytics, while discarding queued usage events.
- Preserve analytics identity/attribution fields when app settings are saved from the renderer.
- Add direct capture coverage for consent, first open, web attribution, and app close fallback payloads.
- Add unit and Playwright coverage for identity resolution and consent event ordering.

## Visual Overview
```mermaid
flowchart LR
  subgraph Before["Before: fragile person-level funnel"]
    B1["consent_dialog_shown"]
    B2["PostHog init / identify later"]
    B3["analytics_opted_in or analytics_opted_out"]
    B4["app_first_opened / usage"]
    B1 --> B2 --> B3 --> B4
    B1 -. "anonymous event can split from decision" .-> B3
  end

  subgraph After["After: identity-first funnel"]
    A0["resolve identity in main process\nGitHub CLI email, git email, install_id"]
    A1["consent_dialog_shown"]
    A2["enable or disable decision"]
    A3["app_first_opened / usage / app_closed"]
    A0 --> A1 --> A2 --> A3
    A0 -->|"shared distinct_id + install_id + app_version"| A3
  end
```

Truth statement: the consent funnel is now person-stitchable because identity is available before either enable or disable is captured.

Term explainer:
- `distinct_id`: PostHog's person key for joining events.
- `install_id`: Pane's stable app-install fallback when no Git identity is available.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [ ] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [ ] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)
N/A.

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter main exec vitest run src/services/analyticsIdentity.test.ts`
- `pnpm test -- tests/analytics-consent.spec.ts`
- `pnpm test -- tests/smoke.spec.ts`

## Additional Notes
Live Pane PostHog ingestion could not be validated through the connected PostHog app because the connector is scoped to a different project. The new Playwright tests validate event ordering and payload shape through network interception.
