### PR TITLE
Fix website release dispatch target

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -9,9 +9,9 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch to foozol-website
+      - name: Dispatch to runpane-website
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.SITE_REPO_DISPATCH_TOKEN }}
-          repository: parsakhaz/foozol-website
+          repository: parsakhaz/runpane-website
           event-type: pane-release


### PR DESCRIPTION
## Summary
- update the release website notification workflow to dispatch to the canonical runpane website repository
- rename the workflow step so logs point at the current target

## Root cause
The workflow still targeted the renamed `parsakhaz/foozol-website` repository. After upgrading to `peter-evans/repository-dispatch@v4`, the dispatch POST failed while following that repository redirect with `Request body length does not match content-length header`.

## Validation
- `git diff --check`
- pre-commit `pnpm run -r typecheck`
- pre-commit `pnpm run -r lint` (existing warnings only)
- manual workflow dispatch succeeded: https://github.com/dcouple/Pane/actions/runs/27812875075