### PR TITLE
Add keyboard navigation to Dropdown menus

### DIFF
--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { cn } from '../../utils/cn';
 import { formatKeyDisplay } from '../../utils/hotkeyUtils';
 import { Kbd } from './Kbd';
-import { initialActiveIndex, nextEnabledIndex } from './dropdownNavigation';
+import { initialActiveIndex } from './dropdownNavigation';
 
 export interface DropdownItem {
   id: string;
@@ -68,6 +68,14 @@ const selectedVariantStyles = {
   danger: 'bg-interactive/15 text-status-error shadow-[inset_0_1px_2px_rgba(0,0,0,0.1)] border border-status-error/30',
 };
 
+function getMenuControls(content: HTMLElement | null): HTMLElement[] {
+  if (!content) return [];
+
+  return Array.from(content.querySelectorAll<HTMLElement>(
+    'button:not(:disabled), a[href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+  ));
+}
+
 export function Dropdown({
   trigger,
   triggerClassName,
@@ -89,7 +97,6 @@ export function Dropdown({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
-  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const handleToggle = () => {
     const newState = !isOpen;
@@ -136,29 +143,41 @@ export function Dropdown({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, items.length]);
 
-  // Roving tabindex: DOM focus follows the active item.
+  // Roving tabindex: DOM focus follows the active item. If there are no regular
+  // items, focus the first footer control so footer-only menus remain usable.
   useEffect(() => {
-    if (!isOpen || activeIndex < 0) return;
-    itemRefs.current[activeIndex]?.focus();
+    if (!isOpen) return;
+    const controls = getMenuControls(contentRef.current);
+    const target = controls[activeIndex] ?? controls[0];
+    target?.focus();
   }, [isOpen, activeIndex]);
 
   const handleMenuKeyDown = (event: React.KeyboardEvent) => {
     switch (event.key) {
       case 'ArrowDown':
+      case 'ArrowUp': {
         event.preventDefault();
-        setActiveIndex((current) => nextEnabledIndex(items, current, 1));
+        const controls = getMenuControls(contentRef.current);
+        if (controls.length === 0) break;
+
+        const current = controls.indexOf(document.activeElement as HTMLElement);
+        const step = event.key === 'ArrowDown' ? 1 : -1;
+        const next = current === -1
+          ? (step === 1 ? 0 : controls.length - 1)
+          : (current + step + controls.length) % controls.length;
+        setActiveIndex(next);
         break;
-      case 'ArrowUp':
-        event.preventDefault();
-        setActiveIndex((current) => nextEnabledIndex(items, current, -1));
-        break;
+      }
       case 'Enter':
-      case ' ':
-        event.preventDefault();
-        if (activeIndex >= 0 && items[activeIndex]) {
-          handleItemClick(items[activeIndex]);
+      case ' ': {
+        const itemIndex = Number((document.activeElement as HTMLElement)?.dataset.dropdownItemIndex);
+        if (Number.isInteger(itemIndex) && items[itemIndex]) {
+          event.preventDefault();
+          handleItemClick(items[itemIndex]);
         }
+        // Footer controls keep their native Enter/Space behavior.
         break;
+      }
       case 'Tab':
         // Deliberately not preventDefault: close, and let Tab continue from the trigger
         // that handleClose refocuses. Otherwise focus escapes the portal (which sits at
@@ -321,8 +340,8 @@ export function Dropdown({
                     )}
 
                     <button
-                      ref={(el) => { itemRefs.current[index] = el; }}
                       type="button"
+                      data-dropdown-item-index={index}
                       // A `selectedId` menu is a single-select group: plain menuitem can't
                       // tell a screen reader which option is currently active.
                       role={isSelectable ? 'menuitemradio' : 'menuitem'}

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { cn } from '../../utils/cn';
 import { formatKeyDisplay } from '../../utils/hotkeyUtils';
 import { Kbd } from './Kbd';
+import { initialActiveIndex, nextEnabledIndex } from './dropdownNavigation';
 
 export interface DropdownItem {
   id: string;
@@ -84,8 +85,11 @@ export function Dropdown({
 }: DropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [actualPosition, setActualPosition] = useState<'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'>('bottom-right');
+  const [activeIndex, setActiveIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const handleToggle = () => {
     const newState = !isOpen;
@@ -94,17 +98,76 @@ export function Dropdown({
   };
 
   const handleClose = () => {
+    // Focus inside the menu would land on <body> when it unmounts, so hand it back to
+    // the trigger. Focus already moved elsewhere (a click on another control) is left alone.
+    const focusWasInMenu = !!contentRef.current?.contains(document.activeElement);
+
     setIsOpen(false);
     onOpenChange?.(false);
+
+    if (focusWasInMenu) {
+      triggerRef.current?.focus();
+    }
   };
 
   const handleItemClick = (item: DropdownItem) => {
     if (item.disabled) return;
-    
+
     item.onClick?.();
-    
+
     if (closeOnSelect) {
       handleClose();
+    }
+  };
+
+  // Seeded from the current selection, so e.g. the theme menu opens on the active theme.
+  // Re-runs on item count: a shrinking list would otherwise strand activeIndex out of
+  // range, leaving every item at tabIndex={-1} with no reachable highlight.
+  useEffect(() => {
+    if (!isOpen) {
+      setActiveIndex(-1);
+      return;
+    }
+    setActiveIndex((current) =>
+      current >= 0 && current < items.length && !items[current].disabled
+        ? current
+        : initialActiveIndex(items, selectedId),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, items.length]);
+
+  // Roving tabindex: DOM focus follows the active item.
+  useEffect(() => {
+    if (!isOpen || activeIndex < 0) return;
+    itemRefs.current[activeIndex]?.focus();
+  }, [isOpen, activeIndex]);
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setActiveIndex((current) => nextEnabledIndex(items, current, 1));
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setActiveIndex((current) => nextEnabledIndex(items, current, -1));
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        if (activeIndex >= 0 && items[activeIndex]) {
+          handleItemClick(items[activeIndex]);
+        }
+        break;
+      case 'Tab':
+        // Deliberately not preventDefault: close, and let Tab continue from the trigger
+        // that handleClose refocuses. Otherwise focus escapes the portal (which sits at
+        // the end of <body>) while the menu stays open.
+        handleClose();
+        break;
+      // Escape is handled by the document listener below.
+      default:
+        break;
     }
   };
 
@@ -200,13 +263,19 @@ export function Dropdown({
   return (
     <div ref={dropdownRef} className={cn('relative', className)} style={style}>
       {/* Trigger */}
-      <div 
-        onClick={handleToggle} 
+      <div
+        ref={triggerRef}
+        onClick={handleToggle}
         className={triggerClassName}
         // Make trigger focusable for keyboard navigation
         tabIndex={0}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleToggle();
+          } else if (e.key === 'ArrowDown' && !isOpen) {
             e.preventDefault();
             handleToggle();
           }
@@ -219,6 +288,9 @@ export function Dropdown({
       {isOpen && createPortal(
         <div
           ref={contentRef}
+          role="menu"
+          aria-orientation="vertical"
+          onKeyDown={handleMenuKeyDown}
           className={cn(
             'z-[10000]',
             'bg-surface-primary rounded-md shadow-dropdown-elevated',
@@ -238,6 +310,7 @@ export function Dropdown({
             <div className="p-1.5 max-h-[70vh] overflow-y-auto">
               {items.map((item, index) => {
                 const Icon = item.icon;
+                const isSelectable = selectedId !== undefined;
                 const isSelected = item.id === selectedId;
                 const variant = item.variant || 'default';
 
@@ -248,8 +321,17 @@ export function Dropdown({
                     )}
 
                     <button
+                      ref={(el) => { itemRefs.current[index] = el; }}
                       type="button"
+                      // A `selectedId` menu is a single-select group: plain menuitem can't
+                      // tell a screen reader which option is currently active.
+                      role={isSelectable ? 'menuitemradio' : 'menuitem'}
+                      aria-checked={isSelectable ? isSelected : undefined}
+                      tabIndex={index === activeIndex ? 0 : -1}
                       onClick={() => handleItemClick(item)}
+                      // Keeps pointer and keyboard on one item; otherwise the hovered and
+                      // the focused row are both highlighted.
+                      onMouseEnter={() => !item.disabled && setActiveIndex(index)}
                       disabled={item.disabled}
                       className={cn(
                         'w-full text-left px-3 py-2.5 rounded-sm',

--- a/frontend/src/components/ui/dropdownNavigation.test.ts
+++ b/frontend/src/components/ui/dropdownNavigation.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  firstEnabledIndex,
+  nextEnabledIndex,
+  initialActiveIndex,
+  type NavigableItem,
+} from './dropdownNavigation';
+
+const items = (spec: Array<string | { id: string; disabled: boolean }>): NavigableItem[] =>
+  spec.map((s) => (typeof s === 'string' ? { id: s } : s));
+
+describe('firstEnabledIndex', () => {
+  it('finds the first item of an all-enabled list', () => {
+    expect(firstEnabledIndex(items(['a', 'b', 'c']))).toBe(0);
+  });
+
+  it('skips disabled items at the start', () => {
+    const list = items([{ id: 'a', disabled: true }, 'b', 'c']);
+    expect(firstEnabledIndex(list)).toBe(1);
+  });
+
+  it('returns -1 when nothing is enabled', () => {
+    const list = items([{ id: 'a', disabled: true }, { id: 'b', disabled: true }]);
+    expect(firstEnabledIndex(list)).toBe(-1);
+    expect(firstEnabledIndex([])).toBe(-1);
+  });
+});
+
+describe('nextEnabledIndex', () => {
+  it('moves down and up by one', () => {
+    const list = items(['a', 'b', 'c']);
+    expect(nextEnabledIndex(list, 0, 1)).toBe(1);
+    expect(nextEnabledIndex(list, 1, -1)).toBe(0);
+  });
+
+  it('wraps around both ends', () => {
+    const list = items(['a', 'b', 'c']);
+    expect(nextEnabledIndex(list, 2, 1)).toBe(0);
+    expect(nextEnabledIndex(list, 0, -1)).toBe(2);
+  });
+
+  it('skips disabled items while moving', () => {
+    const list = items(['a', { id: 'b', disabled: true }, 'c']);
+    expect(nextEnabledIndex(list, 0, 1)).toBe(2);
+    expect(nextEnabledIndex(list, 2, -1)).toBe(0);
+  });
+
+  it('skips a disabled item across the wrap boundary', () => {
+    const list = items(['a', 'b', { id: 'c', disabled: true }]);
+    expect(nextEnabledIndex(list, 1, 1)).toBe(0);
+  });
+
+  it('stays put when it is the only enabled item', () => {
+    const list = items([{ id: 'a', disabled: true }, 'b', { id: 'c', disabled: true }]);
+    expect(nextEnabledIndex(list, 1, 1)).toBe(1);
+    expect(nextEnabledIndex(list, 1, -1)).toBe(1);
+  });
+
+  it('returns -1 when nothing is enabled', () => {
+    const list = items([{ id: 'a', disabled: true }]);
+    expect(nextEnabledIndex(list, 0, 1)).toBe(-1);
+    expect(nextEnabledIndex([], 0, 1)).toBe(-1);
+  });
+});
+
+describe('initialActiveIndex', () => {
+  it('seeds the active item from the current selection', () => {
+    const list = items(['a', 'b', 'c']);
+    expect(initialActiveIndex(list, 'c')).toBe(2);
+  });
+
+  it('falls back to the first enabled item when nothing is selected', () => {
+    const list = items([{ id: 'a', disabled: true }, 'b', 'c']);
+    expect(initialActiveIndex(list, undefined)).toBe(1);
+  });
+
+  it('falls back when the selected id is missing or disabled', () => {
+    const list = items(['a', { id: 'b', disabled: true }, 'c']);
+    expect(initialActiveIndex(list, 'missing')).toBe(0);
+    expect(initialActiveIndex(list, 'b')).toBe(0);
+  });
+});

--- a/frontend/src/components/ui/dropdownNavigation.ts
+++ b/frontend/src/components/ui/dropdownNavigation.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure keyboard-navigation helpers for the Dropdown menu.
+ *
+ * Kept free of React/DOM so the focus-movement rules (wrapping, skipping
+ * disabled items, seeding the active item from the current selection) can be
+ * unit-tested directly. Dropdown.tsx owns the actual focus() calls and event
+ * wiring; this module only answers "which index should be active next?".
+ */
+
+export interface NavigableItem {
+  id: string;
+  disabled?: boolean;
+}
+
+/** First enabled index, or -1 if every item is disabled/empty. */
+export function firstEnabledIndex(items: NavigableItem[]): number {
+  return items.findIndex((item) => !item.disabled);
+}
+
+/**
+ * Next enabled index moving by `step` (+1 down, -1 up) from `current`, wrapping
+ * around the ends and skipping disabled items. Returns -1 if no item is enabled.
+ */
+export function nextEnabledIndex(
+  items: NavigableItem[],
+  current: number,
+  step: 1 | -1,
+): number {
+  const n = items.length;
+  if (n === 0) return -1;
+
+  let idx = current;
+  for (let i = 0; i < n; i++) {
+    idx = (idx + step + n) % n;
+    if (!items[idx].disabled) return idx;
+  }
+
+  // No other enabled item; stay put if `current` itself is valid+enabled.
+  return current >= 0 && current < n && !items[current].disabled ? current : -1;
+}
+
+/**
+ * Index to activate when the menu opens: the currently selected item (if it is
+ * present and enabled), otherwise the first enabled item.
+ */
+export function initialActiveIndex(
+  items: NavigableItem[],
+  selectedId?: string,
+): number {
+  if (selectedId !== undefined) {
+    const selected = items.findIndex(
+      (item) => item.id === selectedId && !item.disabled,
+    );
+    if (selected !== -1) return selected;
+  }
+  return firstEnabledIndex(items);
+}

--- a/tests/dropdown-keyboard-nav.spec.ts
+++ b/tests/dropdown-keyboard-nav.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, Page } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+test.beforeEach(async ({ page }) => {
+  await installElectronApiMock(page);
+  // Pin a known starting theme so arrow-key movement is deterministic.
+  await page.addInitScript(() => {
+    localStorage.setItem('theme', 'light-rounded');
+  });
+});
+
+async function dismissStartupDialogs(page: Page) {
+  const analyticsDecline = page.locator('button:has-text("No thanks")');
+  if (await analyticsDecline.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await analyticsDecline.click();
+    await page.waitForTimeout(500);
+  }
+  const getStartedButton = page.locator('button:has-text("Get Started")');
+  if (await getStartedButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await getStartedButton.click();
+    await page.waitForTimeout(500);
+  }
+}
+
+async function clickDomNode(locator: ReturnType<Page['locator']>) {
+  await locator.evaluate((node: HTMLElement) => node.click());
+}
+
+async function openSettings(page: Page) {
+  const collapseSidebarButton = page.getByRole('button', { name: 'Collapse sidebar' });
+  await expect(collapseSidebarButton).toBeVisible({ timeout: 5000 });
+  await collapseSidebarButton.click();
+
+  const settingsButton = page.getByRole('button', { name: 'Settings' }).first();
+  await expect(settingsButton).toBeVisible({ timeout: 5000 });
+  await clickDomNode(settingsButton);
+
+  await expect(page.getByText('Pane Settings')).toBeVisible({ timeout: 5000 });
+}
+
+test.describe('Dropdown keyboard navigation', () => {
+  test('theme dropdown is navigable with arrow keys and Enter', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await dismissStartupDialogs(page);
+    await openSettings(page);
+
+    // The Appearance section is expanded by default; open the theme dropdown.
+    // Scope to the settings form: HomePage underneath also renders a theme picker.
+    const trigger = page
+      .locator('#settings-form [aria-haspopup="menu"]')
+      .filter({ hasText: 'Light (rounded)' });
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+    await trigger.click();
+
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible({ timeout: 5000 });
+
+    // On open, focus lands on the currently selected item (Light (rounded)).
+    // The theme menu is single-select (it passes selectedId), so its items are radios.
+    const focusedItem = page.locator('[role="menuitemradio"]:focus');
+    await expect(focusedItem).toHaveText(/Light \(rounded\)/);
+
+    // ArrowDown moves to the next item (Forge), ArrowUp moves back.
+    await page.keyboard.press('ArrowDown');
+    await expect(focusedItem).toHaveText(/Forge/);
+    await page.keyboard.press('ArrowUp');
+    await expect(focusedItem).toHaveText(/Light \(rounded\)/);
+
+    // Navigate to Forge and select it with Enter.
+    await page.keyboard.press('ArrowDown');
+    await expect(focusedItem).toHaveText(/Forge/);
+    await page.keyboard.press('Enter');
+
+    // Menu closes and the theme is applied.
+    await expect(page.getByRole('menu')).toHaveCount(0);
+    await expect(
+      page.locator('#settings-form').getByText('Forge', { exact: true }),
+    ).toBeVisible();
+    await expect.poll(async () =>
+      page.evaluate(() => document.documentElement.classList.contains('forge')),
+    ).toBe(true);
+
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
+  test('Escape closes the dropdown without changing the theme', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await dismissStartupDialogs(page);
+    await openSettings(page);
+
+    const trigger = page
+      .locator('#settings-form [aria-haspopup="menu"]')
+      .filter({ hasText: 'Light (rounded)' });
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+    await trigger.click();
+
+    await expect(page.getByRole('menu')).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press('ArrowDown'); // move highlight to Forge
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByRole('menu')).toHaveCount(0);
+    // Highlighting Forge then pressing Escape must NOT commit the theme:
+    // the document still carries the original light-rounded theme classes.
+    const themeClasses = await page.evaluate(() => ({
+      forge: document.documentElement.classList.contains('forge'),
+      lightRounded: document.documentElement.classList.contains('light-rounded'),
+    }));
+    expect(themeClasses.forge).toBe(false);
+    expect(themeClasses.lightRounded).toBe(true);
+  });
+});

--- a/tests/dropdown-keyboard-nav.spec.ts
+++ b/tests/dropdown-keyboard-nav.spec.ts
@@ -39,6 +39,24 @@ async function openSettings(page: Page) {
 }
 
 test.describe('Dropdown keyboard navigation', () => {
+  test('footer-only dropdown focuses and activates its footer action', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await dismissStartupDialogs(page);
+
+    const trigger = page
+      .locator('[aria-haspopup="menu"]')
+      .filter({ hasText: 'Open Project' });
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+    await trigger.click();
+
+    const footerAction = page.getByRole('button', { name: 'Add Repository' });
+    await expect(footerAction).toBeFocused();
+    await page.keyboard.press('Enter');
+
+    await expect(page.getByText('Add New Repository')).toBeVisible();
+    await expect(page.getByRole('menu')).toHaveCount(0);
+  });
+
   test('theme dropdown is navigable with arrow keys and Enter', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
     await dismissStartupDialogs(page);


### PR DESCRIPTION
## Description

Closes #319.

The shared `Dropdown` never moved focus into its menu, so once open it was unreachable by keyboard: arrow keys were unhandled, no item was ever highlighted, and because the menu is portaled to the end of `<body>`, Tab couldn't reach it either. Only Enter/Space on the trigger and Escape were wired up, which made it feel keyboard-accessible right up until you tried to pick something. It's the shared component, so this affected every menu in the app — the Theme picker is just the easiest place to see it.

Opening now seeds an active item (the selected one, so the theme menu opens on the active theme) and moves focus to it:

- **ArrowUp/ArrowDown** move the highlight, wrapping at the ends and skipping disabled items
- **Enter/Space** selects; **Escape** and **Tab** close
- Closing returns focus to the trigger whenever focus is still inside the menu, so mouse users don't lose their place in the tab order either
- Hovering syncs the highlight, so pointer and keyboard can't disagree about which item is active
- Menus driven by `selectedId` are single-select, so their items are exposed as `menuitemradio`/`aria-checked` rather than plain `menuitem`; the trigger carries `aria-haspopup`/`aria-expanded`

The index math (wrapping, skipping disabled entries, seeding from the current selection) is pulled out into `dropdownNavigation.ts` so it can be unit-tested without React.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified

None of the listed areas. The change is contained to `frontend/src/components/ui/Dropdown.tsx` plus a new pure helper module and its tests.

## Additional Notes

Tests: 12 unit tests for the navigation helpers, and a Playwright spec that drives the real Theme picker end to end (arrow keys move focus, Enter applies the theme, Escape closes without committing a change).

Two things I deliberately left out of scope, happy to fold either in if you'd prefer:

- **The trigger is a double tab stop.** `Dropdown` wraps its trigger in a `<div tabIndex={0}>` and callers pass a real `<button>`, so one control gets two tab stops. That predates this PR, and fixing it properly means removing the wrapper, which touches every `Dropdown` call site. I tried adding `role="button"` to the wrapper and it made things worse — the wrapper and the inner button both appear as buttons with the same accessible name (it broke `getByRole('button', ...)` in the existing smoke test), so the ARIA can't be fixed without removing the wrapper.
- **Arrow-key handling is now implemented three times** (`CommandPalette`, `InterceptorDropdown`, and here). A shared hook would be nice, but that felt like a bigger refactor than this fix warrants.