### PR TITLE
Teach Pane Chat work question skills

### DIFF
--- a/main/src/services/paneChatManager.ts
+++ b/main/src/services/paneChatManager.ts
@@ -18,7 +18,7 @@ import {
 import { RUNPANE_CONTRACT } from '../../../shared/types/generatedRunpaneContract';
 
 const PANE_CHAT_TITLE = 'Pane Chat';
-const PANE_CHAT_BOOTSTRAP_VERSION = 8;
+const PANE_CHAT_BOOTSTRAP_VERSION = 9;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isValidUuid(value: unknown): value is string {

--- a/main/src/services/skillCacheManager.test.ts
+++ b/main/src/services/skillCacheManager.test.ts
@@ -41,6 +41,9 @@ describe('SkillCacheManager Pane Chat guide', () => {
     expect(guide).toContain('RunPane orchestrator skill for Codex');
     expect(normalizedGuide).toContain('/skills/dcouple/parsa/.codex/skills/runpane-orchestrator/SKILL.md');
     expect(normalizedGuide).toContain('/skills/dcouple/docs/readme-workflow-map.png');
+    expect(guide).toContain('pane-work-recap');
+    expect(guide).toContain('pane-work-prioritizer');
+    expect(guide).toContain('when they ask what to work on next');
     expect(guide).toContain('Do not replace orchestration with a normal chat answer for Pane work.');
     expect(guide).toContain('verify its state with');
   });
@@ -92,6 +95,9 @@ describe('SkillCacheManager Pane Chat guide', () => {
     expect(canonicalSkill).toContain('After a PR is merged, the user can archive the Pane');
     expect(canonicalSkill).toContain('Workflow map source:');
     expect(canonicalSkill).toContain('Skill legend source:');
+    expect(canonicalSkill).toContain('pane-work-recap');
+    expect(canonicalSkill).toContain('pane-work-prioritizer');
+    expect(canonicalSkill).toContain('Do not start implementation panes for those answers');
   });
 
   it('mirrors cached repository skills into project-scoped Codex and Claude skill roots', async () => {

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -62,7 +62,13 @@ const OPTIONAL_FALLBACK_RAW_FILES = [
   'parsa/.codex/skills/plan/plan_base.md',
   'parsa/.codex/skills/pr-test-automation/agents/openai.yaml',
   'parsa/.codex/skills/teach-back/agents/openai.yaml',
+  'parsa/.codex/skills/pane-work-recap/SKILL.md',
+  'parsa/.codex/skills/pane-work-recap/agents/openai.yaml',
+  'parsa/.codex/skills/pane-work-prioritizer/SKILL.md',
+  'parsa/.codex/skills/pane-work-prioritizer/agents/openai.yaml',
   'parsa/.claude/skills/create-plan/plan_base.md',
+  'parsa/.claude/skills/pane-work-recap/SKILL.md',
+  'parsa/.claude/skills/pane-work-prioritizer/SKILL.md',
 ] as const;
 
 const FALLBACK_RAW_FILES = [
@@ -342,6 +348,11 @@ Use the cached RunPane orchestrator skill as the primary workflow reference. The
 cached files may be refreshed by Pane in the background; do not fetch GitHub just
 to initialize yourself.
 
+For read-only work questions, use \`pane-work-recap\` when the user asks what
+they worked on and \`pane-work-prioritizer\` when they ask what to work on next.
+Ground both answers in RunPane, git, GitHub, and agent-log evidence before
+starting new implementation panes.
+
 ## Orchestrator Contract
 
 For any request that asks you to inspect, change, plan, test, review, or
@@ -413,6 +424,10 @@ with generic cached RunPane documentation, follow the runtime context.
 
 Do not claim initialization is complete until you have loaded these workflow
 references and can name the intended lifecycle for the user's task.
+
+For read-only work questions, use \`pane-work-recap\` when the user asks what
+they worked on and \`pane-work-prioritizer\` when they ask what to work on next.
+Do not start implementation panes for those answers unless the user asks you to.
 
 ## Role Boundary
 


### PR DESCRIPTION
## Summary

- Teach generated Pane Chat bootstrap guidance to route read-only work questions to `pane-work-recap` and `pane-work-prioritizer`.
- Add optional raw fallback downloads for those skills so fallback sync can pick them up without making them hard boot dependencies.
- Bump the Pane Chat bootstrap version to refresh existing Pane Chat panels and assert both generated outputs mention the new workflows.

## Visual Overview

```mermaid
flowchart LR
  subgraph Before["Before"]
    A["Pane Chat initialization"] --> B["RunPane lifecycle guidance"]
    B --> C["Implementation pane workflows"]
  end

  subgraph After["After"]
    D["Pane Chat initialization v9"] --> E["RunPane lifecycle guidance"]
    E --> F["Read-only work questions"]
    F --> G["pane-work-recap"]
    F --> H["pane-work-prioritizer"]
    E --> I["Implementation panes only when asked"]
  end
```

## Testing

- `../../node_modules/.bin/vitest run main/src/services/skillCacheManager.test.ts`
- `PATH=/Users/parsas/allGitHubRepos/dcouple/Pane/node_modules/.bin:/Users/parsas/allGitHubRepos/dcouple/Pane/main/node_modules/.bin:$PATH pnpm --filter main typecheck`
- `PATH=/Users/parsas/allGitHubRepos/dcouple/Pane/node_modules/.bin:/Users/parsas/allGitHubRepos/dcouple/Pane/main/node_modules/.bin:$PATH pnpm --filter main lint`
  - Passes with the repo's existing 163 warnings.
- `PATH=/Users/parsas/allGitHubRepos/dcouple/Pane/node_modules/.bin:/Users/parsas/allGitHubRepos/dcouple/Pane/main/node_modules/.bin:$PATH pnpm --filter main build`
  - Passes with existing npm env config warnings.
- `git diff --check`

Related: dcouple/skills#33, parsakhaz/runpane-website#124
