### PR TITLE
Add sidebar pane row layout preference

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -26,6 +26,13 @@ const SIDEBAR_ROW_PADDING = 'px-4';
 const SIDEBAR_ROW_GAP = 'gap-2.5';
 const SIDEBAR_SECTION_ROW = 'mt-2 flex w-full items-center justify-between gap-2 pl-3.5 pr-2 pt-1 pb-1';
 const SIDEBAR_SECTION_LABEL = 'truncate text-[13px] font-semibold uppercase leading-4 text-text-tertiary';
+const SIDEBAR_PANE_ROW_LAYOUT_PREFERENCE = 'sidebar_pane_row_layout';
+
+type SidebarPaneRowLayout = 'single' | 'two-row';
+
+function normalizeSidebarPaneRowLayout(value: unknown): SidebarPaneRowLayout {
+  return value === 'two-row' ? 'two-row' : 'single';
+}
 
 interface ProjectSessionListProps {
   sessionSortAscending: boolean;
@@ -51,6 +58,7 @@ export function ProjectSessionList({
   const [projects, setProjects] = useState<Project[]>([]);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [createForProject, setCreateForProject] = useState<Project | null>(null);
+  const [sidebarPaneRowLayout, setSidebarPaneRowLayout] = useState<SidebarPaneRowLayout>('single');
   const knownSessionIdsRef = useRef<Set<string> | null>(null);
 
   // Add project dialog state
@@ -97,6 +105,37 @@ export function ProjectSessionList({
       window.removeEventListener('project-sessions-refresh', handle);
     };
   }, [loadProjects]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadSidebarPaneRowLayout = async () => {
+      try {
+        const result = await window.electron?.invoke(
+          'preferences:get',
+          SIDEBAR_PANE_ROW_LAYOUT_PREFERENCE
+        ) as { success?: boolean; data?: string } | undefined;
+        if (!cancelled) {
+          setSidebarPaneRowLayout(normalizeSidebarPaneRowLayout(result?.data));
+        }
+      } catch {
+        if (!cancelled) setSidebarPaneRowLayout('single');
+      }
+    };
+
+    const handlePreferenceChanged = (event: Event) => {
+      const detail = (event as CustomEvent<{ layout?: unknown }>).detail;
+      setSidebarPaneRowLayout(normalizeSidebarPaneRowLayout(detail?.layout));
+    };
+
+    void loadSidebarPaneRowLayout();
+    window.addEventListener('sidebar-pane-row-layout-changed', handlePreferenceChanged);
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('sidebar-pane-row-layout-changed', handlePreferenceChanged);
+    };
+  }, []);
 
   // Group sessions by project
   const sessionsByProject = useMemo(
@@ -311,6 +350,7 @@ export function ProjectSessionList({
                     onClick={() => handleSessionClick(session.id, 'pinned')}
                     onArchive={() => handleArchiveSession(session.id)}
                     onTogglePinned={() => handleTogglePinnedSession(session.id)}
+                    rowLayout={sidebarPaneRowLayout}
                   />
                 ))}
               </div>
@@ -450,6 +490,7 @@ export function ProjectSessionList({
                       onClick={() => handleSessionClick(session.id, 'repositories')}
                       onArchive={() => handleArchiveSession(session.id)}
                       onTogglePinned={() => handleTogglePinnedSession(session.id)}
+                      rowLayout={sidebarPaneRowLayout}
                     />
                   ))}
                 </div>
@@ -495,6 +536,7 @@ function SessionRowContent({
   displayName,
   showActivity,
   showUnviewedCompleted,
+  rowLayout,
 }: {
   session: Session;
   gs: GitStatus | undefined;
@@ -505,10 +547,38 @@ function SessionRowContent({
   displayName?: string;
   showActivity: boolean;
   showUnviewedCompleted: boolean;
+  rowLayout: SidebarPaneRowLayout;
 }) {
   const title = displayName || gs?.prTitle || session.name || 'Untitled';
   const prNumber = gs?.prNumber;
   const showMetadata = Boolean(prNumber || hasDiff);
+
+  if (rowLayout === 'single') {
+    return (
+      <div className="flex min-w-0 w-full items-center gap-1.5">
+        {prNumber ? (
+          <GitPullRequest className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
+        ) : (
+          <GitBranch className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
+        )}
+        <span className={cn(
+          'min-w-0 flex-1 truncate text-sm font-medium text-text-primary decoration-status-info decoration-2 underline-offset-4',
+          showActivity && 'animate-sidebar-active-label',
+          showUnviewedCompleted && 'underline decoration-dashed'
+        )}>
+          {title}
+        </span>
+        {prNumber ? (
+          <span className="flex-shrink-0 text-xs text-text-tertiary">#{prNumber}</span>
+        ) : hasDiff ? (
+          <span className="flex flex-shrink-0 items-center gap-1 text-xs">
+            <span className="font-semibold text-status-success">+{adds}</span>
+            <span className="font-semibold text-status-error">-{dels}</span>
+          </span>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-w-0 w-full items-start gap-1.5">
@@ -553,6 +623,7 @@ interface SessionRowProps {
   onArchive: () => void;
   onTogglePinned: () => void;
   displayName?: string;
+  rowLayout: SidebarPaneRowLayout;
 }
 
 interface GitStatusIPCResponse {
@@ -562,7 +633,7 @@ interface GitStatusIPCResponse {
 
 function SessionRow({
   session, isActive, globalIndex, onClick,
-  onArchive, onTogglePinned, displayName,
+  onArchive, onTogglePinned, displayName, rowLayout,
 }: SessionRowProps) {
   const [localGitStatus, setLocalGitStatus] = useState<GitStatus | undefined>(session.gitStatus);
 
@@ -636,11 +707,13 @@ function SessionRow({
       interactive
     >
       <div
-        className={`group/session relative w-full text-left pl-2 pr-2 py-2 transition-colors flex items-center gap-1 cursor-pointer ${
+        className={cn(
+          'group/session relative w-full text-left pl-2 pr-2 transition-colors flex items-center gap-1 cursor-pointer',
+          rowLayout === 'single' ? 'py-1.5' : 'py-2',
           isActive
             ? 'bg-interactive/30 border-l-4 border-interactive'
             : 'hover:bg-surface-hover border-l-4 border-transparent'
-        }`}
+        )}
         onClick={onClick}
         role="button"
         tabIndex={0}
@@ -661,6 +734,7 @@ function SessionRow({
           displayName={displayName}
           showActivity={showActivity}
           showUnviewedCompleted={hasUnviewedCompletedActivity && !isActive && !showActivity}
+          rowLayout={rowLayout}
         />
 
         <div className="flex flex-shrink-0 items-center gap-0.5">

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -69,7 +69,8 @@ import {
   Copy,
   Server,
   ExternalLink,
-  Mic
+  Mic,
+  PanelLeftOpen
 } from 'lucide-react';
 import { Input, Textarea, Checkbox } from './ui/Input';
 import { Button } from './ui/Button';
@@ -111,6 +112,13 @@ function isVoiceTranscriptionMode(value: unknown): value is VoiceTranscriptionMo
 }
 
 const REMOTE_DESKTOP_URL = 'https://remotedesktop.google.com/access';
+const SIDEBAR_PANE_ROW_LAYOUT_PREFERENCE = 'sidebar_pane_row_layout';
+
+type SidebarPaneRowLayout = 'single' | 'two-row';
+
+function normalizeSidebarPaneRowLayout(value: unknown): SidebarPaneRowLayout {
+  return value === 'two-row' ? 'two-row' : 'single';
+}
 
 function formatRemoteBaseUrl(host: string, port: number): string {
   const trimmedHost = host.trim();
@@ -163,6 +171,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [enableCommitFooter, setEnableCommitFooter] = useState(true);
   const [managedAgentsMd, setManagedAgentsMd] = useState(true);
   const [autoRenameToPR, setAutoRenameToPR] = useState<boolean>(true);
+  const [sidebarPaneRowLayout, setSidebarPaneRowLayout] = useState<SidebarPaneRowLayout>('single');
   const [uiScale, setUiScale] = useState(1.0);
   const [terminalFontFamily, setTerminalFontFamily] = useState('');
   const [terminalFontSize, setTerminalFontSize] = useState(14);
@@ -369,6 +378,19 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
         }
       };
       loadAutoRename();
+
+      const loadSidebarPaneRowLayout = async () => {
+        try {
+          const result = await window.electron?.invoke(
+            'preferences:get',
+            SIDEBAR_PANE_ROW_LAYOUT_PREFERENCE
+          ) as IPCResponse<string>;
+          setSidebarPaneRowLayout(normalizeSidebarPaneRowLayout(result?.data));
+        } catch (error) {
+          console.error('Failed to load sidebar pane row layout preference:', error);
+        }
+      };
+      loadSidebarPaneRowLayout();
 
       // Load @terminal preferences
       const loadAtTerminalPrefs = async () => {
@@ -812,6 +834,19 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
       await window.electron?.invoke('preferences:set', 'auto_rename_sessions_to_pr', checked ? 'true' : 'false');
     } catch (error) {
       console.error('Failed to save auto-rename preference:', error);
+    }
+  };
+
+  const handleSidebarPaneRowLayoutChange = async (layout: SidebarPaneRowLayout) => {
+    setSidebarPaneRowLayout(layout);
+    window.dispatchEvent(new CustomEvent('sidebar-pane-row-layout-changed', {
+      detail: { layout },
+    }));
+
+    try {
+      await window.electron?.invoke('preferences:set', SIDEBAR_PANE_ROW_LAYOUT_PREFERENCE, layout);
+    } catch (error) {
+      console.error('Failed to save sidebar pane row layout preference:', error);
     }
   };
 
@@ -1754,6 +1789,32 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                       </button>
                     ))}
                   </div>
+                </div>
+              </SettingsSection>
+
+              <SettingsSection
+                title="Sidebar Pane Rows"
+                description="Choose how pane metadata appears in the left sidebar"
+                icon={<PanelLeftOpen className="w-4 h-4" />}
+              >
+                <div className="grid grid-cols-2 gap-2">
+                  {[
+                    { id: 'single' as const, label: 'Single row' },
+                    { id: 'two-row' as const, label: 'Two rows' },
+                  ].map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => handleSidebarPaneRowLayoutChange(option.id)}
+                      className={`px-3 py-2 text-sm font-medium rounded-md border transition-colors ${
+                        sidebarPaneRowLayout === option.id
+                          ? 'bg-interactive text-text-on-interactive border-interactive'
+                          : 'bg-surface-secondary text-text-secondary border-border-secondary hover:bg-surface-hover'
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
                 </div>
               </SettingsSection>
 


### PR DESCRIPTION
## Summary

- Default left sidebar pane rows back to the compact single-row layout from the pre-two-row sidebar PR
- Add an Appearance setting to choose between single-row and two-row sidebar pane metadata
- Persist the preference with the existing `preferences:get` / `preferences:set` IPC path and update the mounted sidebar immediately

## Visual Overview

Diagram source saved at `/tmp/codex-pr-diagrams/two-rows-vs-one-row-toggle/sidebar-row-layout.excalidraw`.

```mermaid
flowchart LR
  subgraph Before
    B1[Sidebar pane row]
    B2[One fixed metadata layout]
    B1 --> B2
  end

  subgraph After
    A1[Settings: Sidebar Pane Rows]
    A2{sidebar_pane_row_layout}
    A3[Single row default]
    A4[Two rows optional]
    A5[ProjectSessionList renders matching row]
    A1 --> A2
    A2 -->|missing, unknown, single| A3
    A2 -->|two-row| A4
    A3 --> A5
    A4 --> A5
  end

  Before --> After
```

## Testing

- `pnpm typecheck`
- `pnpm run build:frontend`
- `pnpm --filter frontend exec eslint src/components/ProjectSessionList.tsx src/components/Settings.tsx`

Notes: commands currently print the repo's Node engine warning in this shell because Node is `v20.19.3` and the repo asks for `>=22.14.0`.
