### PR TITLE
Improve cached PR state hydration

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -659,6 +659,7 @@ function SessionRow({
   onArchive, onTogglePinned, displayName, rowLayout,
 }: SessionRowProps) {
   const [localGitStatus, setLocalGitStatus] = useState<GitStatus | undefined>(session.gitStatus);
+  const initialGitStatusRequestRef = useRef<string | null>(null);
 
   const sessionActivity = usePanelStore(s => {
     const sessionPanels = s.panels[session.id] || [];
@@ -666,9 +667,11 @@ function SessionRow({
   });
   const hasUnviewedCompletedActivity = usePanelStore(s => Boolean(s.unviewedCompletedActivity[session.id]));
 
-  // Fetch git status if not available
+  // Queue the initial refresh even when cached status is available, so cached
+  // PR state is corrected by the background git/PR refresh path.
   useEffect(() => {
-    if (localGitStatus || session.gitStatus || session.archived || session.status === 'error') return;
+    if (initialGitStatusRequestRef.current === session.id || session.archived || session.status === 'error') return;
+    initialGitStatusRequestRef.current = session.id;
     const fetchStatus = async () => {
       try {
         if (!window.electron?.invoke) return;
@@ -686,7 +689,7 @@ function SessionRow({
       }
     };
     fetchStatus();
-  }, [session.id, session.archived, session.status, localGitStatus, session.gitStatus]);
+  }, [session.id, session.archived, session.status]);
 
   // Sync from session prop when store updates
   useEffect(() => {

--- a/frontend/src/components/SessionDetailTooltip.tsx
+++ b/frontend/src/components/SessionDetailTooltip.tsx
@@ -58,6 +58,7 @@ export function SessionDetailTooltip({ session, gitStatus, showName = true, show
   const dels = (gs?.commitDeletions ?? 0) + (gs?.deletions ?? 0);
   const hasDiff = adds > 0 || dels > 0;
   const filesChanged = (gs?.commitFilesChanged ?? 0) + (gs?.filesChanged ?? 0);
+  const shouldShowDiffStats = hasDiff && (showDiffStats || Boolean(gs?.prNumber));
 
   return (
     <div className="max-w-xs space-y-1.5">
@@ -94,7 +95,7 @@ export function SessionDetailTooltip({ session, gitStatus, showName = true, show
         </div>
       </div>
 
-      {showDiffStats && hasDiff && (
+      {shouldShowDiffStats && (
         <>
           <div className="border-t border-border-primary" />
           <div className="flex items-center gap-3 text-[10px]">

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs/promises';
 import { existsSync } from 'fs';
 import type { AppServices } from './types';
 import type { PaneCommandRegistry } from '../daemon/commandRegistry';
-import type { CreateSessionRequest } from '../types/session';
+import type { CreateSessionRequest, Session } from '../types/session';
 import { getAppSubdirectory } from '../utils/appDirectory';
 import { convertDbFolderToRendererFolder } from '../services/folderEvents';
 import { sessionImageCounters } from './panels';
@@ -106,10 +106,15 @@ export function registerSessionHandlers(
   // NOTE: Current IPC handlers use claudeCodeManager directly for backward compatibility
   // Future versions will use getCliManager() to support multiple CLI tools dynamically
 
+  const attachCachedGitStatus = (session: Session): Session => {
+    const cached = gitStatusManager.getCachedStatus(session.id)?.status;
+    return cached ? { ...session, gitStatus: cached } : session;
+  };
+
   // Session management handlers
   commandRegistry.register('sessions:get-all', async () => {
     try {
-      const sessions = await sessionManager.getAllSessions();
+      const sessions = (await sessionManager.getAllSessions()).map(attachCachedGitStatus);
       return { success: true, data: sessions };
     } catch (error) {
       console.error('Failed to get sessions:', error);
@@ -124,7 +129,7 @@ export function registerSessionHandlers(
       if (!session) {
         return { success: false, error: 'Session not found' };
       }
-      return { success: true, data: session };
+      return { success: true, data: attachCachedGitStatus(session) };
     } catch (error) {
       console.error('Failed to get session:', error);
       return { success: false, error: 'Failed to get session' };
@@ -135,7 +140,7 @@ export function registerSessionHandlers(
     try {
       const allProjects = databaseService.getAllProjects();
       const projectsWithSessions = allProjects.map(project => {
-        const sessions = sessionManager.getSessionsForProject(project.id);
+        const sessions = sessionManager.getSessionsForProject(project.id).map(attachCachedGitStatus);
         const folders = databaseService.getFoldersForProject(project.id);
         const convertedFolders = folders.map(convertDbFolderToRendererFolder);
         return {

--- a/main/src/services/__tests__/gitStatusManager.test.ts
+++ b/main/src/services/__tests__/gitStatusManager.test.ts
@@ -14,14 +14,17 @@ import type { DatabaseService } from '../../database/database';
 // Type for accessing private members in tests
 interface GitStatusManagerPrivates {
   fetchGitStatus(sessionId: string): Promise<GitStatus | null>;
+  processInitialLoadQueue(): Promise<void>;
   fetchPrForSession(
     branchName: string,
     projectPath: string,
     commandRunner: CommandRunner
   ): Promise<{ prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string }>;
   enrichWithPrData(sessionId: string): Promise<void>;
-  updateCache(sessionId: string, status: GitStatus): void;
+  updateCache(sessionId: string, status: GitStatus): GitStatus;
+  schedulePrEnrichment(sessionId: string, immediate?: boolean): void;
   cache: Record<string, { status: GitStatus; lastChecked: number }>;
+  initialLoadQueue: string[];
   prCache: Map<string, { prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string; fetchedAt: number }>;
   activeSessionId: string | null;
 }
@@ -371,6 +374,44 @@ describe('GitStatusManager', () => {
         expect.any(Number),
       );
     });
+
+    it('preserves cached PR fields when local status refresh has no PR fields', () => {
+      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      privates.cache['test-session'] = {
+        status: {
+          state: 'ahead',
+          ahead: 1,
+          prNumber: 12,
+          prUrl: 'https://github.com/example/repo/pull/12',
+          prTitle: 'Ready review',
+          prState: 'OPEN',
+          prBody: 'Body',
+        },
+        lastChecked: Date.now(),
+      };
+
+      const updated = privates.updateCache('test-session', {
+        state: 'ahead',
+        ahead: 2,
+        commitAdditions: 20,
+      });
+
+      expect(updated).toMatchObject({
+        state: 'ahead',
+        ahead: 2,
+        commitAdditions: 20,
+        prNumber: 12,
+        prUrl: 'https://github.com/example/repo/pull/12',
+        prTitle: 'Ready review',
+        prState: 'OPEN',
+        prBody: 'Body',
+      });
+      expect(mockDatabaseService.saveSessionGitStatusCache).toHaveBeenLastCalledWith(
+        'test-session',
+        expect.objectContaining({ prNumber: 12, ahead: 2 }),
+        expect.any(Number),
+      );
+    });
   });
 
   describe('PR enrichment', () => {
@@ -476,6 +517,85 @@ describe('GitStatusManager', () => {
       expect((mockProjectContext.commandRunner.execAsync as Mock).mock.calls[0][0]).not.toContain('not-the-branch');
       expect(status.prNumber).toBe(12);
       expect(status.prUrl).toBe('https://github.com/example/repo/pull/12');
+    });
+
+    it('clears cached PR fields on a confirmed PR miss', async () => {
+      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      privates.cache['test-session'] = {
+        status: {
+          state: 'ahead',
+          ahead: 1,
+          prNumber: 12,
+          prUrl: 'https://github.com/example/repo/pull/12',
+          prTitle: 'Ready review',
+          prState: 'OPEN',
+          prBody: 'Body',
+        },
+        lastChecked: Date.now(),
+      };
+      (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('feature-branch\n');
+      (mockProjectContext.commandRunner.execAsync as Mock).mockResolvedValue({ stdout: '[]' });
+
+      const updated = new Promise<GitStatus>((resolve) => {
+        gitStatusManager.once('git-status-updated', (_sessionId, status) => resolve(status));
+      });
+      void privates.enrichWithPrData('test-session');
+      const status = await updated;
+
+      expect(status.prNumber).toBeUndefined();
+      expect(status.prUrl).toBeUndefined();
+      expect(status.prTitle).toBeUndefined();
+      expect(status.prState).toBeUndefined();
+      expect(status.prBody).toBeUndefined();
+      expect(status.ahead).toBe(1);
+      expect(mockDatabaseService.saveSessionGitStatusCache).toHaveBeenLastCalledWith(
+        'test-session',
+        expect.not.objectContaining({ prNumber: expect.any(Number) }),
+        expect.any(Number),
+      );
+    });
+
+    it('keeps cached PR fields when PR lookup fails', async () => {
+      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const cachedStatus: GitStatus = {
+        state: 'ahead',
+        ahead: 1,
+        prNumber: 12,
+        prUrl: 'https://github.com/example/repo/pull/12',
+        prTitle: 'Ready review',
+        prState: 'OPEN',
+        prBody: 'Body',
+      };
+      privates.cache['test-session'] = {
+        status: cachedStatus,
+        lastChecked: Date.now(),
+      };
+      (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('feature-branch\n');
+      (mockProjectContext.commandRunner.execAsync as Mock).mockRejectedValue(new Error('gh unavailable'));
+
+      await privates.enrichWithPrData('test-session');
+
+      expect(privates.cache['test-session'].status).toEqual(cachedStatus);
+      expect(mockDatabaseService.saveSessionGitStatusCache).not.toHaveBeenCalled();
+    });
+
+    it('schedules staggered PR enrichment for non-active relevant initial-load status', async () => {
+      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      privates.initialLoadQueue.push('test-session');
+      privates.activeSessionId = null;
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+      const fetchSpy = vi
+        .spyOn(privates, 'fetchGitStatus')
+        .mockResolvedValue({ state: 'ahead', ahead: 1, isReadyToMerge: true });
+      const scheduleSpy = vi
+        .spyOn(privates, 'schedulePrEnrichment')
+        .mockImplementation(() => {});
+
+      await privates.processInitialLoadQueue();
+
+      expect(fetchSpy).toHaveBeenCalledWith('test-session');
+      expect(scheduleSpy).toHaveBeenCalledWith('test-session', false);
+      randomSpy.mockRestore();
     });
   });
 

--- a/main/src/services/gitStatusManager.ts
+++ b/main/src/services/gitStatusManager.ts
@@ -18,6 +18,19 @@ interface GitStatusCache {
   };
 }
 
+type PrData = {
+  prNumber?: number;
+  prUrl?: string;
+  prTitle?: string;
+  prState?: string;
+  prBody?: string;
+};
+
+type PrLookupResult =
+  | { ok: true; pr?: PrData }
+  | { ok: false };
+
+const PR_FIELDS = ['prNumber', 'prUrl', 'prTitle', 'prState', 'prBody'] as const;
 
 export class GitStatusManager extends EventEmitter {
   private cache: GitStatusCache = {};
@@ -254,7 +267,7 @@ export class GitStatusManager extends EventEmitter {
     // Fetch fresh status
     const status = await this.fetchGitStatus(sessionId);
     if (status) {
-      this.updateCache(sessionId, status);
+      return this.updateCache(sessionId, status);
     }
     return status;
   }
@@ -405,8 +418,8 @@ export class GitStatusManager extends EventEmitter {
       }
 
       // Update cache and emit
-      this.updateCache(sessionId, updatedStatus);
-      this.emitThrottled(sessionId, 'updated', updatedStatus);
+      const cachedStatus = this.updateCache(sessionId, updatedStatus);
+      this.emitThrottled(sessionId, 'updated', cachedStatus);
       
       this.logger?.info(`[GitStatus] Updated status after ${rebaseType} rebase for session ${sessionId}`);
     } catch (error) {
@@ -451,7 +464,9 @@ export class GitStatusManager extends EventEmitter {
             const cached = this.cache[sessionId]?.status || null;
             if (cached) {
               this.emitThrottled(sessionId, 'updated', cached);
-              this.schedulePrEnrichment(sessionId);
+              if (this.shouldSchedulePrEnrichment(cached)) {
+                this.schedulePrEnrichment(sessionId);
+              }
             }
             resolve(cached);
             return;
@@ -460,11 +475,13 @@ export class GitStatusManager extends EventEmitter {
         
         const status = await this.fetchGitStatus(sessionId);
         if (status) {
-          this.updateCache(sessionId, status);
-          this.emitThrottled(sessionId, 'updated', status);
-          this.schedulePrEnrichment(sessionId, isUserInitiated);
+          const cachedStatus = this.updateCache(sessionId, status);
+          this.emitThrottled(sessionId, 'updated', cachedStatus);
+          if (this.shouldSchedulePrEnrichment(cachedStatus)) {
+            this.schedulePrEnrichment(sessionId, isUserInitiated);
+          }
         }
-        resolve(status);
+        resolve(status ? this.cache[sessionId]?.status || status : status);
       }, this.DEBOUNCE_MS);
 
       this.refreshDebounceTimers.set(sessionId, timer);
@@ -528,10 +545,10 @@ export class GitStatusManager extends EventEmitter {
             }
             const status = await this.fetchGitStatus(sessionId);
             if (status) {
-              this.updateCache(sessionId, status);
-              this.emitThrottled(sessionId, 'updated', status);
-              if (sessionId === this.activeSessionId) {
-                this.schedulePrEnrichment(sessionId, true);
+              const cachedStatus = this.updateCache(sessionId, status);
+              this.emitThrottled(sessionId, 'updated', cachedStatus);
+              if (this.shouldSchedulePrEnrichment(cachedStatus)) {
+                this.schedulePrEnrichment(sessionId, sessionId === this.activeSessionId);
               }
             }
           } catch (error) {
@@ -556,11 +573,25 @@ export class GitStatusManager extends EventEmitter {
     projectPath: string,
     commandRunner: CommandRunner
   ): Promise<{ prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string }> {
+    const result = await this.fetchPrForSessionResult(branchName, projectPath, commandRunner);
+    return result.ok && result.pr ? result.pr : {};
+  }
+
+  private async fetchPrForSessionResult(
+    branchName: string,
+    projectPath: string,
+    commandRunner: CommandRunner
+  ): Promise<PrLookupResult> {
     const cacheKey = `${projectPath}:${branchName}`;
     const cached = this.prCache.get(cacheKey);
     const cacheTtl = cached?.prNumber !== undefined ? this.PR_HIT_CACHE_TTL : this.PR_MISS_CACHE_TTL;
     if (cached && Date.now() - cached.fetchedAt < cacheTtl) {
-      return { prNumber: cached.prNumber, prUrl: cached.prUrl, prTitle: cached.prTitle, prState: cached.prState, prBody: cached.prBody };
+      return {
+        ok: true,
+        pr: cached.prNumber !== undefined
+          ? { prNumber: cached.prNumber, prUrl: cached.prUrl, prTitle: cached.prTitle, prState: cached.prState, prBody: cached.prBody }
+          : undefined,
+      };
     }
 
     try {
@@ -580,10 +611,14 @@ export class GitStatusManager extends EventEmitter {
         fetchedAt: Date.now()
       };
       this.prCache.set(cacheKey, entry);
-      return { prNumber: entry.prNumber, prUrl: entry.prUrl, prTitle: entry.prTitle, prState: entry.prState, prBody: entry.prBody };
+      return {
+        ok: true,
+        pr: entry.prNumber !== undefined
+          ? { prNumber: entry.prNumber, prUrl: entry.prUrl, prTitle: entry.prTitle, prState: entry.prState, prBody: entry.prBody }
+          : undefined,
+      };
     } catch {
-      this.prCache.set(cacheKey, { fetchedAt: Date.now() });
-      return {};
+      return { ok: false };
     }
   }
 
@@ -660,10 +695,14 @@ export class GitStatusManager extends EventEmitter {
     const branchName = this.getCurrentBranchName(session.worktreePath, ctx.commandRunner);
     if (!branchName) return;
 
-    const prData = await this.fetchPrForSession(branchName, project.path, ctx.commandRunner);
+    const prResult = await this.fetchPrForSessionResult(branchName, project.path, ctx.commandRunner);
+    if (!prResult.ok) return;
 
-    if (prData.prNumber !== undefined) {
-      const currentStatus = this.cache[sessionId]?.status;
+    const currentStatus = this.cache[sessionId]?.status;
+    if (!currentStatus) return;
+
+    const prData = prResult.pr;
+    if (prData?.prNumber !== undefined) {
       if (currentStatus && (
         currentStatus.prNumber !== prData.prNumber ||
         currentStatus.prState !== prData.prState ||
@@ -686,6 +725,18 @@ export class GitStatusManager extends EventEmitter {
         this.persistCachedStatus(sessionId, enrichedStatus, lastChecked);
         this.emit('git-status-updated', sessionId, enrichedStatus);
       }
+      return;
+    }
+
+    if (currentStatus.prNumber !== undefined) {
+      const clearedStatus = this.clearPrFields(currentStatus);
+      const lastChecked = this.cache[sessionId].lastChecked;
+      this.cache[sessionId] = {
+        status: clearedStatus,
+        lastChecked
+      };
+      this.persistCachedStatus(sessionId, clearedStatus, lastChecked);
+      this.emit('git-status-updated', sessionId, clearedStatus);
     }
   }
 
@@ -970,21 +1021,61 @@ export class GitStatusManager extends EventEmitter {
   /**
    * Update cache with new status
    */
-  private updateCache(sessionId: string, status: GitStatus): void {
+  private updateCache(sessionId: string, status: GitStatus): GitStatus {
+    const statusToStore = this.mergePreservedPrFields(sessionId, status);
     const previousStatus = this.cache[sessionId]?.status;
-    const hasChanged = !previousStatus || JSON.stringify(previousStatus) !== JSON.stringify(status);
+    const hasChanged = !previousStatus || JSON.stringify(previousStatus) !== JSON.stringify(statusToStore);
     const lastChecked = Date.now();
     
     this.cache[sessionId] = {
-      status,
+      status: statusToStore,
       lastChecked
     };
-    this.persistCachedStatus(sessionId, status, lastChecked);
+    this.persistCachedStatus(sessionId, statusToStore, lastChecked);
 
     // Only emit event if status actually changed
     if (hasChanged) {
-      this.emitThrottled(sessionId, 'updated', status);
+      this.emitThrottled(sessionId, 'updated', statusToStore);
     }
+    return statusToStore;
+  }
+
+  private mergePreservedPrFields(sessionId: string, nextStatus: GitStatus): GitStatus {
+    if (nextStatus.prNumber !== undefined) return nextStatus;
+
+    const previousStatus = this.cache[sessionId]?.status;
+    if (previousStatus?.prNumber === undefined) return nextStatus;
+
+    return {
+      ...nextStatus,
+      prNumber: previousStatus.prNumber,
+      prUrl: previousStatus.prUrl,
+      prTitle: previousStatus.prTitle,
+      prState: previousStatus.prState,
+      prBody: previousStatus.prBody,
+    };
+  }
+
+  private clearPrFields(status: GitStatus): GitStatus {
+    const cleared = { ...status };
+    for (const field of PR_FIELDS) {
+      delete cleared[field];
+    }
+    return cleared;
+  }
+
+  private shouldSchedulePrEnrichment(status: GitStatus): boolean {
+    return Boolean(
+      status.prNumber ||
+      status.ahead ||
+      status.isReadyToMerge ||
+      status.commitFilesChanged ||
+      status.commitAdditions ||
+      status.commitDeletions ||
+      status.filesChanged ||
+      status.additions ||
+      status.deletions
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- hydrate session payloads with cached git status so reopened panes can immediately show last-known PR state
- preserve cached PR metadata across local git status refreshes, then update or clear it through PR enrichment
- stagger PR enrichment for PR-relevant non-active panes and show diff stats in PR tooltips

## Testing
- pnpm --filter main exec vitest run src/services/__tests__/gitStatusManager.test.ts
- pnpm typecheck
- pnpm lint
- pnpm run build:frontend
- pnpm run build:main

## Notes
- Commands currently warn that this shell is using Node v20.19.3 while the repo declares Node >=22.14.0; checks still passed in this environment.
- An earlier watch-mode Vitest invocation also ran unrelated tests and hit an existing better-sqlite3 native ABI mismatch under Node 20; the focused one-shot gitStatusManager test passed.