### PR TITLE
Fix Windows updater metadata publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
   publish-release:
     if: github.ref_type == 'tag'
-    needs: [build, build-windows]
+    needs: [publish-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -216,7 +216,7 @@ jobs:
         arch: [x64, arm64]
     runs-on: windows-2022
     permissions:
-      contents: write
+      contents: read
     steps:
     - uses: actions/checkout@v7
     - uses: pnpm/action-setup@v6
@@ -233,17 +233,10 @@ jobs:
         restore-keys: windows-${{ matrix.arch }}-electron-
     - run: pnpm install
 
-    - name: Build and optionally publish
+    - name: Build Windows artifact
       run: |
-        if ("${{ github.ref_type }}" -eq "tag" -or "${{ inputs.publish }}" -eq "true") {
-          Write-Host "Release build — publishing to GitHub Releases"
-          pnpm run release:win:${{ matrix.arch }}
-        } else {
-          Write-Host "CI build — artifacts only"
-          node scripts/build-win.js ${{ matrix.arch }}
-        }
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        Write-Host "Building Windows ${{ matrix.arch }} artifact without publishing"
+        node scripts/build-win.js ${{ matrix.arch }}
 
     - run: dir dist-electron
 
@@ -252,6 +245,57 @@ jobs:
         name: pane-windows-${{ matrix.arch }}-${{ github.ref_name }}
         path: |
           dist-electron/*-Windows-${{ matrix.arch }}.exe
+          dist-electron/*-Windows-${{ matrix.arch }}.exe.blockmap
           dist-electron/latest.yml
         if-no-files-found: error
         retention-days: 30
+
+  publish-windows:
+    if: github.ref_type == 'tag' || inputs.publish == true
+    needs: [build, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v7
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22.15.1'
+        cache: 'pnpm'
+    - run: pnpm install --ignore-scripts
+
+    - uses: actions/download-artifact@v7
+      with:
+        name: pane-windows-x64-${{ github.ref_name }}
+        path: windows-artifacts/x64
+
+    - uses: actions/download-artifact@v7
+      with:
+        name: pane-windows-arm64-${{ github.ref_name }}
+        path: windows-artifacts/arm64
+
+    - name: Merge Windows updater metadata
+      run: |
+        mkdir -p windows-release
+        cp windows-artifacts/x64/*-Windows-x64.exe windows-release/
+        cp windows-artifacts/x64/*-Windows-x64.exe.blockmap windows-release/
+        cp windows-artifacts/arm64/*-Windows-arm64.exe windows-release/
+        cp windows-artifacts/arm64/*-Windows-arm64.exe.blockmap windows-release/
+        node scripts/merge-windows-latest.js \
+          windows-artifacts/x64/latest.yml \
+          windows-artifacts/arm64/latest.yml \
+          windows-release/latest.yml
+        ls -la windows-release
+
+    - name: Upload Windows release assets
+      run: |
+        VERSION="$(node -p "require('./package.json').version")"
+        TAG="v${VERSION}"
+        if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+          TAG="${GITHUB_REF_NAME}"
+        fi
+        gh release upload "${TAG}" windows-release/* \
+          --repo "${{ github.repository }}" --clobber
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/merge-windows-latest.js
+++ b/scripts/merge-windows-latest.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const WINDOWS_EXE_PATTERN = /Windows-(x64|arm64)\.exe$/;
+
+function usage() {
+  console.error('Usage: node scripts/merge-windows-latest.js <x64-latest.yml> <arm64-latest.yml> <output-latest.yml>');
+}
+
+function fail(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readUpdateInfo(filePath, expectedArch) {
+  if (!filePath) {
+    fail(`Missing ${expectedArch} latest.yml path`);
+  }
+
+  const absolutePath = path.resolve(filePath);
+  if (!fs.existsSync(absolutePath)) {
+    fail(`${expectedArch} latest.yml not found: ${absolutePath}`);
+  }
+
+  let info;
+  try {
+    info = yaml.load(fs.readFileSync(absolutePath, 'utf8'));
+  } catch (error) {
+    fail(`Failed to parse ${absolutePath}: ${getErrorMessage(error)}`);
+  }
+
+  if (!info || typeof info !== 'object') {
+    fail(`${absolutePath} did not contain a YAML object`);
+  }
+
+  if (typeof info.version !== 'string' || !info.version.trim()) {
+    fail(`${absolutePath} is missing version`);
+  }
+
+  if (!Array.isArray(info.files) || info.files.length === 0) {
+    fail(`${absolutePath} is missing files`);
+  }
+
+  const matchingFiles = info.files.filter(file => {
+    return file && typeof file.url === 'string' && file.url.endsWith(`Windows-${expectedArch}.exe`);
+  });
+
+  if (matchingFiles.length !== 1) {
+    fail(`${absolutePath} must contain exactly one Windows-${expectedArch}.exe file entry; found ${matchingFiles.length}`);
+  }
+
+  const file = matchingFiles[0];
+  if (typeof file.sha512 !== 'string' || !file.sha512.trim()) {
+    fail(`${absolutePath} ${file.url} is missing sha512`);
+  }
+
+  if (typeof file.size !== 'number' || file.size <= 0) {
+    fail(`${absolutePath} ${file.url} is missing a positive size`);
+  }
+
+  return { info, file };
+}
+
+function ensureNoUnexpectedWindowsInstaller(info, sourcePath) {
+  const windowsInstallers = info.files.filter(file => {
+    return file && typeof file.url === 'string' && WINDOWS_EXE_PATTERN.test(file.url);
+  });
+
+  if (windowsInstallers.length !== 1) {
+    fail(`${sourcePath} must contain one Windows installer entry before merging; found ${windowsInstallers.length}`);
+  }
+}
+
+function main() {
+  const [x64Path, arm64Path, outputPath] = process.argv.slice(2);
+
+  if (!x64Path || !arm64Path || !outputPath) {
+    usage();
+    process.exit(1);
+  }
+
+  const x64 = readUpdateInfo(x64Path, 'x64');
+  const arm64 = readUpdateInfo(arm64Path, 'arm64');
+  ensureNoUnexpectedWindowsInstaller(x64.info, path.resolve(x64Path));
+  ensureNoUnexpectedWindowsInstaller(arm64.info, path.resolve(arm64Path));
+
+  if (x64.info.version !== arm64.info.version) {
+    fail(`Version mismatch: x64=${x64.info.version}, arm64=${arm64.info.version}`);
+  }
+
+  const releaseDate = x64.info.releaseDate || arm64.info.releaseDate;
+  if (releaseDate && typeof releaseDate !== 'string') {
+    fail('releaseDate must be a string when present');
+  }
+
+  const merged = {
+    version: x64.info.version,
+    files: [x64.file, arm64.file],
+    path: x64.file.url,
+    sha512: x64.file.sha512,
+  };
+
+  if (releaseDate) {
+    merged.releaseDate = releaseDate;
+  }
+
+  const absoluteOutputPath = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(absoluteOutputPath), { recursive: true });
+  fs.writeFileSync(absoluteOutputPath, yaml.dump(merged, { lineWidth: -1 }), 'utf8');
+
+  console.log(`Merged Windows latest.yml for ${merged.version}:`);
+  for (const file of merged.files) {
+    console.log(`  - ${file.url} (${file.size} bytes)`);
+  }
+  console.log(`Wrote ${absoluteOutputPath}`);
+}
+
+main();


### PR DESCRIPTION
## Description
Fixes the Windows updater metadata publishing race that can point x64 users at the ARM64 installer. Related to #289.

Windows x64 and arm64 builds now publish artifacts only. A single follow-up job downloads both artifacts, validates and merges their updater metadata, then uploads both installers, both blockmaps, and one combined `latest.yml` to the GitHub release before the release is marked latest.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [ ] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [ ] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)
Not applicable.

## Additional Notes
Validation run:
- `node -c scripts/merge-windows-latest.js`
- workflow YAML parse with `js-yaml`
- synthetic x64/arm64 metadata merge
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:frontend`
- `pnpm build:main`

Local caveat: commands ran under Node `v20.19.3`, which prints the repo engine warning for `>=22.14.0`, but the checks completed successfully.