### PR TITLE
Fix macOS blank rendering after idle

### DIFF
--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -13,6 +13,12 @@ const launchRemoteSetup = hasRemoteSetupLaunchArg();
 // This MUST be done before importing electron
 import { app } from 'electron';
 
+if (process.platform === 'darwin') {
+  // Work around unrecoverable Skia Graphite rendering glitches on macOS.
+  // https://github.com/electron/electron/pull/49608
+  app.commandLine.appendSwitch('disable-skia-graphite');
+}
+
 function getStartupTerminalPowerMode(): 'performance' | 'batterySaver' {
   try {
     const rawConfig = JSON.parse(


### PR DESCRIPTION
## Summary
- disable Skia Graphite on macOS before Electron starts the GPU process
- preserve GPU compositing, xterm WebGL, and the existing low-power GPU mode
- document the upstream Electron rendering failure and track the longer-term Electron upgrade in #324

## Root cause
Pane 2.4.18 uses Electron 37 / Chromium 138. Skia Graphite is enabled on macOS in that Chromium range and can enter an unrecoverable state when GPU recordings are inserted out of order. The renderer remains interactive, but the affected window stops painting correctly until the GPU process restarts.

This matches the behavior reported in #321: intermittent corruption after an idle/minimized period, working hit testing and clipboard operations, a healthy secondary About window, and recovery only after quitting Pane.

Upstream references:
- https://github.com/electron/electron/pull/49608
- https://github.com/microsoft/vscode/issues/284162
- https://github.com/microsoft/vscode/commit/ae524952a1de76a3cc4d612775536bfd4cde7e97

## Testing
- `pnpm --filter main typecheck`
- `pnpm --filter main lint` (0 errors; existing repository warnings remain)
- `pnpm build:main` through an isolated `PANE_DIR=/tmp/pane-graphite-smoke pnpm dev` launch
- verified the isolated GPU helper received `--disable-skia-graphite`
- `git diff --check`
- independent implementation review found no must-fix or should-fix issues

The intermittent minimize/idle/restore scenario still needs a release soak test on affected Apple Silicon hardware.

Closes #321
