### PR TITLE
Improve startup performance modes and git status caching

### DIFF
--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -157,6 +157,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [usePtyHost, setUsePtyHost] = useState(false);
   const [initialUsePtyHost, setInitialUsePtyHost] = useState(false);
   const [terminalPowerMode, setTerminalPowerMode] = useState<PreferredTerminalPowerMode>('performance');
+  const [initialTerminalPowerMode, setInitialTerminalPowerMode] = useState<PreferredTerminalPowerMode>('performance');
   const [additionalPathsText, setAdditionalPathsText] = useState('');
   const [platform, setPlatform] = useState<string>('darwin');
   const [enableCommitFooter, setEnableCommitFooter] = useState(true);
@@ -285,7 +286,11 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
       setDevMode(data.devMode || false);
       setUsePtyHost(data.usePtyHost === true);
       setInitialUsePtyHost(data.usePtyHost === true);
-      setTerminalPowerMode(data.terminalPowerMode === 'batterySaver' ? 'batterySaver' : 'performance');
+      {
+        const loadedTerminalPowerMode = data.terminalPowerMode === 'batterySaver' ? 'batterySaver' : 'performance';
+        setTerminalPowerMode(loadedTerminalPowerMode);
+        setInitialTerminalPowerMode(loadedTerminalPowerMode);
+      }
       setClaudeExecutablePath(data.claudeExecutablePath || '');
       setEnableCommitFooter(data.enableCommitFooter !== false); // Default to true
       setManagedAgentsMd(data.agentContext?.managedAgentsMd !== false); // Default to true
@@ -2808,7 +2813,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                     >
                       <div className="text-sm font-medium">Performance</div>
                       <div className="text-xs text-text-tertiary mt-1">
-                        Keep mounted terminals live for best scrollback and instant resume. Uses more battery.
+                        Keep mounted terminals live and let Electron or the OS choose the best GPU. Uses more battery.
                       </div>
                     </button>
                     <button
@@ -2822,10 +2827,15 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                     >
                       <div className="text-sm font-medium">Battery Saver</div>
                       <div className="text-xs text-text-tertiary mt-1">
-                        Suspend inactive or unfocused terminal rendering. May replay scrollback when shown.
+                        Suspend inactive rendering and prefer the low-power GPU where available. Large workspaces may take longer to refresh after startup.
                       </div>
                     </button>
                   </div>
+                  {terminalPowerMode !== initialTerminalPowerMode && (
+                    <p className="text-xs text-status-warning mt-2">
+                      Restart Pane for the GPU preference change to take effect.
+                    </p>
+                  )}
                 </div>
               </SettingsSection>
 

--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -166,7 +166,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
     skipValidation: true,
   });
   const gitDiffManager = new GitDiffManager(logger, analyticsManager);
-  const gitStatusManager = new GitStatusManager(sessionManager, worktreeManager, gitDiffManager, logger);
+  const gitStatusManager = new GitStatusManager(sessionManager, worktreeManager, gitDiffManager, logger, databaseService);
   const executionTracker = new ExecutionTracker(sessionManager, gitDiffManager);
   const worktreeNameGenerator = new WorktreeNameGenerator(configManager);
   const runCommandManager = new RunCommandManager(databaseService);

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -21,6 +21,7 @@ import type {
   ToolPanelState,
   ToolPanelMetadata,
 } from "../../../shared/types/panels";
+import type { GitStatus } from "../types/session";
 
 // Interface for legacy claude_panel_settings during migration
 interface ClaudePanelSetting {
@@ -61,6 +62,12 @@ interface ExecutionDiffRow {
   after_commit_hash?: string;
   commit_message?: string;
   timestamp: string;
+}
+
+interface SessionGitStatusCacheRow {
+  session_id: string;
+  status_json: string;
+  last_checked_ms: number;
 }
 
 const DEBUG_DB_PANEL_STATE = process.env.PANE_DEBUG_DB_PANEL_STATE === "1";
@@ -2886,6 +2893,67 @@ export class DatabaseService {
         "SELECT * FROM sessions WHERE (archived = 0 OR archived IS NULL) AND (is_main_repo = 0 OR is_main_repo IS NULL) ORDER BY display_order ASC, created_at DESC",
       )
       .all() as Session[];
+  }
+
+  getAllSessionGitStatusCache(): Array<{ sessionId: string; gitStatus: GitStatus; lastChecked: number }> {
+    const rows = this.db
+      .prepare("SELECT session_id, status_json, last_checked_ms FROM session_git_status_cache")
+      .all() as SessionGitStatusCacheRow[];
+
+    return rows.flatMap((row) => {
+      try {
+        return [{
+          sessionId: row.session_id,
+          gitStatus: JSON.parse(row.status_json) as GitStatus,
+          lastChecked: row.last_checked_ms,
+        }];
+      } catch {
+        return [];
+      }
+    });
+  }
+
+  getSessionGitStatusCache(sessionId: string): { gitStatus: GitStatus; lastChecked: number } | null {
+    const row = this.db
+      .prepare("SELECT status_json, last_checked_ms FROM session_git_status_cache WHERE session_id = ?")
+      .get(sessionId) as Pick<SessionGitStatusCacheRow, "status_json" | "last_checked_ms"> | undefined;
+
+    if (!row) return null;
+
+    try {
+      return {
+        gitStatus: JSON.parse(row.status_json) as GitStatus,
+        lastChecked: row.last_checked_ms,
+      };
+    } catch {
+      this.deleteSessionGitStatusCache(sessionId);
+      return null;
+    }
+  }
+
+  saveSessionGitStatusCache(sessionId: string, gitStatus: GitStatus, lastChecked = Date.now()): void {
+    this.db
+      .prepare(
+        `
+        INSERT INTO session_git_status_cache (session_id, status_json, last_checked_ms, updated_at)
+        VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+        ON CONFLICT(session_id) DO UPDATE SET
+          status_json = excluded.status_json,
+          last_checked_ms = excluded.last_checked_ms,
+          updated_at = CURRENT_TIMESTAMP
+      `,
+      )
+      .run(sessionId, JSON.stringify(gitStatus), lastChecked);
+  }
+
+  deleteSessionGitStatusCache(sessionId: string): void {
+    this.db
+      .prepare("DELETE FROM session_git_status_cache WHERE session_id = ?")
+      .run(sessionId);
+  }
+
+  clearSessionGitStatusCache(): void {
+    this.db.prepare("DELETE FROM session_git_status_cache").run();
   }
 
   getAllSessionsIncludingArchived(): Session[] {

--- a/main/src/database/schema.sql
+++ b/main/src/database/schema.sql
@@ -49,9 +49,19 @@ CREATE TABLE IF NOT EXISTS conversation_messages (
   FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
 );
 
+-- Derived git status cache for fast startup rendering.
+CREATE TABLE IF NOT EXISTS session_git_status_cache (
+  session_id TEXT PRIMARY KEY,
+  status_json TEXT NOT NULL,
+  last_checked_ms INTEGER NOT NULL,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
 -- Index for faster lookups
 CREATE INDEX IF NOT EXISTS idx_session_outputs_session_id ON session_outputs(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_outputs_timestamp ON session_outputs(timestamp);
 CREATE INDEX IF NOT EXISTS idx_conversation_messages_session_id ON conversation_messages(session_id);
 CREATE INDEX IF NOT EXISTS idx_conversation_messages_timestamp ON conversation_messages(timestamp);
 CREATE INDEX IF NOT EXISTS idx_sessions_project_id ON sessions(project_id);
+CREATE INDEX IF NOT EXISTS idx_session_git_status_cache_updated_at ON session_git_status_cache(updated_at);

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -2,6 +2,9 @@
 import './polyfills/readablestream';
 
 import { hasHeadlessDaemonLaunchArg, hasRemoteSetupLaunchArg } from './utils/runtimeMode';
+import { getAppDirectory } from './utils/appDirectory';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 const launchHeadlessDaemon = hasHeadlessDaemonLaunchArg();
 const launchRemoteSetup = hasRemoteSetupLaunchArg();
@@ -9,6 +12,20 @@ const launchRemoteSetup = hasRemoteSetupLaunchArg();
 // Fix GTK 2/3 and GTK 4 conflict on Linux (Electron 36 issue)
 // This MUST be done before importing electron
 import { app } from 'electron';
+
+function getStartupTerminalPowerMode(): 'performance' | 'batterySaver' {
+  try {
+    const rawConfig = JSON.parse(
+      readFileSync(join(getAppDirectory(), 'config.json'), 'utf-8'),
+    ) as { terminalPowerMode?: unknown };
+
+    return rawConfig.terminalPowerMode === 'batterySaver'
+      ? 'batterySaver'
+      : 'performance';
+  } catch {
+    return 'performance';
+  }
+}
 
 if (process.platform === 'linux') {
   app.commandLine.appendSwitch('gtk-version', '3');
@@ -21,8 +38,9 @@ if (process.platform === 'linux') {
   }
 }
 
-// Force integrated GPU for better battery life on dual-GPU systems
-app.commandLine.appendSwitch('force_low_power_gpu');
+if (getStartupTerminalPowerMode() === 'batterySaver') {
+  app.commandLine.appendSwitch('force_low_power_gpu');
+}
 
 // Set Windows AUMID to match electron-builder's appId so Windows resolves
 // the installed Start Menu shortcut for notification icon and display name.
@@ -46,7 +64,7 @@ import type { ArchiveProgressManager } from './services/archiveProgressManager';
 import type { AnalyticsManager } from './services/analyticsManager';
 import { readWebAttribution, resolveAnalyticsIdentity } from './services/analyticsIdentity';
 import { resourceMonitorService } from './services/resourceMonitorService';
-import { applyAppDirectoryOverrideFromArgs, migrateDataDirectory, getAppDirectory } from './utils/appDirectory';
+import { applyAppDirectoryOverrideFromArgs, migrateDataDirectory } from './utils/appDirectory';
 import { getCurrentWorktreeName } from './utils/worktreeUtils';
 import { setupAutoUpdater } from './autoUpdater';
 import { getCloudVmManager } from './ipc/cloud';

--- a/main/src/services/__tests__/gitStatusManager.test.ts
+++ b/main/src/services/__tests__/gitStatusManager.test.ts
@@ -9,6 +9,7 @@ import type { Logger } from '../../utils/logger';
 import type { GitStatus } from '../../types/session';
 import type { GitIndexStatus } from '../gitPlumbingCommands';
 import type { CommandRunner } from '../../utils/commandRunner';
+import type { DatabaseService } from '../../database/database';
 
 // Type for accessing private members in tests
 interface GitStatusManagerPrivates {
@@ -18,7 +19,8 @@ interface GitStatusManagerPrivates {
     projectPath: string,
     commandRunner: CommandRunner
   ): Promise<{ prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string }>;
-  enrichWithPrData(sessionId: string): void;
+  enrichWithPrData(sessionId: string): Promise<void>;
+  updateCache(sessionId: string, status: GitStatus): void;
   cache: Record<string, { status: GitStatus; lastChecked: number }>;
   prCache: Map<string, { prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string; fetchedAt: number }>;
   activeSessionId: string | null;
@@ -80,6 +82,18 @@ describe('GitStatusManager', () => {
   let mockWorktreeManager: WorktreeManager;
   let mockGitDiffManager: GitDiffManager;
   let mockLogger: Logger;
+  let mockDatabaseService: Partial<Pick<
+    DatabaseService,
+    'getAllSessionGitStatusCache' |
+    'saveSessionGitStatusCache' |
+    'deleteSessionGitStatusCache' |
+    'clearSessionGitStatusCache'
+  >> & {
+    getAllSessionGitStatusCache: Mock;
+    saveSessionGitStatusCache: Mock;
+    deleteSessionGitStatusCache: Mock;
+    clearSessionGitStatusCache: Mock;
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -106,11 +120,19 @@ describe('GitStatusManager', () => {
       verbose: vi.fn(),
     } as Partial<Logger> as Logger;
 
+    mockDatabaseService = {
+      getAllSessionGitStatusCache: vi.fn().mockReturnValue([]),
+      saveSessionGitStatusCache: vi.fn(),
+      deleteSessionGitStatusCache: vi.fn(),
+      clearSessionGitStatusCache: vi.fn(),
+    };
+
     gitStatusManager = new GitStatusManager(
       mockSessionManager,
       mockWorktreeManager,
       mockGitDiffManager,
-      mockLogger
+      mockLogger,
+      mockDatabaseService as DatabaseService
     );
 
     // Default: no uncommitted changes, no ahead/behind
@@ -315,6 +337,42 @@ describe('GitStatusManager', () => {
     });
   });
 
+  describe('persistent cache', () => {
+    it('hydrates cached statuses from the database on construction', () => {
+      const cachedStatus: GitStatus = { state: 'ahead', ahead: 1, lastChecked: '2026-01-01T00:00:00.000Z' };
+      mockDatabaseService.getAllSessionGitStatusCache.mockReturnValue([
+        { sessionId: 'cached-session', gitStatus: cachedStatus, lastChecked: 1234 },
+      ]);
+
+      const manager = new GitStatusManager(
+        mockSessionManager,
+        mockWorktreeManager,
+        mockGitDiffManager,
+        mockLogger,
+        mockDatabaseService as DatabaseService,
+      );
+      const privates = manager as unknown as GitStatusManagerPrivates;
+
+      expect(privates.cache['cached-session']).toEqual({
+        status: cachedStatus,
+        lastChecked: 1234,
+      });
+    });
+
+    it('persists successful cache updates', () => {
+      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const status: GitStatus = { state: 'modified', hasUncommittedChanges: true };
+
+      privates.updateCache('test-session', status);
+
+      expect(mockDatabaseService.saveSessionGitStatusCache).toHaveBeenCalledWith(
+        'test-session',
+        status,
+        expect.any(Number),
+      );
+    });
+  });
+
   describe('PR enrichment', () => {
     it('caches PR misses for 20 seconds', async () => {
       const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
@@ -402,7 +460,7 @@ describe('GitStatusManager', () => {
       const updated = new Promise<GitStatus>((resolve) => {
         gitStatusManager.once('git-status-updated', (_sessionId, status) => resolve(status));
       });
-      privates.enrichWithPrData('test-session');
+      void privates.enrichWithPrData('test-session');
       const status = await updated;
 
       expect(mockProjectContext.commandRunner.exec).toHaveBeenCalledWith(

--- a/main/src/services/gitStatusManager.ts
+++ b/main/src/services/gitStatusManager.ts
@@ -5,6 +5,7 @@ import type { SessionManager } from './sessionManager';
 import type { WorktreeManager } from './worktreeManager';
 import type { GitDiffManager } from './gitDiffManager';
 import type { CommandRunner } from '../utils/commandRunner';
+import type { DatabaseService } from '../database/database';
 import { GitStatusLogger } from './gitStatusLogger';
 import { GitFileWatcher } from './gitFileWatcher';
 import { fastCheckWorkingDirectory, fastGetAheadBehind, fastGetDiffStats } from './gitPlumbingCommands';
@@ -44,6 +45,7 @@ export class GitStatusManager extends EventEmitter {
   private isInitialLoadInProgress = false;
   private initialLoadQueue: string[] = [];
   private readonly INITIAL_LOAD_DELAY_MS = 200; // Increased to 200ms for better staggering
+  private readonly INITIAL_LOAD_JITTER_MS = 2500;
 
   // Track active session and window visibility for optimized refreshes
   private activeSessionId: string | null = null;
@@ -53,12 +55,17 @@ export class GitStatusManager extends EventEmitter {
   private prCache = new Map<string, { prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string; fetchedAt: number }>();
   private readonly PR_HIT_CACHE_TTL = 2.5 * 60 * 1000;
   private readonly PR_MISS_CACHE_TTL = 20 * 1000;
+  private readonly PR_ENRICHMENT_JITTER_MS = 10_000;
+  private readonly MAX_CONCURRENT_PR_ENRICHMENT = 1;
+  private activePrEnrichmentOperations = 0;
+  private prEnrichmentTimers: Map<string, NodeJS.Timeout> = new Map();
 
   constructor(
     private sessionManager: SessionManager,
     private worktreeManager: WorktreeManager,
     private gitDiffManager: GitDiffManager,
-    private logger?: Logger
+    private logger?: Logger,
+    private databaseService?: DatabaseService
   ) {
     super();
     // Increase max listeners to prevent warnings when many components listen to git status events
@@ -75,6 +82,35 @@ export class GitStatusManager extends EventEmitter {
         this.logger?.error(`[GitStatus] Failed to refresh after file change for session ${sessionId}:`, error);
       });
     });
+
+    this.hydratePersistentCache();
+  }
+
+  private hydratePersistentCache(): void {
+    if (!this.databaseService) return;
+
+    try {
+      const cachedStatuses = this.databaseService.getAllSessionGitStatusCache();
+      for (const cached of cachedStatuses) {
+        this.cache[cached.sessionId] = {
+          status: cached.gitStatus,
+          lastChecked: cached.lastChecked,
+        };
+      }
+      if (cachedStatuses.length > 0) {
+        this.logger?.info(`[GitStatus] Hydrated ${cachedStatuses.length} cached git statuses`);
+      }
+    } catch (error) {
+      this.logger?.error('[GitStatus] Failed to hydrate persisted git status cache:', error as Error);
+    }
+  }
+
+  private persistCachedStatus(sessionId: string, status: GitStatus, lastChecked: number): void {
+    try {
+      this.databaseService?.saveSessionGitStatusCache(sessionId, status, lastChecked);
+    } catch (error) {
+      this.logger?.error(`[GitStatus] Failed to persist status cache for ${sessionId}:`, error as Error);
+    }
   }
 
 
@@ -159,6 +195,9 @@ export class GitStatusManager extends EventEmitter {
       this.eventThrottleTimer = null;
     }
     this.pendingEvents.clear();
+
+    this.prEnrichmentTimers.forEach(timer => clearTimeout(timer));
+    this.prEnrichmentTimers.clear();
     
     // Cancel all active operations
     this.abortControllers.forEach(controller => controller.abort());
@@ -412,7 +451,7 @@ export class GitStatusManager extends EventEmitter {
             const cached = this.cache[sessionId]?.status || null;
             if (cached) {
               this.emitThrottled(sessionId, 'updated', cached);
-              this.enrichWithPrData(sessionId);
+              this.schedulePrEnrichment(sessionId);
             }
             resolve(cached);
             return;
@@ -423,7 +462,7 @@ export class GitStatusManager extends EventEmitter {
         if (status) {
           this.updateCache(sessionId, status);
           this.emitThrottled(sessionId, 'updated', status);
-          this.enrichWithPrData(sessionId);
+          this.schedulePrEnrichment(sessionId, isUserInitiated);
         }
         resolve(status);
       }, this.DEBOUNCE_MS);
@@ -443,11 +482,14 @@ export class GitStatusManager extends EventEmitter {
       return cached.status;
     }
 
-    // Add to initial load queue if not already there
+    // Add to initial load queue if not already there. Return stale status
+    // immediately so startup can render from the persisted cache while the
+    // authoritative refresh happens in the background.
     if (!this.initialLoadQueue.includes(sessionId)) {
       this.initialLoadQueue.push(sessionId);
-      // Show loading immediately for this session
-      this.emitThrottled(sessionId, 'loading');
+      if (!cached) {
+        this.emitThrottled(sessionId, 'loading');
+      }
     }
 
     // Start processing queue if not already running
@@ -478,11 +520,19 @@ export class GitStatusManager extends EventEmitter {
       const promises = batch.map(sessionId => 
         this.executeWithLimit(async () => {
           try {
+            if (sessionId !== this.activeSessionId) {
+              await new Promise(resolve => setTimeout(
+                resolve,
+                Math.floor(Math.random() * this.INITIAL_LOAD_JITTER_MS),
+              ));
+            }
             const status = await this.fetchGitStatus(sessionId);
             if (status) {
               this.updateCache(sessionId, status);
               this.emitThrottled(sessionId, 'updated', status);
-              this.enrichWithPrData(sessionId);
+              if (sessionId === this.activeSessionId) {
+                this.schedulePrEnrichment(sessionId, true);
+              }
             }
           } catch (error) {
             this.logger?.error(`[GitStatus] Error fetching status for session ${sessionId}:`, error as Error);
@@ -580,50 +630,63 @@ export class GitStatusManager extends EventEmitter {
     return worktreePath.replace(/\\/g, '/').split('/').pop() || null;
   }
 
-  private enrichWithPrData(sessionId: string): void {
-    setImmediate(async () => {
-      try {
-        const session = await this.sessionManager.getSession(sessionId);
-        if (!session?.worktreePath) return;
+  private schedulePrEnrichment(sessionId: string, immediate = false): void {
+    if (this.prEnrichmentTimers.has(sessionId)) return;
 
-        const project = this.sessionManager.getProjectForSession(sessionId);
-        if (!project?.path) return;
+    const jitter = immediate || sessionId === this.activeSessionId
+      ? 0
+      : Math.floor(Math.random() * this.PR_ENRICHMENT_JITTER_MS);
 
-        const ctx = this.sessionManager.getProjectContext(sessionId);
-        if (!ctx) return;
+    const timer = setTimeout(() => {
+      this.prEnrichmentTimers.delete(sessionId);
+      this.executePrEnrichmentWithLimit(() => this.enrichWithPrData(sessionId)).catch(() => {
+        // PR enrichment is best-effort; fetchPrForSession records misses in cache.
+      });
+    }, jitter);
 
-        const branchName = this.getCurrentBranchName(session.worktreePath, ctx.commandRunner);
-        if (!branchName) return;
+    this.prEnrichmentTimers.set(sessionId, timer);
+  }
 
-        const prData = await this.fetchPrForSession(branchName, project.path, ctx.commandRunner);
+  private async enrichWithPrData(sessionId: string): Promise<void> {
+    const session = await this.sessionManager.getSession(sessionId);
+    if (!session?.worktreePath) return;
 
-        if (prData.prNumber !== undefined) {
-          const currentStatus = this.cache[sessionId]?.status;
-          if (currentStatus && (
-            currentStatus.prNumber !== prData.prNumber ||
-            currentStatus.prState !== prData.prState ||
-            currentStatus.prTitle !== prData.prTitle ||
-            currentStatus.prBody !== prData.prBody
-          )) {
-            const enrichedStatus = {
-              ...currentStatus,
-              prNumber: prData.prNumber,
-              prUrl: prData.prUrl,
-              prTitle: prData.prTitle,
-              prState: prData.prState,
-              prBody: prData.prBody
-            };
-            this.cache[sessionId] = {
-              status: enrichedStatus,
-              lastChecked: this.cache[sessionId].lastChecked
-            };
-            this.emit('git-status-updated', sessionId, enrichedStatus);
-          }
-        }
-      } catch {
-        // Silent — PR enrichment is best-effort
+    const project = this.sessionManager.getProjectForSession(sessionId);
+    if (!project?.path) return;
+
+    const ctx = this.sessionManager.getProjectContext(sessionId);
+    if (!ctx) return;
+
+    const branchName = this.getCurrentBranchName(session.worktreePath, ctx.commandRunner);
+    if (!branchName) return;
+
+    const prData = await this.fetchPrForSession(branchName, project.path, ctx.commandRunner);
+
+    if (prData.prNumber !== undefined) {
+      const currentStatus = this.cache[sessionId]?.status;
+      if (currentStatus && (
+        currentStatus.prNumber !== prData.prNumber ||
+        currentStatus.prState !== prData.prState ||
+        currentStatus.prTitle !== prData.prTitle ||
+        currentStatus.prBody !== prData.prBody
+      )) {
+        const enrichedStatus = {
+          ...currentStatus,
+          prNumber: prData.prNumber,
+          prUrl: prData.prUrl,
+          prTitle: prData.prTitle,
+          prState: prData.prState,
+          prBody: prData.prBody
+        };
+        const lastChecked = this.cache[sessionId].lastChecked;
+        this.cache[sessionId] = {
+          status: enrichedStatus,
+          lastChecked
+        };
+        this.persistCachedStatus(sessionId, enrichedStatus, lastChecked);
+        this.emit('git-status-updated', sessionId, enrichedStatus);
       }
-    });
+    }
   }
 
   /**
@@ -910,11 +973,13 @@ export class GitStatusManager extends EventEmitter {
   private updateCache(sessionId: string, status: GitStatus): void {
     const previousStatus = this.cache[sessionId]?.status;
     const hasChanged = !previousStatus || JSON.stringify(previousStatus) !== JSON.stringify(status);
+    const lastChecked = Date.now();
     
     this.cache[sessionId] = {
       status,
-      lastChecked: Date.now()
+      lastChecked
     };
+    this.persistCachedStatus(sessionId, status, lastChecked);
 
     // Only emit event if status actually changed
     if (hasChanged) {
@@ -946,6 +1011,18 @@ export class GitStatusManager extends EventEmitter {
       this.abortControllers.delete(sessionId);
     }
 
+    const prTimer = this.prEnrichmentTimers.get(sessionId);
+    if (prTimer) {
+      clearTimeout(prTimer);
+      this.prEnrichmentTimers.delete(sessionId);
+    }
+
+    try {
+      this.databaseService?.deleteSessionGitStatusCache(sessionId);
+    } catch (error) {
+      this.logger?.error(`[GitStatus] Failed to delete persisted status cache for ${sessionId}:`, error as Error);
+    }
+
     // L3: stop the file watcher for this session. No-op for
     // non-active sessions (they never had a watcher started).
     this.fileWatcher.stopWatching(sessionId);
@@ -956,6 +1033,13 @@ export class GitStatusManager extends EventEmitter {
    */
   clearAllCache(): void {
     this.cache = {};
+    this.prEnrichmentTimers.forEach(timer => clearTimeout(timer));
+    this.prEnrichmentTimers.clear();
+    try {
+      this.databaseService?.clearSessionGitStatusCache();
+    } catch (error) {
+      this.logger?.error('[GitStatus] Failed to clear persisted status cache:', error as Error);
+    }
   }
 
   /**
@@ -1033,6 +1117,19 @@ export class GitStatusManager extends EventEmitter {
           });
         }
       }
+    }
+  }
+
+  private async executePrEnrichmentWithLimit<T>(operation: () => Promise<T>): Promise<T> {
+    while (this.activePrEnrichmentOperations >= this.MAX_CONCURRENT_PR_ENRICHMENT) {
+      await new Promise(resolve => setTimeout(resolve, 250));
+    }
+
+    this.activePrEnrichmentOperations++;
+    try {
+      return await operation();
+    } finally {
+      this.activePrEnrichmentOperations--;
     }
   }
 }


### PR DESCRIPTION
## Summary
- map Performance/Battery Saver terminal power mode to startup GPU behavior so Performance lets Electron/OS choose and Battery Saver prefers the low-power GPU
- persist stale git status in SQLite and hydrate it at startup for immediate sidebar rendering
- jitter background git status refreshes and separate low-priority PR enrichment to reduce startup fanout and GitHub API pressure

## Testing
- pnpm --filter main exec vitest run src/services/__tests__/gitStatusManager.test.ts
- pnpm typecheck
- pnpm lint

Note: local Node is v20.19.3 while the repo wants >=22.14.0; checks still passed.