### PR TITLE
docs: keep fallback installers visible in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@
 <br />
 <br />
 
-<details>
-<summary><sub>Other install methods</sub></summary>
-<br />
+**Package-manager alternatives**
 
 <sub>pnpm</sub><br />
 <pre><code>pnpm dlx runpane@latest</code></pre>
@@ -46,11 +44,15 @@
 <pre><code>npm i -g runpane
 runpane setup</code></pre>
 
+**Shell installers**
+
 <sub>Mac / Linux shell installer</sub><br />
 <pre><code>curl -fsSL https://runpane.com/install.sh | sh</code></pre>
 
 <sub>Windows PowerShell installer</sub><br />
 <pre><code>irm https://runpane.com/install.ps1 | iex</code></pre>
+
+**Direct downloads**
 
 <a href="https://runpane.com/api/download?platform=mac&source=readme">
   <img src="https://img.shields.io/badge/Download_for_macOS-000?style=for-the-badge&logo=apple&logoColor=white" height="40" alt="Download for macOS">
@@ -61,8 +63,6 @@ runpane setup</code></pre>
 <a href="https://runpane.com/api/download?platform=linux&source=readme">
   <img src="https://img.shields.io/badge/Download_for_Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" height="40" alt="Download for Linux">
 </a>
-
-</details>
 
 <br />
 <br />
@@ -204,7 +204,7 @@ npx --yes runpane@latest
 The wizard can install Pane on this machine, configure this machine as a remote
 host, update Pane, or run diagnostics.
 
-### Advanced Install Methods
+### Package Manager Commands
 
 Explicit desktop install:
 
@@ -220,6 +220,8 @@ Persistent npm install:
 npm i -g runpane
 runpane setup
 ```
+
+### Shell Installers
 
 Mac / Linux shell installer:
 

--- a/packages/runpane-py/README.md
+++ b/packages/runpane-py/README.md
@@ -95,6 +95,22 @@ PyPI package downloads use `source=pip` when requesting release artifacts from
 `runpane.com/api/download`. If that route is unavailable, the CLI falls back to
 matching GitHub release assets and prints a warning.
 
+## Maintenance Notes
+
+Keep the npm and PyPI clients in sync with each Pane release. When changing
+shared installer behavior:
+
+- If release asset names or platforms change, update both npm and PyPI wrapper
+  artifact matching.
+- If `runpane` CLI behavior changes, update both clients and the shared smoke
+  tests.
+- If the website `/api/download` contract changes, verify npm and PyPI fallback
+  behavior.
+- If daemon setup flags change, update docs, README files, and wrapper tests
+  together.
+- Keep the CI wrapper matrix green: Linux, macOS, Windows, Node 18/22, and
+  Python 3.8/3.13.
+
 ## Publishing
 
 This package should be published through PyPI Trusted Publishing from GitHub

--- a/packages/runpane/README.md
+++ b/packages/runpane/README.md
@@ -97,6 +97,22 @@ npm package downloads use `source=npm` when requesting release artifacts from
 `runpane.com/api/download`. If that route is unavailable, the CLI falls back to
 matching GitHub release assets and prints a warning.
 
+## Maintenance Notes
+
+Keep the npm and PyPI clients in sync with each Pane release. When changing
+shared installer behavior:
+
+- If release asset names or platforms change, update both npm and PyPI wrapper
+  artifact matching.
+- If `runpane` CLI behavior changes, update both clients and the shared smoke
+  tests.
+- If the website `/api/download` contract changes, verify npm and PyPI fallback
+  behavior.
+- If daemon setup flags change, update docs, README files, and wrapper tests
+  together.
+- Keep the CI wrapper matrix green: Linux, macOS, Windows, Node 18/22, and
+  Python 3.8/3.13.
+
 ## Publishing
 
 This package should be published through npm Trusted Publishing from GitHub


### PR DESCRIPTION
## Summary

- keep the `npx --yes runpane@latest` quick install as the recommended README path
- make package-manager alternatives, shell installers, and direct download badges visible instead of hiding them in a collapsed block
- split the Installation section so shell installers are not labeled as advanced package-manager methods
- add client maintenance notes to both npm and PyPI package READMEs so wrapper sync rules stay visible

## Testing

- `git diff --check`
- checked edited README HTML structure for balanced top-level blocks/code snippets

Note: the local pre-commit hook attempted the full workspace typecheck, but this fresh docs worktree has no installed dependencies and the shell is on Node 20 while the repo requires Node 22. This PR is README-only; no code paths changed.