### PR TITLE
Fix terminal polish and editor resizing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,22 +100,14 @@ function App() {
   const activeProjectId = useNavigationStore(s => s.activeProjectId);
   const sidebarCollapsed = useNavigationStore(s => s.sidebarCollapsed);
   const setSidebarCollapsed = useNavigationStore(s => s.setSidebarCollapsed);
-  const immersiveMode = useNavigationStore(s => s.immersiveMode);
-  const setImmersiveMode = useNavigationStore(s => s.setImmersiveMode);
 
-  // When in immersive mode, the sidebar is forced collapsed.
-  // The toggle button needs to clear immersive mode to expand, not just toggle sidebarCollapsed.
   const handleToggleSidebar = useCallback(() => {
-    const isVisuallyCollapsed = immersiveMode || sidebarCollapsed;
-    if (isVisuallyCollapsed) {
-      // User wants to expand
-      if (immersiveMode) setImmersiveMode(false);
-      if (sidebarCollapsed) setSidebarCollapsed(false);
+    if (sidebarCollapsed) {
+      setSidebarCollapsed(false);
     } else {
-      // User wants to collapse
       setSidebarCollapsed(true);
     }
-  }, [immersiveMode, sidebarCollapsed, setImmersiveMode, setSidebarCollapsed]);
+  }, [sidebarCollapsed, setSidebarCollapsed]);
   const { currentError, clearError } = useErrorStore();
   const { sessions, isLoaded } = useSessionStore();
   const { fetchConfig, config: appConfig } = useConfigStore();
@@ -198,7 +190,7 @@ function App() {
     keys: 'mod+shift+e',
     category: 'navigation',
     action: () => {
-      if (sidebarCollapsed || immersiveMode) handleToggleSidebar();
+      if (sidebarCollapsed) handleToggleSidebar();
     },
   });
 
@@ -706,7 +698,7 @@ function App() {
         <MainProcessLogger />
         <div
           className="pane-sidebar-slot flex-shrink-0 overflow-hidden transition-[width] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]"
-          style={{ width: (immersiveMode || sidebarCollapsed) ? '48px' : `${sidebarWidth}px` }}
+          style={{ width: sidebarCollapsed ? '48px' : `${sidebarWidth}px` }}
         >
           <Sidebar
             onAboutClick={() => setIsAboutOpen(true)}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1404,7 +1404,7 @@ export const SessionView = memo(() => {
     setLayoutSwapped(prev => !prev);
   }, []);
 
-  // Auto-collapse sidebars for immersive panels (diff, explorer)
+  // Focused tool panels reserve the right/detail rail for the main workspace.
   const isImmersivePanel = currentActivePanel ? currentActivePanel.type === 'diff' || currentActivePanel.type === 'explorer' : false;
   const setImmersiveMode = useNavigationStore(s => s.setImmersiveMode);
   const immersiveMode = useNavigationStore(s => s.immersiveMode);
@@ -1487,13 +1487,6 @@ export const SessionView = memo(() => {
   // Layout-aware detail panel toggle that also handles immersive mode override
   const handleToggleDetailPanel = useCallback(() => {
     if (immersiveMode) {
-      setImmersiveMode(false);
-      if (layoutSwapped) {
-        setIsDetailCollapsed(false);
-        localStorage.setItem('pane-detail-collapsed', 'false');
-      } else {
-        setDetailVisible(true);
-      }
       return;
     }
     if (layoutSwapped) {
@@ -1501,7 +1494,7 @@ export const SessionView = memo(() => {
     } else {
       setDetailVisible(v => !v);
     }
-  }, [immersiveMode, layoutSwapped, setImmersiveMode, toggleDetailCollapse]);
+  }, [immersiveMode, layoutSwapped, toggleDetailCollapse]);
 
   // Terminal collapse state with localStorage persistence (collapsed by default)
   const [isTerminalCollapsed, setIsTerminalCollapsed] = useState(() => {
@@ -1533,7 +1526,7 @@ export const SessionView = memo(() => {
     label: 'Toggle Detail Panel',
     keys: 'mod+shift+b',
     category: 'view',
-    enabled: () => isInSessionView,
+    enabled: () => isInSessionView && !immersiveMode,
     action: handleToggleDetailPanel,
   });
 
@@ -1731,6 +1724,8 @@ export const SessionView = memo(() => {
           onPanelCreate={handlePanelCreate}
           onToggleDetailPanel={handleToggleDetailPanel}
           detailPanelVisible={detailVisible}
+          detailPanelToggleDisabled={immersiveMode}
+          detailPanelToggleDisabledReason="Hidden in Explorer and Diff views"
           primaryGroupPanels={topBarPanels}
           primaryGroupActivePanelId={isSplitLayout ? (currentActivePanel?.id ?? null) : primaryGroupNode?.activePanelId}
           primaryGroupFocused={!primaryGroupNode || primaryGroupNode.id === focusedGroupId}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -60,6 +60,9 @@ interface SidebarProps {
 
 const REMOTE_DESKTOP_URL = 'https://remotedesktop.google.com/access';
 const REMOTE_DESKTOP_TOOLTIP = 'Use Remote Desktop to access the host device for Electron apps, native windows, and UI running on the remote machine.';
+const RESOURCE_POPOVER_WIDTH = 320;
+const RESOURCE_POPOVER_GAP = 8;
+const RESOURCE_POPOVER_VIEWPORT_MARGIN = 8;
 type SidebarSection = 'pinned' | 'repositories';
 
 function formatMemory(mb: number): string {
@@ -241,10 +244,21 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
     const updatePosition = () => {
       if (!resourceMenuButtonRef.current) return;
       const rect = resourceMenuButtonRef.current.getBoundingClientRect();
+      const popoverWidth = Math.min(
+        RESOURCE_POPOVER_WIDTH,
+        window.innerWidth - RESOURCE_POPOVER_VIEWPORT_MARGIN * 2,
+      );
+      const rightSideLeft = rect.right + RESOURCE_POPOVER_GAP;
+      const leftSideLeft = rect.left - RESOURCE_POPOVER_GAP - popoverWidth;
+      const maxLeft = window.innerWidth - popoverWidth - RESOURCE_POPOVER_VIEWPORT_MARGIN;
+      const left = rightSideLeft <= maxLeft
+        ? rightSideLeft
+        : Math.max(RESOURCE_POPOVER_VIEWPORT_MARGIN, leftSideLeft);
+
       setResourcePopoverStyle({
         position: 'fixed',
         top: rect.bottom + 8,
-        right: Math.max(8, window.innerWidth - rect.right),
+        left: Math.min(left, maxLeft),
         zIndex: 10000,
       });
     };
@@ -367,8 +381,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
   }, [projects, activeProjectId]);
 
   // Collapsed sidebar view
-  const immersiveMode = useNavigationStore(s => s.immersiveMode);
-  if (collapsed || immersiveMode) {
+  if (collapsed) {
     return (
       <>
         <div
@@ -661,7 +674,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
       {showResourcePopover && createPortal(
         <div
           ref={resourcePopoverRef}
-          className="bg-surface-primary border border-border-subtle/60 rounded-lg shadow-dropdown-elevated backdrop-blur-sm animate-dropdown-enter overflow-hidden w-[320px]"
+          className="bg-surface-primary border border-border-subtle/60 rounded-lg shadow-dropdown-elevated backdrop-blur-sm animate-dropdown-enter overflow-hidden w-[320px] max-w-[calc(100vw-16px)]"
           style={resourcePopoverStyle}
         >
           <div className="flex items-center justify-between px-3 py-2 border-b border-border-secondary">

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -60,6 +60,8 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   context = 'worktree',  // Default to worktree for backward compatibility
   onToggleDetailPanel,
   detailPanelVisible,
+  detailPanelToggleDisabled = false,
+  detailPanelToggleDisabledReason = 'Unavailable in this view',
   // Optional split tab group integration
   primaryGroupPanels,
   primaryGroupActivePanelId,
@@ -674,16 +676,20 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
 
           {/* Detail panel toggle */}
           {onToggleDetailPanel && (
-            <Tooltip content={hotkeyDisplay('toggle-detail-panel') ? <Kbd>{hotkeyDisplay('toggle-detail-panel')}</Kbd> : undefined} side="bottom">
+            <Tooltip content={detailPanelToggleDisabled ? detailPanelToggleDisabledReason : (hotkeyDisplay('toggle-detail-panel') ? <Kbd>{hotkeyDisplay('toggle-detail-panel')}</Kbd> : undefined)} side="bottom">
               <button
-                onClick={onToggleDetailPanel}
+                onClick={detailPanelToggleDisabled ? undefined : onToggleDetailPanel}
+                disabled={detailPanelToggleDisabled}
+                aria-disabled={detailPanelToggleDisabled}
                 className={cn(
                   "inline-flex items-center justify-center h-[var(--panel-tab-height)] px-2.5 rounded transition-colors flex-shrink-0",
-                  detailPanelVisible
+                  detailPanelToggleDisabled
+                    ? "text-text-muted cursor-not-allowed opacity-50"
+                    : detailPanelVisible
                     ? "text-text-primary bg-surface-hover"
                     : "text-text-tertiary hover:text-text-primary hover:bg-surface-hover"
                 )}
-                title={detailPanelVisible ? "Hide detail panel" : "Show detail panel"}
+                title={detailPanelToggleDisabled ? detailPanelToggleDisabledReason : detailPanelVisible ? "Hide detail panel" : "Show detail panel"}
               >
                 <PanelRight className="w-4 h-4" />
               </button>

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -1635,7 +1635,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
       {/* Terminal scroll buttons — compact, revealed on hover */}
       {isInitialized && (
-        <div className="absolute -top-0.5 right-2 z-30 flex items-center gap-0.5 opacity-0 pointer-events-none group-hover/terminal:opacity-100 group-hover/terminal:pointer-events-auto transition-opacity">
+        <div className="absolute top-2 right-5 z-30 flex items-center gap-0.5 opacity-0 pointer-events-none group-hover/terminal:opacity-100 group-hover/terminal:pointer-events-auto transition-opacity">
           <button
             onClick={handleRefreshTerminal}
             className="p-0.5 rounded bg-surface-secondary/60 hover:bg-surface-tertiary/80 text-text-tertiary hover:text-text-secondary transition-colors"
@@ -1680,7 +1680,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             isNearBottomRef.current = true;
             setShowScrollDown(false);
           }}
-          className="absolute bottom-3 left-1/2 -translate-x-1/2 z-30 flex items-center justify-center w-7 h-7 rounded-full text-text-tertiary hover:text-text-secondary transition-colors duration-150"
+          className="absolute bottom-3 left-1/2 -translate-x-1/2 z-30 flex items-center justify-center w-7 h-7 rounded-full bg-[color-mix(in_srgb,var(--color-text-primary)_6%,transparent)] hover:bg-[color-mix(in_srgb,var(--color-text-primary)_8%,transparent)] text-text-tertiary hover:text-text-secondary transition-colors duration-150"
           title="Jump to bottom"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -1585,9 +1585,9 @@ export function FileEditor({
   }, [selectedFile?.path]); // Run cleanup when file changes
 
   return (
-    <div className="h-full flex">
+    <div className="h-full w-full min-w-0 flex overflow-hidden">
       <div 
-        className="bg-surface-secondary border-r border-border-primary relative flex-shrink-0"
+        className="bg-surface-secondary border-r border-border-primary relative flex-shrink-0 max-w-[45%]"
         style={{ width: `${fileTreeWidth}px` }}
       >
         <HeadlessFileTree
@@ -1612,13 +1612,13 @@ export function FileEditor({
           <div className="absolute -left-2 -right-2 top-0 bottom-0" />
         </div>
       </div>
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
         {selectedFile ? (
           <>
             <div className="flex items-center justify-between px-4 py-2 bg-surface-secondary border-b border-border-primary">
-              <div className="flex items-center gap-2">
+              <div className="flex min-w-0 items-center gap-2">
                 <File className="w-4 h-4 text-text-tertiary" />
-                <span className="text-sm text-text-primary">
+                <span className="min-w-0 truncate text-sm text-text-primary">
                   {selectedFile.path}
                   {hasUnsavedChanges && <span className="text-status-warning ml-2">●</span>}
                 </span>
@@ -1632,7 +1632,7 @@ export function FileEditor({
                   </span>
                 )}
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-shrink-0 items-center gap-2">
                 {/* Preview Toggle for Markdown/Notebook Files */}
                 {!isBinaryPreview && (isMarkdownFile || isNotebookFile) && (
                   <div className="flex items-center rounded-lg border border-border-primary bg-surface-tertiary">
@@ -1684,7 +1684,7 @@ export function FileEditor({
                 Error: {error}
               </div>
             )}
-            <div className="flex-1 overflow-hidden">
+            <div className="flex-1 min-w-0 overflow-hidden">
               {viewMode === 'preview' && isMarkdownFile ? (
                 <div className="h-full overflow-auto bg-bg-primary">
                   <MarkdownPreview

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -471,14 +471,26 @@ body.light-rounded {
   animation: sidebar-active-label-breathe 2.4s ease-in-out infinite;
 }
 
-.xterm .xterm-screen {
-  margin: 6px;
-}
-
 /* Terminal specific styling */
 .xterm {
+  --pane-terminal-padding-x: 6px;
+  --pane-terminal-fit-padding-y: 6px;
+  --pane-terminal-screen-offset-y: 3px;
+  box-sizing: border-box;
   height: 100%;
+  padding: var(--pane-terminal-fit-padding-y) var(--pane-terminal-padding-x);
   width: 100%;
+}
+
+.xterm .xterm-viewport {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.xterm .xterm-screen {
+  margin: var(--pane-terminal-screen-offset-y) 0 0 var(--pane-terminal-padding-x);
 }
 
 /* Light mode: invert the dark terminal instead of fighting ANSI color issues */
@@ -502,18 +514,18 @@ body.light-rounded {
 
 /* xterm v6 custom scrollbar — thin, matches app scrollbars */
 .xterm .xterm-scrollable-element > .scrollbar {
-  width: 4px !important;
+  width: 3px !important;
 }
 .xterm .xterm-scrollable-element > .scrollbar > .scra,
 .xterm .xterm-scrollable-element > .scrollbar > .scra * {
-  width: 4px !important;
+  width: 3px !important;
   left: 0 !important;
-  background: var(--color-scrollbar-thumb) !important;
+  background: color-mix(in srgb, var(--color-scrollbar-thumb) 55%, transparent) !important;
   border-radius: 9999px !important;
 }
 .xterm .xterm-scrollable-element > .scrollbar > .scra:hover,
 .xterm .xterm-scrollable-element > .scrollbar > .scra:hover * {
-  background: var(--color-scrollbar-thumb-hover) !important;
+  background: color-mix(in srgb, var(--color-scrollbar-thumb-hover) 70%, transparent) !important;
 }
 .xterm .xterm-scrollable-element > .shadow {
   display: none !important;

--- a/frontend/src/types/panelComponents.ts
+++ b/frontend/src/types/panelComponents.ts
@@ -24,6 +24,8 @@ export interface PanelTabBarProps {
   context?: PanelContext;  // Optional context to filter available panels
   onToggleDetailPanel?: () => void;
   detailPanelVisible?: boolean;
+  detailPanelToggleDisabled?: boolean;
+  detailPanelToggleDisabledReason?: string;
 
   // --- Optional split tab group integration ---
   /** Panels in layout order for the primary group (overrides internal sort). */


### PR DESCRIPTION
## Summary

- Fix xterm spacing so terminal rows are not pressed into the rounded container edge
- Make terminal overlay controls and scrollbar feel lighter and correctly placed
- Make the Explorer/Monaco editor shrink correctly when the left sidebar or file tree gets wide
- Keep immersive sidebar/detail controls from presenting unavailable actions

## Visual Overview

Before: terminal spacing was implemented as screen margin, which could visually clip the bottom row and make the scrollbar/hover controls feel misaligned. The editor pane could also resist shrinking because its flex children and path header kept intrinsic width.

After: terminal spacing is part of xterm fit math, the scrollbar remains full height and subtle, overlay controls sit inside the chrome, and the editor column can shrink via `min-w-0` with truncated path text.

Diagram source: `/tmp/codex-pr-diagrams/quick-fixes-1/terminal-editor-polish.excalidraw`

## Testing

- `pnpm --filter frontend typecheck`
- pre-commit `pnpm run -r typecheck`
- pre-commit `pnpm run -r lint` (passes with existing warnings)

Note: local shell reports Node `v20.19.3`; repo engine requests Node `>=22.14.0`.
