### PR TITLE
Fix pane navigation and pinned ordering

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -13,6 +13,12 @@ import { cn } from '../utils/cn';
 import type { Session, GitStatus } from '../types/session';
 import type { Project } from '../types/project';
 import { usePanelStore } from '../stores/panelStore';
+import {
+  createProjectById,
+  flattenSessionsByProjects,
+  getPinnedSessions,
+  groupSessionsByProject,
+} from '../utils/sessionOrdering';
 
 
 
@@ -77,47 +83,16 @@ export function ProjectSessionList({
   }, [loadProjects]);
 
   // Group sessions by project
-  const sessionsByProject = useMemo(() => {
-    const map = new Map<number, Session[]>();
-    sessions
-      .filter(s => !s.archived)
-      .forEach(s => {
-        if (s.projectId != null) {
-          const list = map.get(s.projectId) || [];
-          list.push(s);
-          map.set(s.projectId, list);
-        }
-      });
-    map.forEach((list, key) => {
-      map.set(key, list.sort((a, b) => {
-        const da = new Date(a.createdAt).getTime();
-        const db = new Date(b.createdAt).getTime();
-        return sessionSortAscending ? da - db : db - da;
-      }));
-    });
-    return map;
-  }, [sessions, sessionSortAscending]);
+  const sessionsByProject = useMemo(
+    () => groupSessionsByProject(sessions, sessionSortAscending),
+    [sessions, sessionSortAscending]
+  );
 
-  const projectById = useMemo(() => {
-    const map = new Map<number, Project>();
-    projects.forEach(project => map.set(project.id, project));
-    return map;
-  }, [projects]);
-
-  const getPinnedSessionLabel = useCallback((session: Session) => {
-    const projectName = session.projectId != null ? projectById.get(session.projectId)?.name : undefined;
-    return `${projectName || 'Unknown'}/${session.name || 'Untitled'}`;
-  }, [projectById]);
+  const projectById = useMemo(() => createProjectById(projects), [projects]);
 
   const pinnedSessions = useMemo(() => {
-    return sessions
-      .filter(session => !session.archived && session.isFavorite)
-      .map(session => ({
-        session,
-        label: getPinnedSessionLabel(session),
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
-  }, [sessions, getPinnedSessionLabel]);
+    return getPinnedSessions(sessions, projectById);
+  }, [sessions, projectById]);
 
   // mod+1-9 session switch hotkeys are registered in useSessionNavigationHotkeys
   // (always mounted in Sidebar), and new-project auto-expansion lives there too.
@@ -216,6 +191,7 @@ export function ProjectSessionList({
     if (payload.length > 0) {
       try {
         await API.projects.reorder(payload);
+        window.dispatchEvent(new Event('project-changed'));
       } catch (err) {
         console.error('Failed to reorder projects:', err);
         loadProjects();
@@ -231,15 +207,8 @@ export function ProjectSessionList({
   // Compute global index for each session (for hotkey labels in tooltips)
   const globalSessionIndex = useMemo(() => {
     const map = new Map<string, number>();
-    let idx = 0;
-    projects.forEach(p => {
-      if (expandedProjects.has(p.id)) {
-        const list = sessionsByProject.get(p.id) || [];
-        list.forEach(s => {
-          map.set(s.id, idx);
-          idx++;
-        });
-      }
+    flattenSessionsByProjects(projects, sessionsByProject, expandedProjects).forEach((session, index) => {
+      map.set(session.id, index);
     });
     return map;
   }, [projects, expandedProjects, sessionsByProject]);

--- a/frontend/src/hooks/useSessionNavigationHotkeys.ts
+++ b/frontend/src/hooks/useSessionNavigationHotkeys.ts
@@ -4,7 +4,11 @@ import { useHotkeyStore } from '../stores/hotkeyStore';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
 import { cycleIndex } from '../utils/arrayUtils';
-import type { Session } from '../types/session';
+import {
+  createProjectById,
+  flattenSessionsByProjects,
+  groupSessionsByProject,
+} from '../utils/sessionOrdering';
 import type { Project } from '../types/project';
 
 interface UseSessionNavigationHotkeysOptions {
@@ -21,54 +25,16 @@ export function useSessionNavigationHotkeys({
   const setActiveSession = useSessionStore(s => s.setActiveSession);
   const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
 
-  const sessionsByProject = useMemo(() => {
-    const map = new Map<number, Session[]>();
-    sessions
-      .filter(s => !s.archived)
-      .forEach(s => {
-        if (s.projectId != null) {
-          const list = map.get(s.projectId) || [];
-          list.push(s);
-          map.set(s.projectId, list);
-        }
-      });
-    map.forEach((list, key) => {
-      map.set(key, list.sort((a, b) => {
-        const da = new Date(a.createdAt).getTime();
-        const db = new Date(b.createdAt).getTime();
-        return sessionSortAscending ? da - db : db - da;
-      }));
-    });
-    return map;
-  }, [sessions, sessionSortAscending]);
+  const sessionsByProject = useMemo(
+    () => groupSessionsByProject(sessions, sessionSortAscending),
+    [sessions, sessionSortAscending]
+  );
 
-  const projectById = useMemo(() => {
-    const map = new Map<number, Project>();
-    projects.forEach(project => map.set(project.id, project));
-    return map;
-  }, [projects]);
+  const projectById = useMemo(() => createProjectById(projects), [projects]);
 
   const allActiveSessions = useMemo(() => {
-    const result: Session[] = [];
-    projects.forEach(project => {
-      const list = sessionsByProject.get(project.id) || [];
-      result.push(...list);
-    });
-    return result;
+    return flattenSessionsByProjects(projects, sessionsByProject);
   }, [projects, sessionsByProject]);
-
-  const pinnedSessions = useMemo(() => {
-    return sessions
-      .filter(session => !session.archived && session.isFavorite)
-      .map(session => {
-        const projectName = session.projectId != null ? projectById.get(session.projectId)?.name : undefined;
-        return {
-          session,
-          label: `${projectName || 'Unknown'}/${session.name || 'Untitled'}`,
-        };
-      })
-      .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
-  }, [sessions, projectById]);
 
   const expandedProjects = useNavigationStore(s => s.expandedProjects);
   const registerProjectIds = useNavigationStore(s => s.registerProjectIds);
@@ -81,23 +47,16 @@ export function useSessionNavigationHotkeys({
   }, [projects, registerProjectIds]);
 
   // Sessions in the exact order ProjectSessionList renders them: projects in
-  // display order, collapsed projects skipped, sessions sorted by createdAt.
+  // display order, collapsed projects skipped, sessions in display order.
   // Pinned rows are excluded, matching the list's hotkey numbering.
   const visibleSessions = useMemo(() => {
-    const result: Session[] = [];
-    projects.forEach(project => {
-      if (expandedProjects.has(project.id)) {
-        const list = sessionsByProject.get(project.id) || [];
-        result.push(...list);
-      }
-    });
-    return result;
+    return flattenSessionsByProjects(projects, sessionsByProject, expandedProjects);
   }, [projects, expandedProjects, sessionsByProject]);
 
   const allActiveSessionsRef = useRef(allActiveSessions);
   allActiveSessionsRef.current = allActiveSessions;
-  const pinnedSessionsRef = useRef(pinnedSessions);
-  pinnedSessionsRef.current = pinnedSessions;
+  const visibleSessionsRef = useRef(visibleSessions);
+  visibleSessionsRef.current = visibleSessions;
   const activeSessionIdRef = useRef(activeSessionId);
   activeSessionIdRef.current = activeSessionId;
   const setActiveSessionRef = useRef(setActiveSession);
@@ -118,9 +77,10 @@ export function useSessionNavigationHotkeys({
     navigateToSessionsRef.current();
   }, []);
 
-  const cyclePinnedOrAllSessions = useCallback((direction: 'next' | 'prev') => {
-    const pinned = pinnedSessionsRef.current.map(item => item.session);
-    const sessions = pinned.length > 0 ? pinned : allActiveSessionsRef.current;
+  const cycleVisibleOrAllSessions = useCallback((direction: 'next' | 'prev') => {
+    const sessions = visibleSessionsRef.current.length > 0
+      ? visibleSessionsRef.current
+      : allActiveSessionsRef.current;
     if (sessions.length === 0) return;
 
     const currentId = activeSessionIdRef.current;
@@ -151,31 +111,27 @@ export function useSessionNavigationHotkeys({
   });
 
   useHotkey({
-    id: 'cycle-pinned-or-all-next',
-    label: 'Next Pinned Pane',
+    id: 'cycle-sidebar-session-next',
+    label: 'Next Pane in Sidebar',
     keys: 'mod+ArrowDown',
     category: 'session',
     enabled: () => {
-      const pinnedCount = pinnedSessionsRef.current.length;
-      return pinnedCount > 1 || (pinnedCount === 0 && allActiveSessionsRef.current.length > 1);
+      return visibleSessionsRef.current.length > 1 || allActiveSessionsRef.current.length > 1;
     },
-    action: () => cyclePinnedOrAllSessions('next'),
+    action: () => cycleVisibleOrAllSessions('next'),
   });
 
   useHotkey({
-    id: 'cycle-pinned-or-all-prev',
-    label: 'Previous Pinned Pane',
+    id: 'cycle-sidebar-session-prev',
+    label: 'Previous Pane in Sidebar',
     keys: 'mod+ArrowUp',
     category: 'session',
     enabled: () => {
-      const pinnedCount = pinnedSessionsRef.current.length;
-      return pinnedCount > 1 || (pinnedCount === 0 && allActiveSessionsRef.current.length > 1);
+      return visibleSessionsRef.current.length > 1 || allActiveSessionsRef.current.length > 1;
     },
-    action: () => cyclePinnedOrAllSessions('prev'),
+    action: () => cycleVisibleOrAllSessions('prev'),
   });
 
-  const visibleSessionsRef = useRef(visibleSessions);
-  visibleSessionsRef.current = visibleSessions;
   const projectByIdRef = useRef(projectById);
   projectByIdRef.current = projectById;
 

--- a/frontend/src/remote/components/RemoteSidebar.tsx
+++ b/frontend/src/remote/components/RemoteSidebar.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import type { RemoteProjectWithSessions } from '../runtime/remoteRuntimeAdapter';
 import type { Session } from '../../types/session';
 import { RemoteDesktopLink } from './RemoteDesktopLink';
+import { createProjectById, getPinnedSessions } from '../../utils/sessionOrdering';
 
 interface RemoteSidebarProps {
   projects: RemoteProjectWithSessions[];
@@ -32,14 +33,11 @@ export function RemoteSidebar({
   className = 'flex w-80 shrink-0',
 }: RemoteSidebarProps) {
   const pinnedSessions = useMemo(() => {
-    return projects
-      .flatMap(project => (project.sessions ?? [])
-        .filter(session => !session.archived && session.isFavorite)
-        .map(session => ({
-          session,
-          label: getPinnedSessionLabel(project, session),
-        })))
-      .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+    const projectById = createProjectById(projects);
+    return getPinnedSessions(
+      projects.flatMap(project => project.sessions ?? []),
+      projectById
+    );
   }, [projects]);
 
   return (
@@ -207,8 +205,4 @@ function RemoteSessionRow({
       </span>
     </div>
   );
-}
-
-function getPinnedSessionLabel(project: RemoteProjectWithSessions, session: Session): string {
-  return `${project.name || 'Unknown'}/${session.name || 'Untitled'}`;
 }

--- a/frontend/src/remote/runtime/remoteRuntimeAdapter.ts
+++ b/frontend/src/remote/runtime/remoteRuntimeAdapter.ts
@@ -117,8 +117,8 @@ export class RemoteRuntimeAdapter {
     return this.invoke<VoiceTranscriptionResult>('voice:finalize-streaming', [request]);
   }
 
-  toggleFavorite(sessionId: string): Promise<{ isFavorite: boolean }> {
-    return this.invoke<{ isFavorite: boolean }>('sessions:toggle-favorite', [sessionId]);
+  toggleFavorite(sessionId: string): Promise<{ isFavorite: boolean; favoritePinnedAt?: string | null }> {
+    return this.invoke<{ isFavorite: boolean; favoritePinnedAt?: string | null }>('sessions:toggle-favorite', [sessionId]);
   }
 
   archiveSession(sessionId: string): Promise<void> {

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -96,6 +96,7 @@ export interface Session {
   isMainRepo?: boolean;
   displayOrder?: number;
   isFavorite?: boolean;
+  favoritePinnedAt?: string;
   toolType?: 'claude' | 'none';
   archived?: boolean;
   gitStatus?: GitStatus;

--- a/frontend/src/utils/sessionNormalization.ts
+++ b/frontend/src/utils/sessionNormalization.ts
@@ -2,11 +2,12 @@ import type { Session, SessionOutput } from '../types/session';
 
 type TimestampLike = string | Date | null | undefined;
 
-type SessionWire = Omit<Session, 'createdAt' | 'lastActivity' | 'lastViewedAt' | 'runStartedAt'> & {
+type SessionWire = Omit<Session, 'createdAt' | 'lastActivity' | 'lastViewedAt' | 'runStartedAt' | 'favoritePinnedAt'> & {
   createdAt?: TimestampLike;
   lastActivity?: TimestampLike;
   lastViewedAt?: TimestampLike;
   runStartedAt?: TimestampLike;
+  favoritePinnedAt?: TimestampLike;
 };
 
 type SessionOutputWire = Omit<SessionOutput, 'timestamp'> & {
@@ -32,6 +33,7 @@ export function normalizeSession(session: SessionWire): Session {
     lastActivity: normalizeTimestamp(session.lastActivity),
     lastViewedAt: normalizeTimestamp(session.lastViewedAt),
     runStartedAt: normalizeTimestamp(session.runStartedAt),
+    favoritePinnedAt: normalizeTimestamp(session.favoritePinnedAt),
   };
 }
 

--- a/frontend/src/utils/sessionOrdering.test.ts
+++ b/frontend/src/utils/sessionOrdering.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { Project } from '../types/project';
+import type { Session } from '../types/session';
+import {
+  flattenSessionsByProjects,
+  getPinnedSessions,
+  groupSessionsByProject,
+} from './sessionOrdering';
+
+function session(overrides: Partial<Session> & Pick<Session, 'id' | 'projectId'>): Session {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? overrides.id,
+    worktreePath: '',
+    prompt: '',
+    status: 'stopped',
+    createdAt: overrides.createdAt ?? '2026-01-01T00:00:00.000Z',
+    output: [],
+    jsonMessages: [],
+    projectId: overrides.projectId,
+    displayOrder: overrides.displayOrder,
+    isFavorite: overrides.isFavorite,
+    favoritePinnedAt: overrides.favoritePinnedAt,
+    archived: overrides.archived,
+  };
+}
+
+function project(id: number, name = `Project ${id}`): Project {
+  return {
+    id,
+    name,
+    path: '',
+    active: false,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('sessionOrdering', () => {
+  it('orders sessions by displayOrder in the default ascending view', () => {
+    const grouped = groupSessionsByProject([
+      session({ id: 'newer', projectId: 1, displayOrder: 2, createdAt: '2026-01-03T00:00:00.000Z' }),
+      session({ id: 'older', projectId: 1, displayOrder: 0, createdAt: '2026-01-01T00:00:00.000Z' }),
+      session({ id: 'middle', projectId: 1, displayOrder: 1, createdAt: '2026-01-02T00:00:00.000Z' }),
+    ], true);
+
+    expect(grouped.get(1)?.map(item => item.id)).toEqual(['older', 'middle', 'newer']);
+  });
+
+  it('keeps newest-first sorting when the user flips the sort direction', () => {
+    const grouped = groupSessionsByProject([
+      session({ id: 'newer', projectId: 1, displayOrder: 2, createdAt: '2026-01-03T00:00:00.000Z' }),
+      session({ id: 'older', projectId: 1, displayOrder: 0, createdAt: '2026-01-01T00:00:00.000Z' }),
+      session({ id: 'middle', projectId: 1, displayOrder: 1, createdAt: '2026-01-02T00:00:00.000Z' }),
+    ], false);
+
+    expect(grouped.get(1)?.map(item => item.id)).toEqual(['newer', 'middle', 'older']);
+  });
+
+  it('uses createdAt sort when displayOrder is absent', () => {
+    const grouped = groupSessionsByProject([
+      session({ id: 'old', projectId: 1, createdAt: '2026-01-01T00:00:00.000Z' }),
+      session({ id: 'new', projectId: 1, createdAt: '2026-01-03T00:00:00.000Z' }),
+    ], false);
+
+    expect(grouped.get(1)?.map(item => item.id)).toEqual(['new', 'old']);
+  });
+
+  it('flattens sessions in project order while respecting collapsed projects', () => {
+    const projects = [project(2), project(1)];
+    const grouped = groupSessionsByProject([
+      session({ id: 'one', projectId: 1, displayOrder: 0 }),
+      session({ id: 'two', projectId: 2, displayOrder: 0 }),
+    ], true);
+
+    expect(flattenSessionsByProjects(projects, grouped).map(item => item.id)).toEqual(['two', 'one']);
+    expect(flattenSessionsByProjects(projects, grouped, new Set([1])).map(item => item.id)).toEqual(['one']);
+  });
+
+  it('orders pinned rows by newest pin first', () => {
+    const projects = new Map([
+      [1, project(1, 'Zed')],
+      [2, project(2, 'Alpha')],
+    ]);
+
+    const pinned = getPinnedSessions([
+      session({ id: 'older', name: 'Pane', projectId: 1, isFavorite: true, favoritePinnedAt: '2026-01-01T00:00:00.000Z' }),
+      session({ id: 'newer', name: 'Pane', projectId: 2, isFavorite: true, favoritePinnedAt: '2026-01-03T00:00:00.000Z' }),
+      session({ id: 'unpinned', projectId: 1, isFavorite: false }),
+    ], projects);
+
+    expect(pinned.map(item => item.session.id)).toEqual(['newer', 'older']);
+  });
+
+  it('falls back to createdAt for pinned rows without a pin timestamp', () => {
+    const projects = new Map([[1, project(1, 'Project')]]);
+
+    const pinned = getPinnedSessions([
+      session({ id: 'old', projectId: 1, isFavorite: true, createdAt: '2026-01-01T00:00:00.000Z' }),
+      session({ id: 'new', projectId: 1, isFavorite: true, createdAt: '2026-01-03T00:00:00.000Z' }),
+    ], projects);
+
+    expect(pinned.map(item => item.session.id)).toEqual(['new', 'old']);
+  });
+});

--- a/frontend/src/utils/sessionOrdering.ts
+++ b/frontend/src/utils/sessionOrdering.ts
@@ -1,0 +1,107 @@
+import type { Project } from '../types/project';
+import type { Session } from '../types/session';
+
+export interface PinnedSession {
+  session: Session;
+  label: string;
+}
+
+function hasDisplayOrder(session: Session): boolean {
+  return typeof session.displayOrder === 'number' && Number.isFinite(session.displayOrder);
+}
+
+function compareCreatedAt(a: Session, b: Session, ascending: boolean): number {
+  const da = new Date(a.createdAt).getTime();
+  const db = new Date(b.createdAt).getTime();
+  return ascending ? da - db : db - da;
+}
+
+function pinnedAtTime(session: Session): number {
+  const pinnedAt = session.favoritePinnedAt
+    ? new Date(session.favoritePinnedAt).getTime()
+    : Number.NaN;
+  if (!Number.isNaN(pinnedAt)) {
+    return pinnedAt;
+  }
+
+  const createdAt = new Date(session.createdAt).getTime();
+  return Number.isNaN(createdAt) ? 0 : createdAt;
+}
+
+export function compareSessionsForSidebar(
+  a: Session,
+  b: Session,
+  createdAtAscending: boolean
+): number {
+  if (createdAtAscending && hasDisplayOrder(a) && hasDisplayOrder(b) && a.displayOrder !== b.displayOrder) {
+    return (a.displayOrder ?? 0) - (b.displayOrder ?? 0);
+  }
+
+  return compareCreatedAt(a, b, createdAtAscending);
+}
+
+export function groupSessionsByProject(
+  sessions: Session[],
+  createdAtAscending: boolean
+): Map<number, Session[]> {
+  const map = new Map<number, Session[]>();
+
+  sessions
+    .filter(session => !session.archived)
+    .forEach(session => {
+      if (session.projectId == null) return;
+      const list = map.get(session.projectId) || [];
+      list.push(session);
+      map.set(session.projectId, list);
+    });
+
+  map.forEach((list, key) => {
+    map.set(key, list.slice().sort((a, b) => compareSessionsForSidebar(a, b, createdAtAscending)));
+  });
+
+  return map;
+}
+
+export function createProjectById(projects: Project[]): Map<number, Project> {
+  const map = new Map<number, Project>();
+  projects.forEach(project => map.set(project.id, project));
+  return map;
+}
+
+export function flattenSessionsByProjects(
+  projects: Project[],
+  sessionsByProject: Map<number, Session[]>,
+  expandedProjects?: Set<number>
+): Session[] {
+  const result: Session[] = [];
+
+  projects.forEach(project => {
+    if (expandedProjects && !expandedProjects.has(project.id)) return;
+    result.push(...(sessionsByProject.get(project.id) || []));
+  });
+
+  return result;
+}
+
+export function getPinnedSessions(
+  sessions: Session[],
+  projectById: Map<number, Project>,
+  getProjectName?: (session: Session) => string | undefined
+): PinnedSession[] {
+  return sessions
+    .filter(session => !session.archived && session.isFavorite)
+    .map(session => {
+      const projectName = getProjectName
+        ? getProjectName(session)
+        : session.projectId != null ? projectById.get(session.projectId)?.name : undefined;
+      return {
+        session,
+        label: `${projectName || 'Unknown'}/${session.name || 'Untitled'}`,
+      };
+    })
+    .sort((a, b) => {
+      const pinnedDiff = pinnedAtTime(b.session) - pinnedAtTime(a.session);
+      if (pinnedDiff !== 0) return pinnedDiff;
+      return a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
+    });
+}

--- a/main/src/daemon/remotePwaBrowserRuntime.test.ts
+++ b/main/src/daemon/remotePwaBrowserRuntime.test.ts
@@ -337,7 +337,7 @@ describe('Remote PWA browser runtime', () => {
       return new Response(JSON.stringify({
         ok: true,
         result: body.channel === 'sessions:toggle-favorite'
-          ? { success: true, data: { isFavorite: true } }
+          ? { success: true, data: { isFavorite: true, favoritePinnedAt: '2026-01-03T00:00:00.000Z' } }
           : { success: true },
       }), {
         headers: { 'Content-Type': 'application/json' },
@@ -354,7 +354,10 @@ describe('Remote PWA browser runtime', () => {
       transport: 'http+sse',
     });
 
-    await expect(adapter.toggleFavorite('session-1')).resolves.toEqual({ isFavorite: true });
+    await expect(adapter.toggleFavorite('session-1')).resolves.toEqual({
+      isFavorite: true,
+      favoritePinnedAt: '2026-01-03T00:00:00.000Z',
+    });
     await expect(adapter.archiveSession('session-1')).resolves.toBeUndefined();
 
     expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -903,6 +903,22 @@ export class DatabaseService {
       console.log("[Database] Added is_favorite column to sessions table");
     }
 
+    const hasFavoritePinnedAtColumn = sessionTableInfoFavorite.some(
+      (col: SqliteTableInfo) => col.name === "favorite_pinned_at",
+    );
+
+    if (!hasFavoritePinnedAtColumn) {
+      this.db
+        .prepare("ALTER TABLE sessions ADD COLUMN favorite_pinned_at DATETIME")
+        .run();
+      this.db
+        .prepare(
+          "UPDATE sessions SET favorite_pinned_at = created_at WHERE is_favorite = 1 AND favorite_pinned_at IS NULL",
+        )
+        .run();
+      console.log("[Database] Added favorite_pinned_at column to sessions table");
+    }
+
     // Add auto_commit column to sessions table if it doesn't exist
     const hasAutoCommitColumn = sessionTableInfoFavorite.some(
       (col: SqliteTableInfo) => col.name === "auto_commit",
@@ -1099,6 +1115,7 @@ export class DatabaseService {
             is_main_repo BOOLEAN DEFAULT 0,
             display_order INTEGER,
             is_favorite BOOLEAN DEFAULT 0,
+            favorite_pinned_at DATETIME,
             folder_id TEXT REFERENCES folders(id) ON DELETE SET NULL,
             auto_commit BOOLEAN DEFAULT 1
           )
@@ -2957,6 +2974,14 @@ export class DatabaseService {
       updates.push("is_favorite = ?");
       values.push(data.is_favorite ? 1 : 0);
     }
+    if (data.favorite_pinned_at !== undefined) {
+      if (data.favorite_pinned_at === "CURRENT_TIMESTAMP") {
+        updates.push("favorite_pinned_at = CURRENT_TIMESTAMP");
+      } else {
+        updates.push("favorite_pinned_at = ?");
+        values.push(data.favorite_pinned_at);
+      }
+    }
     if (data.skip_continue_next !== undefined) {
       updates.push("skip_continue_next = ?");
       const boolValue = data.skip_continue_next ? 1 : 0;
@@ -2976,11 +3001,16 @@ export class DatabaseService {
 
     // Only update the updated_at timestamp if we're changing something other than is_favorite, skip_continue_next, or pr_renamed
     // This prevents the session from showing as "unviewed" when just toggling these settings
-    const isOnlyToggleUpdate =
-      updates.length === 1 &&
-      (updates[0] === "is_favorite = ?" ||
-        updates[0] === "skip_continue_next = ?" ||
-        updates[0] === "pr_renamed = ?");
+    const toggleOnlyFields = new Set([
+      "is_favorite = ?",
+      "favorite_pinned_at = ?",
+      "favorite_pinned_at = CURRENT_TIMESTAMP",
+      "skip_continue_next = ?",
+      "pr_renamed = ?",
+    ]);
+    const isOnlyToggleUpdate = updates.every((update) =>
+      toggleOnlyFields.has(update),
+    );
     if (!isOnlyToggleUpdate) {
       updates.push("updated_at = CURRENT_TIMESTAMP");
     }

--- a/main/src/database/migrations/add_favorite_support.sql
+++ b/main/src/database/migrations/add_favorite_support.sql
@@ -1,2 +1,6 @@
 -- Add favorite support to sessions
 ALTER TABLE sessions ADD COLUMN is_favorite BOOLEAN DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN favorite_pinned_at DATETIME;
+UPDATE sessions
+SET favorite_pinned_at = created_at
+WHERE is_favorite = 1 AND favorite_pinned_at IS NULL;

--- a/main/src/database/models.ts
+++ b/main/src/database/models.ts
@@ -74,6 +74,7 @@ export interface Session {
   is_main_repo?: boolean;
   display_order?: number;
   is_favorite?: boolean;
+  favorite_pinned_at?: string | null;
   tool_type?: "claude" | "none";
   base_commit?: string;
   base_branch?: string;
@@ -125,6 +126,7 @@ export interface UpdateSessionData {
   claude_session_id?: string;
   run_started_at?: string;
   is_favorite?: boolean;
+  favorite_pinned_at?: string | null;
   skip_continue_next?: boolean;
   pr_renamed?: boolean;
 }

--- a/main/src/database/schema.sql
+++ b/main/src/database/schema.sql
@@ -24,7 +24,9 @@ CREATE TABLE IF NOT EXISTS sessions (
   exit_code INTEGER,
   pid INTEGER,
   claude_session_id TEXT,
-  project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE
+  project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+  is_favorite BOOLEAN DEFAULT 0,
+  favorite_pinned_at DATETIME
 );
 
 -- Session outputs table to store terminal output history

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -1319,7 +1319,10 @@ export function registerSessionHandlers(
       const newFavoriteStatus = !currentSession.is_favorite;
       console.log('[IPC] Toggling favorite status to:', newFavoriteStatus);
       
-      const updatedSession = databaseService.updateSession(sessionId, { is_favorite: newFavoriteStatus });
+      const updatedSession = databaseService.updateSession(sessionId, {
+        is_favorite: newFavoriteStatus,
+        favorite_pinned_at: newFavoriteStatus ? 'CURRENT_TIMESTAMP' : null,
+      });
       if (!updatedSession) {
         console.error('[IPC] Failed to update session in database');
         return { success: false, error: 'Failed to update session' };
@@ -1331,13 +1334,14 @@ export function registerSessionHandlers(
       const session = sessionManager.getSession(sessionId);
       if (session) {
         session.isFavorite = newFavoriteStatus;
+        session.favoritePinnedAt = updatedSession.favorite_pinned_at ?? undefined;
         console.log('[IPC] Emitting session-updated event with favorite status:', session.isFavorite);
         sessionManager.emit('session-updated', session);
       } else {
         console.warn('[IPC] Session not found in session manager:', sessionId);
       }
 
-      return { success: true, data: { isFavorite: newFavoriteStatus } };
+      return { success: true, data: { isFavorite: newFavoriteStatus, favoritePinnedAt: updatedSession.favorite_pinned_at } };
     } catch (error) {
       console.error('Failed to toggle favorite status:', error);
       if (error instanceof Error) {

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -244,6 +244,7 @@ export class SessionManager extends EventEmitter {
       folderId: dbSession.folder_id,
       displayOrder: dbSession.display_order, // Include displayOrder for proper sorting
       isFavorite: dbSession.is_favorite,
+      favoritePinnedAt: dbSession.favorite_pinned_at ?? undefined,
       // Model is now managed at panel level
       toolType: normalizedToolType,
       archived: dbSession.archived || false,

--- a/main/src/types/session.ts
+++ b/main/src/types/session.ts
@@ -20,6 +20,7 @@ export interface Session {
   projectId?: number;
   folderId?: string;
   isFavorite?: boolean;
+  favoritePinnedAt?: string;
   model?: string;
   toolType?: 'claude' | 'none';
   archived?: boolean;


### PR DESCRIPTION
## Summary
- Make Cmd/Ctrl+Up and Cmd/Ctrl+Down follow the same visible sidebar ordering used by the project/session list.
- Centralize sidebar session ordering so the UI and keyboard shortcuts share one grouping/flattening path.
- Refresh hotkey project ordering after project drag reorder succeeds.
- Track when sessions are pinned and order pinned lists by newest pin first, with migration/backfill for existing pinned sessions.

## Root cause
The visible sidebar and keyboard navigation had separate ordering implementations. Project drag reorder updated the visible list state, but the always-mounted hotkey state could keep an older project order. Pinned navigation also used a separate alphabetical/pinned-only order, so shortcuts could diverge from what the user saw.

## Testing
- pnpm --filter frontend test -- src/utils/sessionOrdering.test.ts
- pnpm --filter main exec vitest run src/daemon/remotePwaBrowserRuntime.test.ts
- pnpm typecheck
- pnpm lint
- git diff --check

Note: local Node is v20.19.3 while the repo declares >=22.14.0; pnpm emitted engine warnings, but the checks above passed.
