### PR TITLE
Fix RunPane background session focus

### DIFF
--- a/frontend/src/stores/sessionStore.test.ts
+++ b/frontend/src/stores/sessionStore.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Session } from '../types/session';
+import { useSessionStore } from './sessionStore';
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-new',
+    name: 'New pane',
+    worktreePath: '/repo/worktrees/new-pane',
+    prompt: '',
+    status: 'stopped',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    output: [],
+    jsonMessages: [],
+    ...overrides,
+  };
+}
+
+describe('sessionStore', () => {
+  beforeEach(() => {
+    useSessionStore.setState({
+      sessions: [],
+      activeSessionId: null,
+      activeMainRepoSession: null,
+      isLoaded: false,
+      terminalOutput: {},
+      deletingSessionIds: new Set(),
+      gitStatusLoading: new Set(),
+      pendingGitStatusLoading: new Map(),
+      pendingGitStatusUpdates: new Map(),
+      gitStatusBatchTimer: null,
+      activeSpotlights: new Map(),
+    });
+  });
+
+  it('keeps the current active pane when a background-created session arrives', () => {
+    useSessionStore.setState({ activeSessionId: 'session-existing' });
+
+    useSessionStore.getState().addSession(session({
+      id: 'session-background',
+      activateOnCreate: false,
+    }));
+
+    const state = useSessionStore.getState();
+    expect(state.sessions[0].id).toBe('session-background');
+    expect(state.activeSessionId).toBe('session-existing');
+  });
+
+  it('activates newly created sessions by default', () => {
+    useSessionStore.setState({ activeSessionId: 'session-existing' });
+
+    useSessionStore.getState().addSession(session({
+      id: 'session-foreground',
+    }));
+
+    expect(useSessionStore.getState().activeSessionId).toBe('session-foreground');
+  });
+});

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -92,6 +92,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   
   addSession: (session) => set((state) => {
     const normalizedSession = normalizeSession(session);
+    const shouldActivate = normalizedSession.activateOnCreate !== false;
     
     // Initialize arrays if they don't exist
     const sessionWithArrays = {
@@ -102,7 +103,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     
     return {
       sessions: [sessionWithArrays, ...state.sessions],  // Add new sessions at the top
-      activeSessionId: normalizedSession.id  // Automatically set as active
+      activeSessionId: shouldActivate ? normalizedSession.id : state.activeSessionId
     };
   }),
   

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -102,6 +102,7 @@ export interface Session {
   gitStatus?: GitStatus;
   baseCommit?: string;
   baseBranch?: string;
+  activateOnCreate?: boolean;
 }
 
 export interface GitStatus {

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -1107,6 +1107,7 @@ describe('runpane IPC handlers', () => {
       projectId: project.id,
       baseBranch: 'main',
       toolType: 'none',
+      activateOnCreate: false,
     }, { timeoutMs: 1234 });
     expect(panelManager.createPanel).toHaveBeenCalledWith({
       sessionId: session.id,

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -624,6 +624,7 @@ async function createPaneItem(
       projectId: repo.id,
       baseBranch: item.baseBranch,
       toolType: 'none',
+      activateOnCreate: options.activate !== false,
     }, { timeoutMs: options.timeoutMs });
 
     const session = sessionManager.getSession(sessionResult.sessionId);

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -491,8 +491,11 @@ export class SessionManager extends EventEmitter {
     });
   }
 
-  emitSessionCreated(session: Session): void {
-    this.emit('session-created', session);
+  emitSessionCreated(session: Session, options: { activateOnCreate?: boolean } = {}): void {
+    this.emit('session-created', {
+      ...session,
+      activateOnCreate: options.activateOnCreate !== false,
+    });
   }
 
   updateSession(id: string, update: SessionUpdate): void {

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -40,6 +40,7 @@ interface CreateSessionJob {
   baseBranch?: string;
   toolType?: 'claude' | 'none';
   startPinned?: boolean;
+  activateOnCreate?: boolean;
 }
 
 interface ContinueSessionJob {
@@ -291,7 +292,9 @@ export class TaskQueue {
         }
 
         // Emit the session-created event BEFORE running build script so UI shows immediately
-        sessionManager.emitSessionCreated(session);
+        sessionManager.emitSessionCreated(session, {
+          activateOnCreate: job.data.activateOnCreate !== false,
+        });
 
         // Worktree file sync — copy gitignored files in background, then run install
         // Fire-and-forget: copies first, then writes install command to the terminal

--- a/main/src/types/session.ts
+++ b/main/src/types/session.ts
@@ -28,6 +28,7 @@ export interface Session {
   baseCommit?: string;
   baseBranch?: string;
   pr_renamed?: boolean;
+  activateOnCreate?: boolean;
 }
 
 export interface GitStatus {


### PR DESCRIPTION
## Summary

- Fixes the RunPane background pane focus path where agent-created panes could still switch the visible active Pane UI pane.
- Threads an `activateOnCreate` hint through task-queue session creation and `session:created` renderer handling.
- Keeps default app-created sessions activating normally while preserving the current active pane for background RunPane creation.

Fixes #282.

## Tests

- `pnpm --filter main exec vitest run src/ipc/runpane.test.ts --reporter=dot`
- `pnpm --filter frontend exec vitest run src/stores/sessionStore.test.ts --reporter=dot`
- `pnpm --filter main typecheck`
- `pnpm --filter frontend typecheck`
- `git diff --check`

## Notes

No merge, deploy, or release has been performed. This is ready for manual review.
