### PR TITLE
Add start pinned option for new panes

### DIFF
--- a/docs/SELF_HOSTED_REMOTE_DAEMON.md
+++ b/docs/SELF_HOSTED_REMOTE_DAEMON.md
@@ -120,6 +120,10 @@ For Android, open the URL in Chrome, open the browser menu, then tap `Add to Hom
 
 SSH tunnel mode is mainly useful from desktop clients. For mobile browser access, prefer Tailscale or Manual HTTPS so the phone can reach the daemon URL directly.
 
+### Remote PWA Implementation Notes
+
+The Remote Pane PWA is a browser runtime. It does not have `window.electronAPI`, so client-side PWA preferences must use browser-safe storage such as `localStorage` or explicit daemon adapter calls. Do not reuse desktop renderer preference stores that persist through Electron IPC unless the call path is guarded for browser mode.
+
 ## Security Model
 
 - The daemon listener only supports loopback hosts: `127.0.0.1`, `::1`, or `localhost`.

--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -3,7 +3,7 @@ import { API } from '../utils/api';
 import type { CreateSessionRequest } from '../types/session';
 import type { Project } from '../types/project';
 import { useErrorStore } from '../stores/errorStore';
-import { GitBranch, ChevronRight, ChevronDown, X, Search, Check, GitFork } from 'lucide-react';
+import { GitBranch, ChevronRight, ChevronDown, X, Search, Check, GitFork, Pin } from 'lucide-react';
 import { ToggleField } from './ui/Toggle';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
@@ -55,6 +55,7 @@ export function CreateSessionDialog({
   const [branches, setBranches] = useState<BranchInfo[]>([]);
   const [isLoadingBranches, setIsLoadingBranches] = useState(false);
   const [useWorktree, setUseWorktree] = useState(true);
+  const [startPinned, setStartPinned] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showSessionOptions, setShowSessionOptions] = useState(false);
   const [branchSearch, setBranchSearch] = useState('');
@@ -91,6 +92,7 @@ export function CreateSessionDialog({
     if (preferences) {
       setShowAdvanced(preferences.showAdvanced);
       setShowSessionOptions(preferences.showSessionOptions ?? false);
+      setStartPinned(preferences.startPinned ?? false);
     }
   }, [preferences]);
 
@@ -372,7 +374,8 @@ export function CreateSessionDialog({
         sessionName: cleanedName,
         count: sessionCount,
         toolType: 'none',
-        folderId
+        folderId,
+        startPinned
       });
 
       const response = await API.sessions.create({
@@ -384,7 +387,8 @@ export function CreateSessionDialog({
         projectId,
         folderId,
         isMainRepo: !useWorktree,
-        baseBranch: formData.baseBranch
+        baseBranch: formData.baseBranch,
+        startPinned
       });
 
       if (!response.success) {
@@ -642,6 +646,21 @@ export function CreateSessionDialog({
             {/* Advanced Options - Collapsible */}
             {showAdvanced && (
               <div className="px-6 pb-6 space-y-4 border-t border-border-primary pt-4">
+                {/* Start Pinned Toggle */}
+                <div className="flex items-center gap-2">
+                  <Pin className="w-4 h-4 text-text-tertiary" />
+                  <ToggleField
+                    label="Start pinned"
+                    description="Show this pane in the pinned section immediately."
+                    checked={startPinned}
+                    onChange={(checked) => {
+                      setStartPinned(checked);
+                      savePreferences({ startPinned: checked });
+                    }}
+                    size="sm"
+                  />
+                </div>
+
                 {/* Worktree Toggle */}
                 <div className="flex items-center gap-2">
                   <GitFork className="w-4 h-4 text-text-tertiary" />

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -1,6 +1,13 @@
-import { ChevronDown, GitBranch, GitFork, Search, X } from 'lucide-react';
+import { ChevronDown, GitBranch, GitFork, Pin, Search, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import type { RemoteBranchInfo, RemoteProjectWithSessions, RemoteRuntimeAdapter } from '../runtime/remoteRuntimeAdapter';
+
+/**
+ * Remote Pane runs as a browser PWA, not inside Electron. Keep create-dialog
+ * preferences on browser-safe storage or daemon adapter calls; do not use the
+ * desktop session preference store because it writes through window.electronAPI.
+ */
+const REMOTE_START_PINNED_PREFERENCE_KEY = 'pane.remoteCreateSession.startPinned';
 
 interface RemoteCreateSessionDialogProps {
   adapter: RemoteRuntimeAdapter;
@@ -20,6 +27,7 @@ export function RemoteCreateSessionDialog({
   const [paneName, setPaneName] = useState('');
   const [branchSearch, setBranchSearch] = useState('');
   const [useWorktree, setUseWorktree] = useState(true);
+  const [startPinned, setStartPinned] = useState(() => loadRemoteStartPinnedPreference());
   const [loadingBranches, setLoadingBranches] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -126,6 +134,7 @@ export function RemoteCreateSessionDialog({
         projectId: project.id,
         isMainRepo: !useWorktree,
         baseBranch,
+        startPinned,
       });
       await onCreated(cleanedName);
       onClose();
@@ -232,6 +241,32 @@ export function RemoteCreateSessionDialog({
             <p className="mt-2 text-xs text-text-tertiary">Auto-filled from branch. Edit to customize.</p>
           </section>
 
+          <section className="border-b border-border-primary p-5">
+            <label className="flex items-center justify-between gap-4">
+              <span className="flex min-w-0 gap-3">
+                <Pin className="mt-1 h-4 w-4 shrink-0 text-text-tertiary" />
+                <span className="min-w-0">
+                  <span className="block text-sm font-semibold text-text-primary">Start pinned</span>
+                  <span className="mt-1 block text-sm text-text-secondary">Show this pane in the pinned section immediately.</span>
+                </span>
+              </span>
+              <span className={`relative h-7 w-12 shrink-0 rounded-full transition-colors ${startPinned ? 'bg-interactive' : 'bg-surface-tertiary'}`}>
+                <input
+                  type="checkbox"
+                  checked={startPinned}
+                  onChange={(event) => {
+                    const checked = event.target.checked;
+                    setStartPinned(checked);
+                    saveRemoteStartPinnedPreference(checked);
+                  }}
+                  className="peer sr-only"
+                  aria-label="Start pinned"
+                />
+                <span className={`absolute top-1 h-5 w-5 rounded-full bg-text-primary transition-transform ${startPinned ? 'translate-x-6' : 'translate-x-1'}`} />
+              </span>
+            </label>
+          </section>
+
           <section className="p-5">
             <label className="flex items-center justify-between gap-4">
               <span className="flex min-w-0 gap-3">
@@ -302,4 +337,22 @@ function sanitizePaneName(name: string): string {
     .replace(/\.{2,}/g, '.')
     .replace(/^\.+|\.+$/g, '')
     .trim();
+}
+
+function loadRemoteStartPinnedPreference(): boolean {
+  try {
+    return typeof window !== 'undefined' && window.localStorage.getItem(REMOTE_START_PINNED_PREFERENCE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function saveRemoteStartPinnedPreference(value: boolean): void {
+  try {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(REMOTE_START_PINNED_PREFERENCE_KEY, value ? 'true' : 'false');
+    }
+  } catch {
+    // Ignore storage failures so the current create flow can still use local state.
+  }
 }

--- a/frontend/src/stores/sessionPreferencesStore.ts
+++ b/frontend/src/stores/sessionPreferencesStore.ts
@@ -14,6 +14,7 @@ export interface SessionCreationPreferences {
   };
   showAdvanced: boolean;
   showSessionOptions: boolean;
+  startPinned: boolean;
   baseBranch?: string;
 }
 
@@ -29,7 +30,8 @@ const defaultPreferences: SessionCreationPreferences = {
     ultrathink: false
   },
   showAdvanced: false,
-  showSessionOptions: false
+  showSessionOptions: false,
+  startPinned: false
 };
 
 interface SessionPreferencesStore {

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -101,6 +101,7 @@ export interface AppConfig {
       ultrathink?: boolean;
     };
     showAdvanced?: boolean;
+    startPinned?: boolean;
     baseBranch?: string;
   };
   // Pane commit footer setting (enabled by default)

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -141,6 +141,7 @@ export interface CreateSessionRequest {
   folderId?: string;
   isMainRepo?: boolean;
   baseBranch?: string;
+  startPinned?: boolean;
   toolType?: 'claude' | 'none';
   claudeConfig?: {
     model?: string;

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -2833,8 +2833,8 @@ export class DatabaseService {
       this.db
         .prepare(
           `
-        INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path, status, project_id, folder_id, permission_mode, is_main_repo, display_order, tool_type, base_commit, base_branch)
-        VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO sessions (id, name, initial_prompt, worktree_name, worktree_path, status, project_id, folder_id, permission_mode, is_main_repo, display_order, tool_type, base_commit, base_branch, is_favorite, favorite_pinned_at)
+        VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, CASE WHEN ? = 'CURRENT_TIMESTAMP' THEN CURRENT_TIMESTAMP WHEN ? = 1 AND ? IS NULL THEN CURRENT_TIMESTAMP ELSE ? END)
       `,
         )
         .run(
@@ -2851,6 +2851,11 @@ export class DatabaseService {
           data.tool_type || "claude",
           data.base_commit || null,
           data.base_branch || null,
+          data.is_favorite ? 1 : 0,
+          data.favorite_pinned_at || null,
+          data.is_favorite ? 1 : 0,
+          data.favorite_pinned_at || null,
+          data.favorite_pinned_at || null,
         );
 
       const session = this.getSession(data.id);

--- a/main/src/database/models.ts
+++ b/main/src/database/models.ts
@@ -113,6 +113,8 @@ export interface CreateSessionData {
   tool_type?: "claude" | "none";
   base_commit?: string;
   base_branch?: string;
+  is_favorite?: boolean;
+  favorite_pinned_at?: string;
 }
 
 export interface UpdateSessionData {

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -209,7 +209,8 @@ export function registerSessionHandlers(
           request.baseBranch,
           sessionToolType,
           request.folderId,
-          request.isMainRepo
+          request.isMainRepo,
+          request.startPinned
         );
 
         return { success: true, data: { jobIds: jobs.map(job => job.id) } };
@@ -222,7 +223,8 @@ export function registerSessionHandlers(
           folderId: request.folderId,
           isMainRepo: request.isMainRepo,
           baseBranch: request.baseBranch,
-          toolType: sessionToolType
+          toolType: sessionToolType,
+          startPinned: request.startPinned
         });
 
         return { success: true, data: { jobId: job.id } };

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -373,7 +373,8 @@ export class ConfigManager extends EventEmitter {
         permissionMode: 'ignore',
         ultrathink: false
       },
-      showAdvanced: false
+      showAdvanced: false,
+      startPinned: false
     };
   }
 

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -305,7 +305,8 @@ export class SessionManager extends EventEmitter {
     folderId?: string,
     toolType?: 'claude' | 'none',
     baseCommit?: string,
-    baseBranch?: string
+    baseBranch?: string,
+    startPinned?: boolean
   ): Promise<Session> {
     return await withLock(`session-creation`, async () => {
       return this.createSessionWithId(
@@ -320,7 +321,8 @@ export class SessionManager extends EventEmitter {
         folderId,
         toolType,
         baseCommit,
-        baseBranch
+        baseBranch,
+        startPinned
       );
     });
   }
@@ -337,7 +339,8 @@ export class SessionManager extends EventEmitter {
     folderId?: string,
     toolType?: 'claude' | 'none',
     baseCommit?: string,
-    baseBranch?: string
+    baseBranch?: string,
+    startPinned?: boolean
   ): Session {
     // Ensure this session ID isn't already being created
     if (this.activeSessions.has(id) || this.db.getSession(id)) {
@@ -375,7 +378,9 @@ export class SessionManager extends EventEmitter {
       // Model is now managed at panel level
       base_commit: baseCommit,
       base_branch: baseBranch,
-      tool_type: toolType
+      tool_type: toolType,
+      is_favorite: startPinned,
+      favorite_pinned_at: startPinned ? 'CURRENT_TIMESTAMP' : undefined
     };
 
     const dbSession = this.db.createSession(sessionData);

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -39,6 +39,7 @@ interface CreateSessionJob {
   isMainRepo?: boolean;
   baseBranch?: string;
   toolType?: 'claude' | 'none';
+  startPinned?: boolean;
 }
 
 interface ContinueSessionJob {
@@ -156,7 +157,7 @@ export class TaskQueue {
     const sessionConcurrency = isLinux ? 1 : 5;
     
     this.sessionQueue.process(sessionConcurrency, async (job) => {
-      const { prompt, worktreeTemplate, index, permissionMode, projectId, baseBranch, toolType } = job.data;
+      const { prompt, worktreeTemplate, index, permissionMode, projectId, baseBranch, toolType, startPinned } = job.data;
       const { sessionManager, worktreeManager, claudeCodeManager } = this.options;
 
       // Processing session creation job - verbose debug logging removed
@@ -244,7 +245,8 @@ export class TaskQueue {
           job.data.folderId,
           toolType,
           baseCommit,
-          actualBaseBranch
+          actualBaseBranch,
+          startPinned
         );
 
         // Only add prompt-related data if there's actually a prompt
@@ -504,7 +506,8 @@ export class TaskQueue {
     baseBranch?: string,
     toolType?: 'claude' | 'none',
     providedFolderId?: string,
-    isMainRepo?: boolean
+    isMainRepo?: boolean,
+    startPinned?: boolean
   ): Promise<(Bull.Job<CreateSessionJob> | { id: string; data: CreateSessionJob; status: string })[]> {
     let folderId: string | undefined = providedFolderId;
     let generatedBaseName: string | undefined;
@@ -551,7 +554,7 @@ export class TaskQueue {
     for (let i = 0; i < count; i++) {
       // Use the generated base name if no template was provided
       const templateToUse = worktreeTemplate || generatedBaseName || '';
-      jobs.push(this.sessionQueue.add({ prompt, worktreeTemplate: templateToUse, index: i, permissionMode, projectId, folderId, isMainRepo, baseBranch, toolType }));
+      jobs.push(this.sessionQueue.add({ prompt, worktreeTemplate: templateToUse, index: i, permissionMode, projectId, folderId, isMainRepo, baseBranch, toolType, startPinned }));
     }
     return Promise.all(jobs);
   }

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -101,6 +101,7 @@ export interface AppConfig {
       ultrathink?: boolean;
     };
     showAdvanced?: boolean;
+    startPinned?: boolean;
     baseBranch?: string;
   };
   // Pane commit footer setting (enabled by default)
@@ -166,6 +167,7 @@ export interface UpdateConfigRequest {
       ultrathink?: boolean;
     };
     showAdvanced?: boolean;
+    startPinned?: boolean;
     baseBranch?: string;
   };
   enableCommitFooter?: boolean;

--- a/main/src/types/session.ts
+++ b/main/src/types/session.ts
@@ -67,6 +67,7 @@ export interface CreateSessionRequest {
   folderId?: string;
   isMainRepo?: boolean;
   baseBranch?: string;
+  startPinned?: boolean;
   model?: string;
   toolType?: 'claude' | 'none';
   claudeConfig?: {


### PR DESCRIPTION
## Summary
- add a remembered Start pinned toggle to local and remote new-pane dialogs
- persist the last Start pinned choice in session creation preferences
- set pinned session metadata during creation so new panes appear pinned immediately

## Testing
- pnpm typecheck
- pnpm lint (passes with existing warning-only lint baseline)
- pnpm --filter main exec vitest run src/daemon/remotePwaBrowserRuntime.test.ts
- pnpm build (frontend/main build completed; Electron packaging failed locally during native rebuild because this machine is linux arm64 while node-gyp invoked x64 -m64 for msgpackr-extract)

## Notes
- No DB migration required; this uses existing is_favorite and favorite_pinned_at columns.
- Local shell uses Node v20.19.3 while the repo declares >=22.14.0, so commands emit engine warnings.