### PR TITLE
Fix analytics for RP

### DIFF
--- a/docs/ANALYTICS_INVARIANTS.md
+++ b/docs/ANALYTICS_INVARIANTS.md
@@ -64,6 +64,58 @@ App version should come from the running app context and be attached to consent,
 first-open, usage, attribution, and close events. This lets PostHog distinguish
 current users from older installs.
 
+## Remote Pane Privacy
+
+Remote Pane analytics must use explicit sanitized events. Do not rely on
+autocapture for Remote Pane connection-code, token, host, or command surfaces.
+Any UI that renders or accepts `pane-remote://` codes, remote access tokens, or
+remote setup commands must include `ph-no-capture`.
+
+Remote Pane events must never include:
+
+- connection codes
+- bearer tokens
+- token hashes
+- base URLs
+- hostnames or IP addresses
+- profile labels
+- client labels
+- device labels
+- raw error messages
+- local paths or Pane data directories
+- remote runtime ids
+
+Allowed properties should stay enum-like: `surface`, `role`, `flow`, `result`,
+`tunnel_preference`, `tunnel_kind`, `data_mode`, `client_kind`,
+`connection_mode`, `failure_stage`, `failure_category`, and connected-client
+count buckets.
+
+## Remote Pane Event Catalog
+
+| Event | Primary source | Funnel role |
+|---|---|---|
+| `remote_pane_host_setup_started` | `main/src/ipc/remoteDaemon.ts` | Host setup started |
+| `remote_pane_host_setup_succeeded` | `main/src/ipc/remoteDaemon.ts` | Host setup completed |
+| `remote_pane_host_setup_failed` | `main/src/ipc/remoteDaemon.ts`, `main/src/daemon/remoteTransportController.ts` | Host setup or transport failed |
+| `remote_pane_setup_terminal_opened` | `main/src/ipc/remoteDaemon.ts` | Setup command opened in terminal |
+| `remote_pane_connection_code_created` | `main/src/ipc/remoteDaemon.ts` | Host code created |
+| `remote_pane_connection_code_copied` | `frontend/src/components/Settings.tsx` | Host code copied |
+| `remote_pane_connection_pair_created` | `main/src/ipc/remoteDaemon.ts` | Advanced paired profile created |
+| `remote_pane_connection_code_imported` | `main/src/ipc/remoteDaemon.ts` | Client imported code |
+| `remote_pane_connection_code_import_failed` | `main/src/ipc/remoteDaemon.ts` | Client import failed |
+| `remote_pane_client_connect_started` | `main/src/daemon/client/remotePaneClient.ts` | Desktop client connection started |
+| `remote_pane_client_connected` | `main/src/daemon/client/remotePaneClient.ts`, `main/src/daemon/httpApiServer.ts` | Desktop client connected |
+| `remote_pane_client_connection_failed` | `main/src/daemon/client/remotePaneClient.ts`, `main/src/ipc/remoteDaemon.ts` | Desktop client connection failed |
+| `remote_pane_client_disconnected` | `main/src/daemon/client/remotePaneClient.ts`, `main/src/daemon/httpApiServer.ts` | Desktop client disconnected |
+| `remote_pane_profile_deleted` | `main/src/ipc/remoteDaemon.ts` | Client profile removed |
+| `remote_pane_host_access_cleared` | `main/src/ipc/remoteDaemon.ts` | Host access revoked |
+| `remote_pane_host_clients_disconnected` | `main/src/ipc/remoteDaemon.ts` | Host disconnected clients |
+| `remote_pane_host_transport_started` | `main/src/daemon/remoteTransportController.ts` | Host transport live |
+| `remote_pane_host_transport_stopped` | `main/src/daemon/remoteTransportController.ts` | Host transport stopped |
+| `remote_pane_pwa_client_connected` | `main/src/daemon/httpApiServer.ts` | Browser/PWA client connected |
+| `remote_pane_pwa_client_disconnected` | `main/src/daemon/httpApiServer.ts` | Browser/PWA client disconnected |
+| `remote_pane_remote_runtime_used` | `main/src/daemon/client/remotePaneClient.ts` | Remote runtime actually used |
+
 ## Test Coverage
 
 Changes to consent, analytics config, or first-run event ordering should update

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -5,6 +5,7 @@ import { API } from '../utils/api';
 import {
   aliasWebVisitor,
   aliasWebVisitorDirect,
+  capture,
   captureAndOptOut,
   captureUnconditionally,
   discardPendingEvents,
@@ -634,6 +635,12 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
     }
     try {
       await navigator.clipboard.writeText(remoteSetupResult.connectionCode);
+      capture('remote_pane_connection_code_copied', {
+        surface: 'desktop',
+        role: 'host',
+        flow: 'setup',
+        result: 'succeeded',
+      });
       setRemoteSetupCopyResult('Copied connection code.');
     } catch {
       setError('Failed to copy connection code');
@@ -647,6 +654,12 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
     }
     try {
       await navigator.clipboard.writeText(connectionCode);
+      capture('remote_pane_connection_code_copied', {
+        surface: 'desktop',
+        role: 'host',
+        flow: 'setup',
+        result: 'succeeded',
+      });
       setRemoteSetupCopyResult('Copied connection code.');
     } catch {
       setError('Failed to copy connection code');
@@ -667,6 +680,12 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
       setRemoteHostConnectionCode(response.data.connectionCode);
       try {
         await navigator.clipboard.writeText(response.data.connectionCode);
+        capture('remote_pane_connection_code_copied', {
+          surface: 'desktop',
+          role: 'host',
+          flow: 'setup',
+          result: 'succeeded',
+        });
         setRemoteSetupCopyResult('Created and copied connection code.');
       } catch {
         setRemoteSetupCopyResult('Connection code ready. Click the code to copy it.');
@@ -1331,7 +1350,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                 )}
 
                 {remoteSetupResult && (
-                  <div className="p-3 rounded-lg bg-surface-secondary border border-border-secondary space-y-3">
+                  <div className="ph-no-capture p-3 rounded-lg bg-surface-secondary border border-border-secondary space-y-3">
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
                         <p className="text-sm font-medium text-text-primary">Connection code ready</p>
@@ -1356,6 +1375,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                       rows={3}
                       readOnly
                       fullWidth
+                      className="ph-no-capture"
                     />
                     {remoteSetupCopyResult && (
                       <p className="text-xs text-status-success">{remoteSetupCopyResult}</p>
@@ -1383,6 +1403,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                         rows={2}
                         readOnly
                         fullWidth
+                        className="ph-no-capture"
                       />
                     )}
                     {remoteSetupFallbackCommands.length > 0 && (
@@ -1393,6 +1414,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                         rows={Math.min(3, remoteSetupFallbackCommands.length)}
                         readOnly
                         fullWidth
+                        className="ph-no-capture"
                       />
                     )}
                     {remoteSetupResult.dataDirectoryMode === 'isolated' && !remoteSetupResult.service.started && (
@@ -1403,6 +1425,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                         rows={2}
                         readOnly
                         fullWidth
+                        className="ph-no-capture"
                       />
                     )}
                   </div>
@@ -1527,6 +1550,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                     placeholder="pane-remote://..."
                     rows={2}
                     fullWidth
+                    className="ph-no-capture"
                   />
                   <Button
                     type="button"
@@ -2161,6 +2185,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                     placeholder="pane-remote://..."
                     rows={3}
                     fullWidth
+                    className="ph-no-capture"
                   />
                   <div className="flex items-center justify-between gap-3">
                     <div className="min-w-0">
@@ -2349,7 +2374,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                       </Button>
                     </div>
                     {remoteCreatedToken && (
-                      <div className="p-3 rounded-lg bg-surface-secondary border border-border-secondary space-y-2">
+                      <div className="ph-no-capture p-3 rounded-lg bg-surface-secondary border border-border-secondary space-y-2">
                         <p className="text-sm font-medium text-text-primary">Latest generated remote token</p>
                         <Textarea
                           value={remoteCreatedToken}
@@ -2357,6 +2382,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                           rows={2}
                           readOnly
                           fullWidth
+                          className="ph-no-capture"
                         />
                         <p className="text-xs text-text-tertiary">
                           Use this token when creating a matching remote profile on another client machine.

--- a/frontend/src/remote/components/RemoteConnectionScreen.tsx
+++ b/frontend/src/remote/components/RemoteConnectionScreen.tsx
@@ -143,7 +143,7 @@ export function RemoteConnectionScreen({
               value={code}
               onChange={event => setCode(event.target.value)}
               placeholder="pane-remote://..."
-              className="min-h-32 max-h-52 w-full resize-y rounded-md border border-border-primary bg-bg-secondary p-3 font-mono text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-border-focus"
+              className="ph-no-capture min-h-32 max-h-52 w-full resize-y rounded-md border border-border-primary bg-bg-secondary p-3 font-mono text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-border-focus"
             />
 
             {(error || clipboardError) && (

--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -209,7 +209,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
   const commandRegistry = registerIpcHandlers(services);
 
   let paneDaemonServer: PaneDaemonServer | null = null;
-  const remoteTransportController = new PaneRemoteTransportController(commandRegistry, configManager);
+  const remoteTransportController = new PaneRemoteTransportController(commandRegistry, configManager, analyticsManager);
   try {
     paneDaemonServer = new PaneDaemonServer(commandRegistry, getAppDirectory());
     await paneDaemonServer.start();

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -6,6 +6,8 @@ import { isIP, type LookupFunction } from 'net';
 import { hostname as getOsHostname } from 'os';
 import { noopPaneEventSink, type PaneEventSink } from '../../core/eventSink';
 import type { ConfigManager } from '../../services/configManager';
+import type { AnalyticsManager } from '../../services/analyticsManager';
+import { getRemoteFailureCategory, trackRemotePaneEvent } from '../../services/remoteAnalytics';
 import { isPaneDaemonEventChannel } from '../server';
 import {
   createDefaultRemotePaneConnectionState,
@@ -451,14 +453,17 @@ export class RemotePaneClient {
 interface RemotePaneClientControllerOptions {
   configManager: ConfigManager;
   rendererEventSink: PaneEventSink;
+  analyticsManager?: Pick<AnalyticsManager, 'track'>;
 }
 
 export class RemotePaneClientController extends EventEmitter {
   private configManager: ConfigManager | null = null;
   private rendererEventSink: PaneEventSink = noopPaneEventSink;
+  private analyticsManager: Pick<AnalyticsManager, 'track'> | undefined;
   private activeClient: RemotePaneClient | null = null;
   private state = createDefaultRemotePaneConnectionState();
   private configListenerAttached = false;
+  private remoteRuntimeUsageTracked = false;
 
   private readonly configUpdatedListener = () => {
     void this.syncToConfig().catch((error) => {
@@ -479,6 +484,7 @@ export class RemotePaneClientController extends EventEmitter {
 
     this.configManager = options.configManager;
     this.rendererEventSink = options.rendererEventSink;
+    this.analyticsManager = options.analyticsManager;
     this.configManager.on('config-updated', this.configUpdatedListener);
     this.configListenerAttached = true;
 
@@ -513,7 +519,20 @@ export class RemotePaneClientController extends EventEmitter {
       throw new Error(this.state.lastError ?? 'Remote Pane client is not connected');
     }
 
-    return this.activeClient.invoke(channel, args);
+    const result = await this.activeClient.invoke(channel, args);
+    if (!this.remoteRuntimeUsageTracked) {
+      this.remoteRuntimeUsageTracked = true;
+      trackRemotePaneEvent(this.analyticsManager, 'remote_pane_remote_runtime_used', {
+        surface: 'desktop',
+        role: 'client',
+        flow: 'usage',
+        result: 'succeeded',
+        connection_mode: 'remote',
+        client_kind: 'desktop',
+        remote_runtime_used: true,
+      });
+    }
+    return result;
   }
 
   async activateProfile(profile: RemotePaneConnectionProfile): Promise<RemotePaneConnectionState> {
@@ -581,10 +600,40 @@ export class RemotePaneClientController extends EventEmitter {
     options: RemotePaneClientConnectOptions,
   ): Promise<void> {
     await this.disconnectActiveClient();
+    trackRemotePaneEvent(this.analyticsManager, 'remote_pane_client_connect_started', {
+      surface: 'desktop',
+      role: 'client',
+      flow: 'connect',
+      result: 'started',
+      connection_mode: 'remote',
+      tunnel_kind: profile.tunnel?.kind ?? 'unknown',
+      client_kind: 'desktop',
+    });
 
     const client = new RemotePaneClient(profile, {
       eventSink: this.rendererEventSink,
       onConnectionStateChange: (status, errorMessage, metadata) => {
+        if (status === 'connected') {
+          trackRemotePaneEvent(this.analyticsManager, 'remote_pane_client_connected', {
+            surface: 'desktop',
+            role: 'client',
+            flow: 'connect',
+            result: 'succeeded',
+            connection_mode: 'remote',
+            tunnel_kind: profile.tunnel?.kind ?? 'unknown',
+            client_kind: 'desktop',
+          });
+        } else if (status === 'error') {
+          trackRemotePaneEvent(this.analyticsManager, 'remote_pane_client_connection_failed', {
+            surface: 'desktop',
+            role: 'client',
+            flow: 'connect',
+            result: 'failed',
+            failure_stage: 'remote_client_state',
+            failure_category: getRemoteFailureCategory(errorMessage),
+            client_kind: 'desktop',
+          });
+        }
         this.setConnectionState({
           mode: 'remote',
           status,
@@ -616,6 +665,15 @@ export class RemotePaneClientController extends EventEmitter {
       });
     } catch (error) {
       if (options.retryOnInitialFailure && this.activeClient === client) {
+        trackRemotePaneEvent(this.analyticsManager, 'remote_pane_client_connection_failed', {
+          surface: 'desktop',
+          role: 'client',
+          flow: 'connect',
+          result: 'failed',
+          failure_stage: 'initial_connect_retrying',
+          failure_category: getRemoteFailureCategory(error),
+          client_kind: 'desktop',
+        });
         this.setConnectionState({
           mode: 'remote',
           status: 'reconnecting',
@@ -634,6 +692,15 @@ export class RemotePaneClientController extends EventEmitter {
         }
         await client.disconnect();
       }
+      trackRemotePaneEvent(this.analyticsManager, 'remote_pane_client_connection_failed', {
+        surface: 'desktop',
+        role: 'client',
+        flow: 'connect',
+        result: 'failed',
+        failure_stage: 'initial_connect',
+        failure_category: getRemoteFailureCategory(error),
+        client_kind: 'desktop',
+      });
       this.setConnectionState({
         mode: 'remote',
         status: 'error',
@@ -652,6 +719,14 @@ export class RemotePaneClientController extends EventEmitter {
     this.activeClient = null;
     if (client) {
       await client.disconnect();
+      trackRemotePaneEvent(this.analyticsManager, 'remote_pane_client_disconnected', {
+        surface: 'desktop',
+        role: 'client',
+        flow: 'connect',
+        result: 'succeeded',
+        connection_mode: 'local',
+        client_kind: 'desktop',
+      });
     }
   }
 

--- a/main/src/daemon/httpApiServer.ts
+++ b/main/src/daemon/httpApiServer.ts
@@ -3,6 +3,10 @@ import type { Duplex } from 'stream';
 import WebSocket, { type RawData, WebSocketServer } from 'ws';
 import { createFanoutEventSink, noopPaneEventSink, type PaneEventSink } from '../core/eventSink';
 import type { ConfigManager } from '../services/configManager';
+import {
+  getConnectedClientCountBucket,
+  type RemotePaneAnalyticsSink,
+} from '../services/remoteAnalytics';
 import { terminalPanelManager } from '../services/terminalPanelManager';
 import type { PaneCommandRegistry } from './commandRegistry';
 import { authenticateRemoteDaemonBearerToken } from './auth';
@@ -145,6 +149,7 @@ const REMOTE_DAEMON_CORS_HEADERS = {
 
 interface PaneRemoteHttpApiServerOptions {
   heartbeatIntervalMs?: number;
+  analyticsSink?: RemotePaneAnalyticsSink;
 }
 
 class RemoteDaemonBadRequestError extends Error {
@@ -166,6 +171,7 @@ export class PaneRemoteHttpApiServer {
   private address: RemoteHttpAddress | null = null;
   private nextClientConnectionId = 1;
   private readonly heartbeatIntervalMs: number;
+  private readonly analyticsSink?: RemotePaneAnalyticsSink;
 
   constructor(
     private readonly commandRegistry: PaneCommandRegistry,
@@ -173,6 +179,7 @@ export class PaneRemoteHttpApiServer {
     options: PaneRemoteHttpApiServerOptions = {},
   ) {
     this.heartbeatIntervalMs = options.heartbeatIntervalMs ?? DEFAULT_REMOTE_DAEMON_HEARTBEAT_INTERVAL_MS;
+    this.analyticsSink = options.analyticsSink;
     this.daemonEventSink = createFanoutEventSink([
       {
         send: (channel, ...args) => {
@@ -577,7 +584,7 @@ export class PaneRemoteHttpApiServer {
     const heartbeatTimer = setInterval(() => {
       this.sendHeartbeat(clientConnectionId);
     }, this.heartbeatIntervalMs);
-    this.eventClients.set(clientConnectionId, {
+    const connectedClient: ConnectedRemoteEventClient = {
       id: clientConnectionId,
       response,
       remoteClientId: auth.client?.id ?? null,
@@ -589,8 +596,10 @@ export class PaneRemoteHttpApiServer {
       connectedAt,
       lastSeenAt: connectedAt,
       heartbeatTimer,
-    });
+    };
+    this.eventClients.set(clientConnectionId, connectedClient);
     this.publishConnectedClients();
+    this.trackRemoteClientConnection(connectedClient, 'connected');
     this.sendHeartbeat(clientConnectionId);
 
     const cleanup = () => {
@@ -717,6 +726,7 @@ export class PaneRemoteHttpApiServer {
       client.response.end();
     }
     this.publishConnectedClients();
+    this.trackRemoteClientConnection(client, 'disconnected');
   }
 
   private sendHeartbeat(clientConnectionId: string): void {
@@ -791,6 +801,45 @@ export class PaneRemoteHttpApiServer {
   private getRemoteConfig(): RemoteDaemonConfig {
     return this.configManager.getConfig().remoteDaemon ?? createDefaultRemoteDaemonConfig();
   }
+
+  private trackRemoteClientConnection(
+    client: ConnectedRemoteEventClient,
+    status: 'connected' | 'disconnected',
+  ): void {
+    const clientKind = getRemoteClientKind(client);
+    let eventName: 'remote_pane_pwa_client_connected'
+      | 'remote_pane_pwa_client_disconnected'
+      | 'remote_pane_client_connected'
+      | 'remote_pane_client_disconnected';
+    if (clientKind === 'browser_pwa') {
+      eventName = status === 'connected'
+        ? 'remote_pane_pwa_client_connected'
+        : 'remote_pane_pwa_client_disconnected';
+    } else {
+      eventName = status === 'connected'
+        ? 'remote_pane_client_connected'
+        : 'remote_pane_client_disconnected';
+    }
+
+    this.analyticsSink?.track(eventName, {
+      surface: 'host_transport',
+      role: 'host',
+      flow: 'connect',
+      result: 'succeeded',
+      client_kind: clientKind,
+      connected_client_count_bucket: getConnectedClientCountBucket(this.eventClients.size),
+    });
+  }
+}
+
+function getRemoteClientKind(client: ConnectedRemoteEventClient): 'desktop' | 'browser_pwa' | 'unknown' {
+  if (client.deviceLabel) {
+    return 'desktop';
+  }
+  if (client.remoteRuntimeId || client.label) {
+    return 'browser_pwa';
+  }
+  return 'unknown';
 }
 
 async function readRequestBody(request: IncomingMessage, maxBodyBytes: number): Promise<string> {

--- a/main/src/daemon/remoteTransportController.ts
+++ b/main/src/daemon/remoteTransportController.ts
@@ -1,5 +1,12 @@
 import type { PaneEventSink } from '../core/eventSink';
 import type { ConfigManager } from '../services/configManager';
+import type { AnalyticsManager } from '../services/analyticsManager';
+import {
+  createRemotePaneAnalyticsSink,
+  getConnectedClientCountBucket,
+  getRemoteFailureCategory,
+  trackRemotePaneEvent,
+} from '../services/remoteAnalytics';
 import { getRemoteDaemonHostConfigValidationError } from '../../../shared/types/remoteDaemon';
 import type { RemoteDaemonHostConfig } from '../../../shared/types/remoteDaemon';
 import type { PaneCommandRegistry } from './commandRegistry';
@@ -33,6 +40,7 @@ export class PaneRemoteTransportController {
   constructor(
     private readonly commandRegistry: PaneCommandRegistry,
     private readonly configManager: ConfigManager,
+    private readonly analyticsManager?: Pick<AnalyticsManager, 'track'>,
   ) {}
 
   getEventSink(): PaneEventSink {
@@ -92,16 +100,33 @@ export class PaneRemoteTransportController {
 
       await this.stopRemoteHttpServer();
 
-      const remoteHttpApiServer = new PaneRemoteHttpApiServer(this.commandRegistry, this.configManager);
+      const remoteHttpApiServer = new PaneRemoteHttpApiServer(this.commandRegistry, this.configManager, {
+        analyticsSink: createRemotePaneAnalyticsSink(this.analyticsManager),
+      });
       try {
         await remoteHttpApiServer.start();
         this.remoteHttpApiServer = remoteHttpApiServer;
         this.activeBindingKey = nextBindingKey;
         activeRemoteHttpApiServer = remoteHttpApiServer;
         remoteHostRuntimeStateStore.setLive(hostConfig, remoteHttpApiServer.getAddress());
+        trackRemotePaneEvent(this.analyticsManager, 'remote_pane_host_transport_started', {
+          surface: 'host_transport',
+          role: 'host',
+          flow: 'setup',
+          result: 'succeeded',
+          connected_client_count_bucket: getConnectedClientCountBucket(0),
+        });
       } catch (error) {
         await remoteHttpApiServer.stop();
         remoteHostRuntimeStateStore.setError(hostConfig, error);
+        trackRemotePaneEvent(this.analyticsManager, 'remote_pane_host_setup_failed', {
+          surface: 'host_transport',
+          role: 'host',
+          flow: 'setup',
+          result: 'failed',
+          failure_stage: 'start_host_transport',
+          failure_category: getRemoteFailureCategory(error),
+        });
         throw error;
       }
     });
@@ -114,6 +139,13 @@ export class PaneRemoteTransportController {
 
     if (remoteHttpApiServer) {
       await remoteHttpApiServer.stop();
+      trackRemotePaneEvent(this.analyticsManager, 'remote_pane_host_transport_stopped', {
+        surface: 'host_transport',
+        role: 'host',
+        flow: 'maintenance',
+        result: 'succeeded',
+        connected_client_count_bucket: getConnectedClientCountBucket(0),
+      });
     }
 
     if (activeRemoteHttpApiServer === remoteHttpApiServer) {

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -45,6 +45,7 @@ export function registerIpcHandlers(services: AppServices): PaneCommandRegistry 
   remotePaneClientController.initialize({
     configManager: services.configManager,
     rendererEventSink,
+    analyticsManager: services.analyticsManager,
   });
   const bridgeRouter = createDaemonBridgeRouter(commandRegistry);
 

--- a/main/src/ipc/remoteDaemon.ts
+++ b/main/src/ipc/remoteDaemon.ts
@@ -37,6 +37,14 @@ import { readConfiguredTailscaleServeAccess, setupRemoteHost } from '../daemon/s
 import { getAppDirectory } from '../utils/appDirectory';
 import { ShellDetector } from '../utils/shellDetector';
 import { disconnectActiveRemoteHostClients } from '../daemon/remoteTransportController';
+import {
+  getConnectedClientCountBucket,
+  getRemoteFailureCategory,
+  getRemoteImportProperties,
+  getRemoteSetupProperties,
+  getRemoteSetupResultProperties,
+  trackRemotePaneEvent,
+} from '../services/remoteAnalytics';
 
 interface IpcMainHandleLike {
   handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
@@ -45,6 +53,7 @@ interface IpcMainHandleLike {
 interface RemoteDaemonHandlerServices {
   app?: Pick<AppServices['app'], 'isPackaged'>;
   getMainWindow?: AppServices['getMainWindow'];
+  analyticsManager?: AppServices['analyticsManager'];
   configManager: Pick<AppServices['configManager'], 'getConfig' | 'updateConfig'> & {
     getPreferredShell?: () => string;
   };
@@ -56,7 +65,7 @@ let remoteHostStateForwarder:
 
 export function registerRemoteDaemonHandlers(
   ipcMain: IpcMainHandleLike,
-  { configManager, app, getMainWindow }: RemoteDaemonHandlerServices,
+  { configManager, app, getMainWindow, analyticsManager }: RemoteDaemonHandlerServices,
 ): void {
   attachRemoteHostStateForwarder(getMainWindow);
 
@@ -119,6 +128,10 @@ export function registerRemoteDaemonHandlers(
         ? ShellDetector.getDefaultShell(configManager.getPreferredShell?.()).name
         : undefined;
       const command = buildInteractiveSetupCommand(request, app?.isPackaged === true, shellName);
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_setup_terminal_opened', {
+        ...getRemoteSetupProperties(request),
+        result: 'succeeded',
+      });
       return {
         success: true,
         data: { command } satisfies RemoteHostSetupTerminalCommandResult,
@@ -145,8 +158,13 @@ export function registerRemoteDaemonHandlers(
   });
 
   ipcMain.handle('remote-daemon:setup-host', async (_event, input: unknown) => {
+    let request: RemoteHostSetupRequest | null = null;
     try {
-      const request = parseRemoteHostSetupRequest(input);
+      request = parseRemoteHostSetupRequest(input);
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_host_setup_started', {
+        ...getRemoteSetupProperties(request),
+        result: 'started',
+      });
       const dataDirectoryMode = request.dataDirectoryMode ?? 'current';
       const useCurrentDataDirectory = dataDirectoryMode === 'current';
       const result = await setupRemoteHost({
@@ -169,6 +187,14 @@ export function registerRemoteDaemonHandlers(
             }
           : undefined,
       });
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_host_setup_succeeded', {
+        ...getRemoteSetupProperties(request),
+        ...getRemoteSetupResultProperties({
+          ...result,
+          dataDirectoryMode,
+        }),
+        result: 'succeeded',
+      });
 
       return {
         success: true,
@@ -178,6 +204,12 @@ export function registerRemoteDaemonHandlers(
         } satisfies RemoteHostSetupResult,
       };
     } catch (error) {
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_host_setup_failed', {
+        ...(request ? getRemoteSetupProperties(request) : { surface: 'desktop', role: 'host', flow: 'setup' }),
+        result: 'failed',
+        failure_stage: 'setup_host',
+        failure_category: getRemoteFailureCategory(error),
+      });
       return { success: false, error: getErrorMessage(error, 'Failed to set up remote daemon host') };
     }
   });
@@ -216,6 +248,12 @@ export function registerRemoteDaemonHandlers(
       });
 
       await configManager.updateConfig({ remoteDaemon: next });
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_connection_pair_created', {
+        surface: 'desktop',
+        role: 'host',
+        flow: 'setup',
+        result: 'succeeded',
+      });
       return {
         success: true,
         data: pair satisfies RemoteDaemonConnectionPair,
@@ -258,6 +296,14 @@ export function registerRemoteDaemonHandlers(
         throw new Error('Created remote connection code was not saved. Try again before sharing this code.');
       }
 
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_connection_code_created', {
+        surface: 'desktop',
+        role: 'host',
+        flow: 'setup',
+        result: 'succeeded',
+        tunnel_kind: access.tunnel?.kind ?? 'unknown',
+      });
+
       return {
         success: true,
         data: {
@@ -272,6 +318,7 @@ export function registerRemoteDaemonHandlers(
   });
 
   ipcMain.handle('remote-daemon:import-connection-code', async (_event, input: unknown) => {
+    let payload: PaneRemoteConnectionImportPayload | null = null;
     try {
       if (!isRecord(input)) {
         throw new Error('Remote daemon import request must be an object');
@@ -283,14 +330,15 @@ export function registerRemoteDaemonHandlers(
       }
 
       const connect = input.connect !== false;
-      const payload = decodePaneRemoteConnection(code);
-      let profile = remoteImportPayloadToProfile(payload);
+      const importPayload = decodePaneRemoteConnection(code);
+      payload = importPayload;
+      let profile = remoteImportPayloadToProfile(importPayload);
 
       let connected = false;
       let connectionError: string | undefined;
       await applyRemoteClientTransition(async (current) => {
-        const existingProfile = findMatchingConnectionProfile(current.client.profiles, payload);
-        profile = remoteImportPayloadToProfile(payload, existingProfile?.id);
+        const existingProfile = findMatchingConnectionProfile(current.client.profiles, importPayload);
+        profile = remoteImportPayloadToProfile(importPayload, existingProfile?.id);
 
         if (connect) {
           try {
@@ -315,6 +363,18 @@ export function registerRemoteDaemonHandlers(
         };
       });
 
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_connection_code_imported', {
+        ...getRemoteImportProperties(payload),
+        result: connectionError ? 'failed' : 'succeeded',
+        connected,
+        ...(connectionError
+          ? {
+              failure_stage: 'connect_imported_profile',
+              failure_category: getRemoteFailureCategory(connectionError),
+            }
+          : {}),
+      });
+
       return {
         success: true,
         data: {
@@ -324,6 +384,12 @@ export function registerRemoteDaemonHandlers(
         } satisfies RemoteDaemonImportResult,
       };
     } catch (error) {
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_connection_code_import_failed', {
+        ...(payload ? getRemoteImportProperties(payload) : { surface: 'desktop', role: 'client', flow: 'connect' }),
+        result: 'failed',
+        failure_stage: 'import_connection_code',
+        failure_category: getRemoteFailureCategory(error),
+      });
       return { success: false, error: getErrorMessage(error, 'Failed to import remote daemon connection code') };
     }
   });
@@ -371,6 +437,12 @@ export function registerRemoteDaemonHandlers(
 
       await configManager.updateConfig({ remoteDaemon: next });
       disconnectActiveRemoteHostClients();
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_host_access_cleared', {
+        surface: 'desktop',
+        role: 'host',
+        flow: 'maintenance',
+        result: 'succeeded',
+      });
       return { success: true, data: next.host };
     } catch (error) {
       return { success: false, error: getErrorMessage(error, 'Failed to clear remote host access') };
@@ -381,6 +453,13 @@ export function registerRemoteDaemonHandlers(
     try {
       const parsedClientIds = parseOptionalClientIds(clientIds);
       const disconnectedCount = disconnectActiveRemoteHostClients(parsedClientIds);
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_host_clients_disconnected', {
+        surface: 'desktop',
+        role: 'host',
+        flow: 'maintenance',
+        result: 'succeeded',
+        connected_client_count_bucket: getConnectedClientCountBucket(disconnectedCount),
+      });
       return { success: true, data: { disconnectedCount } };
     } catch (error) {
       return { success: false, error: getErrorMessage(error, 'Failed to disconnect remote daemon clients') };
@@ -486,6 +565,12 @@ export function registerRemoteDaemonHandlers(
           resyncRenderer: isActiveRemoteProfile,
         };
       });
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_profile_deleted', {
+        surface: 'desktop',
+        role: 'client',
+        flow: 'maintenance',
+        result: 'succeeded',
+      });
       return { success: true, data: next.client };
     } catch (error) {
       return { success: false, error: getErrorMessage(error, 'Failed to delete remote daemon connection profile') };
@@ -526,6 +611,15 @@ export function registerRemoteDaemonHandlers(
       });
       return { success: true, data: next.client };
     } catch (error) {
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_client_connection_failed', {
+        surface: 'desktop',
+        role: 'client',
+        flow: 'connect',
+        result: 'failed',
+        failure_stage: 'update_client_state',
+        failure_category: getRemoteFailureCategory(error),
+        client_kind: 'desktop',
+      });
       return { success: false, error: getErrorMessage(error, 'Failed to update remote daemon client state') };
     }
   });

--- a/main/src/services/remoteAnalytics.ts
+++ b/main/src/services/remoteAnalytics.ts
@@ -1,0 +1,199 @@
+import type { AnalyticsManager } from './analyticsManager';
+import type {
+  PaneRemoteConnectionImportPayload,
+  RemoteHostSetupRequest,
+  RemoteHostSetupResult,
+} from '../../../shared/types/remoteDaemon';
+
+export type RemotePaneAnalyticsEventName =
+  | 'remote_pane_host_setup_started'
+  | 'remote_pane_host_setup_succeeded'
+  | 'remote_pane_host_setup_failed'
+  | 'remote_pane_setup_terminal_opened'
+  | 'remote_pane_connection_code_created'
+  | 'remote_pane_connection_code_copied'
+  | 'remote_pane_connection_pair_created'
+  | 'remote_pane_connection_code_imported'
+  | 'remote_pane_connection_code_import_failed'
+  | 'remote_pane_client_connect_started'
+  | 'remote_pane_client_connected'
+  | 'remote_pane_client_connection_failed'
+  | 'remote_pane_client_disconnected'
+  | 'remote_pane_profile_deleted'
+  | 'remote_pane_host_access_cleared'
+  | 'remote_pane_host_clients_disconnected'
+  | 'remote_pane_host_transport_started'
+  | 'remote_pane_host_transport_stopped'
+  | 'remote_pane_pwa_client_connected'
+  | 'remote_pane_pwa_client_disconnected'
+  | 'remote_pane_remote_runtime_used';
+
+export type RemotePaneAnalyticsProperties = {
+  surface?: 'desktop' | 'remote_pwa' | 'host_transport';
+  role?: 'host' | 'client';
+  flow?: 'setup' | 'connect' | 'usage' | 'maintenance';
+  result?: 'started' | 'succeeded' | 'failed';
+  tunnel_preference?: 'tailscale' | 'ssh' | 'manual' | 'auto' | 'unknown';
+  tunnel_kind?: 'tailscale' | 'ssh' | 'manual' | 'unknown';
+  data_mode?: 'current' | 'isolated' | 'unknown';
+  client_kind?: 'desktop' | 'browser_pwa' | 'unknown';
+  connection_mode?: 'remote' | 'local';
+  failure_stage?: string;
+  failure_category?: string;
+  connected?: boolean;
+  connected_client_count_bucket?: '0' | '1' | '2-3' | '4+';
+  remote_runtime_used?: boolean;
+  install_service_requested?: boolean;
+  service_strategy?: string;
+  service_installed?: boolean;
+  service_started?: boolean;
+  channel?: 'stable' | 'nightly';
+};
+
+export interface RemotePaneAnalyticsSink {
+  track(eventName: RemotePaneAnalyticsEventName, properties?: RemotePaneAnalyticsProperties): void;
+}
+
+export function createRemotePaneAnalyticsSink(
+  analyticsManager?: Pick<AnalyticsManager, 'track'>,
+): RemotePaneAnalyticsSink | undefined {
+  if (!analyticsManager) {
+    return undefined;
+  }
+
+  return {
+    track(eventName, properties) {
+      trackRemotePaneEvent(analyticsManager, eventName, properties);
+    },
+  };
+}
+
+export function trackRemotePaneEvent(
+  analyticsManager: Pick<AnalyticsManager, 'track'> | undefined,
+  eventName: RemotePaneAnalyticsEventName,
+  properties: RemotePaneAnalyticsProperties = {},
+): void {
+  if (!analyticsManager) {
+    return;
+  }
+
+  analyticsManager.track(eventName, sanitizeRemotePaneProperties(properties));
+}
+
+export function getRemoteSetupProperties(request: RemoteHostSetupRequest): RemotePaneAnalyticsProperties {
+  return {
+    surface: 'desktop',
+    role: 'host',
+    flow: 'setup',
+    tunnel_preference: normalizeTunnelPreference(request.preferTunnel),
+    data_mode: request.dataDirectoryMode ?? 'current',
+    install_service_requested: request.dataDirectoryMode === 'isolated'
+      ? request.installService !== false
+      : false,
+    channel: request.channel,
+  };
+}
+
+export function getRemoteSetupResultProperties(result: RemoteHostSetupResult): RemotePaneAnalyticsProperties {
+  return {
+    tunnel_kind: normalizeTunnelKind(result.tunnel?.kind),
+    data_mode: result.dataDirectoryMode,
+    service_strategy: result.service.strategy,
+    service_installed: result.service.installed,
+    service_started: result.service.started,
+    channel: result.channel,
+  };
+}
+
+export function getRemoteImportProperties(
+  payload: PaneRemoteConnectionImportPayload,
+): RemotePaneAnalyticsProperties {
+  return {
+    surface: 'desktop',
+    role: 'client',
+    flow: 'connect',
+    tunnel_kind: normalizeTunnelKind(payload.tunnel?.kind),
+    client_kind: 'desktop',
+  };
+}
+
+export function getRemoteFailureCategory(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  if (normalized.includes('auth') || normalized.includes('token') || normalized.includes('unauthorized')) {
+    return 'auth';
+  }
+  if (normalized.includes('timeout') || normalized.includes('timed out')) {
+    return 'timeout';
+  }
+  if (normalized.includes('dns') || normalized.includes('enotfound') || normalized.includes('lookup')) {
+    return 'dns';
+  }
+  if (normalized.includes('refused') || normalized.includes('econnrefused')) {
+    return 'connection_refused';
+  }
+  if (normalized.includes('network') || normalized.includes('fetch') || normalized.includes('socket')) {
+    return 'network';
+  }
+  if (normalized.includes('validation') || normalized.includes('invalid') || normalized.includes('required')) {
+    return 'validation';
+  }
+  return 'unknown';
+}
+
+export function getConnectedClientCountBucket(count: number): RemotePaneAnalyticsProperties['connected_client_count_bucket'] {
+  if (count <= 0) {
+    return '0';
+  }
+  if (count === 1) {
+    return '1';
+  }
+  if (count <= 3) {
+    return '2-3';
+  }
+  return '4+';
+}
+
+function sanitizeRemotePaneProperties(
+  properties: RemotePaneAnalyticsProperties,
+): Record<string, string | number | boolean | string[] | undefined> {
+  return {
+    surface: properties.surface,
+    role: properties.role,
+    flow: properties.flow,
+    result: properties.result,
+    tunnel_preference: properties.tunnel_preference,
+    tunnel_kind: properties.tunnel_kind,
+    data_mode: properties.data_mode,
+    client_kind: properties.client_kind,
+    connection_mode: properties.connection_mode,
+    failure_stage: properties.failure_stage,
+    failure_category: properties.failure_category,
+    connected: properties.connected,
+    connected_client_count_bucket: properties.connected_client_count_bucket,
+    remote_runtime_used: properties.remote_runtime_used,
+    install_service_requested: properties.install_service_requested,
+    service_strategy: properties.service_strategy,
+    service_installed: properties.service_installed,
+    service_started: properties.service_started,
+    channel: properties.channel,
+  };
+}
+
+function normalizeTunnelPreference(
+  preference: RemoteHostSetupRequest['preferTunnel'],
+): RemotePaneAnalyticsProperties['tunnel_preference'] {
+  if (preference === 'tailscale' || preference === 'ssh' || preference === 'manual' || preference === 'auto') {
+    return preference;
+  }
+  return 'unknown';
+}
+
+function normalizeTunnelKind(
+  kind: NonNullable<PaneRemoteConnectionImportPayload['tunnel']>['kind'] | undefined,
+): RemotePaneAnalyticsProperties['tunnel_kind'] {
+  if (kind === 'tailscale' || kind === 'ssh' || kind === 'manual') {
+    return kind;
+  }
+  return 'unknown';
+}


### PR DESCRIPTION
## Summary
- Add sanitized Remote Pane analytics helpers and main-process instrumentation for host setup, code creation/import, client lifecycle, host transport, PWA connections, and first remote runtime use.
- Mask connection-code/token/command UI with `ph-no-capture`.
- Document Remote Pane analytics privacy invariants and event catalog.

## Testing
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `(cd main && pnpm exec vitest run remoteDaemon remotePaneClient httpApiServer remoteTransportController)`

## Notes
- Events intentionally avoid connection codes, tokens, URLs, paths, hostnames, and raw errors.