### PR TITLE
[codex] Persist and polish left sidebar state

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -21,7 +21,11 @@ import {
   groupSessionsByProject,
 } from '../utils/sessionOrdering';
 
-
+const SIDEBAR_ROW_BASE = 'flex w-full items-center text-left transition-colors';
+const SIDEBAR_ROW_PADDING = 'px-4';
+const SIDEBAR_ROW_GAP = 'gap-2.5';
+const SIDEBAR_SECTION_ROW = 'mt-2 flex w-full items-center justify-between gap-2 px-3.5 pt-1 pb-1';
+const SIDEBAR_SECTION_LABEL = 'truncate text-[13px] font-semibold uppercase leading-4 text-text-tertiary';
 
 interface ProjectSessionListProps {
   sessionSortAscending: boolean;
@@ -258,7 +262,7 @@ export function ProjectSessionList({
             setActiveSession(null);
             navigateToSessions();
           }}
-          className="flex items-center gap-2.5 px-4 py-2 text-sm text-text-secondary hover:bg-surface-hover hover:text-text-primary transition-colors"
+          className={cn(SIDEBAR_ROW_BASE, SIDEBAR_ROW_GAP, SIDEBAR_ROW_PADDING, 'py-2 text-sm text-text-secondary hover:bg-surface-hover hover:text-text-primary')}
         >
           <Home className="w-4 h-4" />
           <span>Home</span>
@@ -269,7 +273,7 @@ export function ProjectSessionList({
             <button
               type="button"
               onClick={onRemoteDesktopClick}
-              className="flex w-full items-center gap-2.5 px-4 py-2 text-left text-sm text-text-secondary hover:bg-surface-hover hover:text-text-primary transition-colors"
+              className={cn(SIDEBAR_ROW_BASE, SIDEBAR_ROW_GAP, SIDEBAR_ROW_PADDING, 'py-2 text-sm text-text-secondary hover:bg-surface-hover hover:text-text-primary')}
             >
               <Monitor className="w-4 h-4" />
               <span>Remote Desktop</span>
@@ -279,20 +283,22 @@ export function ProjectSessionList({
 
         {pinnedSessions.length > 0 && (
           <>
-            <button
-              type="button"
-              onClick={() => onPinnedSectionExpandedChange(!pinnedSectionExpanded)}
-              className="group/section mt-2 flex w-full items-center gap-1.5 px-3 pt-1 pb-1 text-left text-sm text-text-tertiary hover:text-text-primary focus-visible:text-text-primary transition-colors"
-            >
-              <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover/section:opacity-100 group-focus-visible/section:opacity-100">
-                {pinnedSectionExpanded ? (
-                  <ChevronDown className="h-3.5 w-3.5 text-current" />
-                ) : (
-                  <ChevronRight className="h-3.5 w-3.5 text-current" />
-                )}
-              </span>
-              <span className="text-sm text-text-tertiary truncate">Pinned</span>
-            </button>
+            <div className={SIDEBAR_SECTION_ROW}>
+              <button
+                type="button"
+                onClick={() => onPinnedSectionExpandedChange(!pinnedSectionExpanded)}
+                className="group/section flex min-w-0 flex-1 items-center justify-between gap-2 text-left text-sm text-text-tertiary hover:text-text-primary focus-visible:text-text-primary transition-colors"
+              >
+                <span className={SIDEBAR_SECTION_LABEL}>Pinned</span>
+                <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover/section:opacity-100 group-focus-visible/section:opacity-100">
+                  {pinnedSectionExpanded ? (
+                    <ChevronDown className="h-3.5 w-3.5 text-current" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5 text-current" />
+                  )}
+                </span>
+              </button>
+            </div>
             {pinnedSectionExpanded && (
               <div className="mt-0.5">
                 {pinnedSessions.map(({ session, label }) => (
@@ -312,12 +318,13 @@ export function ProjectSessionList({
           </>
         )}
 
-        <div className="mt-2 px-3 pt-1 pb-1 flex items-center justify-between gap-2">
+        <div className={SIDEBAR_SECTION_ROW}>
           <button
             type="button"
             onClick={() => onRepositoriesSectionExpandedChange(!repositoriesSectionExpanded)}
-            className="group/section flex min-w-0 flex-1 items-center gap-1.5 text-left text-sm text-text-tertiary hover:text-text-primary focus-visible:text-text-primary transition-colors"
+            className="group/section flex min-w-0 flex-1 items-center justify-between gap-2 text-left text-sm text-text-tertiary hover:text-text-primary focus-visible:text-text-primary transition-colors"
           >
+            <span className={SIDEBAR_SECTION_LABEL}>Repositories</span>
             <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover/section:opacity-100 group-focus-visible/section:opacity-100">
               {repositoriesSectionExpanded ? (
                 <ChevronDown className="h-3.5 w-3.5 text-current" />
@@ -325,7 +332,6 @@ export function ProjectSessionList({
                 <ChevronRight className="h-3.5 w-3.5 text-current" />
               )}
             </span>
-            <span className="text-sm text-text-tertiary truncate">Repositories</span>
           </button>
           <button
             onClick={() => setShowAddProjectDialog(true)}
@@ -367,11 +373,11 @@ export function ProjectSessionList({
           ];
 
           return (
-            <div key={project.id} className="mt-3 first:mt-2">
+            <div key={project.id} className="first:mt-2">
               {/* Project header */}
               <div
                 className={cn(
-                  "group/project flex items-center px-4 py-1.5 hover:bg-surface-hover transition-colors cursor-pointer",
+                  "group/project flex items-center gap-1.5 pl-3 pr-2 py-1.5 hover:bg-surface-hover transition-colors cursor-pointer",
                   dragOverProjectId === project.id && dragProjectId !== project.id && "bg-interactive/20",
                   dragProjectId === project.id && "opacity-50"
                 )}
@@ -394,13 +400,13 @@ export function ProjectSessionList({
                 <Tooltip content={<span className="text-[10px] text-text-tertiary font-mono break-all">{project.path}</span>} side="right">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5 min-w-0">
+                      <span className="min-w-0 truncate text-xs font-semibold text-text-primary">{project.name}</span>
                       <span className={cn(
                         "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
                         projectActivity === 'active'
                           ? 'bg-status-info opacity-100 duration-150'
                           : 'bg-text-muted/20 opacity-40 duration-[3s]'
                       )} />
-                      <span className="text-xs font-semibold text-text-primary truncate">{project.name}</span>
                     </div>
                   </div>
                 </Tooltip>
@@ -501,7 +507,7 @@ function SessionRowContent({
   showUnviewedCompleted: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2 min-w-0 w-full">
+    <div className="flex items-center gap-1.5 min-w-0 w-full">
       {gs?.prNumber ? (
         <GitPullRequest className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
       ) : (
@@ -619,7 +625,7 @@ function SessionRow({
       interactive
     >
       <div
-        className={`group/session relative w-full text-left pl-3 pr-3 py-1.5 transition-colors flex items-center gap-1 cursor-pointer ${
+        className={`group/session relative w-full text-left pl-2 pr-2 py-1.5 transition-colors flex items-center gap-1 cursor-pointer ${
           isActive
             ? 'bg-interactive/30 border-l-4 border-interactive'
             : 'hover:bg-surface-hover border-l-4 border-transparent'
@@ -648,6 +654,15 @@ function SessionRow({
 
         <div className="flex flex-shrink-0 items-center gap-0.5">
           <button
+            onClick={(e) => { e.stopPropagation(); onArchive(); }}
+            className="inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-text-muted hover:text-status-error hover:bg-surface-hover transition-all opacity-0 group-hover/session:opacity-100"
+            title="Archive"
+            aria-label="Archive pane"
+          >
+            <Archive className="w-3.5 h-3.5" />
+          </button>
+
+          <button
             onClick={(e) => { e.stopPropagation(); onTogglePinned(); }}
             className={`inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded transition-all ${
               session.isFavorite
@@ -658,15 +673,6 @@ function SessionRow({
             aria-label={session.isFavorite ? 'Unpin pane' : 'Pin pane'}
           >
             <Pin className="w-3.5 h-3.5 rotate-45" />
-          </button>
-
-          {/* Archive button - on hover */}
-          <button
-            onClick={(e) => { e.stopPropagation(); onArchive(); }}
-            className="inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-text-muted hover:text-status-error hover:bg-surface-hover transition-all opacity-0 group-hover/session:opacity-100"
-            title="Archive"
-          >
-            <Archive className="w-3.5 h-3.5" />
           </button>
         </div>
       </div>

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { useSessionStore } from '../stores/sessionStore';
@@ -25,6 +25,10 @@ import {
 
 interface ProjectSessionListProps {
   sessionSortAscending: boolean;
+  pinnedSectionExpanded: boolean;
+  repositoriesSectionExpanded: boolean;
+  onPinnedSectionExpandedChange: (expanded: boolean) => void;
+  onRepositoriesSectionExpandedChange: (expanded: boolean) => void;
   showRemoteDesktopLink?: boolean;
   onRemoteDesktopClick?: () => void;
   remoteDesktopTooltip?: string;
@@ -32,6 +36,10 @@ interface ProjectSessionListProps {
 
 export function ProjectSessionList({
   sessionSortAscending,
+  pinnedSectionExpanded,
+  repositoriesSectionExpanded,
+  onPinnedSectionExpandedChange,
+  onRepositoriesSectionExpandedChange,
   showRemoteDesktopLink = false,
   onRemoteDesktopClick,
   remoteDesktopTooltip,
@@ -39,8 +47,7 @@ export function ProjectSessionList({
   const [projects, setProjects] = useState<Project[]>([]);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [createForProject, setCreateForProject] = useState<Project | null>(null);
-  const [pinnedSectionExpanded, setPinnedSectionExpanded] = useState(true);
-  const [repositoriesSectionExpanded, setRepositoriesSectionExpanded] = useState(true);
+  const knownSessionIdsRef = useRef<Set<string> | null>(null);
 
   // Add project dialog state
   const [showAddProjectDialog, setShowAddProjectDialog] = useState(false);
@@ -50,6 +57,7 @@ export function ProjectSessionList({
   const [dragOverProjectId, setDragOverProjectId] = useState<number | null>(null);
 
   const sessions = useSessionStore(s => s.sessions);
+  const sessionsLoaded = useSessionStore(s => s.isLoaded);
   const activeSessionId = useSessionStore(s => s.activeSessionId);
   const setActiveSession = useSessionStore(s => s.setActiveSession);
   const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
@@ -101,18 +109,40 @@ export function ProjectSessionList({
   // mod+1-9 session switch hotkeys are registered in useSessionNavigationHotkeys
   // (always mounted in Sidebar), and new-project auto-expansion lives there too.
 
-  // Auto-expand the project that contains the active session
-  // (e.g., when a new session is created and auto-activated)
+  const persistExpandedProjects = useCallback((projectIds: number[]) => {
+    void window.electronAPI.uiState.saveExpandedProjects(projectIds).catch(error => {
+      console.error('Failed to save expanded projects:', error);
+    });
+  }, []);
+
+  // Auto-expand only for sessions created after the initial session list is known.
+  // Restoring the previously active session on app launch should not override
+  // the user's saved collapsed project preferences.
   useEffect(() => {
-    if (!activeSessionId) return;
-    const currentSessions = useSessionStore.getState().sessions;
-    const session = currentSessions.find(s => s.id === activeSessionId);
-    if (!session?.projectId) return;
-    expandProject(session.projectId);
-  }, [activeSessionId, expandProject]);
+    if (!sessionsLoaded) return;
+
+    const currentIds = new Set(sessions.map(session => session.id));
+    const previousIds = knownSessionIdsRef.current;
+
+    if (!previousIds) {
+      knownSessionIdsRef.current = currentIds;
+      return;
+    }
+
+    if (activeSessionId && !previousIds.has(activeSessionId)) {
+      const session = sessions.find(item => item.id === activeSessionId);
+      if (session?.projectId) {
+        const expandedProjectIds = expandProject(session.projectId);
+        if (expandedProjectIds) persistExpandedProjects(expandedProjectIds);
+      }
+    }
+
+    knownSessionIdsRef.current = currentIds;
+  }, [activeSessionId, expandProject, persistExpandedProjects, sessions, sessionsLoaded]);
 
   const toggleProject = (id: number) => {
-    toggleProjectExpanded(id);
+    const expandedProjectIds = toggleProjectExpanded(id);
+    persistExpandedProjects(expandedProjectIds);
   };
 
   const handleSessionClick = (sessionId: string, scope: SidebarNavigationScope = 'repositories') => {
@@ -251,7 +281,7 @@ export function ProjectSessionList({
           <>
             <button
               type="button"
-              onClick={() => setPinnedSectionExpanded(expanded => !expanded)}
+              onClick={() => onPinnedSectionExpandedChange(!pinnedSectionExpanded)}
               className="group/section mt-2 flex w-full items-center gap-1.5 px-3 pt-1 pb-1 text-left text-sm text-text-tertiary hover:text-text-primary focus-visible:text-text-primary transition-colors"
             >
               <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover/section:opacity-100 group-focus-visible/section:opacity-100">
@@ -285,7 +315,7 @@ export function ProjectSessionList({
         <div className="mt-2 px-3 pt-1 pb-1 flex items-center justify-between gap-2">
           <button
             type="button"
-            onClick={() => setRepositoriesSectionExpanded(expanded => !expanded)}
+            onClick={() => onRepositoriesSectionExpandedChange(!repositoriesSectionExpanded)}
             className="group/section flex min-w-0 flex-1 items-center gap-1.5 text-left text-sm text-text-tertiary hover:text-text-primary focus-visible:text-text-primary transition-colors"
           >
             <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover/section:opacity-100 group-focus-visible/section:opacity-100">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -60,6 +60,7 @@ interface SidebarProps {
 
 const REMOTE_DESKTOP_URL = 'https://remotedesktop.google.com/access';
 const REMOTE_DESKTOP_TOOLTIP = 'Use Remote Desktop to access the host device for Electron apps, native windows, and UI running on the remote machine.';
+type SidebarSection = 'pinned' | 'repositories';
 
 function formatMemory(mb: number): string {
   if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
@@ -84,6 +85,10 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
   const [gitCommit, setGitCommit] = useState<string>('');
   const [worktreeName, setWorktreeName] = useState<string>('');
   const [sessionSortAscending, setSessionSortAscending] = useState<boolean>(true); // Default to ascending (newest at bottom)
+  const [sidebarSectionExpansion, setSidebarSectionExpansion] = useState<Record<SidebarSection, boolean>>({
+    pinned: true,
+    repositories: true,
+  });
   const [remoteConnectionState, setRemoteConnectionState] = useState<RemotePaneConnectionState>(createDefaultRemotePaneConnectionState());
   const [remoteHostState, setRemoteHostState] = useState<RemoteDaemonHostRuntimeState>(createDefaultRemoteDaemonHostRuntimeState());
   const resourceMenuButtonRef = useRef<HTMLButtonElement>(null);
@@ -92,6 +97,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
   const [resourcePopoverStyle, setResourcePopoverStyle] = useState<React.CSSProperties>({});
   const [expandedResourceSections, setExpandedResourceSections] = useState<Set<string>>(new Set(['pane-app']));
   const { snapshot, isLoading: resourceLoading, startActive, stopActive, refresh } = useResourceMonitor();
+  const hydrateExpandedProjects = useNavigationStore(s => s.hydrateExpandedProjects);
 
   useEffect(() => {
     // Fetch version info and UI state on component mount
@@ -127,6 +133,11 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
         const result = await window.electronAPI.uiState.getExpanded();
         if (result.success && result.data) {
           setSessionSortAscending(result.data.sessionSortAscending ?? true);
+          hydrateExpandedProjects(result.data.expandedProjects ?? []);
+          setSidebarSectionExpansion({
+            pinned: result.data.pinnedSectionExpanded ?? true,
+            repositories: result.data.repositoriesSectionExpanded ?? true,
+          });
         }
       } catch (error) {
         console.error('Failed to load UI state:', error);
@@ -135,7 +146,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
 
     fetchVersion();
     loadUIState();
-  }, []);
+  }, [hydrateExpandedProjects]);
 
   useEffect(() => {
     let cancelled = false;
@@ -180,6 +191,25 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
       console.error('Failed to save session sort order:', error);
     }
   };
+
+  const handleSidebarSectionExpandedChange = useCallback((section: SidebarSection, expanded: boolean) => {
+    setSidebarSectionExpansion(prev => ({
+      ...prev,
+      [section]: expanded,
+    }));
+
+    void window.electronAPI.uiState.saveSidebarSectionExpanded(section, expanded).catch(error => {
+      console.error('Failed to save sidebar section expanded state:', error);
+    });
+  }, []);
+
+  const handlePinnedSectionExpandedChange = useCallback((expanded: boolean) => {
+    handleSidebarSectionExpandedChange('pinned', expanded);
+  }, [handleSidebarSectionExpandedChange]);
+
+  const handleRepositoriesSectionExpandedChange = useCallback((expanded: boolean) => {
+    handleSidebarSectionExpandedChange('repositories', expanded);
+  }, [handleSidebarSectionExpandedChange]);
 
   const openResourcePopover = useCallback(() => {
     setShowResourcePopover(true);
@@ -571,6 +601,10 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
         <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
           <ProjectSessionList
             sessionSortAscending={sessionSortAscending}
+            pinnedSectionExpanded={sidebarSectionExpansion.pinned}
+            repositoriesSectionExpanded={sidebarSectionExpansion.repositories}
+            onPinnedSectionExpandedChange={handlePinnedSectionExpandedChange}
+            onRepositoriesSectionExpandedChange={handleRepositoriesSectionExpandedChange}
             showRemoteDesktopLink={showRemoteDesktopLink}
             onRemoteDesktopClick={handleOpenRemoteDesktop}
             remoteDesktopTooltip={REMOTE_DESKTOP_TOOLTIP}

--- a/frontend/src/hooks/useSessionNavigationHotkeys.ts
+++ b/frontend/src/hooks/useSessionNavigationHotkeys.ts
@@ -47,7 +47,13 @@ export function useSessionNavigationHotkeys({
   // because this hook stays mounted when the sidebar is collapsed or immersive
   // mode hides it, keeping mod+1-9 numbering alive and consistent.
   useEffect(() => {
-    registerProjectIds(projects.map(p => p.id));
+    if (projects.length === 0) return;
+    const expandedProjectIds = registerProjectIds(projects.map(p => p.id));
+    if (expandedProjectIds) {
+      void window.electronAPI.uiState.saveExpandedProjects(expandedProjectIds).catch(error => {
+        console.error('Failed to save expanded projects:', error);
+      });
+    }
   }, [projects, registerProjectIds]);
 
   // Sessions in the exact order ProjectSessionList renders them: projects in

--- a/frontend/src/stores/navigationStore.test.ts
+++ b/frontend/src/stores/navigationStore.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+async function loadNavigationStore() {
+  vi.resetModules();
+  vi.stubGlobal('localStorage', new MemoryStorage());
+  return import('./navigationStore');
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('navigationStore project expansion', () => {
+  it('does not auto-expand the initial project list', async () => {
+    const { useNavigationStore } = await loadNavigationStore();
+
+    const expandedProjectIds = useNavigationStore.getState().registerProjectIds([1, 2]);
+
+    expect(expandedProjectIds).toBeNull();
+    expect(Array.from(useNavigationStore.getState().expandedProjects)).toEqual([]);
+  });
+
+  it('hydrates persisted expansion and only auto-expands later project additions', async () => {
+    const { useNavigationStore } = await loadNavigationStore();
+
+    useNavigationStore.getState().hydrateExpandedProjects([2]);
+    expect(useNavigationStore.getState().registerProjectIds([1, 2])).toBeNull();
+
+    const expandedProjectIds = useNavigationStore.getState().registerProjectIds([1, 2, 3]);
+
+    expect(expandedProjectIds).toEqual([2, 3]);
+    expect(Array.from(useNavigationStore.getState().expandedProjects).sort()).toEqual([2, 3]);
+  });
+
+  it('returns the persisted shape after user project toggles', async () => {
+    const { useNavigationStore } = await loadNavigationStore();
+
+    useNavigationStore.getState().hydrateExpandedProjects([3]);
+
+    expect(useNavigationStore.getState().toggleProjectExpanded(1)).toEqual([1, 3]);
+    expect(useNavigationStore.getState().toggleProjectExpanded(3)).toEqual([1]);
+  });
+});

--- a/frontend/src/stores/navigationStore.ts
+++ b/frontend/src/stores/navigationStore.ts
@@ -5,6 +5,10 @@ export type SidebarNavigationScope = 'repositories' | 'pinned';
 // Tracks which project ids have already been seen so registerProjectIds only
 // auto-expands genuinely new projects (preserves user-collapsed state)
 let knownProjectIds = new Set<number>();
+let hasRegisteredInitialProjectIds = false;
+
+const toProjectIdArray = (projectIds: Set<number>): number[] =>
+  Array.from(projectIds).sort((a, b) => a - b);
 
 interface NavigationState {
   activeView: 'sessions' | 'project';
@@ -22,9 +26,10 @@ interface NavigationState {
   // Sidebar project expansion, shared between ProjectSessionList and the
   // always-mounted session hotkeys so mod+1-9 numbering matches the visible list
   expandedProjects: Set<number>;
-  toggleProjectExpanded: (projectId: number) => void;
-  expandProject: (projectId: number) => void;
-  registerProjectIds: (projectIds: number[]) => void;
+  hydrateExpandedProjects: (projectIds: number[]) => void;
+  toggleProjectExpanded: (projectId: number) => number[];
+  expandProject: (projectId: number) => number[] | null;
+  registerProjectIds: (projectIds: number[]) => number[] | null;
 
   // Last sidebar section used to enter the active pane. Cmd/Ctrl+Arrow uses
   // this to keep cycling within Pinned after a pinned-row click.
@@ -38,7 +43,7 @@ interface NavigationState {
   navigateToSessions: () => void;
 }
 
-export const useNavigationStore = create<NavigationState>((set) => ({
+export const useNavigationStore = create<NavigationState>((set, get) => ({
   activeView: 'sessions',
   activeProjectId: null,
 
@@ -60,26 +65,39 @@ export const useNavigationStore = create<NavigationState>((set) => ({
   setSidebarNavigationScope: (scope) => set({ sidebarNavigationScope: scope }),
 
   expandedProjects: new Set<number>(),
-  toggleProjectExpanded: (projectId) => set((state) => {
-    const next = new Set(state.expandedProjects);
+  hydrateExpandedProjects: (projectIds) => {
+    set({ expandedProjects: new Set(projectIds) });
+  },
+  toggleProjectExpanded: (projectId) => {
+    const next = new Set(get().expandedProjects);
     if (next.has(projectId)) next.delete(projectId);
     else next.add(projectId);
-    return { expandedProjects: next };
-  }),
-  expandProject: (projectId) => set((state) => {
-    if (state.expandedProjects.has(projectId)) return state;
-    const next = new Set(state.expandedProjects);
+    set({ expandedProjects: next });
+    return toProjectIdArray(next);
+  },
+  expandProject: (projectId) => {
+    const current = get().expandedProjects;
+    if (current.has(projectId)) return null;
+    const next = new Set(current);
     next.add(projectId);
-    return { expandedProjects: next };
-  }),
-  registerProjectIds: (projectIds) => set((state) => {
+    set({ expandedProjects: next });
+    return toProjectIdArray(next);
+  },
+  registerProjectIds: (projectIds) => {
+    if (!hasRegisteredInitialProjectIds) {
+      knownProjectIds = new Set(projectIds);
+      hasRegisteredInitialProjectIds = true;
+      return null;
+    }
+
     const newIds = projectIds.filter(id => !knownProjectIds.has(id));
     knownProjectIds = new Set(projectIds);
-    if (newIds.length === 0) return state;
-    const next = new Set(state.expandedProjects);
+    if (newIds.length === 0) return null;
+    const next = new Set(get().expandedProjects);
     newIds.forEach(id => next.add(id));
-    return { expandedProjects: next };
-  }),
+    set({ expandedProjects: next });
+    return toProjectIdArray(next);
+  },
 
   setActiveView: (view) => set({ activeView: view }),
 

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -292,11 +292,18 @@ interface ElectronAPI {
 
   // UI State management
   uiState: {
-    getExpanded: () => Promise<IPCResponse<{ expandedProjects: number[]; expandedFolders: string[]; sessionSortAscending: boolean }>>;
+    getExpanded: () => Promise<IPCResponse<{
+      expandedProjects: number[];
+      expandedFolders: string[];
+      sessionSortAscending: boolean;
+      pinnedSectionExpanded: boolean;
+      repositoriesSectionExpanded: boolean;
+    }>>;
     saveExpanded: (projectIds: number[], folderIds: string[]) => Promise<IPCResponse>;
     saveExpandedProjects: (projectIds: number[]) => Promise<IPCResponse>;
     saveExpandedFolders: (folderIds: string[]) => Promise<IPCResponse>;
     saveSessionSortAscending: (ascending: boolean) => Promise<IPCResponse>;
+    saveSidebarSectionExpanded: (section: 'pinned' | 'repositories', expanded: boolean) => Promise<IPCResponse>;
   };
 
   // Event listeners for real-time updates

--- a/main/src/ipc/uiState.ts
+++ b/main/src/ipc/uiState.ts
@@ -79,4 +79,23 @@ export function registerUIStateHandlers(services: AppServices) {
       };
     }
   });
+
+  ipcMain.handle('ui-state:save-sidebar-section-expanded', async (_, section: 'pinned' | 'repositories', expanded: boolean) => {
+    try {
+      if (section !== 'pinned' && section !== 'repositories') {
+        throw new Error(`Invalid sidebar section: ${section}`);
+      }
+
+      uiStateManager.saveSidebarSectionExpanded(section, expanded);
+      return {
+        success: true
+      };
+    } catch (error) {
+      console.error('Error saving sidebar section expanded state:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  });
 }

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -736,6 +736,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     saveExpandedProjects: (projectIds: number[]): Promise<IPCResponse> => invokeIpc('ui-state:save-expanded-projects', projectIds),
     saveExpandedFolders: (folderIds: string[]): Promise<IPCResponse> => invokeIpc('ui-state:save-expanded-folders', folderIds),
     saveSessionSortAscending: (ascending: boolean): Promise<IPCResponse> => invokeIpc('ui-state:save-session-sort-ascending', ascending),
+    saveSidebarSectionExpanded: (section: 'pinned' | 'repositories', expanded: boolean): Promise<IPCResponse> => invokeIpc('ui-state:save-sidebar-section-expanded', section, expanded),
   },
 
   // Event listeners for real-time updates

--- a/main/src/services/uiStateManager.ts
+++ b/main/src/services/uiStateManager.ts
@@ -1,12 +1,11 @@
 import { DatabaseService } from '../database/database';
 
-interface UIState {
-  treeView: {
-    expandedProjects: number[];
-    expandedFolders: string[];
-    sessionSortAscending: boolean;
-  };
-}
+type SidebarSection = 'pinned' | 'repositories';
+
+const SIDEBAR_SECTION_KEYS: Record<SidebarSection, string> = {
+  pinned: 'treeView.pinnedSectionExpanded',
+  repositories: 'treeView.repositoriesSectionExpanded'
+};
 
 class UIStateManager {
   private db: DatabaseService;
@@ -45,6 +44,17 @@ class UIStateManager {
     }
   }
 
+  getSidebarSectionExpanded(section: SidebarSection): boolean {
+    const value = this.db.getUIState(SIDEBAR_SECTION_KEYS[section]);
+    if (!value) return true;
+    try {
+      const parsed = JSON.parse(value);
+      return typeof parsed === 'boolean' ? parsed : true;
+    } catch {
+      return true;
+    }
+  }
+
   saveExpandedProjects(projectIds: number[]): void {
     this.db.setUIState('treeView.expandedProjects', JSON.stringify(projectIds));
   }
@@ -57,16 +67,28 @@ class UIStateManager {
     this.db.setUIState('treeView.sessionSortAscending', JSON.stringify(ascending));
   }
 
+  saveSidebarSectionExpanded(section: SidebarSection, expanded: boolean): void {
+    this.db.setUIState(SIDEBAR_SECTION_KEYS[section], JSON.stringify(expanded));
+  }
+
   saveExpandedState(projectIds: number[], folderIds: string[]): void {
     this.saveExpandedProjects(projectIds);
     this.saveExpandedFolders(folderIds);
   }
 
-  getExpandedState(): { expandedProjects: number[]; expandedFolders: string[]; sessionSortAscending: boolean } {
+  getExpandedState(): {
+    expandedProjects: number[];
+    expandedFolders: string[];
+    sessionSortAscending: boolean;
+    pinnedSectionExpanded: boolean;
+    repositoriesSectionExpanded: boolean;
+  } {
     return {
       expandedProjects: this.getExpandedProjects(),
       expandedFolders: this.getExpandedFolders(),
-      sessionSortAscending: this.getSessionSortAscending()
+      sessionSortAscending: this.getSessionSortAscending(),
+      pinnedSectionExpanded: this.getSidebarSectionExpanded('pinned'),
+      repositoriesSectionExpanded: this.getSidebarSectionExpanded('repositories')
     };
   }
 
@@ -74,6 +96,8 @@ class UIStateManager {
     this.db.deleteUIState('treeView.expandedProjects');
     this.db.deleteUIState('treeView.expandedFolders');
     this.db.deleteUIState('treeView.sessionSortAscending');
+    this.db.deleteUIState(SIDEBAR_SECTION_KEYS.pinned);
+    this.db.deleteUIState(SIDEBAR_SECTION_KEYS.repositories);
   }
 }
 

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -509,8 +509,18 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           subscribe('remote-daemon:host-state-changed', callback),
       }),
       uiState: namespace({
-        getExpanded: () => success([]),
+        getExpanded: () => success({
+          expandedProjects: [],
+          expandedFolders: [],
+          sessionSortAscending: true,
+          pinnedSectionExpanded: true,
+          repositoriesSectionExpanded: true,
+        }),
+        saveExpanded: () => success(),
+        saveExpandedProjects: () => success(),
+        saveExpandedFolders: () => success(),
         saveSessionSortAscending: () => success(),
+        saveSidebarSectionExpanded: () => success(),
       }),
     };
 


### PR DESCRIPTION
## Summary
- Persist per-project left sidebar expansion in the existing `ui_state` table.
- Persist the top-level Pinned and Repositories section collapsed/expanded state.
- Stop treating every project as new on renderer startup, while still auto-expanding genuinely newly added repositories.
- Tighten the left sidebar layout so category labels, repository rows, and workspace rows feel aligned and compact.
- Add regression coverage for navigation-store expansion behavior and update the Electron API test mock.

## Why
Closing and reopening Pane should preserve the user's left sidebar preferences instead of reopening Pinned, Repositories, and every project by default. The sidebar should also keep its hierarchy without wasting horizontal or vertical space.

## Visual Overview

```mermaid
flowchart LR
  subgraph Before["Before: reopen pane"]
    B1["Renderer starts"] --> B2["Registers project ids"]
    B2 --> B3["Existing projects look new"]
    B3 --> B4["Pinned, Repositories, and projects expand"]
    B4 --> B5["User collapse choices are lost"]
  end

  subgraph After["After: reopen pane"]
    A1["Renderer starts"] --> A2["Hydrates ui_state"]
    A2 --> A3["Restores section + project expansion"]
    A3 --> A4["Initial project list does not auto-expand"]
    A4 --> A5["Only genuinely new active projects expand"]
    A5 --> A6["Compact rows keep the tree readable"]
  end
```

Truth: reopening the pane now restores the user's sidebar shape instead of recreating the default expanded tree.

Diagram source: `/tmp/codex-pr-diagrams/left-sidebar-compact/sidebar-state-and-layout.excalidraw`

## Validation
- `pnpm typecheck`
- `pnpm lint` (passes with the existing warning backlog)
- `pnpm --filter frontend test`
- `pnpm --filter frontend typecheck`
- `git diff --check`
