### PR TITLE
fix: harden GitFileWatcher degradation guards from PR #311 review

### DIFF
--- a/main/src/services/__tests__/gitFileWatcher.test.ts
+++ b/main/src/services/__tests__/gitFileWatcher.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GitFileWatcher } from '../gitFileWatcher';
+import type { CommandRunner } from '../../utils/commandRunner';
+import type { Logger } from '../../utils/logger';
+
+// Typed access to the private pure logic under test (no-any policy).
+interface GitFileWatcherInternals {
+  isIgnoredEventPath(relPath: string, gitignoredDirs: Set<string>, isLeafDirectory?: boolean): boolean;
+  getGitignoredDirs(watchPath: string): Set<string>;
+  transitionToPolling(sessionId: string, worktreePath: string, err: Error): void;
+  pollStatusSnapshot(sessionId: string): void;
+  handleWatcherFailure(sessionId: string, err: unknown): void;
+  watchedSessions: Map<string, { mode: string; watcherErrorLogged: boolean; lastStatusSnapshot?: string }>;
+}
+
+function makeLogger(): Logger & { warns: string[]; errors: string[] } {
+  const warns: string[] = [];
+  const errors: string[] = [];
+  return {
+    warns,
+    errors,
+    info: vi.fn(),
+    verbose: vi.fn(),
+    warn: (m: string) => warns.push(m),
+    error: (m: string) => errors.push(m),
+  } as unknown as Logger & { warns: string[]; errors: string[] };
+}
+
+function makeCommandRunner(exec: (command: string, cwd: string) => string): CommandRunner {
+  return { exec, wslContext: undefined } as unknown as CommandRunner;
+}
+
+describe('GitFileWatcher pure logic', () => {
+  let watcher: GitFileWatcher;
+  let internals: GitFileWatcherInternals;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logger = makeLogger();
+  });
+
+  afterEach(() => {
+    watcher?.stopAll();
+    vi.useRealTimers();
+  });
+
+  function build(exec: (command: string, cwd: string) => string = () => ''): void {
+    watcher = new GitFileWatcher(logger, makeCommandRunner(exec));
+    internals = watcher as unknown as GitFileWatcherInternals;
+  }
+
+  describe('isIgnoredEventPath', () => {
+    const none = new Set<string>();
+
+    it('drops anything under .git (narrow watcher owns those signals)', () => {
+      build();
+      expect(internals.isIgnoredEventPath('.git/index.lock', none)).toBe(true);
+      expect(internals.isIgnoredEventPath('.git', none)).toBe(true);
+    });
+
+    it('drops IGNORED_DIRS at any depth, including the leaf segment', () => {
+      build();
+      expect(internals.isIgnoredEventPath('node_modules/pkg/index.js', none)).toBe(true);
+      expect(internals.isIgnoredEventPath('apps/web/node_modules/x', none)).toBe(true);
+      expect(internals.isIgnoredEventPath('node_modules', none)).toBe(true);
+    });
+
+    it('drops gitignore-derived relative prefixes, including nested ones', () => {
+      build();
+      const gitignored = new Set(['worktrees', 'main/dist']);
+      expect(internals.isIgnoredEventPath('worktrees/wt1/src/a.ts', gitignored)).toBe(true);
+      expect(internals.isIgnoredEventPath('main/dist/index.js', gitignored)).toBe(true);
+      expect(internals.isIgnoredEventPath('main/src/index.ts', gitignored)).toBe(false);
+      // "worktrees" must match as a path prefix, not a substring
+      expect(internals.isIgnoredEventPath('worktrees-notes.md', gitignored)).toBe(false);
+    });
+
+    it('handles win32 backslash separators', () => {
+      build();
+      expect(internals.isIgnoredEventPath('node_modules\\pkg\\x.js', none)).toBe(true);
+      expect(internals.isIgnoredEventPath('src\\a.ts', none)).toBe(false);
+    });
+
+    it('applies IGNORED_FILE_PATTERNS to the leaf only when it may be a file', () => {
+      build();
+      expect(internals.isIgnoredEventPath('src/.DS_Store', none)).toBe(true);
+      expect(internals.isIgnoredEventPath('src/backup~', none)).toBe(true);
+      // a DIRECTORY named like a temp file must not be pruned when the caller
+      // knows it is a directory (chokidar registration path has stats)
+      expect(internals.isIgnoredEventPath('src/backup~', none, true)).toBe(false);
+      expect(internals.isIgnoredEventPath('src/regular.ts', none)).toBe(false);
+    });
+
+    it('never ignores an empty path', () => {
+      build();
+      expect(internals.isIgnoredEventPath('', none)).toBe(false);
+    });
+  });
+
+  describe('getGitignoredDirs', () => {
+    it('keeps only trailing-slash directory lines, stripped of the slash', () => {
+      build(() => 'node_modules/\nmain/dist/\nsome-ignored-file.log\nworktrees/\n');
+      const dirs = internals.getGitignoredDirs('/repo');
+      expect(dirs).toEqual(new Set(['node_modules', 'main/dist', 'worktrees']));
+    });
+
+    it('returns an empty set (hardcoded list still applies) when git fails', () => {
+      build(() => {
+        throw new Error('not a git repository');
+      });
+      expect(internals.getGitignoredDirs('/not-a-repo').size).toBe(0);
+    });
+
+    it('caches per watchPath and refreshes only after the TTL', () => {
+      const exec = vi.fn(() => 'worktrees/\n');
+      build(exec);
+      internals.getGitignoredDirs('/repo');
+      internals.getGitignoredDirs('/repo');
+      expect(exec).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(5 * 60_000 + 1);
+      internals.getGitignoredDirs('/repo');
+      expect(exec).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('transitionToPolling / handleWatcherFailure', () => {
+    it('builds a complete record with no prior session, warns once, seeds the baseline, emits once', () => {
+      const exec = vi.fn((cmd: string) => (cmd.startsWith('git status') ? 'M file.txt\n' : ''));
+      build(exec);
+      const emits: string[] = [];
+      watcher.on('needs-refresh', (sid: string) => emits.push(sid));
+
+      internals.transitionToPolling('s1', '/repo', new Error('EMFILE: too many open files'));
+
+      const record = internals.watchedSessions.get('s1');
+      expect(record?.mode).toBe('polling');
+      expect(record?.watcherErrorLogged).toBe(true);
+      // baseline seeded SYNCHRONOUSLY — a change in the 0-5s window diffs against it
+      expect(record?.lastStatusSnapshot).toBe('M file.txt\n');
+      expect(logger.warns).toHaveLength(1);
+      expect(emits).toEqual(['s1']); // immediate reconcile emit, no seed emit
+    });
+
+    it('polling emits only on snapshot CHANGE, never while dirty-but-unchanged', () => {
+      let status = 'M file.txt\n';
+      build((cmd: string) => (cmd.startsWith('git status') ? status : ''));
+      const emits: string[] = [];
+      watcher.on('needs-refresh', (sid: string) => emits.push(sid));
+
+      internals.transitionToPolling('s1', '/repo', new Error('EMFILE'));
+      expect(emits).toHaveLength(1); // the immediate degrade emit
+
+      vi.advanceTimersByTime(5_000); // tick with unchanged dirty status
+      vi.advanceTimersByTime(5_000);
+      expect(emits).toHaveLength(1); // no spam
+
+      status = 'M file.txt\nM other.ts\n';
+      vi.advanceTimersByTime(5_000);
+      expect(emits).toHaveLength(2); // change detected
+    });
+
+    it('handleWatcherFailure swallows repeat failures once degraded', () => {
+      build((cmd: string) => (cmd.startsWith('git status') ? '' : ''));
+      internals.transitionToPolling('s1', '/repo', new Error('EMFILE'));
+      internals.handleWatcherFailure('s1', new Error('EMFILE'));
+      internals.handleWatcherFailure('s1', new Error('EMFILE'));
+      expect(logger.warns).toHaveLength(1);
+    });
+
+    it('handleWatcherFailure no-ops for unknown sessions', () => {
+      build();
+      internals.handleWatcherFailure('ghost', new Error('EMFILE'));
+      expect(logger.warns).toHaveLength(0);
+      expect(internals.watchedSessions.size).toBe(0);
+    });
+  });
+});

--- a/main/src/services/gitFileWatcher.ts
+++ b/main/src/services/gitFileWatcher.ts
@@ -58,6 +58,7 @@ interface WatchedSession {
   selfHealTimer?: NodeJS.Timeout; // 60s snapshot-diff (native/chokidar modes)
   lastStatusSnapshot?: string; // last `git status --porcelain` output
   watcherErrorLogged: boolean; // rate-limits the fallback warn
+  nonFatalErrorLogged?: boolean; // rate-limits log-only watcher errors (separate from the degrade warn)
   lastModified: number;
   pendingRefresh: boolean;
 }
@@ -145,8 +146,17 @@ export class GitFileWatcher extends EventEmitter {
             },
           );
         } catch (err) {
-          // creation failure (e.g. EMFILE/ENOSPC on the handle) → degrade to
-          // polling before any record exists
+          // ENOENT means the worktree was deleted out from under the session —
+          // polling it would be a silent no-op loop, so log and give up (the
+          // pre-native behavior). Everything else (EMFILE/ENOSPC-style handle
+          // exhaustion) degrades to polling before any record exists.
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            this.logger?.error(
+              `[GitFileWatcher] Failed to start watching session ${sessionId} (worktree missing):`,
+              err as Error,
+            );
+            return;
+          }
           this.transitionToPolling(sessionId, worktreePath, err as Error);
           return;
         }
@@ -164,6 +174,13 @@ export class GitFileWatcher extends EventEmitter {
           pendingRefresh: false,
         });
 
+        // Seed the self-heal snapshot baseline off the activation critical path.
+        // Without a baseline, the first 60s tick after a MISSED event would only
+        // record the already-dirty snapshot without emitting, leaving status
+        // stale until the next real change. (pollStatusSnapshot no-ops if the
+        // session was torn down before this runs.)
+        setImmediate(() => this.pollStatusSnapshot(sessionId));
+
         // Validation signal — keep in production: confirms watcher count is bounded
         this.logger?.info(
           `[GitFileWatcher] startWatching(${sessionId}) watchedSessions.size=${this.watchedSessions.size}`
@@ -176,17 +193,16 @@ export class GitFileWatcher extends EventEmitter {
       // so it both prunes descent (handle budget) AND matches the native
       // event-time filter, keeping behavior uniform across platforms.
       const gitignoredDirs = this.getGitignoredDirs(watchPath);
-      // Function-form ignored: short-circuits descent into heavy directories
-      // stats may be undefined on initial calls — return false (don't ignore) if unknown
+      // Function-form ignored: short-circuits descent into heavy directories.
+      // stats may be undefined on initial calls — return false (don't ignore)
+      // if unknown. Unlike event-time callers, stats IS available here, so
+      // dir-vs-file is passed through and IGNORED_FILE_PATTERNS never prunes
+      // a directory whose name merely looks like a temp file (e.g. `backup~`).
       const ignored = (targetPath: string, stats?: Stats): boolean => {
         if (!stats) return false;
         const rel = path.relative(watchPath, targetPath);
-        if (rel && this.isIgnoredEventPath(rel, gitignoredDirs)) return true;
-        const base = path.basename(targetPath);
-        if (stats.isDirectory()) {
-          return IGNORED_DIRS.has(base);
-        }
-        return IGNORED_FILE_PATTERNS.some((p) => p.test(base));
+        if (!rel) return false; // never ignore the watch root itself
+        return this.isIgnoredEventPath(rel, gitignoredDirs, stats.isDirectory());
       };
 
       const worktreeWatcher = chokidarWatch(watchPath, {
@@ -204,14 +220,27 @@ export class GitFileWatcher extends EventEmitter {
         this.handleFileChange(sessionId, rel, 'change');
       });
       worktreeWatcher.on('error', (err) => {
+        // Storm guard FIRST: during handle exhaustion chokidar emits one error
+        // per failed directory registration and keeps emitting until the
+        // fire-and-forget close() lands — once degraded (or torn down), drop
+        // the remaining events silently instead of re-amplifying #309's log storm.
+        const session = this.watchedSessions.get(sessionId);
+        if (!session || session.mode === 'polling') return;
         // chokidar 5 types the error handler arg as `unknown`; extract the code
         // via ErrnoException cast (the no-any-compliant route). Only the
         // handle-exhaustion errors degrade to polling — other chokidar errors
         // stay log-only to avoid over-eager fallback on transient stat blips.
         const code = (err as NodeJS.ErrnoException).code;
-        this.logger?.error(`[GitFileWatcher] worktree watcher error`, err as Error);
         if (code === 'EMFILE' || code === 'ENOSPC') {
+          this.logger?.error(`[GitFileWatcher] worktree watcher error`, err as Error);
           this.handleWatcherFailure(sessionId, err);
+          return;
+        }
+        // log-only errors are rate-limited to the first per session — repeated
+        // transient blips must not turn into a sustained logger/IPC storm
+        if (!session.nonFatalErrorLogged) {
+          session.nonFatalErrorLogged = true;
+          this.logger?.error(`[GitFileWatcher] worktree watcher error`, err as Error);
         }
       });
 
@@ -228,6 +257,10 @@ export class GitFileWatcher extends EventEmitter {
         lastModified: Date.now(),
         pendingRefresh: false,
       });
+
+      // Seed the self-heal snapshot baseline off the activation critical path
+      // (same rationale as the native branch above).
+      setImmediate(() => this.pollStatusSnapshot(sessionId));
 
       // Validation signal — keep in production: confirms watcher count is bounded
       this.logger?.info(
@@ -487,8 +520,18 @@ export class GitFileWatcher extends EventEmitter {
    * resetting the debounce. EVERY segment (incl. the leaf) is checked against
    * IGNORED_DIRS — a file literally named `node_modules` isn't worth a refresh
    * and this avoids dir-vs-file guessing on event-time paths.
+   *
+   * `isLeafDirectory` is for callers that DO know (chokidar's registration-time
+   * `ignored` fn gets stats): when true, IGNORED_FILE_PATTERNS is skipped so a
+   * directory named like a temp file (e.g. `backup~`) is not silently pruned
+   * from watching. Event-time callers leave it false (unknowable) and accept
+   * the pattern check on the leaf.
    */
-  private isIgnoredEventPath(relPath: string, gitignoredDirs: Set<string>): boolean {
+  private isIgnoredEventPath(
+    relPath: string,
+    gitignoredDirs: Set<string>,
+    isLeafDirectory = false,
+  ): boolean {
     const segments = relPath.split(/[\\/]/).filter(Boolean);
     if (segments.length === 0) return false;
     if (segments[0] === '.git') return true; // narrow watcher owns .git signals
@@ -498,6 +541,7 @@ export class GitFileWatcher extends EventEmitter {
       prefix = prefix ? `${prefix}/${seg}` : seg;
       if (gitignoredDirs.has(prefix)) return true; // relative prefixes, e.g. "worktrees", "main/dist"
     }
+    if (isLeafDirectory) return false;
     return IGNORED_FILE_PATTERNS.some((p) => p.test(segments[segments.length - 1]));
   }
 
@@ -507,6 +551,11 @@ export class GitFileWatcher extends EventEmitter {
    * `needs-refresh` only when the snapshot DIFFERS from the previous poll. The
    * first poll seeds the baseline without emitting (lastStatusSnapshot
    * undefined), so a legitimately-dirty tree does not spam a refresh every tick.
+   *
+   * Known, intentional redundancy in watch modes: the baseline only updates on
+   * these ticks, so the tick after a real (already watcher-emitted) change
+   * emits one extra needs-refresh. That single bounded refresh doubles as the
+   * safety net for coalesced/dropped events, and refresh is idempotent.
    */
   private pollStatusSnapshot(sessionId: string): void {
     const session = this.watchedSessions.get(sessionId);
@@ -557,9 +606,11 @@ export class GitFileWatcher extends EventEmitter {
    * session record exists (the native creation-throw path throws before
    * watchedSessions.set), so it builds a COMPLETE WatchedSession record from
    * its own parameters instead of assuming a prior one. Emits exactly one warn
-   * per session lifetime (guarded by watcherErrorLogged) and one immediate
-   * needs-refresh so consumers reconcile promptly; the first poll tick then
-   * seeds the snapshot baseline.
+   * per session lifetime (guarded by watcherErrorLogged), seeds the snapshot
+   * baseline SYNCHRONOUSLY (a change landing in the 0-5s window before the
+   * first tick must not be absorbed into a late-seeded baseline and go
+   * un-emitted), then emits one immediate needs-refresh so consumers reconcile
+   * promptly with the exact state the baseline captured.
    */
   private transitionToPolling(sessionId: string, worktreePath: string, err: Error): void {
     const session = this.watchedSessions.get(sessionId);
@@ -589,8 +640,11 @@ export class GitFileWatcher extends EventEmitter {
       lastModified: session?.lastModified ?? Date.now(),
       pendingRefresh: false,
     });
-    // one immediate refresh so consumers reconcile promptly after a degrade;
-    // the first poll tick then seeds the snapshot baseline
+    // Seed the baseline NOW (pollStatusSnapshot only records, never emits, when
+    // the baseline is undefined) — deferring it to the first 5s tick would
+    // silently absorb any change made in that window. Then emit one immediate
+    // refresh so consumers reconcile with the state the baseline captured.
+    this.pollStatusSnapshot(sessionId);
     this.emit('needs-refresh', sessionId);
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #311 (merged in v2.4.12), addressing [the post-merge review](https://github.com/dcouple/Pane/pull/311#pullrequestreview-4643135309) — both should-fixes, all four suggestions, and the Codex bot's P2.

## Changes (`main/src/services/gitFileWatcher.ts` + new unit tests)

**Should-fix 1 — 0–5s blind window on degrade:** `transitionToPolling` now seeds the snapshot baseline **synchronously** (then emits the reconcile refresh), instead of letting the first 5s tick seed it. A change landing between degrade and first tick can no longer be absorbed into the baseline and go un-emitted.

**Codex P2 — self-heal baseline never seeded:** native/chokidar branches now seed the baseline at watcher start (deferred via `setImmediate` to keep pane-switch activation O(1)). Previously a *missed* watcher event would leave status stale indefinitely: the first 60s tick only recorded the already-dirty snapshot without emitting.

**Should-fix 2 — Linux error-log storm remnant:** the chokidar worktree error handler is now storm-guarded — silent once the session is degraded/torn down (chokidar keeps emitting one error per failed dir until `close()` lands), EMFILE/ENOSPC logs once and degrades, and non-fatal errors are rate-limited to the first per session via a new `nonFatalErrorLogged` flag (kept separate from `watcherErrorLogged` so it can't suppress the degrade warn).

**Suggestion 2 — dirs named like temp files pruned on Linux:** the chokidar `ignored` fn now passes `stats.isDirectory()` through to the ignore check, which skips `IGNORED_FILE_PATTERNS` for known directories — a dir named `backup~` is watched again. Event-time (native) callers keep the leaf-pattern check since dir-vs-file is unknowable there.

**Suggestion 3 — ENOENT shouldn't degrade:** a worktree deleted out from under a session now logs and gives up (pre-#311 behavior) instead of degrading to a permanent no-op 5s poll where every git call fails silently.

**Suggestion 1 — redundant self-heal emit:** documented as intentional (one bounded extra refresh per real change; doubles as the coalesced-event safety net; refresh is idempotent).

**Suggestion 4 — unit coverage:** new `gitFileWatcher.test.ts` (13 tests) covering `isIgnoredEventPath` (segment/prefix/pattern/backslash/dir-leaf semantics), `getGitignoredDirs` (trailing-slash parsing, failure fallback, TTL cache), and the `transitionToPolling` state machine (complete record from params, single warn, synchronous seed, emit-on-change-only, storm swallowing).

## Testing

- `pnpm typecheck` ✅  · `eslint` on changed files ✅ (0 warnings)
- New `gitFileWatcher.test.ts`: 13/13 ✅
- `gitStatusManager.test.ts` (consumer contract): 23/23 ✅