### PR TITLE
fix: eliminate terminal activation replay and light-theme GPU filter (Mac perf)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -438,10 +438,24 @@ function App() {
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
+    // Also pause animations on window blur — document.hidden rarely fires for a
+    // visible-but-unfocused window (notably on macOS), so gate on the focus event too.
+    window.electronAPI.window?.isFocused?.()
+      .then((focused) => {
+        document.documentElement.classList.toggle('window-blurred', !focused);
+      })
+      .catch(() => {
+        // Default to focused if the focus query is unavailable.
+      });
+    const cleanupFocusChanged = window.electronAPI.events.onWindowFocusChanged((focused) => {
+      document.documentElement.classList.toggle('window-blurred', !focused);
+    });
+
     return () => {
       cleanupDispose();
       window.removeEventListener('session-switched', handleSessionSwitch);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
+      cleanupFocusChanged();
     };
   }, []);
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -98,6 +98,51 @@ function waitForNextPaint(): Promise<void> {
   });
 }
 
+/**
+ * Terminal panel lifecycle — the invariants below keep hidden terminals cheap
+ * and correct; break one and you get mangled buffers or replay storms.
+ *
+ * MOUNT (possibly hidden): keep-alive terminal tabs mount even when inactive
+ * (PanelGroupView renders them behind display:none). The PTY spawns at the
+ * backend default (80×30) when the container has no measurable size, and the
+ * mount-time fit() is SKIPPED for containers below MIN_VIABLE_RECT_PX —
+ * FitAddon has no cols floor, so fitting a 0×0 container would shrink the
+ * grid to a few columns and background PTY output would parse into a
+ * garbage-width buffer that xterm reflow cannot repair. A skipped mount fit
+ * arms `needsFullActivationRefreshRef` so the first activation rebuilds the
+ * buffer at the settled width. The same width guard applies to every other
+ * grid-resizing path (resizePtyToFit, post-restore fit, font-change fit).
+ *
+ * HIDDEN (performance mode): the panel keeps reporting visible to main
+ * (`effectiveVisible` is hard-coded true), so PTY output keeps streaming and
+ * the xterm buffer stays live while display:none. Battery saver instead
+ * reports hidden — main stops renderer delivery — so its buffer genuinely
+ * goes stale while inactive.
+ *
+ * ACTIVATION (tab shown and window focused — `activationVisible`): depth is
+ * chosen by cause. Full reset+replay from `terminal:getState` only when the
+ * buffer may be stale (battery saver, or the armed one-time flag); otherwise
+ * a light fit+repaint (`repaintTerminal`). Panel activations show the
+ * refresh overlay and take focus; a pure window refocus repaints silently.
+ * A delayed backstop re-runs the chosen depth once (REFOCUS_DELAYED_REFRESH_MS)
+ * to cover the async WebGL re-attach race. The manual Refresh button always
+ * runs the full path (`handleRefreshTerminal`).
+ *
+ * WEBGL: one context per VISIBLE terminal. Detached immediately on panel
+ * hide, kept through short app blurs, detached after a sustained blur
+ * (WEBGL_APP_BLUR_DETACH_DELAY_MS). Re-attach paints via a refresh deferred
+ * past the next frame — same-task refreshes can hit an uncomposited canvas.
+ * While detached, xterm falls back to the DOM renderer.
+ *
+ * PERSISTENCE: main owns the raw scrollback (authoritative, ANSI-safe
+ * trimmed); the renderer serializes a formatting-preserving snapshot on
+ * hide (throttled to SNAPSHOT_MIN_INTERVAL_MS) and on unmount, used only for
+ * app-restart restore. Live restores always prefer main's raw scrollback.
+ *
+ * UNMOUNT (session switch / panel close): serialize a final snapshot, then
+ * dispose WebGL, addons, and the xterm instance. Remounts restore from
+ * `terminal:getState` (capped payload) and replay once into a fresh xterm.
+ */
 export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActive, autoFocus = true }) => {
   renderLog('[TerminalPanel] Component rendering, panel:', panel.id, 'isActive:', isActive);
   
@@ -444,7 +489,12 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     }
   }, [panel.id]);
 
-  // Refresh terminal: normal shells replay raw scrollback; live TUIs repaint via resize.
+  // Full-depth refresh: normal shells reset+replay main's raw scrollback at the
+  // settled width; live TUIs (alt-screen) repaint via resize instead. Reached
+  // from exactly three places: the manual Refresh button, battery-saver
+  // activations, and the one-time first activation of a hidden-mounted panel
+  // (armed via needsFullActivationRefreshRef). Routine tab switches use
+  // repaintTerminal instead — see the component lifecycle doc.
   const handleRefreshTerminal = useCallback(async () => {
     const terminal = xtermRef.current;
     if (!terminal) return;
@@ -813,8 +863,18 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             document.fonts.load(`${terminalFontSize}px "${terminalFontFamily}"`).catch(() => {}),
             document.fonts.load(`${terminalFontSize}px "Symbols Nerd Font Mono"`).catch(() => {}),
           ]);
-          fitAddon.fit();
-          console.log('[TerminalPanel] FitAddon fitted');
+          // Never fit against a hidden/mid-layout container (display:none keep-alive
+          // tabs measure 0×0): FitAddon resizes the grid with no floor, and background
+          // PTY output then parses into a garbage-width buffer that reflow can't fix.
+          // Keeping xterm's default grid matches the PTY's default cols; the one-time
+          // full activation refresh rebuilds anything that still parsed mismatched.
+          if ((terminalRef.current?.getBoundingClientRect().width ?? 0) >= MIN_VIABLE_RECT_PX) {
+            fitAddon.fit();
+            console.log('[TerminalPanel] FitAddon fitted');
+          } else {
+            needsFullActivationRefreshRef.current = true;
+            console.log('[TerminalPanel] Skipped mount fit (hidden container); armed full activation refresh');
+          }
           terminal.options.theme = getTerminalTheme();
 
           // Load WebLinksAddon for clickable URLs
@@ -968,7 +1028,11 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             // Force WebGL renderer to redraw after buffer content changes.
             // Without this, macOS WebGL canvas shows stale/stuttered content until
             // a resize event (minimize/fullscreen) forces invalidation.
-            fitAddon.fit();
+            // Same hidden-container guard as the mount fit: WebGL isn't attached
+            // while hidden, and a 0-width fit would mangle the grid.
+            if ((terminalRef.current?.getBoundingClientRect().width ?? 0) >= MIN_VIABLE_RECT_PX) {
+              fitAddon.fit();
+            }
           }
 
           // Handle paste events (Ctrl+V, voice transcription, external text injection)
@@ -1271,7 +1335,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
                 if (!terminal || disposed) return;
                 terminal.options.fontFamily = newFontFamily;
                 terminal.options.fontSize = newFontSize;
-                if (fitAddon) fitAddon.fit();
+                // Hidden-container guard (see mount fit): defer to the activation fit
+                if (fitAddon && (terminalRef.current?.getBoundingClientRect().width ?? 0) >= MIN_VIABLE_RECT_PX) {
+                  fitAddon.fit();
+                }
               });
             }
           });

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -60,6 +60,7 @@ const WEBGL_APP_BLUR_DETACH_DELAY_MS = 10_000;
 const REFOCUS_DELAYED_REFRESH_MS = 300;
 const TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS = 200;
 const TERMINAL_VISIBILITY_REFRESH_MS = 60_000;
+const SNAPSHOT_MIN_INTERVAL_MS = 10_000;
 const MIN_VIABLE_RECT_PX = 100; // below this the container is hidden or mid-layout (Allotment minSize is 120)
 const MIN_PTY_COLS = 20;        // mirrors main-process floor
 const MIN_PTY_ROWS = 5;
@@ -128,11 +129,17 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   // refocus in both power modes (effectiveVisible is hard-coded true in
   // performance mode, so it cannot serve this role).
   const activationVisible = panelVisible && windowFocused;
-  // True when the next activation needs the full reset+replay path: the panel
-  // was hidden (stale rows after display:none→block) or battery saver gated PTY
-  // output while inactive. A pure window refocus in performance mode leaves the
-  // buffer live, so a light repaint is enough.
-  const needsFullActivationRefreshRef = useRef(true);
+  // True when the next activation needs the full reset+replay path: battery
+  // saver gated PTY output while inactive, so the buffer may be stale. In
+  // performance mode hidden panels keep receiving output (effectiveVisible is
+  // hard-coded true), so the buffer is always live and a light repaint is
+  // enough — stale display:none→block pixels are a paint problem, not a
+  // buffer problem.
+  const needsFullActivationRefreshRef = useRef(false);
+  // True when the next activation is a panel activation (tab became visible)
+  // rather than a pure window refocus: the fit can visibly reflow the grid, so
+  // mask it with the refresh overlay and move focus. Pure refocus stays silent.
+  const panelActivationRef = useRef(true);
   const [webglAllowed, setWebglAllowed] = useState(panelVisible);
   const blurDetachTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -281,8 +288,13 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       terminal.loadAddon(addon);
       webglAddonRef.current = addon;
       // xterm's activate() only swaps the renderer via setRenderer with no full
-      // row refresh, so force a redraw on the freshly attached WebGL renderer.
-      if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
+      // row refresh, so force a redraw on the freshly attached WebGL renderer —
+      // deferred past the next paint: refreshing in the same task can hit an
+      // uncomposited canvas on blur→refocus reattach.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        if (webglAddonRef.current !== addon) return;
+        if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
+      }));
       console.log('[TerminalPanel] WebGL renderer loaded for panel', panel.id);
       forwardToMainLog('info', `[TerminalPanel] WebGL renderer loaded for panel ${panel.id} reason=${reason}`);
     } catch (e) {
@@ -300,16 +312,20 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   }, [forwardToMainLog, panel.id]);
 
   // Replaces the old 30 s snapshot interval: fire once on active-to-inactive
-  // transitions (tab switches / panel hides). The dispose-time snapshot in the
-  // terminal init effect stays as a backstop for full unmount.
+  // transitions (tab switches / panel hides), throttled so rapid tab flips
+  // don't do a full buffer walk + IPC each time. The dispose-time snapshot in
+  // the terminal init effect stays as a backstop for full unmount.
   const wasActiveRef = useRef(panelVisible);
+  const lastSnapshotAtRef = useRef(0);
   useEffect(() => {
     const wasActive = wasActiveRef.current;
     wasActiveRef.current = panelVisible;
     if (wasActive && !panelVisible && serializeAddonRef.current) {
+      if (Date.now() - lastSnapshotAtRef.current < SNAPSHOT_MIN_INTERVAL_MS) return;
       try {
         const serialized = serializeAddonRef.current.serialize();
         window.electronAPI.invoke('terminal:saveSnapshot', panel.id, serialized);
+        lastSnapshotAtRef.current = Date.now();
       } catch {
         // xterm buffer in a bad state — not worth surfacing
       }
@@ -645,7 +661,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           altClickMovesCursor: true,
           drawBoldTextInBrightColors: true,
           rescaleOverlappingGlyphs: true,
-          minimumContrastRatio: 1,
+          minimumContrastRatio: document.documentElement.classList.contains('light') ? 4.5 : 1,
           macOptionIsMeta: false,
           linkHandler: {
             activate: (_event, uri) => {
@@ -1482,16 +1498,22 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
   // Shared activation refresh for both power modes: fires on tab activation and
   // window refocus (activationVisible = panelVisible && windowFocused). Depth is
-  // chosen by cause — a full reset+replay (overlay + autoFocus) when the buffer
-  // may be stale, a light repaint (silent, no focus move) on a pure performance-
-  // mode refocus. Declared after the WebGL policy effects so the delayed backstop
+  // chosen by cause — a full reset+replay only when the buffer may be stale
+  // (battery saver cadence-gating), a light fit+repaint otherwise. Panel
+  // activations get the overlay + autoFocus; a pure window refocus stays
+  // silent. Declared after the WebGL policy effects so the delayed backstop
   // covers the WebGL re-attach ordering race.
   useLayoutEffect(() => {
     if (!isInitialized || !fitAddonRef.current || !xtermRef.current) return;
     if (!activationVisible) {
-      // Re-arm full depth when the panel itself hides, or whenever battery saver
-      // is active (its PTY output is cadence-gated while not effectively visible).
-      if (!panelVisible || useBatterySaverTerminalVisibility) {
+      if (!panelVisible) {
+        // The next activation is a tab activation — mask the refit.
+        panelActivationRef.current = true;
+      }
+      // Battery saver gates PTY output while not effectively visible, so the
+      // buffer may be stale on the next activation. Performance mode keeps
+      // hidden buffers live — no full replay needed there.
+      if (useBatterySaverTerminalVisibility) {
         needsFullActivationRefreshRef.current = true;
       }
       return;
@@ -1499,12 +1521,15 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
     // Battery saver is ALWAYS full: its PTY output is cadence-gated while not
     // effectively visible, so the buffer may be stale on any activation (this
-    // also covers a performance→batterySaver toggle mid-session, which re-runs
-    // this effect without an intervening !activationVisible pass).
+    // also covers a batterySaver→performance toggle mid-session via the armed
+    // ref, which re-runs this effect without an intervening hide).
     const fullRefresh = useBatterySaverTerminalVisibility || needsFullActivationRefreshRef.current;
+    const isPanelActivation = panelActivationRef.current;
 
-    // Overlay masks the reset+replay flicker; the light path needs no mask.
-    if (fullRefresh) setIsRefreshing(true);
+    // Overlay masks the reset+replay flicker and the activation refit; a pure
+    // refocus repaint needs no mask.
+    const showMask = fullRefresh || isPanelActivation;
+    if (showMask) setIsRefreshing(true);
 
     let lastWidth = 0;
     let retries = 0;
@@ -1528,20 +1553,21 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       }
 
       // Never settled at a viable size — bail; the ResizeObserver finishes the job
-      // once layout settles. Leave the ref armed so the next activation retries full.
+      // once layout settles. Leave the refs armed so the next activation retries.
       if (containerWidth < MIN_VIABLE_RECT_PX) {
         forwardToMainLog('warn', `[TerminalPanel] Activation refresh bailed for panel ${panel.id}: container ${containerWidth}px`);
         setIsRefreshing(false);
-        if (autoFocus && fullRefresh) xtermRef.current?.focus();
+        if (autoFocus && showMask) xtermRef.current?.focus();
         return;
       }
 
       void document.fonts.ready.then(async () => {
         if (cancelled || !fitAddonRef.current || !xtermRef.current) return;
 
+        // Consume the flags only when the refresh actually executes, so a
+        // bail or an activate-then-blur cancellation leaves them armed.
+        panelActivationRef.current = false;
         if (fullRefresh) {
-          // Consume the flag only when the full refresh actually executes, so a
-          // bail or an activate-then-blur cancellation leaves it armed.
           needsFullActivationRefreshRef.current = false;
           await handleRefreshTerminal();
         } else {
@@ -1550,7 +1576,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         await waitForNextPaint();
         if (cancelled) return;
 
-        if (autoFocus && fullRefresh) {
+        if (autoFocus && showMask) {
           xtermRef.current?.focus();
         }
 
@@ -1561,7 +1587,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           else repaintTerminal();
         }, REFOCUS_DELAYED_REFRESH_MS);
 
-        if (fullRefresh) {
+        if (showMask) {
           hideOverlayTimer = setTimeout(() => {
             if (!cancelled) setIsRefreshing(false);
           }, TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS);
@@ -1587,6 +1613,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     }
     const newTheme = getTerminalTheme();
     xtermRef.current.options.theme = newTheme;
+    xtermRef.current.options.minimumContrastRatio =
+      document.documentElement.classList.contains('light') ? 4.5 : 1;
     const rows = xtermRef.current.rows;
     if (rows > 0) {
       xtermRef.current.refresh(0, rows - 1);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,10 +8,13 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Pause all animations when window is hidden to save battery */
+/* Pause all animations when window is hidden or blurred to save battery */
 html.window-hidden *,
 html.window-hidden *::before,
-html.window-hidden *::after {
+html.window-hidden *::after,
+html.window-blurred *,
+html.window-blurred *::before,
+html.window-blurred *::after {
   animation-play-state: paused !important;
   transition: none !important;
 }
@@ -493,13 +496,7 @@ body.light-rounded {
   margin: var(--pane-terminal-screen-offset-y) 0 0 var(--pane-terminal-padding-x);
 }
 
-/* Light mode: invert the dark terminal instead of fighting ANSI color issues */
-.light .xterm {
-  filter: invert(1) hue-rotate(180deg);
-}
-
 .pane-onboarding-auth-terminal .xterm {
-  filter: none !important;
   background-color: var(--color-terminal-bg) !important;
 }
 

--- a/frontend/src/styles/tokens/colors.css
+++ b/frontend/src/styles/tokens/colors.css
@@ -456,9 +456,31 @@
   --tab-indicator-height: 0px;
 
   /* Terminal Colors - Light Theme
-     No overrides needed: dark terminal colors are used as-is,
-     and CSS filter: invert(1) hue-rotate(180deg) on .xterm
-     handles the visual light mode transformation. */
+     BAKED INVERTED PALETTE (user decision 2026-07-06): each value is the exact result of
+     applying `invert(1) hue-rotate(180deg)` (CSS filter color matrix, sRGB, clamped) to the
+     corresponding dark token at colors.css:304-322 — so ANSI/shell output renders
+     pixel-identical to today's filtered light mode, with zero per-frame GPU filter cost.
+     Regenerate with the one-liner in the plan's Task 1 gotchas if the dark tokens change. */
+  --color-terminal-bg: rgb(249 252 255);
+  --color-terminal-fg: rgb(13 20 26);
+  --color-terminal-cursor: rgb(31 109 198);
+  --color-terminal-black: rgb(249 252 255);
+  --color-terminal-red: rgb(255 104 96);
+  --color-terminal-green: rgb(15 137 32);
+  --color-terminal-yellow: rgb(152 95 0);
+  --color-terminal-blue: rgb(31 109 198);
+  --color-terminal-magenta: rgb(126 78 193);
+  --color-terminal-cyan: rgb(0 108 119);
+  --color-terminal-white: rgb(13 20 26);
+  --color-terminal-bright-black: rgb(131 139 150);
+  --color-terminal-bright-red: rgb(209 77 68);
+  --color-terminal-bright-green: rgb(0 113 2);
+  --color-terminal-bright-yellow: rgb(124 75 0);
+  --color-terminal-bright-blue: rgb(25 88 159);
+  --color-terminal-bright-magenta: rgb(99 57 144);
+  --color-terminal-bright-cyan: rgb(0 86 95);
+  --color-terminal-bright-white: rgb(0 0 0);
+  --color-terminal-selection-bg: #1f6dc640;
 }
 
 /* OLED Black Theme - True black for OLED displays */

--- a/frontend/src/utils/terminalTheme.ts
+++ b/frontend/src/utils/terminalTheme.ts
@@ -59,6 +59,10 @@ const getCSSVariable = (name: string): string => {
 
 // Terminal theme generator that reads from CSS variables
 export const getTerminalTheme = () => {
+  // Only set when the theme defines it (no fallback — dark themes keep xterm's default selection)
+  const selectionBg = getComputedStyle(document.documentElement)
+    .getPropertyValue('--color-terminal-selection-bg')
+    .trim();
   return {
     background: getCSSVariable('--color-terminal-bg'),
     foreground: getCSSVariable('--color-terminal-fg'),
@@ -79,6 +83,7 @@ export const getTerminalTheme = () => {
     brightMagenta: getCSSVariable('--color-terminal-bright-magenta'),
     brightCyan: getCSSVariable('--color-terminal-bright-cyan'),
     brightWhite: getCSSVariable('--color-terminal-bright-white'),
+    ...(selectionBg ? { selectionBackground: selectionBg } : {}),
   };
 };
 

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -26,6 +26,11 @@ const MAX_CONCURRENT_SPAWNS = 3;
 const IDLE_THRESHOLD_MS = 30_000; // 30s — mark panel idle after no PTY output
 const MAX_SCROLLBACK_BUFFER_SIZE = 500_000; // 500KB of normal shell history
 const MAX_ALTERNATE_SCREEN_BUFFER_SIZE = 100_000; // 100KB of recent TUI redraw state
+// Formal ceiling for the raw-ANSI scrollback shipped on restore/getState replay. Peer consensus:
+// Orca (TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT) and Superset (MAX_HISTORY_SCROLLBACK_BYTES) both use
+// 512 * 1024. Above the 500KB live trim, so it does not reduce today's payload — the measurable win
+// is omitting the up-to-8MB serialized snapshot from getState when raw scrollback exists.
+const MAX_RESTORE_PAYLOAD_SIZE = 512 * 1024;
 
 type CliAgentType = NonNullable<TerminalPanelState['agentType']>;
 
@@ -1405,9 +1410,11 @@ export class TerminalPanelManager {
     // Send scrollback to frontend. Dual-path mirrors `flushOutputBuffer`:
     // `terminal:output` IPC for legacy subscribers, ptyHost port for flag-on.
     if (state.scrollbackBuffer) {
-      const output = typeof state.scrollbackBuffer === 'string'
-        ? state.scrollbackBuffer + restorationMsg
-        : state.scrollbackBuffer.join('\n') + restorationMsg;
+      // Cap the renderer replay at the formal ceiling; main's own buffer (set above) keeps full content.
+      const rawScrollback = typeof state.scrollbackBuffer === 'string'
+        ? state.scrollbackBuffer
+        : state.scrollbackBuffer.join('\n');
+      const output = this.trimAnsiSafe(rawScrollback, MAX_RESTORE_PAYLOAD_SIZE) + restorationMsg;
       this.sendRendererEvent('terminal:output', {
         sessionId: panel.sessionId,
         panelId: panel.id,
@@ -1423,18 +1430,21 @@ export class TerminalPanelManager {
   getTerminalState(panelId: string): TerminalPanelState | null {
     const terminal = this.terminals.get(panelId);
     if (!terminal) return null;
-    
+
+    const cappedScrollback = this.trimAnsiSafe(terminal.scrollbackBuffer, MAX_RESTORE_PAYLOAD_SIZE);
     return {
       isInitialized: true,
       cwd: process.cwd(), // Simplified - would need platform-specific implementation
       shellType: process.env.SHELL || 'bash',
-      scrollbackBuffer: terminal.scrollbackBuffer,
+      scrollbackBuffer: cappedScrollback,
       alternateScreenBuffer: terminal.alternateScreenBuffer,
       isAlternateScreen: terminal.isAlternateScreen,
       commandHistory: terminal.commandHistory,
       lastActivityTime: terminal.lastActivity.toISOString(),
       lastActiveCommand: terminal.currentCommand,
-      serializedBuffer: this.serializedBuffers.get(panelId)
+      // Omit the serialized snapshot when raw scrollback exists — the frontend prefers raw whenever
+      // the PTY is alive; the snapshot is only consulted on app-restart (empty raw scrollback).
+      serializedBuffer: cappedScrollback.length > 0 ? undefined : this.serializedBuffers.get(panelId)
     };
   }
 


### PR DESCRIPTION
## Summary
Fixes the multi-second freezes when switching panes/tabs on macOS and the high GPU-helper energy impact (300–400 in Activity Monitor). Root causes found by investigation: every terminal activation replayed its full scrollback through xterm's parser twice (avg 585KB, max 4.8MB per panel measured in a live DB), and light themes ran a per-frame `invert(1) hue-rotate(180deg)` compositor filter over every terminal canvas.

## Work Completed
### Mac terminal performance (tmp/done-plans/2026-07-06-mac-terminal-performance.md)
- **Activation depth by cause** (builds on #308's unified activation effect): performance mode does a masked fit+repaint on tab activation and a silent repaint on pure refocus — no `reset()`, no scrollback replay. Battery saver keeps exactly one full re-sync (its PTY output is cadence-gated while hidden, so the buffer can genuinely be stale). The manual Refresh button keeps full replay.
- **WebGL post-attach repaint deferred past next paint** (double rAF): refreshing in the same task as the addon attach could hit an uncomposited canvas on blur→refocus reattach, leaving stale pixels.
- **Baked inverted light palette**: `:root.light` now defines real `--color-terminal-*` tokens computed as the exact `invert+hue-rotate` of the dark palette, so ANSI output looks identical to the old filtered rendering with zero per-frame GPU cost; the `.light .xterm` filter rule is deleted. Truecolor TUI content now shows true colors (standard emulator behavior). `minimumContrastRatio` 4.5 in light mode.
- **IPC payload cuts**: `terminal:getState` no longer ships the up-to-8MB serialized snapshot alongside raw scrollback, and restore payloads are ceilinged at 512KiB (matches Orca's `TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT` and Superset's `MAX_HISTORY_SCROLLBACK_BYTES`).
- **Serialize-on-hide throttled** to once per 10s per panel (snapshot is only consulted on app restart).
- **Animations pause on window blur** via a `window-blurred` root class wired to `window:focus-changed`, not just `document.hidden` (which rarely fires for a visible-but-unfocused window on macOS).

## Pre-Merge Testing
- [ ] Switch terminal tabs rapidly in performance mode — instant, brief "Refreshing terminal…" mask, no grid-refit jank, no stale content
- [ ] Blur the app 15+ seconds (WebGL detaches), refocus, revisit tabs — no black/blank canvas, no stale pixels
- [ ] Battery saver mode: hide window, generate output, re-show — content catches up with one full re-sync
- [ ] Light / light-rounded theme: shell ANSI output looks identical to pre-change; selection highlight visible; TUIs show true colors
- [ ] TUI (htop/claude) running during tab switches and window resizes — repaints correctly
- [ ] Quit and relaunch — terminals restore scrollback with the `[Session Restored]` marker

## Build Verification
- [x] `pnpm typecheck` passes (all workspaces)
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm build:main` + `pnpm build:frontend` pass (xterm request-mode build verification OK)