### PR TITLE
fix: native recursive file watching on macOS/Windows to prevent EMFILE freeze

### DIFF
--- a/main/src/services/gitFileWatcher.ts
+++ b/main/src/services/gitFileWatcher.ts
@@ -2,6 +2,9 @@ import { EventEmitter } from 'events';
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar';
 import path from 'path';
 import type { Stats } from 'fs';
+// node:fs recursive watcher — aliased so it doesn't collide with chokidar's
+// imported `watch`/`FSWatcher`. Used for the darwin/win32 native path.
+import { watch as fsWatch, type FSWatcher as NodeFsWatcher, type WatchEventType } from 'node:fs';
 import { spawn, type ChildProcess } from 'child_process';
 import { execSync } from '../utils/commandExecutor';
 import type { CommandRunner } from '../utils/commandRunner';
@@ -37,12 +40,24 @@ const IGNORED_FILE_PATTERNS: RegExp[] = [
   /^#.+#$/,
 ];
 
+// The four ways a session's worktree can be watched. `native` is the
+// zero-dependency recursive fs.watch (darwin/win32-non-WSL); `chokidar`
+// is the Linux per-directory path; `wsl` is the in-distro inotifywait
+// process; `polling` is the degraded 5s snapshot-diff fallback.
+type WatchMode = 'native' | 'chokidar' | 'wsl' | 'polling';
+
 interface WatchedSession {
   sessionId: string;
   worktreePath: string;
-  worktreeWatcher?: FSWatcher;
-  gitWatcher?: FSWatcher;
+  mode: WatchMode;
+  worktreeWatcher?: FSWatcher; // chokidar (linux)
+  gitWatcher?: FSWatcher; // chokidar narrow metadata watcher (all non-WSL modes)
+  nativeWatcher?: NodeFsWatcher; // node:fs recursive FSWatcher (darwin/win32)
   wslWatcher?: ChildProcess;
+  pollTimer?: NodeJS.Timeout; // 5s snapshot-diff loop (polling mode)
+  selfHealTimer?: NodeJS.Timeout; // 60s snapshot-diff (native/chokidar modes)
+  lastStatusSnapshot?: string; // last `git status --porcelain` output
+  watcherErrorLogged: boolean; // rate-limits the fallback warn
   lastModified: number;
   pendingRefresh: boolean;
 }
@@ -60,6 +75,14 @@ export class GitFileWatcher extends EventEmitter {
   private watchedSessions: Map<string, WatchedSession> = new Map();
   private refreshDebounceTimers: Map<string, NodeJS.Timeout> = new Map();
   private readonly DEBOUNCE_MS = 1500; // 1.5 second debounce for file changes
+
+  // Gitignore-derived ignored-dir set, cached per watchPath on the INSTANCE
+  // (not per WatchedSession) so it survives blur/focus teardown-rebuild churn
+  // and pane switches without re-running a full `git ls-files` working-tree scan.
+  private gitignoreDirCache: Map<string, { dirs: Set<string>; fetchedAt: number }> = new Map();
+  private static readonly GITIGNORE_CACHE_TTL_MS = 5 * 60_000;
+  private static readonly POLL_INTERVAL_MS = 5_000;
+  private static readonly SELF_HEAL_INTERVAL_MS = 60_000;
 
   constructor(
     private logger?: Logger,
@@ -92,10 +115,73 @@ export class GitFileWatcher extends EventEmitter {
       // Convert path for the watcher (needs platform-appropriate path)
       const watchPath = this.pathResolver ? this.pathResolver.toFileSystem(worktreePath) : worktreePath;
 
+      // Native recursive fs.watch on darwin/win32 (non-WSL). One O(1) recursive
+      // handle instead of chokidar's one-handle-per-directory registration walk,
+      // so a huge repo root no longer EMFILEs. win32+WSL already took the WSL
+      // branch above; recursive fs.watch is fully supported on darwin (FSEvents)
+      // and win32 (ReadDirectoryChangesW) in this Node runtime.
+      const useNative =
+        (process.platform === 'darwin' || process.platform === 'win32') &&
+        !this.commandRunner?.wslContext;
+      if (useNative) {
+        this.getGitignoredDirs(watchPath); // warm the cache before events flow
+        let nativeWatcher: NodeFsWatcher;
+        try {
+          // default (utf8) encoding → Node types filename as string | null (never Buffer)
+          nativeWatcher = fsWatch(
+            watchPath,
+            { recursive: true, persistent: true },
+            (_eventType: WatchEventType, filename: string | null) => {
+              // null filename → conservative: cannot filter, treat as a change.
+              // Re-read the (cache-hit) gitignore set each event so the TTL
+              // refresh takes effect on long-lived spotlight watchers.
+              if (
+                filename !== null &&
+                this.isIgnoredEventPath(filename, this.getGitignoredDirs(watchPath))
+              ) {
+                return;
+              }
+              this.handleFileChange(sessionId, filename ?? '', 'change');
+            },
+          );
+        } catch (err) {
+          // creation failure (e.g. EMFILE/ENOSPC on the handle) → degrade to
+          // polling before any record exists
+          this.transitionToPolling(sessionId, worktreePath, err as Error);
+          return;
+        }
+        nativeWatcher.on('error', (err) => this.handleWatcherFailure(sessionId, err));
+        const gitWatcher = this.createGitMetadataWatcher(sessionId, watchPath);
+        this.watchedSessions.set(sessionId, {
+          sessionId,
+          worktreePath,
+          mode: 'native',
+          nativeWatcher,
+          gitWatcher,
+          selfHealTimer: this.startSelfHeal(sessionId),
+          watcherErrorLogged: false,
+          lastModified: Date.now(),
+          pendingRefresh: false,
+        });
+
+        // Validation signal — keep in production: confirms watcher count is bounded
+        this.logger?.info(
+          `[GitFileWatcher] startWatching(${sessionId}) watchedSessions.size=${this.watchedSessions.size}`
+        );
+        return;
+      }
+
+      // Linux: chokidar per-directory watcher. Union ignore (hardcoded ∪
+      // gitignore-derived) is threaded into the registration-time `ignored` fn
+      // so it both prunes descent (handle budget) AND matches the native
+      // event-time filter, keeping behavior uniform across platforms.
+      const gitignoredDirs = this.getGitignoredDirs(watchPath);
       // Function-form ignored: short-circuits descent into heavy directories
       // stats may be undefined on initial calls — return false (don't ignore) if unknown
       const ignored = (targetPath: string, stats?: Stats): boolean => {
         if (!stats) return false;
+        const rel = path.relative(watchPath, targetPath);
+        if (rel && this.isIgnoredEventPath(rel, gitignoredDirs)) return true;
         const base = path.basename(targetPath);
         if (stats.isDirectory()) {
           return IGNORED_DIRS.has(base);
@@ -118,63 +204,27 @@ export class GitFileWatcher extends EventEmitter {
         this.handleFileChange(sessionId, rel, 'change');
       });
       worktreeWatcher.on('error', (err) => {
+        // chokidar 5 types the error handler arg as `unknown`; extract the code
+        // via ErrnoException cast (the no-any-compliant route). Only the
+        // handle-exhaustion errors degrade to polling — other chokidar errors
+        // stay log-only to avoid over-eager fallback on transient stat blips.
+        const code = (err as NodeJS.ErrnoException).code;
         this.logger?.error(`[GitFileWatcher] worktree watcher error`, err as Error);
+        if (code === 'EMFILE' || code === 'ENOSPC') {
+          this.handleWatcherFailure(sessionId, err);
+        }
       });
 
-      // Resolve the real gitdir. Pane sessions usually run in git
-      // worktrees, where `.git` inside the worktree is a FILE
-      // containing `gitdir: /path/to/main/.git/worktrees/<name>` — the
-      // real `index` and `HEAD` live under that resolved path, not
-      // under `<worktreePath>/.git`. Use `git rev-parse
-      // --absolute-git-dir` so we get the correct location for both
-      // worktrees and normal repos. If resolution fails (e.g., the
-      // path is not yet a valid repo) we skip the narrow .git watcher
-      // and rely on the worktree watcher alone.
-      let gitWatcher: FSWatcher | undefined;
-      try {
-        const resolvedGitDir = this.execGit(
-          'git rev-parse --absolute-git-dir',
-          watchPath,
-        ).trim();
-        if (resolvedGitDir) {
-          gitWatcher = chokidarWatch(
-            [
-              path.join(resolvedGitDir, 'index'),
-              path.join(resolvedGitDir, 'HEAD'),
-            ],
-            {
-              ignoreInitial: true,
-              persistent: true,
-              followSymlinks: false,
-              usePolling: false,
-            },
-          );
-          gitWatcher.on('all', () => {
-            // intentional: bypass any ignore checks, always trigger on
-            // git index/HEAD changes
-            this.handleFileChange(sessionId, '.git/index', 'change');
-          });
-          gitWatcher.on('error', (err) => {
-            this.logger?.error(
-              `[GitFileWatcher] .git watcher error`,
-              err as Error,
-            );
-          });
-        }
-      } catch (gitDirErr) {
-        this.logger?.error(
-          `[GitFileWatcher] Failed to resolve gitdir for ${sessionId}, ` +
-            `narrow .git watcher disabled (metadata-only operations will ` +
-            `not trigger refresh until worktree watcher fires):`,
-          gitDirErr as Error,
-        );
-      }
+      const gitWatcher = this.createGitMetadataWatcher(sessionId, watchPath);
 
       this.watchedSessions.set(sessionId, {
         sessionId,
         worktreePath,
+        mode: 'chokidar',
         worktreeWatcher,
         gitWatcher,
+        selfHealTimer: this.startSelfHeal(sessionId),
+        watcherErrorLogged: false,
         lastModified: Date.now(),
         pendingRefresh: false,
       });
@@ -274,7 +324,9 @@ export class GitFileWatcher extends EventEmitter {
     this.watchedSessions.set(sessionId, {
       sessionId,
       worktreePath,
+      mode: 'wsl',
       wslWatcher: child,
+      watcherErrorLogged: false,
       lastModified: Date.now(),
       pendingRefresh: false,
     });
@@ -296,7 +348,10 @@ export class GitFileWatcher extends EventEmitter {
     // fire-and-forget async close — keeps stopWatching synchronous from callers' perspective
     session.worktreeWatcher?.close().catch(() => {});
     session.gitWatcher?.close().catch(() => {});
+    session.nativeWatcher?.close(); // node:fs FSWatcher.close() is synchronous
     session.wslWatcher?.kill();
+    if (session.pollTimer) clearInterval(session.pollTimer);
+    if (session.selfHealTimer) clearInterval(session.selfHealTimer);
     this.watchedSessions.delete(sessionId);
 
     // Clear any pending refresh timer
@@ -316,6 +371,10 @@ export class GitFileWatcher extends EventEmitter {
     for (const sessionId of this.watchedSessions.keys()) {
       this.stopWatching(sessionId);
     }
+    // Clear the instance-level gitignore cache only here — per-session
+    // stopWatching must NOT clear it (the cache exists to survive
+    // pane-switch/focus teardown-rebuild churn).
+    this.gitignoreDirCache.clear();
   }
 
   /**
@@ -387,6 +446,220 @@ export class GitFileWatcher extends EventEmitter {
       return this.commandRunner.exec(command, cwd, { silent: true });
     }
     return execSync(command, { cwd, encoding: 'utf8', silent: true }) as string;
+  }
+
+  /**
+   * Repo-truth ignored directories, derived from git and cached per watchPath
+   * on the instance with a TTL. This is the gitignore half of the union ignore
+   * set (the other half is the hardcoded IGNORED_DIRS). `git ls-files -o -i
+   * --directory --exclude-standard` emits RELATIVE dir paths (slash-normalized
+   * by git) with a TRAILING SLASH for on-disk ignored directories — we keep
+   * only those lines, stripped of the slash. If the path is not yet a repo the
+   * scan fails and we cache an empty set (the hardcoded list still applies).
+   */
+  private getGitignoredDirs(watchPath: string): Set<string> {
+    const cached = this.gitignoreDirCache.get(watchPath);
+    if (cached && Date.now() - cached.fetchedAt < GitFileWatcher.GITIGNORE_CACHE_TTL_MS) {
+      return cached.dirs;
+    }
+    const dirs = new Set<string>();
+    try {
+      const out = this.execGit('git ls-files -o -i --directory --exclude-standard', watchPath);
+      for (const line of out.split('\n')) {
+        const trimmed = line.trim();
+        // dirs only — git marks ignored directories with a trailing slash
+        if (trimmed.endsWith('/')) {
+          dirs.add(trimmed.slice(0, -1));
+        }
+      }
+    } catch {
+      /* not a repo yet → hardcoded list only */
+    }
+    this.gitignoreDirCache.set(watchPath, { dirs, fetchedAt: Date.now() });
+    return dirs;
+  }
+
+  /**
+   * Event-time ignore check for a root-relative path (native path uses this
+   * instead of chokidar's registration-time descent pruning). O(path depth)
+   * set lookups. `.git` internals are owned by the narrow metadata watcher, so
+   * anything under `.git` is dropped here to keep index.lock churn from
+   * resetting the debounce. EVERY segment (incl. the leaf) is checked against
+   * IGNORED_DIRS — a file literally named `node_modules` isn't worth a refresh
+   * and this avoids dir-vs-file guessing on event-time paths.
+   */
+  private isIgnoredEventPath(relPath: string, gitignoredDirs: Set<string>): boolean {
+    const segments = relPath.split(/[\\/]/).filter(Boolean);
+    if (segments.length === 0) return false;
+    if (segments[0] === '.git') return true; // narrow watcher owns .git signals
+    let prefix = '';
+    for (const seg of segments) {
+      if (IGNORED_DIRS.has(seg)) return true;
+      prefix = prefix ? `${prefix}/${seg}` : seg;
+      if (gitignoredDirs.has(prefix)) return true; // relative prefixes, e.g. "worktrees", "main/dist"
+    }
+    return IGNORED_FILE_PATTERNS.some((p) => p.test(segments[segments.length - 1]));
+  }
+
+  /**
+   * Snapshot-diff poll shared by polling mode (5s) and self-heal (60s). Mirrors
+   * the WSL bash fallback: snapshot `git status --porcelain` and emit
+   * `needs-refresh` only when the snapshot DIFFERS from the previous poll. The
+   * first poll seeds the baseline without emitting (lastStatusSnapshot
+   * undefined), so a legitimately-dirty tree does not spam a refresh every tick.
+   */
+  private pollStatusSnapshot(sessionId: string): void {
+    const session = this.watchedSessions.get(sessionId);
+    if (!session) return;
+    try {
+      // session.worktreePath (unconverted), matching performRefreshCheck →
+      // checkIfRefreshNeeded(session.worktreePath) — execGit/commandRunner
+      // expect the runner-domain path, not the toFileSystem-converted one.
+      const snapshot = this.execGit(
+        'git status --porcelain=v1 --branch --untracked-files=normal',
+        session.worktreePath,
+      );
+      if (session.lastStatusSnapshot !== undefined && snapshot !== session.lastStatusSnapshot) {
+        this.emit('needs-refresh', sessionId);
+      }
+      session.lastStatusSnapshot = snapshot;
+    } catch {
+      /* transient git failure — try again next tick */
+    }
+  }
+
+  /** 60s self-heal tick covering FSEvents coalescing / trailing-debounce starvation */
+  private startSelfHeal(sessionId: string): NodeJS.Timeout {
+    return setInterval(
+      () => this.pollStatusSnapshot(sessionId),
+      GitFileWatcher.SELF_HEAL_INTERVAL_MS,
+    );
+  }
+
+  /**
+   * Watcher-failure entrypoint. No-ops when the session is missing or already
+   * in polling mode — this is the storm-swallower: thousands of per-directory
+   * EMFILE error events collapse to a single degrade. Reads worktreePath from
+   * the session record and normalizes non-Error values.
+   */
+  private handleWatcherFailure(sessionId: string, err: unknown): void {
+    const session = this.watchedSessions.get(sessionId);
+    if (!session || session.mode === 'polling') return; // already degraded (or torn down); swallow the storm
+    this.transitionToPolling(
+      sessionId,
+      session.worktreePath,
+      err instanceof Error ? err : new Error(String(err)),
+    );
+  }
+
+  /**
+   * Degrade a session to the 5s snapshot-diff polling loop. May run BEFORE any
+   * session record exists (the native creation-throw path throws before
+   * watchedSessions.set), so it builds a COMPLETE WatchedSession record from
+   * its own parameters instead of assuming a prior one. Emits exactly one warn
+   * per session lifetime (guarded by watcherErrorLogged) and one immediate
+   * needs-refresh so consumers reconcile promptly; the first poll tick then
+   * seeds the snapshot baseline.
+   */
+  private transitionToPolling(sessionId: string, worktreePath: string, err: Error): void {
+    const session = this.watchedSessions.get(sessionId);
+    // close everything watcher-shaped; keep the debounce map intact
+    session?.nativeWatcher?.close(); // sync
+    session?.worktreeWatcher?.close().catch(() => {});
+    session?.gitWatcher?.close().catch(() => {});
+    if (session?.selfHealTimer) clearInterval(session.selfHealTimer);
+    if (session?.pollTimer) clearInterval(session.pollTimer);
+    if (!session?.watcherErrorLogged) {
+      this.logger?.warn(
+        `[GitFileWatcher] Watcher failed for ${sessionId} (${err.message}); ` +
+          `falling back to 5s git status polling.`,
+      );
+    }
+    const pollTimer = setInterval(
+      () => this.pollStatusSnapshot(sessionId),
+      GitFileWatcher.POLL_INTERVAL_MS,
+    );
+    this.watchedSessions.set(sessionId, {
+      sessionId,
+      worktreePath,
+      mode: 'polling',
+      pollTimer,
+      watcherErrorLogged: true,
+      lastStatusSnapshot: undefined,
+      lastModified: session?.lastModified ?? Date.now(),
+      pendingRefresh: false,
+    });
+    // one immediate refresh so consumers reconcile promptly after a degrade;
+    // the first poll tick then seeds the snapshot baseline
+    this.emit('needs-refresh', sessionId);
+  }
+
+  /**
+   * Narrow `.git`-metadata chokidar watcher, used by BOTH the native and
+   * chokidar branches. Covers the status-relevant metadata that the worktree
+   * watcher would otherwise miss or (on native) is deliberately filtered out:
+   * `index` (staging/commits), `HEAD` (branch switch), and — via the git COMMON
+   * dir — `packed-refs` and `refs/heads` (branch create/delete).
+   *
+   * Pane sessions usually run in git worktrees, where `.git` inside the
+   * worktree is a FILE pointing at `.git/worktrees/<name>`; the real `index`
+   * and `HEAD` live under the resolved `--absolute-git-dir`, while `refs/heads`
+   * and `packed-refs` live under the `--git-common-dir` (the MAIN repo's `.git`
+   * for a linked worktree). `--git-common-dir` may be relative (e.g. `.git`),
+   * unlike `--absolute-git-dir`, so it is resolved against `watchPath`. If
+   * resolution fails (not yet a valid repo) we skip the narrow watcher and rely
+   * on the worktree/native watcher alone, exactly as before.
+   */
+  private createGitMetadataWatcher(sessionId: string, watchPath: string): FSWatcher | undefined {
+    try {
+      // rev-parse emits one line per flag, in flag order — but guard the shape
+      const lines = this.execGit('git rev-parse --absolute-git-dir --git-common-dir', watchPath)
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+      const gitDir = lines[0];
+      if (!gitDir) return undefined;
+      const commonDirRaw = lines[1]; // may be missing or relative, e.g. ".git"
+      const commonDir = commonDirRaw
+        ? path.isAbsolute(commonDirRaw)
+          ? commonDirRaw
+          : path.resolve(watchPath, commonDirRaw)
+        : undefined;
+      const targets = new Set<string>([
+        path.join(gitDir, 'index'),
+        path.join(gitDir, 'HEAD'),
+        // small dir + single file; chokidar handle cost is trivial here
+        ...(commonDir
+          ? [path.join(commonDir, 'packed-refs'), path.join(commonDir, 'refs', 'heads')]
+          : []), // degrade to index/HEAD-only, as today
+      ]);
+      const gitWatcher = chokidarWatch([...targets], {
+        ignoreInitial: true,
+        persistent: true,
+        followSymlinks: false,
+        usePolling: false,
+      });
+      gitWatcher.on('all', () => {
+        // intentional: bypass any ignore checks, always trigger on
+        // git index/HEAD/refs changes
+        this.handleFileChange(sessionId, '.git/index', 'change');
+      });
+      // narrow watcher (~4 paths) cannot EMFILE — keep errors log-only, as
+      // today; do NOT route to handleWatcherFailure or a stat blip on
+      // refs/heads would needlessly degrade a healthy session to polling
+      gitWatcher.on('error', (err) => {
+        this.logger?.error(`[GitFileWatcher] .git watcher error`, err as Error);
+      });
+      return gitWatcher;
+    } catch (gitDirErr) {
+      this.logger?.error(
+        `[GitFileWatcher] Failed to resolve gitdir for ${sessionId}, ` +
+          `narrow .git watcher disabled (metadata-only operations will ` +
+          `not trigger refresh until worktree watcher fires):`,
+        gitDirErr as Error,
+      );
+      return undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #309.

On macOS, `GitFileWatcher` used chokidar 5, which has no FSEvents backend and opens **one `fs.watch` handle per directory**. Activating a session whose worktree is a large repo root (~10k watchable dirs measured on a real repo) exhausted macOS file-handle limits, and the log-only error handler turned that into a sustained `EMFILE` error storm — logger + dev IPC forwarding saturated the main process until the app was SIGKILLed. Every pane switch also paid a full O(tree) chokidar registration walk.

## Changes (all in `main/src/services/gitFileWatcher.ts`)

- **Native recursive watching on darwin/win32 (non-WSL):** one `fs.watch(root, { recursive: true })` handle per worktree (FSEvents / ReadDirectoryChangesW) instead of one per directory. Handle count is now O(watched sessions); pane-switch watcher setup is O(1) with no tree walk. Zero new dependencies.
- **Graceful degradation instead of freezing:** any watcher failure (EMFILE/ENOSPC, creation throw) closes the watchers, logs **one** rate-limited warning, and falls back to a 5s `git status` snapshot-diff poll (same model as the existing WSL fallback). Subsequent error events from a degraded session are swallowed.
- **Union ignore set:** hardcoded `IGNORED_DIRS` ∪ gitignored directories from `git ls-files -o -i --directory --exclude-standard` (instance-cached, 5-min TTL). Repo-root sessions stop watching their gitignored `worktrees/` dir automatically; repos that commit `dist/` keep watching it. On native paths the set filters events; on Linux it also prunes chokidar registration.
- **Narrow `.git` watcher extended:** now covers `refs/heads` and `packed-refs` via the worktree-aware git common dir (branch create/delete from external terminals triggers refresh), in addition to `index`/`HEAD`.
- **60s self-heal tick:** snapshot-diff check while watching, covering FSEvents event coalescing and trailing-debounce starvation.
- **Linux keeps chokidar** (inotify multiplexes through one fd, not exposed the same way); **WSL path unchanged**.

Both consumers are covered through the shared class: the active-session watcher (`GitStatusManager`) and the persistent per-spotlight watcher (`SpotlightManager`).

Prior art: Paseo and Superset (the two comparable agent-manager apps) both avoid chokidar for exactly this reason — Paseo uses zero-dep recursive `fs.watch` on non-Linux with a 5s poll fallback and 60s self-heal; Superset uses FSEvents-backed `@parcel/watcher` plus a recursive `fs.watch` on `.git`. This PR follows the zero-dependency Paseo shape.

## Testing

- `pnpm typecheck` ✅ (all workspaces, re-verified post-rebase)
- `pnpm lint` ✅ (0 errors; `gitFileWatcher.ts` itself is warning-free)
- `main` vitest: 301/302 pass — the 1 failure (`database.hidden-sessions.test.ts`) is a pre-existing better-sqlite3 native-binding issue reproduced on a clean checkout, unrelated to this change
- Manual macOS verification pending: large-repo activation (no EMFILE, flat `lsof` count), refresh on edits/commits/branch ops, forced-failure → polling degrade

## Pre-Merge Testing
- [ ] macOS: activate a session whose worktree is a large repo root (5k+ dirs) — no `EMFILE` in logs, app stays responsive, `lsof -p <main-pid> | wc -l` stays flat
- [ ] Edit a tracked file in the active worktree — status badge refreshes within ~2s
- [ ] `git commit` / `git checkout <branch>` / `git branch new-branch` from an external terminal in the worktree — refresh fires (index/HEAD/refs coverage)
- [ ] `touch` a file under `node_modules/` and under a gitignored dir (e.g. `worktrees/` from a repo-root session) — no refresh-check log spam
- [ ] Forced failure (relaunch with `ulimit -n 64`): exactly one `[GitFileWatcher] Watcher failed` warn, then edits still refresh within ~5-7s via polling
- [ ] Spotlight: enable on a session, edit a worktree file, confirm root sync still fires
- [ ] Windows-native and WSL projects: status refresh unchanged

## Build Verification
- [x] `pnpm typecheck` passes (all workspaces)
- [x] `pnpm lint` passes (0 errors; changed file warning-free)
- [x] `pnpm build:main` and `pnpm build:frontend` pass
- [x] `main` vitest 301/302 (1 pre-existing native-binding failure, reproduced on clean tree)


## Automated Test Results (pre-merge QA)

Harness drove the **compiled artifact** (`main/dist/.../gitFileWatcher.js`) against a generated 1,704-directory git repo (1,200 tracked + 300 `node_modules` + 200 gitignored `worktrees/` dirs). **12/12 checks passed.**

| Check | Result |
|---|---|
| Handle cost, same repo | chokidar 5 (old): **1,401 fds** · native (this PR): **3 fds** |
| Native mode selected on darwin | ✅ `mode=native`, setup 257ms |
| Tracked-file edit → `needs-refresh` | ✅ 1,537ms (right at 1.5s debounce) |
| Commit → index/HEAD watcher fires | ✅ |
| Branch create → refs/heads watcher fires | ✅ |
| `node_modules/` + gitignored `worktrees/` writes | ✅ zero emits, zero refresh-check runs |
| Injected EMFILE at creation | ✅ degrades to `polling`, **exactly 1 warn**, immediate reconcile refresh |
| Polling detects edit | ✅ 4.5s after write |
| No refresh spam while dirty-but-unchanged | ✅ 0 extra emits over 6s |
| `stopAll` teardown | ✅ fd count returns exactly to baseline, 0 sessions |

Live dev app (isolated `PANE_DIR`, driven via `runpane` CLI): registered `bloom-mono` (the issue's 9,960-dir repro repo) and created+focused two panes — **zero EMFILE**, main-process fd count flat at 117→121 across a 1,986-dir worktree activation. (The `runpane panes create --focus` path doesn't route through the renderer's active-session hint, so the `startWatching` log itself requires one manual sidebar click — activation plumbing untouched by this PR.)
