### PR TITLE
Fix auto pane name for main branch

### DIFF
--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -10,6 +10,7 @@ import { Button } from './ui/Button';
 import { Input } from './ui/Input';
 import { useSessionPreferencesStore, type SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import { useSessionStore } from '../stores/sessionStore';
+import { generatePaneName, sanitizePaneName } from '../utils/paneName';
 
 // Interface for branch information
 interface BranchInfo {
@@ -136,16 +137,8 @@ export function CreateSessionDialog({
                 setFormData(prev => ({ ...prev, baseBranch: defaultBranch.name }));
                 // Auto-populate session name from default branch if user hasn't edited
                 if (!initialSessionName && !userEditedNameRef.current) {
-                  const baseName = defaultBranch.name.replace(/^[^/]+\//, '');
                   const existingNames = new Set(existingSessions.map(s => s.name));
-                  let autoName = baseName;
-                  if (existingNames.has(baseName)) {
-                    let suffix = 1;
-                    while (existingNames.has(`${baseName}-${suffix}`)) {
-                      suffix++;
-                    }
-                    autoName = `${baseName}-${suffix}`;
-                  }
+                  const autoName = generatePaneName(defaultBranch.name, existingNames, branchesResponse.data);
                   setSessionName(autoName);
                 }
               }
@@ -211,21 +204,8 @@ export function CreateSessionDialog({
   }, [highlightedBranchIndex, isBranchDropdownOpen]);
 
   const generateSessionName = useCallback((branchName: string): string => {
-    // Strip remote prefix (e.g. "origin/feature-x" -> "feature-x")
-    const baseName = branchName.replace(/^[^/]+\//, '');
-    const existingNames = new Set(existingSessions.map(s => s.name));
-
-    if (!existingNames.has(baseName)) {
-      return baseName;
-    }
-
-    // Find next available suffix
-    let suffix = 1;
-    while (existingNames.has(`${baseName}-${suffix}`)) {
-      suffix++;
-    }
-    return `${baseName}-${suffix}`;
-  }, [existingSessions]);
+    return generatePaneName(branchName, new Set(existingSessions.map(s => s.name)), branches);
+  }, [branches, existingSessions]);
 
   const selectBranch = useCallback((branchName: string) => {
     setFormData(prev => ({ ...prev, baseBranch: branchName }));
@@ -311,16 +291,6 @@ export function CreateSessionDialog({
   }, [isOpen]);
 
   if (!isOpen) return null;
-
-  const sanitizePaneName = (name: string): string => {
-    return name
-      // Strip git-invalid characters and slashes
-      .replace(/[~^:?*\[\]\\/]/g, '')
-      // Collapse consecutive dots into a single dot
-      .replace(/\.{2,}/g, '.')
-      // Strip leading/trailing dots
-      .replace(/^\.+|\.+$/g, '');
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, GitBranch, GitFork, Pin, Search, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import { generatePaneName, sanitizePaneName } from '../../utils/paneName';
 import type { RemoteBranchInfo, RemoteProjectWithSessions, RemoteRuntimeAdapter } from '../runtime/remoteRuntimeAdapter';
 
 /**
@@ -52,9 +53,9 @@ export function RemoteCreateSessionDialog({
     setBranchOpen(false);
     setBranchSearch('');
     if (!userEditedName) {
-      setPaneName(generatePaneName(branchName, existingNames));
+      setPaneName(generatePaneName(branchName, existingNames, branches));
     }
-  }, [existingNames, userEditedName]);
+  }, [branches, existingNames, userEditedName]);
 
   useEffect(() => {
     let cancelled = false;
@@ -77,7 +78,7 @@ export function RemoteCreateSessionDialog({
 
         if (fallbackBranchName) {
           setBaseBranch(fallbackBranchName);
-          setPaneName(generatePaneName(fallbackBranchName, existingNames));
+          setPaneName(generatePaneName(fallbackBranchName, existingNames, branchList));
         }
       } catch (loadError) {
         if (!cancelled) {
@@ -318,26 +319,6 @@ export function RemoteCreateSessionDialog({
   );
 }
 
-function generatePaneName(branchName: string, existingNames: Set<string>): string {
-  const baseName = sanitizePaneName(branchName.replace(/^[^/]+\//, '')) || 'pane';
-  if (!existingNames.has(baseName)) {
-    return baseName;
-  }
-
-  let suffix = 1;
-  while (existingNames.has(`${baseName}-${suffix}`)) {
-    suffix += 1;
-  }
-  return `${baseName}-${suffix}`;
-}
-
-function sanitizePaneName(name: string): string {
-  return name
-    .replace(/[~^:?*[\]\\/]/g, '')
-    .replace(/\.{2,}/g, '.')
-    .replace(/^\.+|\.+$/g, '')
-    .trim();
-}
 
 function loadRemoteStartPinnedPreference(): boolean {
   try {

--- a/frontend/src/utils/paneName.test.ts
+++ b/frontend/src/utils/paneName.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { generatePaneName, sanitizePaneName, type PaneNameBranchInfo } from './paneName';
+
+function branch(overrides: Partial<PaneNameBranchInfo> & Pick<PaneNameBranchInfo, 'name'>): PaneNameBranchInfo {
+  return {
+    isCurrent: false,
+    hasWorktree: false,
+    isRemote: false,
+    ...overrides,
+  };
+}
+
+describe('paneName', () => {
+  it('uses the branch name when it is available', () => {
+    expect(generatePaneName('origin/feature-x', new Set(), [
+      branch({ name: 'main', isCurrent: true }),
+      branch({ name: 'origin/feature-x', isRemote: true }),
+    ])).toBe('feature-x');
+  });
+
+  it('suffixes auto-filled main when local main is already checked out', () => {
+    expect(generatePaneName('origin/main', new Set(), [
+      branch({ name: 'main', isCurrent: true }),
+      branch({ name: 'origin/main', isRemote: true }),
+    ])).toBe('main-1');
+  });
+
+  it('skips suffixes that are already used by panes or checked-out branches', () => {
+    expect(generatePaneName('origin/main', new Set(['main-1']), [
+      branch({ name: 'main', isCurrent: true }),
+      branch({ name: 'main-2', hasWorktree: true }),
+      branch({ name: 'origin/main', isRemote: true }),
+    ])).toBe('main-3');
+  });
+
+  it('does not reserve idle local branches that can be opened as worktrees', () => {
+    expect(generatePaneName('feature-x', new Set(), [
+      branch({ name: 'feature-x' }),
+    ])).toBe('feature-x');
+  });
+
+  it('sanitizes names consistently', () => {
+    expect(sanitizePaneName('../main?')).toBe('main');
+  });
+});

--- a/frontend/src/utils/paneName.ts
+++ b/frontend/src/utils/paneName.ts
@@ -1,0 +1,41 @@
+export interface PaneNameBranchInfo {
+  name: string;
+  isCurrent: boolean;
+  hasWorktree: boolean;
+  isRemote: boolean;
+}
+
+export function sanitizePaneName(name: string): string {
+  return name
+    .replace(/[~^:?*[\]\\/]/g, '')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^\.+|\.+$/g, '')
+    .trim();
+}
+
+export function generatePaneName(
+  branchName: string,
+  existingNames: Set<string>,
+  branches: PaneNameBranchInfo[] = [],
+): string {
+  const baseName = sanitizePaneName(branchName.replace(/^[^/]+\//, '')) || 'pane';
+  const unavailableNames = new Set(existingNames);
+
+  for (const branch of branches) {
+    if (branch.isRemote || (!branch.isCurrent && !branch.hasWorktree)) continue;
+    const unavailableBranchName = sanitizePaneName(branch.name.replace(/^[^/]+\//, ''));
+    if (unavailableBranchName) {
+      unavailableNames.add(unavailableBranchName);
+    }
+  }
+
+  if (!unavailableNames.has(baseName)) {
+    return baseName;
+  }
+
+  let suffix = 1;
+  while (unavailableNames.has(`${baseName}-${suffix}`)) {
+    suffix += 1;
+  }
+  return `${baseName}-${suffix}`;
+}


### PR DESCRIPTION
## Summary
- Add a shared pane-name generator that reserves existing pane names and checked-out/worktree-backed local branch names.
- Use the shared generator in both desktop and remote create-pane dialogs.
- Add coverage for the onboarding-style `origin/main` -> `main-1` default.

## Root Cause
A first-run Pane repo opens on local `main`, while the create dialog auto-filled `main` from `origin/main`. The backend uses the pane/worktree name as the git branch name, so `git worktree add ... main` fails because `main` is already checked out.

## Testing
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter frontend test -- paneName.test.ts`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm typecheck`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm lint` (passes with existing warnings)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm run build:frontend`

## PR Test Automation Notes
- Verified the branch-level target on `main-1` after rebasing on `origin/main`.
- Automated QA covered the naming edge case directly: remote `origin/main` plus local current `main` generates `main-1`; idle local branches remain usable without forced suffixing.
- Existing Playwright harness does not currently expose branch-list fixtures for the create dialog without adding unrelated test harness changes, so this pass used unit coverage plus production frontend build integration.