### PR TITLE
Fix terminal activation resize flash

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import React, { useRef, useEffect, useLayoutEffect, useState, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import type { WebglAddon } from '@xterm/addon-webgl';
@@ -58,6 +58,7 @@ const DEFAULT_TERMINAL_FONT_FAMILY = 'Geist Mono';
 const DEFAULT_TERMINAL_FONT_SIZE = 14;
 const WEBGL_APP_BLUR_DETACH_DELAY_MS = 10_000;
 const REFOCUS_DELAYED_REFRESH_MS = 300;
+const TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS = 200;
 const TERMINAL_VISIBILITY_REFRESH_MS = 60_000;
 const MIN_VIABLE_RECT_PX = 100; // below this the container is hidden or mid-layout (Allotment minSize is 120)
 const MIN_PTY_COLS = 20;        // mirrors main-process floor
@@ -1443,7 +1444,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
   // Handle Battery Saver visibility changes (resize and full refresh when becoming visible)
   // Include isInitialized so this effect re-runs after terminal initialization completes
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!useBatterySaverTerminalVisibility) return;
     if (!effectiveVisible || !isInitialized || !fitAddonRef.current || !xtermRef.current) return;
 
@@ -1499,7 +1500,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
       hideOverlayTimer = setTimeout(() => {
         if (!cancelled) setIsRefreshing(false);
-      }, 0);
+      }, TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS);
     };
 
     const animationFrame = requestAnimationFrame(fitAndRefresh);
@@ -1517,7 +1518,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   // Performance mode keeps mounted terminals live, but xterm/WebGL can still
   // paint stale rows after display:none→block. Use the same canonical refresh
   // path as the manual Refresh button when a terminal tab becomes visible.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (useBatterySaverTerminalVisibility) return;
     if (!panelVisible || !isInitialized || !fitAddonRef.current || !xtermRef.current) return;
 
@@ -1569,7 +1570,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
         hideOverlayTimer = setTimeout(() => {
           if (!cancelled) setIsRefreshing(false);
-        }, 0);
+        }, TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS);
       });
     };
 


### PR DESCRIPTION
## Summary
- keep the terminal activation mask visible for 200ms after the deterministic paint wait
- run terminal activation refresh effects in `useLayoutEffect` so the mask is raised before the newly active terminal paints

## Why
Switching panes or terminal tabs could briefly expose the underlying terminal while xterm/WebGL layout was still settling. The prior `waitForNextPaint()` plus `setTimeout(..., 0)` path was deterministic, but too eager for the final 50-200ms resize/layout settle window.

## Validation
- manually verified in `pnpm dev` with `PANE_DIR=~/.pane_test`
- `pnpm --filter frontend typecheck`
- pre-commit `pnpm typecheck`
- pre-commit `pnpm lint` (passes with existing warnings)
