### PR TITLE
Harden release, analytics, and PR testing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,45 @@ Fixes #42
    - Clear title and description
    - Link to related issues
    - Screenshots for UI changes
+   - Testing notes that list the commands you ran
+
+### PR and Release Workflows
+
+Pull requests to `main` run the `Code Quality` workflow. That workflow covers
+typecheck, lint, main process tests on Linux/macOS/Windows, frontend unit tests,
+and the maintained Playwright smoke suite.
+
+Pushes to `main` run `Code Quality` and `Deploy Remote PWA Preview`. `v*` tags
+run `Build & Release` plus website notification. See
+[docs/RELEASE_INSTRUCTIONS.md](docs/RELEASE_INSTRUCTIONS.md) before cutting a
+release.
 
 ## Testing
 
-### Current Status
-Pane doesn't have automated tests yet - we welcome contributions to add them! If you'd like to help set up a testing framework, please open an issue to discuss the approach.
+### Automated Checks
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm --filter main test
+pnpm --filter frontend test
+pnpm test:ci:minimal
+```
+
+For focused Playwright work, run the relevant spec directly:
+
+```bash
+pnpm test -- tests/smoke.spec.ts
+pnpm test -- tests/analytics-consent.spec.ts
+```
+
+Playwright starts the Electron dev app on port `4521` by default. Do not run
+multiple Playwright invocations concurrently on the same port. Run suites
+sequentially, or assign separate ports:
+
+```bash
+PLAYWRIGHT_PORT=4522 pnpm test -- tests/analytics-consent.spec.ts
+```
 
 ### Manual Testing Requirements
 
@@ -175,6 +209,6 @@ Feel free to:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the AGPL-3.0 License.
 
 Thank you for contributing to Pane! 🎉

--- a/README.md
+++ b/README.md
@@ -302,9 +302,10 @@ pnpm build:linux  # Linux (x64 + ARM64)
 pnpm run release patch   # 0.0.2 -> 0.0.3
 pnpm run release minor   # 0.0.2 -> 0.1.0
 pnpm run release major   # 0.0.2 -> 1.0.0
+pnpm run release 2.2.1   # explicit version when package.json and tags diverge
 ```
 
-Tags and pushes automatically. GitHub Actions builds and publishes installers for all platforms to [Releases](https://github.com/dcouple/Pane/releases).
+Run releases only from a clean `main` checkout that matches `origin/main`. The release script refuses inferred bumps when `package.json` and the latest `v*` tag disagree; use an explicit version after deciding the intended next release. See [Release Instructions](docs/RELEASE_INSTRUCTIONS.md) for the workflow and required GitHub checks.
 
 ---
 

--- a/docs/ANALYTICS_INVARIANTS.md
+++ b/docs/ANALYTICS_INVARIANTS.md
@@ -1,0 +1,75 @@
+# Analytics Invariants
+
+These rules keep Pane's PostHog funnel person-stitchable and privacy-safe.
+
+## Identity Comes First
+
+Resolve analytics identity in the main process before the renderer captures any
+consent event.
+
+Required ordering:
+
+1. Resolve GitHub CLI email, git email, or stable `install_id`.
+2. Persist the analytics identity in config.
+3. Capture `consent_dialog_shown`.
+4. Capture `analytics_opted_in` or `analytics_opted_out`.
+5. Capture `app_first_opened` and usage events only after the consent decision.
+
+Do not let the app-level PostHog initializer flush queued usage while the
+consent dialog is open. The consent dialog owns the first opt-in/opt-out flush.
+
+## Required Event Context
+
+Every first-run funnel event must include:
+
+- `distinct_id`
+- `install_id`
+- `app_version`
+- `platform`
+- `analytics_identity_source`
+
+The event should also set person properties when the identity is known:
+
+- `email`
+- `github_email`
+- `git_email`
+- `install_id`
+- `app_version`
+- `platform`
+
+## Opt-Out Is Still Identified
+
+Capture `analytics_opted_out` with identity context before disabling analytics.
+After that capture, discard queued usage events and keep analytics disabled.
+
+This records who opted out without sending their later product usage.
+
+## Config Saves Preserve Analytics Fields
+
+Renderer settings updates must deep-merge analytics config instead of replacing
+it. In particular, do not drop:
+
+- `identity`
+- `installId`
+- `attribution`
+- `hasTrackedFirstOpen`
+- `hasTrackedWebAttribution`
+
+## Attribution and Versioning
+
+When web attribution is present, emit attribution events with the same
+`distinct_id` and `install_id` as consent and usage events.
+
+App version should come from the running app context and be attached to consent,
+first-open, usage, attribution, and close events. This lets PostHog distinguish
+current users from older installs.
+
+## Test Coverage
+
+Changes to consent, analytics config, or first-run event ordering should update
+or add coverage in:
+
+- `main/src/services/analyticsIdentity.test.ts`
+- `tests/analytics-consent.spec.ts`
+
+The Playwright test should verify both event order and payload shape.

--- a/docs/ANALYTICS_UI_EVENTS_INTEGRATION.md
+++ b/docs/ANALYTICS_UI_EVENTS_INTEGRATION.md
@@ -4,6 +4,11 @@ This document describes how to integrate UI interaction event tracking into Pane
 
 ## Overview
 
+Before changing UI event tracking, read
+[Analytics Invariants](ANALYTICS_INVARIANTS.md). First-run consent events must
+be captured only after identity is resolved, and settings saves must preserve
+analytics identity and attribution config.
+
 The analytics system has been implemented with:
 1. Backend IPC handlers in `/main/src/ipc/analytics.ts`
 2. AnalyticsManager service enhancements to support string arrays

--- a/docs/FEATURE_USAGE_TRACKING_INTEGRATION.md
+++ b/docs/FEATURE_USAGE_TRACKING_INTEGRATION.md
@@ -4,6 +4,11 @@ This document provides guidance on integrating the remaining feature usage track
 
 ## Overview
 
+Before adding or changing tracking, read
+[Analytics Invariants](ANALYTICS_INVARIANTS.md). Consent, identity, attribution,
+and version fields have ordering requirements that keep PostHog funnels
+person-stitchable.
+
 The following feature usage events have been fully implemented:
 - ✅ `run_script_executed` - Tracked in backend (logsManager)
 - ✅ `notification_shown` - Tracked in frontend (useNotifications hook)

--- a/docs/RELEASE_INSTRUCTIONS.md
+++ b/docs/RELEASE_INSTRUCTIONS.md
@@ -1,176 +1,134 @@
 # Pane Release Instructions
 
-This document outlines the process for releasing new versions of Pane for macOS with automatic updates.
+Pane releases are cut from a clean `main` checkout with `scripts/release.js`.
+The script updates `package.json`, commits `release: vX.Y.Z`, tags the same
+commit, pushes `HEAD:main`, and pushes the tag.
 
-## Prerequisites
+## Mechanical Invariants
 
-Configure these secrets in your GitHub repository (Settings → Secrets and variables → Actions):
+Before a release, these facts must be true:
 
-**Required for macOS Signing & Notarization:**
-- `APPLE_CERTIFICATE`: Base64-encoded .p12 certificate
-- `APPLE_CERTIFICATE_PASSWORD`: Certificate password
-- `APPLE_ID`: Apple Developer account email
-- `APPLE_APP_PASSWORD`: App-specific password for notarization
-- `APPLE_TEAM_ID`: Apple Developer Team ID
+- The worktree is clean.
+- `HEAD` matches `origin/main`.
+- For inferred bumps (`patch`, `minor`, `major`), `package.json` version matches
+  the latest `v*` semver tag.
+- The release tag does not already exist locally or on `origin`.
 
-**To encode your certificate for GitHub secrets:**
+If `package.json` and the latest release tag disagree, do not run an inferred
+patch. Decide the intended next version and run an explicit release instead:
+
 ```bash
-base64 -i certificate.p12 -o certificate_base64.txt
+pnpm run release 2.2.1
 ```
-Copy the contents of the base64 file to the GitHub secret.
 
-**Note:** The `GITHUB_TOKEN` is automatically provided by GitHub Actions.
-
-## Release Process
-
-### 1. Prepare the Release
+## Happy Path
 
 ```bash
-# Ensure you're on the main branch
-git checkout main
-git pull origin main
+git switch main
+git pull --ff-only origin main
+git status --porcelain
+git tag --list 'v*' --sort=-v:refname | head -5
+node -p "require('./package.json').version"
 
-# Run tests and ensure everything passes
-pnpm test
 pnpm typecheck
+pnpm lint
+pnpm test:ci:minimal
+
+pnpm run release patch
 ```
 
-### 2. Update Version
-
-Edit `package.json` and update the version number:
-```json
-{
-  "version": "0.1.2"  // Update this
-}
-```
-
-### 3. Update Changelog
-
-Create or update `CHANGELOG.md` with release notes:
-```markdown
-## v0.1.2 - 2024-06-14
-
-### Added
-- Feature X
-- Feature Y
-
-### Fixed
-- Bug A
-- Bug B
-
-### Changed
-- Improvement C
-```
-
-### 4. Commit Version Changes
+Use `minor`, `major`, or an explicit version when that is the intended release:
 
 ```bash
-git add package.json CHANGELOG.md
-git commit -m "chore: bump version to 0.1.2"
-git push origin main
+pnpm run release minor
+pnpm run release major
+pnpm run release 2.3.0
 ```
 
-### 5. Create and Push Git Tag
+## GitHub Workflows
+
+Pull requests to `main` run:
+
+- `Code Quality`
+  - typecheck
+  - lint
+  - main process tests on Linux, macOS, and Windows
+  - frontend unit tests
+  - maintained Playwright smoke tests
+
+Pushes to `main` run:
+
+- `Code Quality`
+- `Deploy Remote PWA Preview`
+
+`v*` tag pushes run:
+
+- `Build & Release`
+  - macOS universal installer
+  - Linux installer artifacts
+  - Windows x64 installer
+  - Windows arm64 installer
+  - GitHub release publishing
+  - `SHA256SUMS.txt`
+- `Notify website on release`
+
+The release is not considered complete until the tag-triggered `Build & Release`
+run succeeds and the GitHub release is published.
+
+## Verification
+
+After `pnpm run release ...` finishes:
 
 ```bash
-git tag v0.1.2
-git push origin v0.1.2
+git fetch origin main --tags
+git rev-parse HEAD
+git rev-parse origin/main
+git tag --points-at HEAD
+gh run list --limit 10
+gh release view vX.Y.Z
 ```
 
-### 6. Automated Release
+Confirm:
 
-Once you push the tag, GitHub Actions will automatically:
-- Build the macOS application
-- Sign and notarize the app (if certificates are configured)
-- Generate auto-update metadata files (`latest-mac.yml`)
-- Create a GitHub release with the .dmg file
+- `HEAD` and `origin/main` point at the release commit.
+- The release commit has the expected `vX.Y.Z` tag.
+- `Build & Release` succeeded for the tag.
+- `Notify website on release` succeeded for the tag.
+- `Code Quality` succeeded for the release commit on `main`.
+- `Deploy Remote PWA Preview` succeeded for the release commit on `main`.
 
-**No manual action needed** - just wait for the workflow to complete.
+## Required Secrets
 
-### 7. Verify Release
+GitHub Actions provides `GITHUB_TOKEN` automatically.
 
-1. Go to https://github.com/dcouple/Pane/releases
-2. Verify the new release is created with:
-   - Proper version tag
-   - Release notes from the commit history
-   - macOS .dmg file
-   - Auto-update metadata file (`latest-mac.yml`)
+The release and preview workflows also depend on repository secrets and
+variables configured in GitHub Actions. Relevant examples include:
+
+- `SITE_REPO_DISPATCH_TOKEN` for website release notification.
+- Google Cloud workload identity, service account, project, and region values
+  for the remote PWA preview deploy.
+- Platform signing or publishing credentials if signing is re-enabled.
 
 ## Auto-Update Files
 
-The build process automatically generates these files required for auto-updates:
+The build process generates update metadata and installers under
+`dist-electron/` in the release workflow:
 
-- **latest-mac.yml** - macOS update metadata
-- **pane-[version]-mac.zip** - macOS update package
-- **pane-[version].dmg** - macOS installer
+- `latest-mac.yml`
+- `latest-linux.yml`
+- `latest-linux-arm64.yml`
+- `latest.yml`
+- macOS `.dmg` and `.zip`
+- Linux `.deb` and `.AppImage`
+- Windows `.exe`
 
-## Build Configuration
+## Rollback
 
-The release configuration is defined in `package.json`:
+Do not retag an existing version. If a release has a critical issue:
 
-```json
-{
-  "build": {
-    "appId": "com.dcouple.pane",
-    "productName": "Pane",
-    "mac": {
-      "category": "public.app-category.developer-tools",
-      "hardenedRuntime": true,
-      "gatekeeperAssess": false,
-      "notarize": true
-    },
-    "publish": {
-      "provider": "github",
-      "owner": "stravu",
-      "repo": "Pane"
-    }
-  }
-}
-```
+1. Fix the issue on `main`.
+2. Cut a new patch version.
+3. Leave the broken tag/release history intact unless maintainers explicitly
+   decide to remove it.
 
-## Troubleshooting
-
-### Auto-update not working
-
-1. **Missing update files**: Ensure the GitHub Actions workflow completed successfully
-2. **Certificate issues**: Check that all Apple certificates are properly configured in GitHub secrets
-3. **Notarization fails**: Verify Apple credentials are correct and the app-specific password is valid
-
-### Build fails
-
-1. **Native dependencies**: The workflow runs `pnpm electron:rebuild` automatically
-2. **Certificate not found**: Ensure the certificate is properly base64 encoded
-3. **Version conflicts**: Make sure the version in package.json matches the git tag
-
-## Testing Updates
-
-To test auto-updates:
-
-1. Install an older version of Pane
-2. Pane will automatically check for updates on startup
-3. When an update is found, the in-app dialog will appear
-4. Click "Download Update" to test the auto-update process
-
-## Best Practices
-
-1. **Semantic Versioning**: Follow semver (MAJOR.MINOR.PATCH)
-2. **Release Notes**: Keep CHANGELOG.md updated with user-friendly notes
-3. **Testing**: Test the release workflow on a test repository first
-4. **Incremental Updates**: Avoid jumping multiple major versions
-
-## Emergency Rollback
-
-If a release has critical issues:
-
-1. Delete the problematic release and tag from GitHub
-2. Fix the issue in the code
-3. Create a new version (e.g., if 0.1.2 was bad, release 0.1.3)
-4. Follow the normal release process
-
-## Additional Notes
-
-- Auto-updates only work for signed and notarized applications
-- Development builds cannot auto-update
-- Users can always manually download from GitHub releases if auto-update fails
-- Settings and data are preserved during updates
-- Pane checks for updates on startup and every 24 hours
+Users can always manually download the latest good release from GitHub Releases.

--- a/playwright.ci.config.ts
+++ b/playwright.ci.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import { getPlaywrightBaseURL, getPlaywrightPort, getPlaywrightServerEnv } from './playwright.shared';
+
+const devServerPort = getPlaywrightPort();
 
 export default defineConfig({
   testDir: './tests',
@@ -25,7 +28,7 @@ export default defineConfig({
   
   use: {
     // Base URL to use in actions like await page.goto('/')
-    baseURL: 'http://localhost:4521',
+    baseURL: getPlaywrightBaseURL(devServerPort),
     // Collect trace only on failure to save time
     trace: 'retain-on-failure',
     // Take screenshot on failure
@@ -55,12 +58,12 @@ export default defineConfig({
   // Run your local dev server before starting the tests
   webServer: {
     command: 'pnpm electron-dev',
-    port: 4521,
+    port: devServerPort,
     reuseExistingServer: false,
     timeout: 60 * 1000, // Reduce from 120s to 60s
-    env: {
+    env: getPlaywrightServerEnv(devServerPort, {
       DISPLAY: ':99',
       ELECTRON_DISABLE_SANDBOX: '1',
-    },
+    }),
   },
 });

--- a/playwright.ci.minimal.config.ts
+++ b/playwright.ci.minimal.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import { getPlaywrightBaseURL, getPlaywrightPort, getPlaywrightServerEnv } from './playwright.shared';
+
+const devServerPort = getPlaywrightPort();
 
 export default defineConfig({
   testDir: './tests',
@@ -26,7 +29,7 @@ export default defineConfig({
   
   use: {
     // Base URL to use in actions like await page.goto('/')
-    baseURL: 'http://localhost:4521',
+    baseURL: getPlaywrightBaseURL(devServerPort),
     // Collect trace only on failure to save time
     trace: 'retain-on-failure',
     // Take screenshot on failure
@@ -56,12 +59,12 @@ export default defineConfig({
   // Run your local dev server before starting the tests
   webServer: {
     command: 'pnpm electron-dev',
-    port: 4521,
+    port: devServerPort,
     reuseExistingServer: false,
     timeout: 45 * 1000,
-    env: {
+    env: getPlaywrightServerEnv(devServerPort, {
       DISPLAY: ':99',
       ELECTRON_DISABLE_SANDBOX: '1',
-    },
+    }),
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
+import { getPlaywrightBaseURL, getPlaywrightPort, getPlaywrightServerEnv } from './playwright.shared';
+
+const devServerPort = getPlaywrightPort();
 
 export default defineConfig({
   testDir: './tests',
@@ -21,7 +24,7 @@ export default defineConfig({
   
   use: {
     // Base URL to use in actions like `await page.goto('/')`
-    baseURL: 'http://localhost:4521',
+    baseURL: getPlaywrightBaseURL(devServerPort),
     // Collect trace when retrying the failed test
     trace: 'on-first-retry',
     // Take screenshot on failure
@@ -39,8 +42,9 @@ export default defineConfig({
   // Run your local dev server before starting the tests
   webServer: {
     command: 'pnpm electron-dev',
-    port: 4521,
+    port: devServerPort,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
+    env: getPlaywrightServerEnv(devServerPort),
   },
 });

--- a/playwright.shared.ts
+++ b/playwright.shared.ts
@@ -1,0 +1,30 @@
+const DEFAULT_PLAYWRIGHT_PORT = 4521;
+
+export function getPlaywrightPort(): number {
+  const rawPort = process.env.PLAYWRIGHT_PORT || process.env.VITE_PORT || process.env.PORT;
+  if (!rawPort) {
+    return DEFAULT_PLAYWRIGHT_PORT;
+  }
+
+  const port = Number.parseInt(rawPort, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid Playwright dev server port: ${rawPort}`);
+  }
+
+  return port;
+}
+
+export function getPlaywrightBaseURL(port = getPlaywrightPort()): string {
+  return `http://localhost:${port}`;
+}
+
+export function getPlaywrightServerEnv(
+  port = getPlaywrightPort(),
+  extraEnv: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    ...extraEnv,
+    PORT: String(port),
+    VITE_PORT: String(port),
+  };
+}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -23,6 +23,67 @@ function run(command, options = {}) {
   return result ? result.trim() : '';
 }
 
+function parseSemver(version) {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(version.trim());
+  if (!match) {
+    return null;
+  }
+
+  return match.slice(1).map(Number);
+}
+
+function compareSemver(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) {
+      return a[i] - b[i];
+    }
+  }
+
+  return 0;
+}
+
+function formatSemver(parts) {
+  return parts.join('.');
+}
+
+function getLatestReleaseTag() {
+  const tagOutput = run('git tag --list "v[0-9]*.[0-9]*.[0-9]*"');
+  const parsedTags = tagOutput
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => ({ tag, version: parseSemver(tag) }))
+    .filter((entry) => entry.version);
+
+  if (parsedTags.length === 0) {
+    return null;
+  }
+
+  parsedTags.sort((a, b) => compareSemver(b.version, a.version));
+  return parsedTags[0];
+}
+
+function incrementVersion(version, bump) {
+  const parts = parseSemver(version);
+  if (!parts) {
+    console.error(`Invalid package.json version: ${version}`);
+    process.exit(1);
+  }
+
+  if (bump === 'patch') {
+    parts[2]++;
+  } else if (bump === 'minor') {
+    parts[1]++;
+    parts[2] = 0;
+  } else if (bump === 'major') {
+    parts[0]++;
+    parts[1] = 0;
+    parts[2] = 0;
+  }
+
+  return formatSemver(parts);
+}
+
 const input = process.argv[2];
 if (!input) {
   console.error('Usage: node scripts/release.js <patch|minor|major|version>');
@@ -33,31 +94,6 @@ if (!input) {
   console.error('  node scripts/release.js 0.1.0   # explicit version');
   process.exit(1);
 }
-
-let cleanVersion;
-
-if (['patch', 'minor', 'major'].includes(input)) {
-  const parts = pkg.version.split('.').map(Number);
-  if (input === 'patch') {
-    parts[2]++;
-  } else if (input === 'minor') {
-    parts[1]++;
-    parts[2] = 0;
-  } else if (input === 'major') {
-    parts[0]++;
-    parts[1] = 0;
-    parts[2] = 0;
-  }
-  cleanVersion = parts.join('.');
-} else {
-  cleanVersion = input.replace(/^v/, '');
-  if (!/^\d+\.\d+\.\d+$/.test(cleanVersion)) {
-    console.error(`Invalid version format: ${cleanVersion}`);
-    process.exit(1);
-  }
-}
-
-console.log(`Releasing v${cleanVersion} (was ${pkg.version})...`);
 
 const status = run('git status --porcelain');
 if (status) {
@@ -75,6 +111,46 @@ if (head !== originMain) {
   console.error(`origin/main: ${originMain}`);
   console.error('Update this worktree to origin/main or create a clean temp worktree from origin/main.');
   process.exit(1);
+}
+
+const latestRelease = getLatestReleaseTag();
+const latestVersion = latestRelease ? formatSemver(latestRelease.version) : null;
+let cleanVersion;
+
+if (['patch', 'minor', 'major'].includes(input)) {
+  if (!latestRelease) {
+    console.error(`Cannot infer a ${input} release because no v* semver tags exist.`);
+    console.error('Use an explicit version, for example: pnpm run release 1.0.0');
+    process.exit(1);
+  }
+
+  if (pkg.version !== latestVersion) {
+    console.error(`Cannot infer a ${input} release because package.json and the latest release tag disagree.`);
+    console.error(`package.json: ${pkg.version}`);
+    console.error(`latest tag:   ${latestRelease.tag}`);
+    console.error('Use an explicit version after deciding the intended next release, for example:');
+    console.error(`  pnpm run release ${latestVersion.split('.').slice(0, 2).join('.')}.${latestRelease.version[2] + 1}`);
+    process.exit(1);
+  }
+
+  cleanVersion = incrementVersion(pkg.version, input);
+} else {
+  cleanVersion = input.replace(/^v/, '');
+  if (!/^\d+\.\d+\.\d+$/.test(cleanVersion)) {
+    console.error(`Invalid version format: ${cleanVersion}`);
+    process.exit(1);
+  }
+
+  const requestedVersion = parseSemver(cleanVersion);
+  if (latestRelease && compareSemver(requestedVersion, latestRelease.version) <= 0) {
+    console.error(`Requested release v${cleanVersion} must be newer than latest tag ${latestRelease.tag}.`);
+    process.exit(1);
+  }
+}
+
+console.log(`Releasing v${cleanVersion} (was ${pkg.version})...`);
+if (latestRelease) {
+  console.log(`Latest release tag: ${latestRelease.tag}`);
 }
 
 const tagName = `v${cleanVersion}`;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# Playwright Testing Notes
+
+Pane's Playwright configs start the Electron dev app and wait for the Vite
+server before running tests.
+
+Default local port:
+
+```bash
+pnpm test -- tests/smoke.spec.ts
+```
+
+Use a different port when another Playwright run or dev app is already using
+`4521`:
+
+```bash
+PLAYWRIGHT_PORT=4522 pnpm test -- tests/analytics-consent.spec.ts
+```
+
+Do not run two Playwright commands concurrently against the same port. The
+second run can attach to or interrupt the first run's dev server and produce
+false failures such as `ERR_CONNECTION_REFUSED`.
+
+CI uses:
+
+```bash
+pnpm test:ci:minimal
+```
+
+That command runs the maintained smoke and health checks through
+`playwright.ci.minimal.config.ts`.


### PR DESCRIPTION
## Description
Adds follow-up guardrails from the analytics/release work so future release and PR-test automation has fewer ambiguous handoffs.

Key changes:
- Hardens `scripts/release.js` so inferred `patch`/`minor`/`major` releases require a clean `origin/main` checkout where `package.json` matches the latest `v*` semver tag.
- Keeps explicit version releases available for intentional recovery when package metadata and tags diverge.
- Rewrites the release guide around the actual script-driven workflow and the GitHub checks that must pass.
- Updates contributor/testing docs now that automated tests and workflows exist.
- Adds `PLAYWRIGHT_PORT` support to all Playwright configs and documents the same-port concurrency failure mode.
- Adds analytics invariants covering identity-before-consent, opt-out capture, config preservation, attribution, and version context.

## Visual Overview
```mermaid
flowchart LR
  subgraph Before["Before: release/test assumptions lived outside the repo"]
    B1["package.json says one version"]
    B2["latest v* tag says another version"]
    B3["pnpm run release patch infers from package.json"]
    B4["wrong next tag possible"]
    B1 --> B3
    B2 -. "not checked for inferred bump" .-> B3 --> B4

    B5["multiple Playwright runs"]
    B6["shared default port 4521"]
    B5 --> B6 --> B7["false server failures"]
  end

  subgraph After["After: executable and documented guardrails"]
    A1["clean HEAD == origin/main"]
    A2["package.json version == latest v* tag"]
    A3["inferred bump allowed"]
    A4["else explicit version required"]
    A1 --> A2 --> A3
    A2 -. "mismatch" .-> A4

    A5["PLAYWRIGHT_PORT"]
    A6["baseURL + dev server env"]
    A7["isolated local suites"]
    A5 --> A6 --> A7

    A8["Analytics invariants"]
    A9["identity before consent"]
    A8 --> A9
  end
```

Truth statement: future agents get executable checks for risky release math and written invariants for analytics/test behavior.

Term explainer:
- `inferred bump`: `pnpm run release patch|minor|major`, where the script calculates the next version.
- `explicit version`: `pnpm run release 2.2.1`, where the operator chooses the exact next version.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [ ] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [ ] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)
N/A.

## Testing
- `node --check scripts/release.js`
- `pnpm typecheck`
- `pnpm lint`
- `PLAYWRIGHT_PORT=4522 pnpm exec playwright test --list --config=playwright.config.ts tests/analytics-consent.spec.ts`
- `PLAYWRIGHT_PORT=4523 pnpm exec playwright test --list --config=playwright.ci.minimal.config.ts`
- `PLAYWRIGHT_PORT=4524 pnpm exec playwright test --list --config=playwright.ci.config.ts tests/analytics-consent.spec.ts`
- `PLAYWRIGHT_PORT=4522 pnpm test -- tests/analytics-consent.spec.ts`

## Additional Notes
The `v2.2.1` release workflow was also verified after the previous release: Build & Release, publish-release, checksums, website notification, Code Quality, and remote PWA preview deploy all succeeded.
