### PR TITLE
Fix macOS RunPane daemon diagnostics

### DIFF
--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -222,9 +222,15 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
   const remoteTransportController = new PaneRemoteTransportController(commandRegistry, configManager, analyticsManager);
   try {
     paneDaemonServer = new PaneDaemonServer(commandRegistry, getAppDirectory());
+    const endpoint = paneDaemonServer.getEndpoint();
+    logger.info(`[Pane daemon] Starting local daemon server on ${endpoint.transport}:${endpoint.path}`);
     await paneDaemonServer.start();
+    logger.info(`[Pane daemon] Local daemon server listening on ${endpoint.transport}:${endpoint.path}`);
   } catch (error) {
-    console.error('[Pane daemon] Failed to start local daemon server; continuing with renderer-only runtime events', error);
+    logger.error(
+      '[Pane daemon] Failed to start local daemon server; continuing with renderer-only runtime events',
+      error instanceof Error ? error : new Error(String(error)),
+    );
   }
 
   if (startRemoteTransport) {

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -1322,6 +1322,13 @@ if (launchRemoteSetup) {
   }, 10_000);
 
   try {
+    if (paneDaemonHost?.paneDaemonServer) {
+      logToFile('Stopping local daemon server early');
+      console.log('[Main] Stopping local daemon server early...');
+      await paneDaemonHost.paneDaemonServer.stop();
+      console.log('[Main] Local daemon server stopped');
+    }
+
     // Stop resource monitoring
     resourceMonitorService.stop();
 

--- a/main/src/utils/consoleWrapper.test.ts
+++ b/main/src/utils/consoleWrapper.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const savedConsole = { ...console };
+
+async function loadConsoleWrapperWithOriginals(originals: Partial<Console>) {
+  vi.resetModules();
+  Object.assign(console, originals);
+  return import('./consoleWrapper');
+}
+
+afterEach(() => {
+  Object.assign(console, savedConsole);
+  vi.resetModules();
+});
+
+describe('setupConsoleWrapper', () => {
+  it('ignores EPIPE from closed stdout or stderr streams', async () => {
+    const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+    const { setupConsoleWrapper } = await loadConsoleWrapperWithOriginals({
+      log: vi.fn(() => {
+        throw epipe;
+      }) as unknown as typeof console.log,
+      error: vi.fn(() => {
+        throw epipe;
+      }) as unknown as typeof console.error,
+    });
+
+    setupConsoleWrapper();
+
+    expect(() => console.log('[Main] startup log')).not.toThrow();
+    expect(() => console.error('[Pane daemon] Failed to start local daemon server')).not.toThrow();
+  });
+
+  it('preserves unexpected console write failures', async () => {
+    const { setupConsoleWrapper } = await loadConsoleWrapperWithOriginals({
+      log: vi.fn(() => {
+        throw new Error('unexpected console failure');
+      }) as unknown as typeof console.log,
+    });
+
+    setupConsoleWrapper();
+
+    expect(() => console.log('[Main] startup log')).toThrow('unexpected console failure');
+  });
+});

--- a/main/src/utils/consoleWrapper.ts
+++ b/main/src/utils/consoleWrapper.ts
@@ -12,6 +12,20 @@ const originalConsole = {
   debug: console.debug
 };
 
+function isBrokenPipeError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === 'EPIPE';
+}
+
+function writeOriginalConsole(method: (...args: unknown[]) => void, args: unknown[]): void {
+  try {
+    method(...args);
+  } catch (error) {
+    if (!isBrokenPipeError(error)) {
+      throw error;
+    }
+  }
+}
+
 // Helper to check if a message should be logged
 function shouldLog(level: 'log' | 'info' | 'debug', args: unknown[]): boolean {
   if (args.length === 0) return false;
@@ -53,25 +67,29 @@ function shouldLog(level: 'log' | 'info' | 'debug', args: unknown[]): boolean {
 export function setupConsoleWrapper() {
   console.log = (...args: unknown[]) => {
     if (shouldLog('log', args)) {
-      originalConsole.log(...args);
+      writeOriginalConsole(originalConsole.log, args);
     }
   };
   
   console.info = (...args: unknown[]) => {
     if (shouldLog('info', args)) {
-      originalConsole.info(...args);
+      writeOriginalConsole(originalConsole.info, args);
     }
   };
   
   console.debug = (...args: unknown[]) => {
     if (shouldLog('debug', args)) {
-      originalConsole.debug(...args);
+      writeOriginalConsole(originalConsole.debug, args);
     }
   };
   
   // Always log warnings and errors
-  console.warn = originalConsole.warn;
-  console.error = originalConsole.error;
+  console.warn = (...args: unknown[]) => {
+    writeOriginalConsole(originalConsole.warn, args);
+  };
+  console.error = (...args: unknown[]) => {
+    writeOriginalConsole(originalConsole.error, args);
+  };
 }
 
 // Export original console for critical logging

--- a/packages/runpane/src/doctor.ts
+++ b/packages/runpane/src/doctor.ts
@@ -1,4 +1,5 @@
 import type { ParsedArgs } from './commands';
+import fs from 'node:fs';
 import {
   getPaneDaemonEndpoint,
   invokeDaemon,
@@ -192,9 +193,21 @@ async function collectDaemonHealth(paneDir: string | undefined, endpoint: PaneDa
       reachable: false,
       endpoint,
       error: errorMessage(error),
-      nextCommand: 'Open Pane, then rerun runpane doctor --json',
+      nextCommand: resolveDaemonRecoveryCommand(endpoint, error),
     };
   }
+}
+
+function resolveDaemonRecoveryCommand(endpoint: PaneDaemonEndpoint, error: unknown): string {
+  const message = errorMessage(error);
+  if (
+    endpoint.transport === 'unix'
+    && (message.includes('ECONNREFUSED') || fs.existsSync(endpoint.path))
+  ) {
+    return 'Quit Pane completely, reopen Pane, then rerun runpane doctor --json';
+  }
+
+  return 'Open Pane, then rerun runpane doctor --json';
 }
 
 function renderDoctorText(report: DoctorReport): void {


### PR DESCRIPTION
## Summary
- harden the main-process console wrapper against EPIPE when packaged macOS stdout/stderr is closed
- log local daemon startup/failure through the durable Pane logger
- stop the local daemon socket early during graceful shutdown
- improve runpane doctor recovery guidance for stale/dead Unix sockets

Closes #303

## Testing
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm exec --yes pnpm@10.19.0 -- --filter main typecheck
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm exec --yes pnpm@10.19.0 -- --filter runpane typecheck
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm exec --yes pnpm@10.19.0 -- --filter runpane build
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm exec --yes pnpm@10.19.0 -- --filter main exec vitest run src/utils/consoleWrapper.test.ts src/database/database.hidden-sessions.test.ts
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm exec --yes pnpm@10.19.0 -- --filter main lint (passes with existing warnings)
- PATH=/opt/homebrew/opt/node@22/bin:$PATH npm exec --yes pnpm@10.19.0 -- --filter runpane lint
- PANE_DIR=/Users/parsas/.pane_daemon_cli_test dev app on macOS arm64, then local wrapper commands:
  - node packages/runpane/dist/cli.js doctor --json --pane-dir /Users/parsas/.pane_daemon_cli_test
  - node packages/runpane/dist/cli.js repos add --path /Users/parsas/allGitHubRepos/dcouple/Pane/worktrees/fix-mac-daemon-cli- --name PaneDaemonCliTest --yes --json --pane-dir /Users/parsas/.pane_daemon_cli_test
  - node packages/runpane/dist/cli.js repos list --json --pane-dir /Users/parsas/.pane_daemon_cli_test
  - node packages/runpane/dist/cli.js panes list --json --pane-dir /Users/parsas/.pane_daemon_cli_test
