### PR TITLE
Fix worktree sync entry editing

### DIFF
--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -2013,21 +2013,17 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                   {worktreeFileSync.map((entry, index) => (
                     <div key={entry.id} className="flex items-center gap-3 p-2 rounded-lg bg-surface-secondary border border-border-secondary">
                       <div className="flex-1 min-w-0">
-                        {entry.path ? (
-                          <span className="text-sm font-mono">{entry.path}</span>
-                        ) : (
-                          <Input
-                            value={entry.path}
-                            onChange={(e) => {
-                              const updated = [...worktreeFileSync];
-                              updated[index] = { ...entry, path: e.target.value };
-                              setWorktreeFileSync(updated);
-                            }}
-                            placeholder="e.g. .myconfig"
-                            className="text-sm"
-                            error="Path is required"
-                          />
-                        )}
+                        <Input
+                          value={entry.path}
+                          onChange={(e) => {
+                            const updated = [...worktreeFileSync];
+                            updated[index] = { ...entry, path: e.target.value };
+                            setWorktreeFileSync(updated);
+                          }}
+                          placeholder="e.g. .myconfig"
+                          className="text-sm font-mono"
+                          error={entry.path.trim().length === 0 ? 'Path is required' : undefined}
+                        />
                         {entry.recursive && (
                           <span className="ml-2 text-xs text-text-tertiary">includes subdirectories</span>
                         )}

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -107,6 +107,27 @@ test.describe('Smoke Tests', () => {
     await page.waitForTimeout(500);
   });
 
+  test('Worktree file sync custom entries remain editable while typing', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    await openSettings(page);
+
+    const worktreeFileSyncButton = page.getByRole('button', { name: /Worktree File Sync/i });
+    await expect(worktreeFileSyncButton).toBeVisible({ timeout: 5000 });
+    await clickDomNode(worktreeFileSyncButton);
+
+    await clickDomNode(page.getByRole('button', { name: 'Add Entry' }));
+
+    const customPathInput = page.getByPlaceholder('e.g. .myconfig').last();
+    await expect(customPathInput).toBeVisible();
+    await customPathInput.pressSequentially('./venv/*');
+
+    await expect(customPathInput).toHaveValue('./venv/*');
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
   test('Remote daemon settings can create a paired profile and switch modes', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 


### PR DESCRIPTION
## Summary
- Keep Worktree File Sync entries editable instead of replacing new custom entries with static text after the first character
- Show the required-path error only while an entry is empty
- Add a Playwright regression for typing ./venv/* into a custom sync entry

Part 1 for #215.

## Testing
- pnpm exec playwright test tests/smoke.spec.ts --grep "Worktree file sync custom entries remain editable"
- pnpm --filter frontend typecheck
- pnpm --filter frontend lint
- pre-commit: pnpm run -r typecheck; pnpm run -r lint

Note: lint passes with existing warnings; no new warning in the changed frontend file.