### PR TITLE
Harden frontend accessibility outside Settings

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -40,12 +40,21 @@ The following packages are licensed under the MIT license:
   - @electron/get (2.0.3) - Samuel Attard
   - @electron/node-gyp (10.2.0-electron.1) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
   - @electron/notarize (2.5.0) - Samuel Attard
-  - @electron/rebuild (4.0.3)
   - @electron/rebuild (3.7.2)
   - @electron/rebuild (4.0.1)
   - @electron/universal (2.0.3) - Samuel Attard
+  - @esbuild/darwin-arm64 (0.21.5)
+  - @esbuild/darwin-arm64 (0.25.7)
+  - @esbuild/darwin-x64 (0.21.5)
+  - @esbuild/darwin-x64 (0.25.7)
   - @esbuild/linux-arm64 (0.21.5)
   - @esbuild/linux-arm64 (0.25.7)
+  - @esbuild/linux-x64 (0.21.5)
+  - @esbuild/linux-x64 (0.25.7)
+  - @esbuild/win32-arm64 (0.21.5)
+  - @esbuild/win32-arm64 (0.25.7)
+  - @esbuild/win32-x64 (0.21.5)
+  - @esbuild/win32-x64 (0.25.7)
   - @eslint-community/regexpp (4.12.1) - Toru Nagashima
   - @floating-ui/core (1.7.2) - atomiks
   - @floating-ui/dom (1.7.2) - atomiks
@@ -55,14 +64,11 @@ The following packages are licensed under the MIT license:
   - @git-diff-view/lowlight (0.0.40) - MrWangJustToDo
   - @git-diff-view/shiki (0.0.40) - MrWangJustToDo
   - @headless-tree/core (1.6.3) - Lukas Bach <npm@lukasbach.com>
-  - @hono/node-server (1.19.9) - Yusuke Wada <yusuke@kamawada.com> (https://github.com/yusukebe)
   - @iconify/types (2.0.0) - Vjacheslav Trushkin
   - @iconify/utils (3.0.2) - Vjacheslav Trushkin
   - @img/colour (1.0.0)
-  - @ioredis/commands (1.5.0) - Zihua Li <i@zihua.li> (http://zihua.li)
   - @ioredis/commands (1.2.0) - Zihua Li <i@zihua.li> (http://zihua.li)
   - @isaacs/balanced-match (4.0.1)
-  - @isaacs/brace-expansion (5.0.1)
   - @isaacs/brace-expansion (5.0.0)
   - @istanbuljs/schema (0.1.3) - Corey Farrell
   - @jridgewell/gen-mapping (0.3.12) - Justin Ridgewell <justin@ridgewell.name>
@@ -70,28 +76,40 @@ The following packages are licensed under the MIT license:
   - @jridgewell/sourcemap-codec (1.5.4) - Justin Ridgewell <justin@ridgewell.name>
   - @jridgewell/trace-mapping (0.3.29) - Justin Ridgewell <justin@ridgewell.name>
   - @lydell/node-pty (1.2.0-beta.3) - Simon Lydell
+  - @lydell/node-pty-darwin-arm64 (1.2.0-beta.3)
+  - @lydell/node-pty-darwin-x64 (1.2.0-beta.3)
   - @lydell/node-pty-linux-arm64 (1.2.0-beta.3)
+  - @lydell/node-pty-linux-x64 (1.2.0-beta.3)
+  - @lydell/node-pty-win32-arm64 (1.2.0-beta.3)
   - @lydell/node-pty-win32-x64 (1.2.0-beta.3)
   - @malept/flatpak-bundler (0.4.0) - Matt Watson <mattdangerw@gmail.com>
   - @mermaid-js/parser (0.6.2) - Yokozuna59
-  - @modelcontextprotocol/sdk (1.26.0) - Anthropic, PBC (https://anthropic.com)
   - @modelcontextprotocol/sdk (1.16.0) - Anthropic, PBC (https://anthropic.com)
   - @monaco-editor/loader (1.5.0) - Suren Atoyan <contact@surenatoyan.com>
+  - @msgpackr-extract/msgpackr-extract-darwin-arm64 (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-darwin-x64 (3.0.3) - Kris Zyp
   - @msgpackr-extract/msgpackr-extract-linux-arm64 (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-linux-x64 (3.0.3) - Kris Zyp
+  - @msgpackr-extract/msgpackr-extract-win32-x64 (3.0.3) - Kris Zyp
   - @nodelib/fs.scandir (2.1.5)
   - @nodelib/fs.stat (2.0.5)
   - @nodelib/fs.walk (1.2.8)
   - @npmcli/move-file (2.0.1) - GitHub Inc.
   - @pkgjs/parseargs (0.11.0)
-  - @posthog/core (1.10.0)
   - @posthog/core (1.23.1)
   - @posthog/types (1.356.1)
   - @radix-ui/number (1.1.1)
   - @radix-ui/primitive (1.1.2)
   - @radix-ui/rect (1.1.1)
   - @rolldown/pluginutils (1.0.0-beta.27)
+  - @rollup/rollup-darwin-arm64 (4.45.1) - Lukas Taegert-Atkinson
+  - @rollup/rollup-darwin-x64 (4.45.1) - Lukas Taegert-Atkinson
   - @rollup/rollup-linux-arm64-gnu (4.45.1) - Lukas Taegert-Atkinson
   - @rollup/rollup-linux-arm64-musl (4.45.1) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-x64-gnu (4.45.1) - Lukas Taegert-Atkinson
+  - @rollup/rollup-linux-x64-musl (4.45.1) - Lukas Taegert-Atkinson
+  - @rollup/rollup-win32-arm64-msvc (4.45.1) - Lukas Taegert-Atkinson
+  - @rollup/rollup-win32-x64-msvc (4.45.1) - Lukas Taegert-Atkinson
   - @shikijs/core (3.23.0) - Pine Wu <octref@gmail.com>; Anthony Fu <anthonyfu117@hotmail.com>
   - @shikijs/engine-javascript (3.23.0) - Anthony Fu <anthonyfu117@hotmail.com>
   - @shikijs/engine-oniguruma (3.23.0) - Anthony Fu <anthonyfu117@hotmail.com>
@@ -100,7 +118,6 @@ The following packages are licensed under the MIT license:
   - @shikijs/types (3.23.0) - Anthony Fu <anthonyfu117@hotmail.com>
   - @shikijs/vscode-textmate (10.0.2) - Microsoft Corporation
   - @sindresorhus/is (4.6.0) - Sindre Sorhus
-  - @standard-schema/spec (1.1.0) - Colin McDonnell
   - @standard-schema/spec (1.0.0) - Colin McDonnell
   - @szmarczak/http-timer (4.0.6) - Szymon Marczak
   - @tootallnate/once (2.0.0) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
@@ -112,7 +129,6 @@ The following packages are licensed under the MIT license:
   - @vitest/utils (2.1.9)
   - @vue/reactivity (3.5.29) - Evan You
   - @vue/shared (3.5.29) - Evan You
-  - @xmldom/xmldom (0.8.11)
   - @xmldom/xmldom (0.8.10)
   - @xterm/addon-fit (0.11.0) - The xterm.js authors
   - @xterm/addon-serialize (0.14.0) - The xterm.js authors
@@ -124,14 +140,15 @@ The following packages are licensed under the MIT license:
   - accepts (2.0.0)
   - acorn (8.15.0)
   - acorn-jsx (5.3.2)
-  - agent-base (7.1.4) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - agent-base (6.0.2) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+  - agent-base (7.1.4) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - agentkeepalive (4.6.0) - fengmk2 <fengmk2@gmail.com> (https://github.com/fengmk2)
   - aggregate-error (3.1.0) - Sindre Sorhus
-  - ajv (8.17.1) - Evgeny Poberezkin
   - ajv (6.12.6) - Evgeny Poberezkin
+  - ajv (8.17.1) - Evgeny Poberezkin
   - ajv-formats (3.0.1) - Evgeny Poberezkin
   - ajv-keywords (3.5.2) - Evgeny Poberezkin
+  - allotment (1.20.5) - johnwalley <john@walley.org.uk>
   - ansi-regex (5.0.1) - Sindre Sorhus
   - ansi-regex (6.1.0) - Sindre Sorhus
   - ansi-styles (4.3.0) - Sindre Sorhus
@@ -139,15 +156,23 @@ The following packages are licensed under the MIT license:
   - ansi-to-html (0.7.2) - Rob Burns
   - any-promise (1.3.0) - Kevin Beaty
   - app-builder-bin (5.0.0-alpha.12)
-  - app-builder-lib (26.7.0) - Vladimir Krivosheev
   - app-builder-lib (26.0.20) - Vladimir Krivosheev
   - arg (5.0.2) - Josh Junon <junon@wavetilt.com>
   - aria-hidden (1.2.6) - Anton Korzunov <thekashey@gmail.com>
+  - array-buffer-byte-length (1.0.2) - Jordan Harband <ljharb@gmail.com>
+  - array-includes (3.1.9) - Jordan Harband
+  - array.prototype.flat (1.3.3) - Jordan Harband
+  - array.prototype.flatmap (1.3.3) - Jordan Harband
+  - arraybuffer.prototype.slice (1.0.4) - Jordan Harband <ljharb@gmail.com>
+  - assert-plus (1.0.0) - Mark Cavage <mcavage@gmail.com>
   - assertion-error (2.0.1) - Jake Luer <jake@qualiancy.com> (http://qualiancy.com)
+  - ast-types-flow (0.0.8) - kyldvs
+  - astral-regex (2.0.0) - Kevin Mårtensson
   - async (3.2.6) - Caolan McMahon
   - async-exit-hook (2.0.1) - Tapani Moilanen
+  - async-function (1.0.0) - Jordan Harbamd <ljharb@gmail.com>
   - asynckit (0.4.0) - Alex Indigo <iam@alexindigo.com>
-  - axios (1.13.5) - Matt Zabriskie
+  - available-typed-arrays (1.0.7) - Jordan Harband <ljharb@gmail.com>
   - axios (1.12.2) - Matt Zabriskie
   - bail (2.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - balanced-match (1.0.2) - Julian Gruber
@@ -156,7 +181,6 @@ The following packages are licensed under the MIT license:
   - binary-extensions (2.3.0) - Sindre Sorhus
   - bindings (1.5.0) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
   - bl (4.1.0)
-  - body-parser (2.2.2)
   - body-parser (2.2.0)
   - boolean (3.2.0)
   - brace-expansion (1.1.12) - Julian Gruber
@@ -166,15 +190,14 @@ The following packages are licensed under the MIT license:
   - buffer (5.7.1) - Feross Aboukhadijeh
   - buffer-crc32 (0.2.13) - Brian J. Brennan <brianloveswords@gmail.com>
   - buffer-from (1.1.2)
-  - builder-util (26.4.1) - Vladimir Krivosheev
   - builder-util (26.0.20) - Vladimir Krivosheev
-  - builder-util-runtime (9.5.1) - Vladimir Krivosheev
   - builder-util-runtime (9.4.0) - Vladimir Krivosheev
   - bull (4.16.5) - OptimalBits
   - bytes (3.1.2) - TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)
   - cac (6.7.14) - egoist <0x142857@gmail.com>
   - cacheable-lookup (5.0.4) - Szymon Marczak
   - cacheable-request (7.0.4) - Luke Childs <lukechilds123@gmail.com> (http://lukechilds.co.uk)
+  - call-bind (1.0.9) - Jordan Harband <ljharb@gmail.com>
   - call-bind-apply-helpers (1.0.2) - Jordan Harband <ljharb@gmail.com>
   - call-bound (1.0.4) - Jordan Harband <ljharb@gmail.com>
   - callsites (3.1.0) - Sindre Sorhus
@@ -191,11 +214,12 @@ The following packages are licensed under the MIT license:
   - chokidar (3.6.0) - Paul Miller (https://paulmillr.com)
   - chokidar (5.0.0) - Paul Miller (https://paulmillr.com)
   - chromium-pickle-js (0.2.0)
-  - ci-info (4.4.0) - Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)
   - ci-info (4.3.0) - Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)
+  - classnames (2.5.1) - Jed Watson
   - clean-stack (2.2.0) - Sindre Sorhus
   - cli-cursor (3.1.0) - Sindre Sorhus
   - cli-spinners (2.9.2) - Sindre Sorhus
+  - cli-truncate (2.1.0) - Sindre Sorhus
   - clone (1.0.4) - Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch/)
   - clone-response (1.0.3) - Luke Childs <lukechilds123@gmail.com> (http://lukechilds.co.uk)
   - clsx (2.1.1) - Luke Edwards
@@ -203,8 +227,8 @@ The following packages are licensed under the MIT license:
   - color-name (1.1.4) - DY <dfcreative@gmail.com>
   - combined-stream (1.0.8) - Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)
   - comma-separated-tokens (2.0.3) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-  - commander (5.1.0) - TJ Holowaychuk <tj@vision-media.ca>
   - commander (4.1.1) - TJ Holowaychuk <tj@vision-media.ca>
+  - commander (5.1.0) - TJ Holowaychuk <tj@vision-media.ca>
   - commander (7.2.0) - TJ Holowaychuk <tj@vision-media.ca>
   - commander (8.3.0) - TJ Holowaychuk <tj@vision-media.ca>
   - compare-version (0.1.2) - Kevin Mårtensson
@@ -212,31 +236,32 @@ The following packages are licensed under the MIT license:
   - conf (15.0.0) - Sindre Sorhus
   - confbox (0.1.8)
   - confbox (0.2.2)
-  - content-disposition (1.0.1) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - content-disposition (1.0.0) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - content-type (1.0.5) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - convert-source-map (2.0.0) - Thorsten Lorenz
   - cookie (0.7.2) - Roman Shtylman <shtylman@gmail.com>
   - cookie-signature (1.2.2) - TJ Holowaychuk <tj@learnboost.com>
   - core-js (3.48.0) - Denis Pushkarev
-  - cors (2.8.6) - Troy Goode <troygoode@gmail.com> (https://github.com/troygoode/)
+  - core-util-is (1.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - cors (2.8.5) - Troy Goode <troygoode@gmail.com> (https://github.com/troygoode/)
   - cose-base (1.0.3)
   - cose-base (2.2.0)
+  - crc (3.8.0) - Alex Gorbatchev
   - cron-parser (4.9.0) - Harri Siirak
-  - cross-dirname (0.1.0)
-  - cross-spawn (7.0.6) - André Cruz <andre@moxy.studio>
   - cross-spawn (6.0.6) - André Cruz <andre@moxy.studio>
+  - cross-spawn (7.0.6) - André Cruz <andre@moxy.studio>
   - cssesc (3.0.0) - Mathias Bynens
   - csstype (3.1.3) - Fredrik Nicol <fredrik.nicol@gmail.com>
   - cytoscape (3.32.1)
   - cytoscape-cose-bilkent (4.1.0)
   - cytoscape-fcose (2.2.0) - iVis-at-Bilkent
   - dagre-d3-es (7.0.11)
+  - data-view-buffer (1.0.2) - Jordan Harband <ljharb@gmail.com>
+  - data-view-byte-length (1.0.2) - Jordan Harband <ljharb@gmail.com>
+  - data-view-byte-offset (1.0.1) - Jordan Harband <ljharb@gmail.com>
   - date-fns (4.1.0)
   - dayjs (1.11.13) - iamkun
   - debounce-fn (6.0.0) - Sindre Sorhus
-  - debug (4.4.3) - Josh Junon (https://github.com/qix-)
   - debug (4.4.1) - Josh Junon (https://github.com/qix-)
   - decode-named-character-reference (1.2.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - decompress-response (6.0.0) - Sindre Sorhus
@@ -255,18 +280,16 @@ The following packages are licensed under the MIT license:
   - devlop (1.1.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - dir-compare (4.2.0) - Liviu Grigorescu
   - dlv (1.1.3) - Jason Miller <jason@developit.ca> (http://jasonformat.com)
-  - dmg-builder (26.7.0) - Vladimir Krivosheev
   - dmg-builder (26.0.20) - Vladimir Krivosheev
+  - dmg-license (1.0.11) - argvminusone
   - dot-prop (10.0.0) - Sindre Sorhus
   - dunder-proto (1.0.1) - Jordan Harband <ljharb@gmail.com>
   - eastasianwidth (0.2.0) - Masaki Komagata
   - ee-first (1.1.1) - Jonathan Ong
   - electron (37.6.0) - Electron Community
-  - electron-publish (26.6.0) - Vladimir Krivosheev
   - electron-publish (26.0.20) - Vladimir Krivosheev
   - electron-store (11.0.0) - Sindre Sorhus
   - electron-updater (6.6.8) - Vladimir Krivosheev
-  - electron-winstaller (5.4.0)
   - emoji-regex (8.0.0) - Mathias Bynens
   - emoji-regex (9.2.2) - Mathias Bynens
   - encodeurl (2.0.0)
@@ -275,11 +298,16 @@ The following packages are licensed under the MIT license:
   - env-paths (2.2.1) - Sindre Sorhus
   - env-paths (3.0.0) - Sindre Sorhus
   - err-code (2.0.3) - IndigoUnited <hello@indigounited.com> (http://indigounited.com)
+  - es-abstract (1.24.2) - Jordan Harband
+  - es-abstract-get (1.0.0) - Jordan Harband <ljharb@gmail.com>
   - es-define-property (1.0.1) - Jordan Harband <ljharb@gmail.com>
   - es-errors (1.3.0) - Jordan Harband <ljharb@gmail.com>
   - es-module-lexer (1.7.0) - Guy Bedford
   - es-object-atoms (1.1.1) - Jordan Harband <ljharb@gmail.com>
+  - es-object-atoms (1.1.2) - Jordan Harband <ljharb@gmail.com>
   - es-set-tostringtag (2.1.0) - Jordan Harband <ljharb@gmail.com>
+  - es-shim-unscopables (1.1.0) - Jordan Harband <ljharb@gmail.com>
+  - es-to-primitive (1.3.4) - Jordan Harband <ljharb@gmail.com>
   - es6-error (4.1.1) - Ben Youngblood
   - esbuild (0.21.5)
   - esbuild (0.25.7)
@@ -290,78 +318,82 @@ The following packages are licensed under the MIT license:
   - estree-util-is-identifier-name (3.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - estree-walker (3.0.3) - Rich Harris
   - etag (1.8.1)
+  - eventemitter3 (5.0.4) - Arnout Kazemier
   - eventsource (3.0.7) - Espen Hovlandsdal <espen@hovlandsdal.com>
-  - eventsource-parser (3.0.6) - Espen Hovlandsdal <espen@hovlandsdal.com>
   - eventsource-parser (3.0.3) - Espen Hovlandsdal <espen@hovlandsdal.com>
   - execa (1.0.0) - Sindre Sorhus
-  - express (5.2.1) - TJ Holowaychuk <tj@vision-media.ca>
   - express (5.1.0) - TJ Holowaychuk <tj@vision-media.ca>
-  - express-rate-limit (8.2.1) - Nathan Friedly
   - express-rate-limit (7.5.1) - Nathan Friedly
   - exsolve (1.0.7)
   - extend (3.0.2) - Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+  - extsprintf (1.4.1)
   - fast-deep-equal (3.1.3) - Evgeny Poberezkin
   - fast-glob (3.3.3) - Denis Malinochkin
   - fast-json-stable-stringify (2.1.0) - James Halliday
   - fast-levenshtein (2.0.6) - Ramesh Nair <ram@hiddentao.com> (http://www.hiddentao.com/)
   - fd-slicer (1.1.0) - Andrew Kelley <superjoe30@gmail.com>
-  - fdir (6.5.0) - thecodrr <thecodrr@protonmail.com>
   - fdir (6.4.6) - thecodrr <thecodrr@protonmail.com>
   - fflate (0.4.8) - Arjun Barrett
   - file-entry-cache (8.0.0) - Jared Wray
   - file-uri-to-path (1.0.0) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - fill-range (7.1.1) - Jon Schlinkert (https://github.com/jonschlinkert)
-  - finalhandler (2.1.1) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - finalhandler (2.1.0) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - find-up (5.0.0) - Sindre Sorhus
   - flat-cache (4.0.1) - Jared Wray
-  - follow-redirects (1.15.11) - Ruben Verborgh <ruben@verborgh.org> (https://ruben.verborgh.org/)
   - follow-redirects (1.15.9) - Ruben Verborgh <ruben@verborgh.org> (https://ruben.verborgh.org/)
-  - form-data (4.0.5) - Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)
+  - for-each (0.3.5) - Raynos <raynos2@gmail.com>
   - form-data (4.0.4) - Felix Geisendörfer <felix@debuggable.com> (http://debuggable.com/)
   - forwarded (0.2.0)
   - fraction.js (4.3.7) - Robert Eisele
   - fresh (2.0.0) - TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)
   - fs-constants (1.0.0) - Mathias Buus (@mafintosh)
-  - fs-extra (8.1.0) - JP Richardson <jprichardson@gmail.com>
   - fs-extra (10.1.0) - JP Richardson <jprichardson@gmail.com>
   - fs-extra (11.3.0) - JP Richardson <jprichardson@gmail.com>
+  - fs-extra (8.1.0) - JP Richardson <jprichardson@gmail.com>
   - fs-extra (9.1.0) - JP Richardson <jprichardson@gmail.com>
+  - fsevents (2.3.2)
+  - fsevents (2.3.3)
   - function-bind (1.1.2) - Raynos <raynos2@gmail.com>
+  - function.prototype.name (1.2.0) - Jordan Harband <ljharb@gmail.com>
+  - functions-have-names (1.2.3) - Jordan Harband <ljharb@gmail.com>
+  - generator-function (2.0.1) - Jordan Harbamd <ljharb@gmail.com>
   - gensync (1.0.0-beta.2) - Logan Smyth <loganfsmyth@gmail.com>
   - get-intrinsic (1.3.0) - Jordan Harband <ljharb@gmail.com>
   - get-nonce (1.0.1) - Anton Korzunov <thekashey@gmail.com>
   - get-port (5.1.1) - Sindre Sorhus
   - get-proto (1.0.1) - Jordan Harband <ljharb@gmail.com>
-  - get-stream (5.2.0) - Sindre Sorhus
   - get-stream (4.1.0) - Sindre Sorhus
+  - get-stream (5.2.0) - Sindre Sorhus
+  - get-symbol-description (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - github-from-package (0.0.0) - James Halliday
   - globalthis (1.0.4) - Jordan Harband <ljharb@gmail.com>
   - gopd (1.2.0) - Jordan Harband <ljharb@gmail.com>
   - got (11.8.6)
   - graphemer (1.4.0) - Matt Davies <matt@filament.so> (https://github.com/mattpauldavies)
   - hachure-fill (0.5.2) - Preet Shihn
+  - has-bigints (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - has-flag (4.0.0) - Sindre Sorhus
   - has-property-descriptors (1.0.2) - Jordan Harband <ljharb@gmail.com>
+  - has-proto (1.2.0) - Jordan Harband <ljharb@gmail.com>
   - has-symbols (1.1.0) - Jordan Harband
   - has-tostringtag (1.0.2) - Jordan Harband
   - hasown (2.0.2) - Jordan Harband <ljharb@gmail.com>
+  - hasown (2.0.4) - Jordan Harband <ljharb@gmail.com>
   - hast-util-to-html (9.0.5) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - hast-util-to-jsx-runtime (2.3.6) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - hast-util-whitespace (3.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-  - hono (4.11.9) - Yusuke Wada <yusuke@kamawada.com> (https://github.com/yusukebe)
   - html-escaper (2.0.2) - Andrea Giammarchi
   - html-url-attributes (3.0.1) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - html-void-elements (3.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-  - http-errors (2.0.1) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
   - http-errors (2.0.0) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
-  - http-proxy-agent (7.0.2) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - http-proxy-agent (5.0.0) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+  - http-proxy-agent (7.0.2) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - http2-wrapper (1.0.3) - Szymon Marczak
-  - https-proxy-agent (7.0.6) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - https-proxy-agent (5.0.1) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+  - https-proxy-agent (7.0.6) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - humanize-ms (1.2.1) - dead-horse
   - icns-lib (1.0.1) - Manuel Rueda
+  - iconv-corefoundation (1.1.7) - argv-minus-one
   - iconv-lite (0.6.3) - Alexander Shtuchkin <ashtuchkin@gmail.com>
   - ignore (5.3.2) - kael
   - ignore (7.0.5) - kael
@@ -370,52 +402,73 @@ The following packages are licensed under the MIT license:
   - imurmurhash (0.1.4) - Jens Taylor
   - indent-string (4.0.0) - Sindre Sorhus
   - inline-style-parser (0.2.4)
+  - internal-slot (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - interpret (1.4.0) - Gulp Team <team@gulpjs.com> (http://gulpjs.com/)
-  - ioredis (5.9.2) - Zihua Li <i@zihua.li> (http://zihua.li)
   - ioredis (5.6.1) - Zihua Li <i@zihua.li> (http://zihua.li)
-  - ip-address (10.0.1) - Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)
   - ip-address (10.1.0) - Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)
   - ip-address (9.0.5) - Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)
   - ipaddr.js (1.9.1) - whitequark <whitequark@whitequark.org>
   - is-alphabetical (2.0.1) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - is-alphanumerical (2.0.1) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+  - is-array-buffer (3.0.5) - Jordan Harband <ljharb@gmail.com>
+  - is-async-function (2.1.1) - Jordan Harband <ljharb@gmail.com>
+  - is-bigint (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - is-binary-path (2.1.0) - Sindre Sorhus
+  - is-boolean-object (1.2.2) - Jordan Harband <ljharb@gmail.com>
+  - is-callable (1.2.7) - Jordan Harband
   - is-core-module (2.16.1) - Jordan Harband <ljharb@gmail.com>
+  - is-data-view (1.0.2) - Jordan Harband <ljharb@gmail.com>
+  - is-date-object (1.1.0) - Jordan Harband
   - is-decimal (2.0.1) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+  - is-document.all (1.0.0) - Jordan Harband <ljharb@gmail.com>
   - is-extglob (2.1.1) - Jon Schlinkert (https://github.com/jonschlinkert)
+  - is-finalizationregistry (1.1.1) - Jordan Harband <ljharb@gmail.com>
   - is-fullwidth-code-point (3.0.0) - Sindre Sorhus
+  - is-generator-function (1.1.2) - Jordan Harband <ljharb@gmail.com>
   - is-glob (4.0.3) - Jon Schlinkert (https://github.com/jonschlinkert)
   - is-hexadecimal (2.0.1) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - is-interactive (1.0.0) - Sindre Sorhus
   - is-lambda (1.0.1) - Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)
+  - is-map (2.0.3) - Jordan Harband <ljharb@gmail.com>
+  - is-negative-zero (2.0.3) - Jordan Harband <ljharb@gmail.com>
   - is-number (7.0.0) - Jon Schlinkert (https://github.com/jonschlinkert)
+  - is-number-object (1.1.1) - Jordan Harband <ljharb@gmail.com>
   - is-plain-obj (4.1.0) - Sindre Sorhus
   - is-promise (4.0.0) - ForbesLindesay
+  - is-regex (1.2.1) - Jordan Harband <ljharb@gmail.com>
+  - is-set (2.0.3) - Jordan Harband <ljharb@gmail.com>
+  - is-shared-array-buffer (1.0.4) - Jordan Harband
   - is-stream (1.1.0) - Sindre Sorhus
+  - is-string (1.1.1) - Jordan Harband <ljharb@gmail.com>
+  - is-symbol (1.1.1) - Jordan Harband <ljharb@gmail.com>
+  - is-typed-array (1.1.15) - Jordan Harband
   - is-unicode-supported (0.1.0) - Sindre Sorhus
-  - isbinaryfile (5.0.7)
+  - is-weakmap (2.0.2) - Jordan Harband <ljharb@gmail.com>
+  - is-weakref (1.1.1) - Jordan Harband <ljharb@gmail.com>
+  - is-weakset (2.0.4) - Jordan Harband <ljharb@gmail.com>
+  - isarray (2.0.5) - Julian Gruber
   - isbinaryfile (4.0.10)
   - isbinaryfile (5.0.4)
-  - jiti (2.6.1)
   - jiti (1.21.7)
   - jiti (2.6.0)
-  - jose (6.1.3) - Filip Skokan <panva.ip@gmail.com>
   - js-tokens (4.0.0) - Simon Lydell
-  - js-yaml (4.1.1) - Vladimir Zapparov <dervus.grim@gmail.com>
   - js-yaml (4.1.0) - Vladimir Zapparov <dervus.grim@gmail.com>
+  - js-yaml (4.1.1) - Vladimir Zapparov <dervus.grim@gmail.com>
   - jsbn (1.1.0) - Tom Wu
   - jsesc (3.1.0) - Mathias Bynens
   - json-buffer (3.0.1) - Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)
-  - json-schema-traverse (1.0.0) - Evgeny Poberezkin
   - json-schema-traverse (0.4.1) - Evgeny Poberezkin
+  - json-schema-traverse (1.0.0) - Evgeny Poberezkin
   - json-stable-stringify-without-jsonify (1.0.1) - James Halliday
   - json5 (2.2.3) - Aseem Kishore <aseem.kishore@gmail.com>
   - jsonfile (4.0.0) - JP Richardson <jprichardson@gmail.com>
   - jsonfile (6.1.0) - JP Richardson <jprichardson@gmail.com>
+  - jsx-ast-utils (3.3.5) - Ethan Cohen
   - katex (0.16.22)
   - keyv (4.5.4) - Jared Wray <me@jaredwray.com> (http://jaredwray.com)
   - kolorist (1.8.0) - Marvin Hagemeister <hello@marvinh.dev>
   - langium (3.3.1) - TypeFox
+  - language-tags (1.0.9) - Matthew Caruana Galizia <mattcg@gmail.com>
   - layout-base (1.0.2)
   - layout-base (2.0.1)
   - lazy-val (1.0.5) - Vladimir Krivosheev
@@ -424,9 +477,10 @@ The following packages are licensed under the MIT license:
   - lines-and-columns (1.2.4) - Brian Donovan <brian@donovans.cc>
   - local-pkg (1.1.1) - Anthony Fu <anthonyfu117@hotmail.com>
   - locate-path (6.0.0) - Sindre Sorhus
-  - lodash (4.17.23) - John-David Dalton <john.david.dalton@gmail.com>
   - lodash (4.17.21) - John-David Dalton <john.david.dalton@gmail.com>
   - lodash-es (4.17.21) - John-David Dalton <john.david.dalton@gmail.com>
+  - lodash.clamp (4.0.3) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+  - lodash.debounce (4.0.8) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - lodash.defaults (4.2.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - lodash.escaperegexp (4.1.2) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
   - lodash.isarguments (3.1.0) - John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
@@ -437,7 +491,6 @@ The following packages are licensed under the MIT license:
   - loupe (3.1.4) - Veselin Todorov <hi@vesln.com>
   - lowercase-keys (2.0.0) - Sindre Sorhus
   - lowlight (3.3.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-  - luxon (3.7.2) - Isaac Cambron
   - luxon (3.7.1) - Isaac Cambron
   - magic-string (0.30.17) - Rich Harris
   - magicast (0.3.5)
@@ -495,9 +548,8 @@ The following packages are licensed under the MIT license:
   - micromark-util-types (2.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - micromatch (4.0.8) - Jon Schlinkert (https://github.com/jonschlinkert)
   - mime (2.6.0) - Robert Kieffer
-  - mime-db (1.54.0)
   - mime-db (1.52.0)
-  - mime-types (3.0.2)
+  - mime-db (1.54.0)
   - mime-types (2.1.35)
   - mime-types (3.0.1)
   - mimic-fn (2.1.0) - Sindre Sorhus
@@ -505,27 +557,26 @@ The following packages are licensed under the MIT license:
   - mimic-response (1.0.1) - Sindre Sorhus
   - mimic-response (3.1.0) - Sindre Sorhus
   - minimist (1.2.8) - James Halliday
-  - minipass-fetch (4.0.1) - GitHub Inc.
   - minipass-fetch (2.1.2) - GitHub Inc.
-  - minizlib (3.1.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - minipass-fetch (4.0.1) - GitHub Inc.
   - minizlib (2.1.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - minizlib (3.1.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - mlly (1.7.4)
   - monaco-editor (0.52.2) - Microsoft Corporation
   - ms (2.1.3)
-  - msgpackr (1.11.8) - Kris Zyp
   - msgpackr (1.11.5) - Kris Zyp
   - msgpackr-extract (3.0.3) - Kris Zyp
   - mz (2.7.0) - Jonathan Ong
   - nanoid (3.3.11) - Andrey Sitnik <andrey@sitnik.ru>
   - napi-build-utils (2.0.0) - Jim Schlight
   - natural-compare (1.4.0) - Lauri Rooden (https://github.com/litejs/natural-compare-lite)
-  - negotiator (1.0.0)
   - negotiator (0.6.4)
+  - negotiator (1.0.0)
   - nice-try (1.0.5)
   - node-abi (3.77.0) - Lukas Geiger
   - node-abi (4.14.0) - Lukas Geiger
+  - node-addon-api (1.7.2)
   - node-api-version (0.2.1) - Tim Fish <tim@timfish.uk>
-  - node-gyp (11.5.0) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
   - node-gyp (11.4.2) - Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)
   - node-gyp-build-optional-packages (5.2.2) - Mathias Buus (@mafintosh)
   - node-releases (2.0.19) - Sergey Rubanov <chi187@gmail.com>
@@ -537,17 +588,20 @@ The following packages are licensed under the MIT license:
   - object-hash (3.0.0) - Scott Puleo <puleos@gmail.com>
   - object-inspect (1.13.4) - James Halliday
   - object-keys (1.1.1) - Jordan Harband
+  - object.assign (4.1.7) - Jordan Harband
+  - object.fromentries (2.0.8) - Jordan Harband <ljharb@gmail.com>
+  - object.values (1.2.1) - Jordan Harband <ljharb@gmail.com>
   - on-finished (2.4.1)
   - onetime (5.1.2) - Sindre Sorhus
   - oniguruma-parser (0.12.1) - Steven Levithan
   - oniguruma-to-es (4.3.4) - Steven Levithan
   - optionator (0.9.4) - George Zahariev <z@georgezahariev.com>
   - ora (5.4.1) - Sindre Sorhus
+  - own-keys (1.0.1) - Jordan Harband <ljharb@gmail.com>
   - p-cancelable (2.1.1) - Sindre Sorhus
   - p-finally (1.0.0) - Sindre Sorhus
   - p-limit (3.1.0) - Sindre Sorhus
   - p-locate (5.0.0) - Sindre Sorhus
-  - p-map (7.0.4) - Sindre Sorhus
   - p-map (4.0.0) - Sindre Sorhus
   - p-map (7.0.3) - Sindre Sorhus
   - package-manager-detector (1.3.0) - Anthony Fu <anthonyfu117@hotmail.com>
@@ -557,21 +611,19 @@ The following packages are licensed under the MIT license:
   - path-data-parser (0.1.0) - Preet Shihn
   - path-exists (4.0.0) - Sindre Sorhus
   - path-is-absolute (1.0.1) - Sindre Sorhus
-  - path-key (3.1.1) - Sindre Sorhus
   - path-key (2.0.1) - Sindre Sorhus
+  - path-key (3.1.1) - Sindre Sorhus
   - path-parse (1.0.7) - Javier Blanco <http://jbgutierrez.info>
-  - path-to-regexp (8.3.0)
   - path-to-regexp (8.2.0)
   - pathe (1.1.2)
   - pathe (2.0.3)
   - pathval (2.0.1) - Veselin Todorov <hi@vesln.com>
   - pe-library (0.4.1) - jet
   - pend (1.2.0) - Andrew Kelley <superjoe30@gmail.com>
-  - picomatch (4.0.3) - Jon Schlinkert (https://github.com/jonschlinkert)
   - picomatch (2.3.1) - Jon Schlinkert (https://github.com/jonschlinkert)
+  - picomatch (4.0.3) - Jon Schlinkert (https://github.com/jonschlinkert)
   - pify (2.3.0) - Sindre Sorhus
   - pirates (4.0.7) - Ari Porad
-  - pkce-challenge (5.0.1) - crouchcd
   - pkce-challenge (5.0.0) - crouchcd
   - pkg-types (1.3.1)
   - pkg-types (2.2.0)
@@ -581,13 +633,12 @@ The following packages are licensed under the MIT license:
   - pngjs (7.0.0)
   - points-on-curve (0.2.0) - Preet Shihn
   - points-on-path (0.2.1) - Preet Shihn
-  - postject (1.0.0-alpha.6)
+  - possible-typed-array-names (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - preact (10.28.4)
   - prebuild-install (7.1.3) - Mathias Buus (@mafintosh)
   - prelude-ls (1.2.1) - George Zahariev <z@georgezahariev.com>
   - progress (2.0.3) - TJ Holowaychuk <tj@vision-media.ca>
   - promise-retry (2.0.1) - IndigoUnited <hello@indigounited.com> (http://indigounited.com)
-  - proper-lockfile (4.1.2) - André Cruz <andre@moxy.studio>
   - property-information (7.1.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - proxy-addr (2.0.7) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - proxy-from-env (1.1.0) - Rob Wu <rob@robwu.nl> (https://robwu.nl/)
@@ -598,7 +649,6 @@ The following packages are licensed under the MIT license:
   - queue-microtask (1.2.3) - Feross Aboukhadijeh
   - quick-lru (5.1.1) - Sindre Sorhus
   - range-parser (1.2.1) - TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)
-  - raw-body (3.0.2) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
   - raw-body (3.0.0) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
   - react (19.1.0)
   - react-dom (19.1.0)
@@ -613,9 +663,11 @@ The following packages are licensed under the MIT license:
   - readdirp (5.0.0) - Thorsten Lorenz <thlorenz@gmx.de> (thlorenz.com)
   - redis-errors (1.2.0) - Ruben Bridgewater
   - redis-parser (3.0.0) - Ruben Bridgewater
+  - reflect.getprototypeof (1.0.10) - Jordan Harband <ljharb@gmail.com>
   - regex (6.1.0) - Steven Levithan
   - regex-recursion (6.0.2) - Steven Levithan
   - regex-utilities (2.3.0) - Steven Levithan
+  - regexp.prototype.flags (1.5.4) - Jordan Harband <ljharb@gmail.com>
   - remark-gfm (4.0.1) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - remark-parse (11.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - remark-rehype (11.1.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
@@ -634,19 +686,23 @@ The following packages are licensed under the MIT license:
   - roughjs (4.6.6) - Preet Shihn <preetshihn@gmail.com>
   - router (2.2.0) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - run-parallel (1.2.0) - Feross Aboukhadijeh
+  - safe-array-concat (1.1.4) - Jordan Harband <ljharb@gmail.com>
   - safe-buffer (5.2.1) - Feross Aboukhadijeh
+  - safe-push-apply (1.0.0) - Jordan Harband <ljharb@gmail.com>
+  - safe-regex-test (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - safer-buffer (2.1.2) - Nikita Skovoroda
   - scheduler (0.26.0)
   - semver-compare (1.0.0) - James Halliday
-  - send (1.2.1) - TJ Holowaychuk <tj@vision-media.ca>
   - send (1.2.0) - TJ Holowaychuk <tj@vision-media.ca>
   - serialize-error (7.0.1) - Sindre Sorhus
-  - serve-static (2.2.1) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - serve-static (2.2.0) - Douglas Christopher Wilson <doug@somethingdoug.com>
-  - shebang-command (2.0.0) - Kevin Mårtensson
+  - set-function-length (1.2.2) - Jordan Harband <ljharb@gmail.com>
+  - set-function-name (2.0.2) - Jordan Harband <ljharb@gmail.com>
+  - set-proto (1.0.0) - Jordan Harband <ljharb@gmail.com>
   - shebang-command (1.2.0) - Kevin Martensson
-  - shebang-regex (3.0.0) - Sindre Sorhus
+  - shebang-command (2.0.0) - Kevin Mårtensson
   - shebang-regex (1.0.0) - Sindre Sorhus
+  - shebang-regex (3.0.0) - Sindre Sorhus
   - shell-quote (1.8.3) - James Halliday
   - shiki (3.23.0) - Pine Wu <octref@gmail.com>; Anthony Fu <anthonyfu117@hotmail.com>
   - shx (0.4.0)
@@ -657,23 +713,29 @@ The following packages are licensed under the MIT license:
   - simple-concat (1.0.1) - Feross Aboukhadijeh
   - simple-get (4.0.1) - Feross Aboukhadijeh
   - simple-update-notifier (2.0.0) - alexbrazier
+  - slice-ansi (3.0.0)
   - smart-buffer (4.2.0) - Josh Glazebrook
-  - socks (2.8.7) - Josh Glazebrook
   - socks (2.8.6) - Josh Glazebrook
-  - socks-proxy-agent (8.0.5) - Nathan Rajlich
+  - socks (2.8.7) - Josh Glazebrook
   - socks-proxy-agent (7.0.0) - Nathan Rajlich
+  - socks-proxy-agent (8.0.5) - Nathan Rajlich
   - source-map-support (0.5.21)
   - space-separated-tokens (2.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - stackback (0.0.2) - Roman Shtylman <shtylman@gmail.com>
   - standard-as-callback (2.1.0) - luin <i@zihua.li>
   - stat-mode (1.0.0) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
   - state-local (1.0.7) - Suren Atoyan <contact@surenatoyan.com>
-  - statuses (2.0.2)
   - statuses (2.0.1)
+  - statuses (2.0.2)
   - std-env (3.9.0)
+  - stop-iteration-iterator (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - string_decoder (1.3.0)
   - string-width (4.2.3) - Sindre Sorhus
   - string-width (5.1.2) - Sindre Sorhus
+  - string.prototype.includes (2.0.1) - Mathias Bynens
+  - string.prototype.trim (1.2.11) - Jordan Harband
+  - string.prototype.trimend (1.0.10) - Jordan Harband <ljharb@gmail.com>
+  - string.prototype.trimstart (1.0.8) - Jordan Harband <ljharb@gmail.com>
   - stringify-entities (4.0.4) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - strip-ansi (6.0.1) - Sindre Sorhus
   - strip-ansi (7.1.0) - Sindre Sorhus
@@ -684,15 +746,13 @@ The following packages are licensed under the MIT license:
   - style-to-object (1.0.9) - Mark <mark@remarkablemark.org>
   - stylis (4.3.6) - Sultan Tarimo <sultantarimo@me.com>
   - sucrase (3.35.0) - Alan Pierce <alangpierce@gmail.com>
-  - supports-color (8.1.1) - Sindre Sorhus
   - supports-color (7.2.0) - Sindre Sorhus
+  - supports-color (8.1.1) - Sindre Sorhus
   - supports-preserve-symlinks-flag (1.0.0) - Jordan Harband <ljharb@gmail.com>
   - tagged-tag (1.0.0) - Sindre Sorhus
   - tailwind-merge (2.6.0) - Dany Castillo
-  - tar-fs (2.1.4) - Mathias Buus
   - tar-fs (2.1.3) - Mathias Buus
   - tar-stream (2.2.0) - Mathias Buus <mathiasbuus@gmail.com>
-  - temp (0.9.4) - Bruce Williams <brwcodes@gmail.com>
   - temp-file (3.4.0) - Vladimir Krivosheev
   - thenify (3.3.1) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
   - thenify-all (1.6.0) - Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)
@@ -701,12 +761,10 @@ The following packages are licensed under the MIT license:
   - tinybench (2.9.0)
   - tinyexec (0.3.2) - James Garbutt (https://github.com/43081j)
   - tinyexec (1.0.1) - James Garbutt (https://github.com/43081j)
-  - tinyglobby (0.2.15) - Superchupu
   - tinyglobby (0.2.14) - Superchupu
   - tinypool (1.1.1)
   - tinyrainbow (1.2.0)
   - tinyspy (3.0.2)
-  - tmp (0.2.5) - KARASZI István <github@spam.raszi.hu>
   - tmp (0.2.3) - KARASZI István <github@spam.raszi.hu> (http://raszi.hu/)
   - tmp-promise (3.0.3) - Benjamin Gruenbaum and Collaborators.
   - to-regex-range (5.0.1) - Jon Schlinkert (https://github.com/jonschlinkert)
@@ -718,8 +776,13 @@ The following packages are licensed under the MIT license:
   - ts-dedent (2.2.0) - Tamino Martinius <dev@zaku.eu>
   - type-check (0.4.0) - George Zahariev <z@georgezahariev.com>
   - type-is (2.0.1)
+  - typed-array-buffer (1.0.3) - Jordan Harband <ljharb@gmail.com>
+  - typed-array-byte-length (1.0.3) - Jordan Harband <ljharb@gmail.com>
+  - typed-array-byte-offset (1.0.4) - Jordan Harband <ljharb@gmail.com>
+  - typed-array-length (1.0.8) - Jordan Harband <ljharb@gmail.com>
   - ufo (1.6.1)
   - uint8array-extras (1.5.0) - Sindre Sorhus
+  - unbox-primitive (1.1.0) - Jordan Harband <ljharb@gmail.com>
   - undici-types (6.21.0)
   - unified (11.0.5) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - unist-util-is (6.0.0) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
@@ -732,11 +795,13 @@ The following packages are licensed under the MIT license:
   - unpipe (1.0.0) - Douglas Christopher Wilson <doug@somethingdoug.com>
   - update-browserslist-db (1.1.3) - Andrey Sitnik <andrey@sitnik.ru>
   - use-sync-external-store (1.6.0)
+  - usehooks-ts (3.1.1) - Julien CARON <juliencaron@protonmail.com>
   - util-deprecate (1.0.2) - Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-  - uuid (8.3.2)
   - uuid (11.1.0)
   - uuid (13.0.0)
+  - uuid (8.3.2)
   - vary (1.1.2) - Douglas Christopher Wilson <doug@somethingdoug.com>
+  - verror (1.10.1)
   - vfile (6.0.3) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - vfile-message (4.0.2) - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
   - vscode-jsonrpc (8.2.0) - Microsoft Corporation
@@ -748,6 +813,10 @@ The following packages are licensed under the MIT license:
   - wcwidth (1.0.1) - Tim Oxley
   - web-streams-polyfill (3.3.3) - Mattias Buelens <mattias@buelens.com>
   - when-exit (2.1.4)
+  - which-boxed-primitive (1.1.1) - Jordan Harband <ljharb@gmail.com>
+  - which-builtin-type (1.2.1) - Jordan Harband <ljharb@gmail.com>
+  - which-collection (1.0.2) - Jordan Harband <ljharb@gmail.com>
+  - which-typed-array (1.1.22) - Jordan Harband
   - why-is-node-running (2.3.0) - Mathias Buus (@mafintosh)
   - word-wrap (1.2.5) - Jon Schlinkert (https://github.com/jonschlinkert)
   - wrap-ansi (7.0.0) - Sindre Sorhus
@@ -779,15 +848,15 @@ The following packages are licensed under the ISC license:
   - @isaacs/cliui (8.0.2) - Ben Coe <ben@npmjs.com>
   - @isaacs/fs-minipass (4.0.1) - Isaac Z. Schlueter
   - @npmcli/agent (3.0.0) - GitHub Inc.
-  - @npmcli/fs (4.0.0) - GitHub Inc.
   - @npmcli/fs (2.1.2) - GitHub Inc.
+  - @npmcli/fs (4.0.0) - GitHub Inc.
   - @ungap/structured-clone (1.3.0) - Andrea Giammarchi
-  - abbrev (3.0.1) - GitHub Inc.
   - abbrev (1.1.1) - Isaac Z. Schlueter <i@izs.me>
+  - abbrev (3.0.1) - GitHub Inc.
   - anymatch (3.1.3) - Elan Shanker
   - at-least-node (1.0.0) - Ryan Zimmerman <opensrc@ryanzim.com>
-  - cacache (19.0.1) - GitHub Inc.
   - cacache (16.1.3) - GitHub Inc.
+  - cacache (19.0.1) - GitHub Inc.
   - chownr (1.1.4) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - chownr (2.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - cliui (8.0.1) - Ben Coe <ben@npmjs.com>
@@ -826,8 +895,8 @@ The following packages are licensed under the ISC license:
   - fastq (1.19.1) - Matteo Collina <hello@matteocollina.com>
   - flatted (3.3.3) - Andrea Giammarchi
   - foreground-child (3.3.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
-  - fs-minipass (3.0.3) - GitHub Inc.
   - fs-minipass (2.1.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - fs-minipass (3.0.3) - GitHub Inc.
   - fs.realpath (1.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - get-caller-file (2.0.5) - Stefan Penner
   - glob (10.4.5) - Isaac Z. Schlueter <i@izs.me> (https://blog.izs.me/)
@@ -847,61 +916,60 @@ The following packages are licensed under the ISC license:
   - isexe (2.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - isexe (3.1.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - json-stringify-safe (5.0.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
-  - lru-cache (6.0.0) - Isaac Z. Schlueter <i@izs.me>
   - lru-cache (10.4.3) - Isaac Z. Schlueter <i@izs.me>
   - lru-cache (11.1.0) - Isaac Z. Schlueter <i@izs.me>
   - lru-cache (5.1.1) - Isaac Z. Schlueter <i@izs.me>
+  - lru-cache (6.0.0) - Isaac Z. Schlueter <i@izs.me>
   - lru-cache (7.18.3) - Isaac Z. Schlueter <i@izs.me>
   - lucide-react (0.468.0) - Eric Fennis
-  - make-fetch-happen (14.0.3) - GitHub Inc.
   - make-fetch-happen (10.2.1) - GitHub Inc.
+  - make-fetch-happen (14.0.3) - GitHub Inc.
   - minimatch (10.0.3) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
   - minimatch (3.1.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
   - minimatch (5.1.6) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
   - minimatch (9.0.5) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
-  - minipass (7.1.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - minipass (3.3.6) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - minipass (5.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
-  - minipass-collect (2.0.1) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
+  - minipass (7.1.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - minipass-collect (1.0.2) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
+  - minipass-collect (2.0.1) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
   - minipass-flush (1.0.5) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
   - minipass-pipeline (1.2.4) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
   - minipass-sized (1.0.3) - Isaac Z. Schlueter <i@izs.me> (https://izs.me)
-  - nopt (8.1.0) - GitHub Inc.
   - nopt (6.0.0) - GitHub Inc.
+  - nopt (8.1.0) - GitHub Inc.
   - once (1.4.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - picocolors (1.1.1) - Alexey Raspopov
-  - proc-log (5.0.0) - GitHub Inc.
   - proc-log (2.0.1) - GitHub Inc.
+  - proc-log (5.0.0) - GitHub Inc.
   - promise-inflight (1.0.1) - Rebecca Turner <me@re-becca.org> (http://re-becca.org/)
   - sax (1.4.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
-  - semver (7.7.4) - GitHub Inc.
   - semver (5.7.2) - GitHub Inc.
   - semver (6.3.1) - GitHub Inc.
   - semver (7.7.2) - GitHub Inc.
+  - semver (7.7.4) - GitHub Inc.
   - setprototypeof (1.2.0) - Wes Todd
   - siginfo (2.0.0) - Emil Bay <github@tixz.dk>
-  - signal-exit (4.1.0) - Ben Coe <ben@npmjs.com>
   - signal-exit (3.0.7) - Ben Coe <ben@npmjs.com>
+  - signal-exit (4.1.0) - Ben Coe <ben@npmjs.com>
   - ssri (12.0.0) - GitHub Inc.
   - ssri (9.0.1) - GitHub Inc.
   - tar (6.2.1) - GitHub Inc.
   - tar (7.5.1) - Isaac Z. Schlueter
   - test-exclude (7.0.1) - Ben Coe <ben@npmjs.com>
-  - unique-filename (4.0.0) - GitHub Inc.
   - unique-filename (2.0.1) - GitHub Inc.
-  - unique-slug (5.0.0) - GitHub Inc.
+  - unique-filename (4.0.0) - GitHub Inc.
   - unique-slug (3.0.0) - GitHub Inc.
-  - which (2.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
+  - unique-slug (5.0.0) - GitHub Inc.
   - which (1.3.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
+  - which (2.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
   - which (5.0.0) - GitHub Inc.
   - wrappy (1.0.2) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - y18n (5.0.8) - Ben Coe <bencoe@gmail.com>
-  - yallist (4.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - yallist (3.1.1) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
+  - yallist (4.0.0) - Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
   - yaml (2.8.0) - Eemeli Aro <eemeli@gmail.com>
   - yargs-parser (21.1.1) - Ben Coe <ben@npmjs.com>
-  - zod-to-json-schema (3.25.1) - Stefan Terdell
   - zod-to-json-schema (3.24.6) - Stefan Terdell
 
 Copyright (c) 2015, Contributors
@@ -918,6 +986,264 @@ LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
 OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+================================================================================
+## Apache-2.0 LICENSE
+================================================================================
+
+The following packages are licensed under the Apache-2.0 license:
+
+  - @ampproject/remapping (2.3.0) - Justin Ridgewell <jridgewell@google.com>
+  - @chevrotain/cst-dts-gen (11.0.3)
+  - @chevrotain/gast (11.0.3)
+  - @chevrotain/regexp-to-ast (11.0.3)
+  - @chevrotain/types (11.0.3) - Shahar Soel
+  - @chevrotain/utils (11.0.3) - Shahar Soel
+  - @humanfs/core (0.19.1) - Nicholas C. Zakas
+  - @humanfs/node (0.16.6) - Nicholas C. Zakas
+  - @humanwhocodes/module-importer (1.0.1) - Nicholas C. Zaks
+  - @humanwhocodes/retry (0.3.1) - Nicholas C. Zaks
+  - @humanwhocodes/retry (0.4.3) - Nicholas C. Zaks
+  - @img/sharp-darwin-arm64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-darwin-arm64 (0.34.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-darwin-x64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-darwin-x64 (0.34.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linux-arm64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linux-arm64 (0.34.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linux-x64 (0.33.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linux-x64 (0.34.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linuxmusl-arm64 (0.34.5) - Lovell Fuller <npm@lovell.info>
+  - @img/sharp-linuxmusl-x64 (0.34.5) - Lovell Fuller <npm@lovell.info>
+  - @malept/cross-spawn-promise (2.0.0) - Mark Lee
+  - @opentelemetry/api (1.9.0) - OpenTelemetry Authors
+  - @opentelemetry/api-logs (0.208.0) - OpenTelemetry Authors
+  - @opentelemetry/semantic-conventions (1.40.0) - OpenTelemetry Authors
+  - aria-query (5.3.2) - Jesse Beach <splendidnoise@gmail.com>
+  - axobject-query (4.1.0) - Jesse Beach <splendidnoise@gmail.com>
+  - chevrotain (11.0.3) - Shahar Soel
+  - class-variance-authority (0.7.1) - Joe Bell (https://joebell.co.uk)
+  - cluster-key-slot (1.1.2) - Mike Diarmid
+  - denque (2.1.0) - Invertase
+  - detect-libc (2.0.4) - Lovell Fuller <npm@lovell.info>
+  - detect-libc (2.1.2) - Lovell Fuller <npm@lovell.info>
+  - didyoumean (1.2.2) - Dave Porter
+  - ejs (3.1.10) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
+  - expect-type (1.2.2)
+  - exponential-backoff (3.1.2) - Sami Sayegh
+  - exponential-backoff (3.1.3) - Sami Sayegh
+  - fast-diff (1.3.0) - Jason Chen <jhchen7@gmail.com>
+  - filelist (1.0.4) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
+  - jake (10.9.2) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
+  - long (5.3.2) - Daniel Wirtz <dcode@dcode.io>
+  - openai (5.10.1) - OpenAI <support@openai.com>
+  - rxjs (7.8.2) - Ben Lesh <ben@benlesh.com>
+  - sharp (0.34.5) - Lovell Fuller <npm@lovell.info>
+  - sumchecker (3.0.1) - Mark Lee
+  - ts-interface-checker (0.1.13) - Dmitry S, Grist Labs
+  - tunnel-agent (0.6.0) - Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.futurealoof.com)
+  - web-vitals (5.1.0) - Philip Walton
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 ================================================================================
 ## BSD-3-Clause LICENSE
@@ -979,7 +1305,7 @@ Package: @hapi/pinpoint
 Version: 2.0.1
 Repository: git://github.com/hapijs/pinpoint
 
-Copyright (c) 2019-2020, Sideway. Inc, and project contributors
+Copyright (c) 2019-2020, Sideway. Inc, and project contributors  
 
 All rights reserved.
 
@@ -989,22 +1315,6 @@ Redistribution and use in source and binary forms, with or without modification,
 * The names of any contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS OFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-
-Package: @hapi/tlds
-Version: 1.1.5
-Repository: git://github.com/hapijs/tlds
-
-Copyright (c) 2019-2022, Sideway, Inc. and Project contributors
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
- * The names of any contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
@@ -1591,46 +1901,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 
 Package: fast-uri
-Version: 3.1.0
-Author: Vincent Le Goff <vince.legoff@gmail.com> (https://github.com/zekth)
-Homepage: https://github.com/fastify/fast-uri
-
-Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
-Copyright (c) 2021-present The Fastify team
-All rights reserved.
-
-The Fastify team members are listed at https://github.com/fastify/fastify#team.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * The names of any contributors may not be used to endorse or promote
-      products derived from this software without specific prior written
-      permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-                                  *   *   *
-
-The complete list of contributors can be found at:
-- https://github.com/garycourt/uri-js/graphs/contributors
-
---------------------------------------------------------------------------------
-
-Package: fast-uri
 Version: 3.0.6
 Author: Vincent Le Goff <vince.legoff@gmail.com> (https://github.com/zekth)
 Homepage: https://github.com/fastify/fast-uri
@@ -1885,24 +2155,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 
 Package: joi
-Version: 18.0.2
-Repository: git://github.com/hapijs/joi
-
-Copyright (c) 2012-2022, Project contributors.
-Copyright (c) 2012-2022, Sideway. Inc.
-Copyright (c) 2012-2014, Walmart.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-* The names of any contributors may not be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
---------------------------------------------------------------------------------
-
-Package: joi
 Version: 18.0.1
 Repository: git://github.com/hapijs/joi
 
@@ -1964,42 +2216,6 @@ Code generated by the command line utilities is owned by the owner
 of the input file used when generating it. This code is not
 standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
-
---------------------------------------------------------------------------------
-
-Package: qs
-Version: 6.14.1
-Homepage: https://github.com/ljharb/qs
-
-BSD 3-Clause License
-
-Copyright (c) 2014, Nathan LaFreniere and other [contributors](https://github.com/ljharb/qs/graphs/contributors)
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
@@ -2244,264 +2460,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 
 ================================================================================
-## Apache-2.0 LICENSE
-================================================================================
-
-The following packages are licensed under the Apache-2.0 license:
-
-  - @ampproject/remapping (2.3.0) - Justin Ridgewell <jridgewell@google.com>
-  - @chevrotain/cst-dts-gen (11.0.3)
-  - @chevrotain/gast (11.0.3)
-  - @chevrotain/regexp-to-ast (11.0.3)
-  - @chevrotain/types (11.0.3) - Shahar Soel
-  - @chevrotain/utils (11.0.3) - Shahar Soel
-  - @humanfs/core (0.19.1) - Nicholas C. Zakas
-  - @humanfs/node (0.16.6) - Nicholas C. Zakas
-  - @humanwhocodes/module-importer (1.0.1) - Nicholas C. Zaks
-  - @humanwhocodes/retry (0.3.1) - Nicholas C. Zaks
-  - @humanwhocodes/retry (0.4.3) - Nicholas C. Zaks
-  - @img/sharp-linux-arm64 (0.33.5) - Lovell Fuller <npm@lovell.info>
-  - @img/sharp-linux-arm64 (0.34.5) - Lovell Fuller <npm@lovell.info>
-  - @img/sharp-linuxmusl-arm64 (0.33.5) - Lovell Fuller <npm@lovell.info>
-  - @img/sharp-linuxmusl-arm64 (0.34.5) - Lovell Fuller <npm@lovell.info>
-  - @malept/cross-spawn-promise (2.0.0) - Mark Lee
-  - @opentelemetry/api (1.9.0) - OpenTelemetry Authors
-  - @opentelemetry/api-logs (0.208.0) - OpenTelemetry Authors
-  - @opentelemetry/semantic-conventions (1.40.0) - OpenTelemetry Authors
-  - chevrotain (11.0.3) - Shahar Soel
-  - class-variance-authority (0.7.1) - Joe Bell (https://joebell.co.uk)
-  - cluster-key-slot (1.1.2) - Mike Diarmid
-  - denque (2.1.0) - Invertase
-  - detect-libc (2.1.2) - Lovell Fuller <npm@lovell.info>
-  - detect-libc (2.0.4) - Lovell Fuller <npm@lovell.info>
-  - didyoumean (1.2.2) - Dave Porter
-  - ejs (3.1.10) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
-  - expect-type (1.2.2)
-  - exponential-backoff (3.1.3) - Sami Sayegh
-  - exponential-backoff (3.1.2) - Sami Sayegh
-  - fast-diff (1.3.0) - Jason Chen <jhchen7@gmail.com>
-  - filelist (1.0.4) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
-  - jake (10.9.4) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
-  - jake (10.9.2) - Matthew Eernisse <mde@fleegix.org> (http://fleegix.org)
-  - long (5.3.2) - Daniel Wirtz <dcode@dcode.io>
-  - openai (5.10.1) - OpenAI <support@openai.com>
-  - rxjs (7.8.2) - Ben Lesh <ben@benlesh.com>
-  - sharp (0.34.5) - Lovell Fuller <npm@lovell.info>
-  - sumchecker (3.0.1) - Mark Lee
-  - ts-interface-checker (0.1.13) - Dmitry S, Grist Labs
-  - tunnel-agent (0.6.0) - Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.futurealoof.com)
-  - web-vitals (5.1.0) - Philip Walton
-
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-================================================================================
 ## BSD-2-Clause LICENSE
 ================================================================================
 
 The following packages are licensed under the BSD-2-Clause license:
 
   - @electron/osx-sign (1.3.3) - electron
-  - @electron/windows-sign (1.2.2) - Felix Rieseberg
+  - damerau-levenshtein (1.0.8) - The Spanish Inquisition
   - dotenv (16.6.1)
   - dotenv-expand (11.0.7) - motdotla
   - entities (2.2.0) - Felix Boehm <me@feedic.com>
@@ -2511,7 +2476,6 @@ The following packages are licensed under the BSD-2-Clause license:
   - esutils (2.0.3)
   - extract-zip (2.0.1) - max ogden
   - http-cache-semantics (4.2.0) - Kornel Lesiński <npms2@geekhood.net> (https://kornel.ski/)
-  - json-schema-typed (8.0.2) - Remy Rylan
   - json-schema-typed (8.0.1) - Jeremy Rylan
   - uri-js (4.4.1) - Gary Court <gary.court@gmail.com>
 
@@ -2541,78 +2505,102 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
-## BlueOak-1.0.0 LICENSE
+## LGPL-3.0-or-later LICENSE
 ================================================================================
 
-Package: @isaacs/cliui
-Version: 9.0.0
-Repository: git+ssh://git@github.com:isaacs/cliui
+Package: @img/sharp-libvips-darwin-arm64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
 
-Several modules are vendored under `./src`, which are used and
-distributed according to their respective licenses, each provided
-in the same directory as the code.
-
-Everything else is released under the following license.
-
-----
-
-# Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules. The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor's
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-<https://blueoakcouncil.org/license/1.0.0>.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice. If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-**_As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim._**
+License: LGPL-3.0-or-later
 
 --------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-darwin-arm64
+Version: 1.2.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-darwin-x64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-darwin-x64
+Version: 1.2.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linux-arm64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linux-arm64
+Version: 1.2.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linux-x64
+Version: 1.0.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linux-x64
+Version: 1.2.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linuxmusl-arm64
+Version: 1.2.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-libvips-linuxmusl-x64
+Version: 1.2.4
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+License: LGPL-3.0-or-later
+
+--------------------------------------------------------------------------------
+
+================================================================================
+## BlueOak-1.0.0 LICENSE
+================================================================================
 
 Package: chownr
 Version: 3.0.0
@@ -2682,69 +2670,6 @@ No contributor can revoke this license.
 without any warranty or condition, and no contributor
 will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
-
---------------------------------------------------------------------------------
-
-Package: jackspeak
-Version: 4.2.3
-Author: Isaac Z. Schlueter <i@izs.me>
-Repository: git+https://github.com/isaacs/jackspeak.git
-
-# Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules. The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor's
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-<https://blueoakcouncil.org/license/1.0.0>.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice. If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-**_As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim._**
 
 --------------------------------------------------------------------------------
 
@@ -2874,69 +2799,6 @@ software or this license, under any kind of legal claim._**
 
 --------------------------------------------------------------------------------
 
-Package: minimatch
-Version: 10.1.2
-Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
-Repository: git@github.com:isaacs/minimatch
-
-# Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules. The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor's
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-<https://blueoakcouncil.org/license/1.0.0>.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice. If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-**_As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim._**
-
---------------------------------------------------------------------------------
-
 Package: package-json-from-dist
 Version: 1.0.1
 Author: Isaac Z. Schlueter <i@izs.me> (https://izs.me)
@@ -2949,69 +2811,6 @@ The remainder of this project is licensed under the Blue Oak
 Model License, as follows:
 
 -----
-
-# Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules.  The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor's
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-<https://blueoakcouncil.org/license/1.0.0>.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice.  If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-***As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.***
-
---------------------------------------------------------------------------------
-
-Package: path-scurry
-Version: 2.0.1
-Author: Isaac Z. Schlueter <i@izs.me> (https://blog.izs.me)
-Repository: git+https://github.com/isaacs/path-scurry
 
 # Blue Oak Model License
 
@@ -3197,132 +2996,6 @@ software or this license, under any kind of legal claim.***
 
 --------------------------------------------------------------------------------
 
-Package: sax
-Version: 1.4.4
-Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
-Repository: git://github.com/isaacs/sax-js.git
-
-# Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules.  The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor's
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-<https://blueoakcouncil.org/license/1.0.0>.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice.  If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-***As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.***
-
---------------------------------------------------------------------------------
-
-Package: tar
-Version: 7.5.7
-Author: Isaac Z. Schlueter
-Repository: https://github.com/isaacs/node-tar.git
-
-# Blue Oak Model License
-
-Version 1.0.0
-
-## Purpose
-
-This license gives everyone as much permission to work with
-this software as possible, while protecting contributors
-from liability.
-
-## Acceptance
-
-In order to receive this license, you must agree to its
-rules.  The rules of this license are both obligations
-under that agreement and conditions to your license.
-You must not do anything with this software that triggers
-a rule that you cannot or will not follow.
-
-## Copyright
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe that contributor's
-copyright in it.
-
-## Notices
-
-You must ensure that everyone who gets a copy of
-any part of this software from you, with or without
-changes, also gets the text of this license or a link to
-<https://blueoakcouncil.org/license/1.0.0>.
-
-## Excuse
-
-If anyone notifies you in writing that you have not
-complied with [Notices](#notices), you can keep your
-license by taking all practical steps to comply within 30
-days after the notice.  If you do not do so, your license
-ends immediately.
-
-## Patent
-
-Each contributor licenses you to do everything with this
-software that would otherwise infringe any patent claims
-they can license or become able to license.
-
-## Reliability
-
-No contributor can revoke this license.
-
-## No Liability
-
-***As far as the law allows, this software comes as is,
-without any warranty or condition, and no contributor
-will be liable to anyone for any damages related to this
-software or this license, under any kind of legal claim.***
-
---------------------------------------------------------------------------------
-
 Package: yallist
 Version: 5.0.0
 Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
@@ -3391,46 +3064,6 @@ No contributor can revoke this license.
 without any warranty or condition, and no contributor
 will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
-
---------------------------------------------------------------------------------
-
-================================================================================
-## LGPL-3.0-or-later LICENSE
-================================================================================
-
-Package: @img/sharp-libvips-linux-arm64
-Version: 1.0.4
-Author: Lovell Fuller <npm@lovell.info>
-Homepage: https://sharp.pixelplumbing.com
-
-License: LGPL-3.0-or-later
-
---------------------------------------------------------------------------------
-
-Package: @img/sharp-libvips-linux-arm64
-Version: 1.2.4
-Author: Lovell Fuller <npm@lovell.info>
-Homepage: https://sharp.pixelplumbing.com
-
-License: LGPL-3.0-or-later
-
---------------------------------------------------------------------------------
-
-Package: @img/sharp-libvips-linuxmusl-arm64
-Version: 1.0.4
-Author: Lovell Fuller <npm@lovell.info>
-Homepage: https://sharp.pixelplumbing.com
-
-License: LGPL-3.0-or-later
-
---------------------------------------------------------------------------------
-
-Package: @img/sharp-libvips-linuxmusl-arm64
-Version: 1.2.4
-Author: Lovell Fuller <npm@lovell.info>
-Homepage: https://sharp.pixelplumbing.com
-
-License: LGPL-3.0-or-later
 
 --------------------------------------------------------------------------------
 
@@ -3549,6 +3182,607 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+================================================================================
+## Apache-2.0 AND LGPL-3.0-or-later LICENSE
+================================================================================
+
+Package: @img/sharp-win32-arm64
+Version: 0.34.5
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-win32-x64
+Version: 0.33.5
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+
+Package: @img/sharp-win32-x64
+Version: 0.34.5
+Author: Lovell Fuller <npm@lovell.info>
+Homepage: https://sharp.pixelplumbing.com
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 --------------------------------------------------------------------------------
 
@@ -4707,28 +4941,6 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
 --------------------------------------------------------------------------------
 
 ================================================================================
-## SEE LICENSE IN README.md LICENSE
-================================================================================
-
-Package: @anthropic-ai/claude-code
-Version: 2.1.39
-Author: Anthropic <support@anthropic.com>
-Homepage: https://github.com/anthropics/claude-code
-
-© Anthropic PBC. All rights reserved. Use is subject to the Legal Agreements outlined here: https://code.claude.com/docs/en/legal-and-compliance.
-
---------------------------------------------------------------------------------
-
-Package: @anthropic-ai/claude-code
-Version: 2.0.0
-Author: Anthropic <support@anthropic.com>
-Homepage: https://github.com/anthropics/claude-code
-
-© Anthropic PBC. All rights reserved. Use is subject to Anthropic's [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms).
-
---------------------------------------------------------------------------------
-
-================================================================================
 ## (BSD-2-Clause OR MIT OR Apache-2.0) LICENSE
 ================================================================================
 
@@ -4741,25 +4953,25 @@ The MIT License
 
 Copyright (c) 2011 Dominic Tarr
 
-Permission is hereby granted, free of charge,
-to any person obtaining a copy of this software and
-associated documentation files (the "Software"), to
-deal in the Software without restriction, including
-without limitation the rights to use, copy, modify,
-merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom
-the Software is furnished to do so,
+Permission is hereby granted, free of charge, 
+to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to 
+deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, 
+merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom 
+the Software is furnished to do so, 
 subject to the following conditions:
 
-The above copyright notice and this permission notice
+The above copyright notice and this permission notice 
 shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
-ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------------------
@@ -4824,7 +5036,7 @@ exhaustive, and do not form part of our licenses.
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More_considerations
-     for the public:
+     for the public: 
 	wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
@@ -5168,6 +5380,379 @@ the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
+
+--------------------------------------------------------------------------------
+
+================================================================================
+## MPL-2.0 LICENSE
+================================================================================
+
+Package: axe-core
+Version: 4.12.1
+Homepage: https://www.deque.com/axe/
+
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
 
 --------------------------------------------------------------------------------
 
@@ -5667,7 +6252,7 @@ limitations under the License.
 ---
 
 Some files in this codebase contain code from getsentry/sentry-javascript or getsentry/sentry-react-native by Software, Inc. dba Sentry.
-In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases. 
 
 MIT License
 
@@ -5694,7 +6279,7 @@ SOFTWARE.
 ---
 
 Some files in this codebase contain code from facebook/metro by Meta Platforms, Inc. and affiliates.
-In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases. 
 
 MIT License
 
@@ -5721,7 +6306,7 @@ SOFTWARE.
 ---
 
 Some files in this codebase contain code from expo/expo by 650 Industries, Inc. (aka Expo).
-In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
+In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases. 
 
 The MIT License (MIT)
 
@@ -5744,6 +6329,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+================================================================================
+## SEE LICENSE IN README.md LICENSE
+================================================================================
+
+Package: @anthropic-ai/claude-code
+Version: 2.0.0
+Author: Anthropic <support@anthropic.com>
+Homepage: https://github.com/anthropics/claude-code
+
+© Anthropic PBC. All rights reserved. Use is subject to Anthropic's [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms).
 
 --------------------------------------------------------------------------------
 
@@ -5788,7 +6386,7 @@ For more information, please refer to <http://unlicense.org>
 ================================================================================
 
 Package: Pane
-Version: 1.1.146
+Version: 2.4.22
 Author: [object Object]
 License: AGPL-3.0
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,5 +1,6 @@
 import js from '@eslint/js';
 import typescript from 'typescript-eslint';
+import jsxA11y from 'eslint-plugin-jsx-a11y';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 
@@ -19,6 +20,7 @@ export default [
       }
     },
     plugins: {
+      'jsx-a11y': jsxA11y,
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh
     },
@@ -26,6 +28,23 @@ export default [
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+      'jsx-a11y/alt-text': 'error',
+      'jsx-a11y/anchor-has-content': 'error',
+      'jsx-a11y/click-events-have-key-events': 'error',
+      'jsx-a11y/aria-props': 'error',
+      'jsx-a11y/aria-proptypes': 'error',
+      'jsx-a11y/aria-unsupported-elements': 'error',
+      'jsx-a11y/heading-has-content': 'error',
+      'jsx-a11y/iframe-has-title': 'error',
+      'jsx-a11y/no-access-key': 'error',
+      'jsx-a11y/no-distracting-elements': 'error',
+      'jsx-a11y/no-static-element-interactions': ['error', {
+        handlers: ['onClick'],
+        allowExpressionValues: true
+      }],
+      'jsx-a11y/role-has-required-aria-props': 'error',
+      'jsx-a11y/role-supports-aria-props': 'error',
+      'jsx-a11y/tabindex-no-positive': 'error',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",

--- a/frontend/src/components/AboutDialog.tsx
+++ b/frontend/src/components/AboutDialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
-import { X, Download, Check, Loader2, Github } from 'lucide-react';
+import { Download, Check, Loader2, Github } from 'lucide-react';
 import { usePaneLogo } from '../hooks/usePaneLogo';
+import { Modal } from './ui/Modal';
+import { LiveRegion } from './ui/LiveRegion';
 
 interface VersionInfo {
   current: string;
@@ -29,9 +31,13 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
   const [versionInfo, setVersionInfo] = useState<VersionInfo | null>(null);
   const [isChecking, setIsChecking] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isHandingOff, setIsHandingOff] = useState(false);
+  const [hasCheckedForUpdates, setHasCheckedForUpdates] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
+      setIsHandingOff(false);
+      setHasCheckedForUpdates(false);
       loadCurrentVersion();
     }
   }, [isOpen]);
@@ -66,7 +72,7 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
       if (result.success) {
         setVersionInfo(result.data);
         if (result.data.hasUpdate) {
-          onUpdate(result.data);
+          handleUpdate(result.data);
         }
       } else {
         setError(result.error || 'Failed to check for updates');
@@ -76,7 +82,13 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
       console.error('Update check failed:', error);
     } finally {
       setIsChecking(false);
+      setHasCheckedForUpdates(true);
     }
+  };
+
+  const handleUpdate = (nextVersionInfo: VersionInfo) => {
+    setIsHandingOff(true);
+    onUpdate(nextVersionInfo);
   };
 
   const formatDate = (dateString: string) => {
@@ -91,28 +103,25 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
     }
   };
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return null;
-
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50" onClick={onClose}>
-      <div className="relative bg-surface-primary rounded-xl shadow-2xl w-[360px] mx-4 overflow-hidden border border-border-primary/50" onClick={(e) => e.stopPropagation()}>
-        {/* Close button - absolute positioned */}
-        <button
-          onClick={onClose}
-          className="absolute top-4 right-4 z-10 text-text-tertiary hover:text-text-primary transition-colors p-1 rounded-md hover:bg-surface-secondary"
-        >
-          <X className="w-4 h-4" />
-        </button>
-
+    <Modal
+      ariaLabel="About Pane"
+      isOpen={isOpen}
+      onClose={onClose}
+      size="sm"
+      restoreFocusOnClose={!isHandingOff}
+      className="mx-auto !w-[360px] max-w-full !rounded-xl border border-border-primary/50 !bg-surface-primary !shadow-2xl"
+    >
+        <LiveRegion>
+          {isChecking
+            ? 'Checking for updates'
+            : hasCheckedForUpdates && !error
+              ? versionInfo?.hasUpdate
+                ? `Pane ${versionInfo.latest} is available`
+                : 'Pane is up to date'
+              : ''}
+        </LiveRegion>
+        <div className="min-h-0 flex-1 overflow-y-auto">
         {/* Main content */}
         <div className="px-8 pt-10 pb-8">
           {/* Logo and branding */}
@@ -140,7 +149,7 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
             </span>
             {!versionInfo?.hasUpdate && versionInfo?.current && !isChecking && (
               <span className="flex items-center gap-1 text-xs text-status-success">
-                <Check className="w-3 h-3" />
+                <Check aria-hidden="true" className="w-3 h-3 text-status-success" />
                 Latest
               </span>
             )}
@@ -161,7 +170,7 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
                   )}
                 </div>
                 <button
-                  onClick={() => versionInfo && onUpdate(versionInfo)}
+                  onClick={() => versionInfo && handleUpdate(versionInfo)}
                   className="px-3 py-1.5 bg-interactive hover:bg-interactive-hover text-on-interactive text-xs font-medium rounded-md transition-colors"
                 >
                   Update
@@ -173,13 +182,15 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
           {/* Action buttons */}
           <div className="space-y-2 mb-6">
             <button
+              type="button"
               onClick={checkForUpdates}
               disabled={isChecking}
+              aria-busy={isChecking}
               className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-surface-secondary hover:bg-surface-tertiary border border-border-primary text-text-primary text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
             >
               {isChecking ? (
                 <>
-                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <Loader2 aria-hidden="true" className="w-4 h-4 animate-spin" />
                   <span>Checking...</span>
                 </>
               ) : (
@@ -203,6 +214,12 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
             </a>
           </div>
 
+          {error && (
+            <div role="alert" className="mb-6 p-2 bg-status-error/10 border border-status-error/20 rounded text-xs text-status-error text-center">
+              {error}
+            </div>
+          )}
+
           {/* Links - minimal style */}
           <div className="flex items-center justify-center gap-4 text-xs text-text-tertiary">
             <a
@@ -214,7 +231,7 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
               <Github className="w-3.5 h-3.5" />
               <span>GitHub</span>
             </a>
-            <span className="text-border-primary">•</span>
+            <span aria-hidden="true" className="text-border-primary">•</span>
             <a
               href="https://runpane.com"
               target="_blank"
@@ -223,7 +240,7 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
             >
               Website
             </a>
-            <span className="text-border-primary">•</span>
+            <span aria-hidden="true" className="text-border-primary">•</span>
             <a
               href="https://runpane.com/docs"
               target="_blank"
@@ -241,14 +258,7 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
             Made by <a href="https://dcouple.ai" target="_blank" rel="noopener noreferrer" className="hover:text-text-secondary">Dcouple</a> · macOS, Windows & Linux
           </p>
         </div>
-
-        {error && (
-          <div className="absolute bottom-16 left-4 right-4 p-2 bg-status-error/10 border border-status-error/20 rounded text-xs text-status-error text-center">
-            {error}
-          </div>
-        )}
-      </div>
-
-    </div>
+        </div>
+    </Modal>
   );
 }

--- a/frontend/src/components/ArchiveProgress.tsx
+++ b/frontend/src/components/ArchiveProgress.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
 import type { IpcRendererEvent } from 'electron';
 import { Loader2, Archive, CheckCircle, AlertCircle } from 'lucide-react';
+import { LiveRegion } from './ui/LiveRegion';
 
 interface ArchiveTask {
   sessionId: string;
@@ -20,6 +21,7 @@ interface ArchiveProgressData {
 }
 
 export function ArchiveProgress() {
+  const taskListId = useId();
   const [progress, setProgress] = useState<ArchiveProgressData | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -59,8 +61,18 @@ export function ArchiveProgress() {
     }
   };
 
+  const completedCount = progress?.tasks.filter(task => task.status === 'completed').length ?? 0;
+  const failedTask = progress?.tasks.find(task => task.status === 'failed');
+  const archiveAnnouncement = progress && progress.totalCount > 0
+    ? progress.activeCount > 0
+      ? `Archiving ${progress.activeCount} ${progress.activeCount === 1 ? 'pane' : 'panes'}`
+      : completedCount === progress.totalCount
+        ? `Archive complete for ${completedCount} ${completedCount === 1 ? 'pane' : 'panes'}`
+        : ''
+    : '';
+
   if (!progress || progress.totalCount === 0) {
-    return null;
+    return <LiveRegion>{archiveAnnouncement}</LiveRegion>;
   }
 
   const getStatusIcon = (status: ArchiveTask['status']) => {
@@ -110,8 +122,13 @@ export function ArchiveProgress() {
 
   return (
     <div className="border-t border-border-primary flex-shrink-0">
+      <LiveRegion>{archiveAnnouncement}</LiveRegion>
+      <LiveRegion mode="assertive">{failedTask ? `Archive failed for ${failedTask.sessionName}: ${failedTask.error ?? 'Unknown error'}` : ''}</LiveRegion>
       <button
+        type="button"
         onClick={() => setIsExpanded(!isExpanded)}
+        aria-expanded={isExpanded}
+        aria-controls={taskListId}
         className="w-full px-4 py-2 flex items-center justify-between hover:bg-surface-hover transition-colors"
       >
         <div className="flex items-center gap-2">
@@ -148,7 +165,7 @@ export function ArchiveProgress() {
       </button>
 
       {isExpanded && (
-        <div className="border-t border-border-primary max-h-48 overflow-y-auto bg-surface-secondary">
+        <div id={taskListId} className="border-t border-border-primary max-h-48 overflow-y-auto bg-surface-secondary">
           {progress.tasks.length === 0 ? (
             <div className="px-4 py-2 text-xs text-text-tertiary">
               No archive tasks

--- a/frontend/src/components/CloudWidget.tsx
+++ b/frontend/src/components/CloudWidget.tsx
@@ -4,6 +4,7 @@ import { createDefaultCloudVmState } from '../../../shared/types/cloud';
 import { useCloudStore } from '../stores/cloudStore';
 import { useSessionStore } from '../stores/sessionStore';
 import { openCloudSetupTerminal } from '../services/cloudSetupTerminal';
+import { LiveRegion } from './ui/LiveRegion';
 
 const DEFAULT_CLOUD_STATE = createDefaultCloudVmState();
 
@@ -208,12 +209,23 @@ export function CloudWidget() {
     if (tunnelConnecting) return 'Connecting tunnel...';
     return 'Loading...';
   };
+  const cloudAnnouncement = isTransitioning || daemonBootstrapping || daemonConnectionReconnecting || tunnelConnecting || loading
+    ? getTransitionLabel()
+    : daemonConnected
+      ? 'Cloud runtime connected'
+      : tunnelReady
+        ? 'Cloud tunnel connected'
+        : isOff
+          ? 'Cloud VM stopped'
+          : '';
 
   return (
-    <div className="fixed bottom-4 right-4 flex items-center gap-1.5" style={{ zIndex: 1300 }}>
+    <div aria-busy={isTransitioning || loading} className="fixed bottom-4 right-4 flex items-center gap-1.5" style={{ zIndex: 1300 }}>
+      <LiveRegion>{cloudAnnouncement}</LiveRegion>
       {/* Error tooltip */}
       {vmState.error && (
         <div
+          role="alert"
           className="px-2 py-1 bg-red-500/10 border border-red-500/30 rounded-lg text-xs text-red-400 max-w-72"
           title={vmState.error}
         >
@@ -224,7 +236,7 @@ export function CloudWidget() {
       {/* Transitioning state (VM starting/stopping or tunnel connecting) */}
       {(isTransitioning || daemonBootstrapping || daemonConnectionReconnecting || tunnelConnecting || loading) && (
         <div className="flex items-center gap-2 px-3 py-2 bg-bg-secondary/95 backdrop-blur-sm border border-border-primary rounded-xl shadow-lg">
-          <Loader2 className="w-4 h-4 animate-spin text-yellow-400" />
+          <Loader2 aria-hidden="true" className="w-4 h-4 animate-spin text-yellow-400" />
           <span className="text-xs text-text-secondary">
             {getTransitionLabel()}
           </span>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useId } from 'react';
 import { Search } from 'lucide-react';
 import { Modal } from './ui/Modal';
 import { Input } from './ui/Input';
@@ -22,6 +22,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
 
   const getAll = useHotkeyStore((s) => s.getAll);
   const search = useHotkeyStore((s) => s.search);
@@ -40,8 +41,6 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
     if (isOpen) {
       setSearchTerm('');
       setSelectedIndex(0);
-      // Focus input after modal animation
-      setTimeout(() => inputRef.current?.focus(), 60);
     }
   }, [isOpen]);
 
@@ -71,10 +70,12 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     switch (e.key) {
       case 'ArrowDown':
+        if (commandCount === 0) break;
         e.preventDefault();
         setSelectedIndex((prev) => (prev + 1) % commandCount);
         break;
       case 'ArrowUp':
+        if (commandCount === 0) break;
         e.preventDefault();
         setSelectedIndex((prev) => (prev - 1 + commandCount) % commandCount);
         break;
@@ -87,8 +88,10 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
 
   return (
     <Modal
+      ariaLabel="Command Palette"
       isOpen={isOpen}
       onClose={onClose}
+      initialFocusRef={inputRef}
       size="md"
       showCloseButton={false}
       className="!max-h-[min(500px,80vh)]"
@@ -101,6 +104,12 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
           </div>
           <Input
             ref={inputRef}
+            aria-label="Search commands"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded={commandCount > 0}
+            aria-controls={listboxId}
+            aria-activedescendant={commandCount > 0 ? `${listboxId}-option-${selectedIndex}` : undefined}
             type="text"
             placeholder="Search commands..."
             value={searchTerm}
@@ -112,7 +121,14 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
       </div>
 
       {/* Results list */}
-      <div ref={listRef} className="overflow-y-auto py-2" style={{ maxHeight: '380px' }}>
+      <div
+        id={listboxId}
+        ref={listRef}
+        role="listbox"
+        aria-label="Commands"
+        className="overflow-y-auto py-2"
+        style={{ maxHeight: '380px' }}
+      >
         {commandCount === 0 ? (
           <div className="px-4 py-8 text-center text-text-tertiary text-sm">
             No commands found
@@ -133,8 +149,13 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
             const button = (
               <button
                 key={item.hotkey.id}
+                id={`${listboxId}-option-${item.flatIndex}`}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
                 data-selected={isSelected}
                 aria-disabled={item.disabled}
+                tabIndex={-1}
                 className={cn(
                   'w-full flex items-center justify-between px-4 py-2 text-sm transition-colors',
                   item.disabled

--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -401,6 +401,7 @@ export function CreateSessionDialog({
       }}
       size="lg"
       closeOnOverlayClick={false}
+      closeOnEscape={!isBranchDropdownOpen}
     >
       <ModalHeader title={`New Pane${projectName ? ` in ${projectName}` : ''}`} />
 
@@ -645,6 +646,7 @@ export function CreateSessionDialog({
                     </div>
                     <Toggle
                       checked={startPinned}
+                      aria-label="Start pinned"
                       onChange={(checked) => {
                         setStartPinned(checked);
                         savePreferences({ startPinned: checked });
@@ -662,6 +664,7 @@ export function CreateSessionDialog({
                     </div>
                     <Toggle
                       checked={useWorktree}
+                      aria-label="Use worktree"
                       onChange={(checked) => {
                         setUseWorktree(checked);
                         if (!checked) {

--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, useId } from 'react';
 import { API } from '../utils/api';
 import type { CreateSessionRequest } from '../types/session';
 import type { Project } from '../types/project';
@@ -42,6 +42,8 @@ export function CreateSessionDialog({
   initialFolderId,
   onSessionCreated
 }: CreateSessionDialogProps) {
+  const branchListboxId = useId();
+  const advancedOptionsId = useId();
   const [sessionName, setSessionName] = useState<string>(initialSessionName || '');
   const [sessionCount, setSessionCount] = useState<number>(1);
   const [formData, setFormData] = useState<CreateSessionRequest>({
@@ -400,9 +402,7 @@ export function CreateSessionDialog({
       size="lg"
       closeOnOverlayClick={false}
     >
-      <ModalHeader>
-        New Pane{projectName && ` in ${projectName}`}
-      </ModalHeader>
+      <ModalHeader title={`New Pane${projectName ? ` in ${projectName}` : ''}`} />
 
       <ModalBody className="p-0">
         <div className="flex-1 overflow-y-auto">
@@ -438,6 +438,13 @@ export function CreateSessionDialog({
                       ref={branchInputRef}
                       id="baseBranch"
                       type="text"
+                      role="combobox"
+                      aria-autocomplete="list"
+                      aria-expanded={isBranchDropdownOpen}
+                      aria-controls={branchListboxId}
+                      aria-activedescendant={isBranchDropdownOpen && flatFilteredBranches[highlightedBranchIndex]
+                        ? `${branchListboxId}-option-${highlightedBranchIndex}`
+                        : undefined}
                       value={isBranchDropdownOpen ? branchSearch : (formData.baseBranch || '')}
                       onChange={(e) => {
                         setBranchSearch(e.target.value);
@@ -460,6 +467,7 @@ export function CreateSessionDialog({
                     <button
                       type="button"
                       tabIndex={-1}
+                      aria-label={isBranchDropdownOpen ? 'Close branch options' : 'Open branch options'}
                       onClick={() => {
                         setIsBranchDropdownOpen(!isBranchDropdownOpen);
                         if (!isBranchDropdownOpen) {
@@ -476,7 +484,10 @@ export function CreateSessionDialog({
 
                   {isBranchDropdownOpen && (
                     <div
+                      id={branchListboxId}
                       ref={branchListRef}
+                      role="listbox"
+                      aria-label="Branches"
                       className="absolute z-50 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-border-primary bg-surface-secondary shadow-lg"
                     >
                       {flatFilteredBranches.length === 0 ? (
@@ -488,15 +499,18 @@ export function CreateSessionDialog({
                           {/* Remote branches group */}
                           {filteredBranches.some(b => b.isRemote) && (
                             <>
-                              <div className="px-3 py-1.5 text-xs font-semibold text-text-tertiary uppercase tracking-wider bg-surface-primary sticky top-0">
+                              <div role="presentation" className="px-3 py-1.5 text-xs font-semibold text-text-tertiary uppercase tracking-wider bg-surface-primary sticky top-0">
                                 Remote Branches
                               </div>
                               {filteredBranches.filter(b => b.isRemote).map(branch => {
                                 const flatIndex = flatFilteredBranches.indexOf(branch);
                                 return (
                                   <div
+                                    id={`${branchListboxId}-option-${flatIndex}`}
                                     key={branch.name}
                                     data-branch-item
+                                    role="option"
+                                    aria-selected={formData.baseBranch === branch.name}
                                     className={`flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer ${
                                       flatIndex === highlightedBranchIndex
                                         ? 'bg-interactive/10 text-text-primary'
@@ -522,15 +536,18 @@ export function CreateSessionDialog({
                           {/* Local branches group */}
                           {filteredBranches.some(b => !b.isRemote) && (
                             <>
-                              <div className="px-3 py-1.5 text-xs font-semibold text-text-tertiary uppercase tracking-wider bg-surface-primary sticky top-0">
+                              <div role="presentation" className="px-3 py-1.5 text-xs font-semibold text-text-tertiary uppercase tracking-wider bg-surface-primary sticky top-0">
                                 Local Branches
                               </div>
                               {filteredBranches.filter(b => !b.isRemote).map(branch => {
                                 const flatIndex = flatFilteredBranches.indexOf(branch);
                                 return (
                                   <div
+                                    id={`${branchListboxId}-option-${flatIndex}`}
                                     key={branch.name}
                                     data-branch-item
+                                    role="option"
+                                    aria-selected={formData.baseBranch === branch.name}
                                     className={`flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer ${
                                       flatIndex === highlightedBranchIndex
                                         ? 'bg-interactive/10 text-text-primary'
@@ -604,6 +621,8 @@ export function CreateSessionDialog({
                   setShowAdvanced(newShowAdvanced);
                   savePreferences({ showAdvanced: newShowAdvanced });
                 }}
+                aria-expanded={showAdvanced}
+                aria-controls={advancedOptionsId}
                 variant="ghost"
                 size="sm"
                 className="text-text-secondary hover:text-text-primary"
@@ -615,7 +634,7 @@ export function CreateSessionDialog({
 
             {/* Advanced Options - Collapsible */}
             {showAdvanced && (
-              <div className="px-6 pb-6 border-t border-border-primary pt-5">
+              <div id={advancedOptionsId} className="px-6 pb-6 border-t border-border-primary pt-5">
                 <div className="rounded-lg border border-border-primary overflow-hidden divide-y divide-border-primary">
                   {/* Start Pinned Toggle */}
                   <div className="flex items-center gap-4 px-5 py-4">

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -226,10 +226,12 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
           {onSwapLayout && (
             <Tooltip content="Swap terminal and detail panel positions" side="top">
               <button
+                type="button"
+                aria-label="Swap terminal and detail panel positions"
                 onClick={onSwapLayout}
                 className="p-1 hover:bg-surface-hover rounded transition-colors flex-shrink-0 mr-2 mt-1"
               >
-                <ArrowLeftRight className="w-3.5 h-3.5 text-text-tertiary" />
+                <ArrowLeftRight aria-hidden="true" className="w-3.5 h-3.5 text-text-tertiary" />
               </button>
             </Tooltip>
           )}
@@ -284,10 +286,12 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
           {onSwapLayout && (
             <Tooltip content="Swap terminal and detail panel positions" side="left">
               <button
+                type="button"
+                aria-label="Swap terminal and detail panel positions"
                 onClick={onSwapLayout}
                 className="p-1 hover:bg-surface-hover rounded transition-colors flex-shrink-0"
               >
-                <ArrowLeftRight className="w-3.5 h-3.5 text-text-tertiary" />
+                <ArrowLeftRight aria-hidden="true" className="w-3.5 h-3.5 text-text-tertiary" />
               </button>
             </Tooltip>
           )}
@@ -566,7 +570,11 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
             <div className="px-2 pt-2 flex-shrink-0">
               <SectionHeader>History</SectionHeader>
             </div>
-            <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
+            <div
+              tabIndex={0}
+              aria-label="Commit history"
+              className="flex-1 min-h-0 overflow-y-auto px-2 pb-2"
+            >
               <GitHistoryGraph
                 sessionId={session.id}
                 baseBranch={session.baseBranch || 'main'}

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -571,6 +571,7 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
               <SectionHeader>History</SectionHeader>
             </div>
             <div
+              role="region"
               tabIndex={0}
               aria-label="Commit history"
               className="flex-1 min-h-0 overflow-y-auto px-2 pb-2"

--- a/frontend/src/components/DocsDialog.tsx
+++ b/frontend/src/components/DocsDialog.tsx
@@ -86,6 +86,7 @@ export function DocsDialog({ isOpen, onClose }: DocsDialogProps) {
 
   return (
     <Modal
+      ariaLabel="Pane documentation"
       isOpen={isOpen}
       onClose={onClose}
       size="full"

--- a/frontend/src/components/ErrorDialog.tsx
+++ b/frontend/src/components/ErrorDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { AlertCircle, ChevronDown, ChevronUp } from 'lucide-react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
@@ -22,6 +22,7 @@ export function ErrorDialog({
   command 
 }: ErrorDialogProps) {
   const [isDetailsExpanded, setIsDetailsExpanded] = useState(false);
+  const detailsId = useId();
   
   // Check if details are long enough to warrant collapsing
   const shouldCollapse = details && details.length > 500;
@@ -31,12 +32,10 @@ export function ErrorDialog({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl">
-      <ModalHeader>
-        <div className="flex items-center space-x-3">
-          <AlertCircle className="w-6 h-6 text-status-error flex-shrink-0" />
-          <span>{title}</span>
-        </div>
-      </ModalHeader>
+      <ModalHeader
+        title={title}
+        icon={<AlertCircle className="w-6 h-6 text-status-error" />}
+      />
       
       <ModalBody>
         <div className="space-y-4">
@@ -62,6 +61,8 @@ export function ErrorDialog({
                 {shouldCollapse && (
                   <Button
                     onClick={() => setIsDetailsExpanded(!isDetailsExpanded)}
+                    aria-expanded={isDetailsExpanded}
+                    aria-controls={detailsId}
                     variant="ghost"
                     size="sm"
                     className="text-xs"
@@ -80,7 +81,7 @@ export function ErrorDialog({
                   </Button>
                 )}
               </div>
-              <Card variant="bordered" padding="sm" className="bg-status-error/10 border-status-error/30">
+              <Card id={detailsId} variant="bordered" padding="sm" className="bg-status-error/10 border-status-error/30">
                 <pre className="text-sm text-status-error font-mono overflow-x-auto whitespace-pre-wrap">
                   {displayDetails}
                 </pre>

--- a/frontend/src/components/ExecutionList.tsx
+++ b/frontend/src/components/ExecutionList.tsx
@@ -65,6 +65,7 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
           Commits <span className="text-text-muted">{executions.filter(e => e.id !== 0).length}</span>
         </span>
         <button
+          type="button"
           onClick={handleSelectAll}
           className="text-[10px] text-text-muted hover:text-interactive transition-colors"
         >
@@ -84,14 +85,20 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
             <div
               key={execution.id}
               className={`
-                group flex items-stretch gap-2 px-3 cursor-pointer transition-colors
+                group relative flex items-stretch gap-2 px-3 transition-colors
                 ${isSelected ? 'bg-interactive/10 border-l-2 border-l-interactive' : 'border-l-2 border-l-transparent hover:bg-surface-hover'}
                 ${isUncommitted ? 'bg-status-warning/5' : ''}
               `}
-              onClick={(e) => handleCommitClick(execution.id, e)}
             >
+              <button
+                type="button"
+                aria-pressed={isSelected}
+                aria-label={`Select ${isUncommitted ? 'uncommitted changes' : execution.commit_message || execution.prompt_text || `commit ${execution.execution_sequence}`}`}
+                onClick={(event) => handleCommitClick(execution.id, event)}
+                className="absolute inset-0 z-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-interactive"
+              />
               {/* Graph rail: vertical line with commit node */}
-              <div className="flex flex-col items-center flex-shrink-0 w-3.5">
+              <div className="relative z-10 pointer-events-none flex flex-col items-center flex-shrink-0 w-3.5">
                 <div className={`w-px flex-1 ${isFirst ? 'bg-transparent' : 'bg-border-secondary'}`} />
                 <GitCommitHorizontal
                   className={`w-3.5 h-3.5 flex-shrink-0 rotate-90 ${
@@ -102,7 +109,7 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
               </div>
 
               {/* Content */}
-              <div className="flex-1 min-w-0 py-1.5">
+              <div className="relative z-10 pointer-events-none flex-1 min-w-0 py-1.5">
                 {/* Message + hash */}
                 <div className="flex items-baseline gap-1.5 min-w-0">
                   <span
@@ -133,9 +140,10 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
                       <span>No changes</span>
                     )}
                   </div>
-                  <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
+                  <div className="pointer-events-auto flex flex-col items-end gap-0.5 flex-shrink-0">
                     {isUncommitted && onCommit && execution.stats_files_changed > 0 && (
                       <button
+                        type="button"
                         onClick={(e) => { e.stopPropagation(); onCommit(); }}
                         className="text-[10px] px-1.5 py-0.5 rounded text-status-success hover:bg-status-success/15 transition-colors font-medium"
                       >
@@ -144,6 +152,7 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
                     )}
                     {isUncommitted && onRestore && execution.stats_files_changed > 0 && (
                       <button
+                        type="button"
                         onClick={(e) => { e.stopPropagation(); onRestore(); }}
                         className="text-[10px] px-1.5 py-0.5 rounded text-status-warning hover:bg-status-warning/15 transition-colors font-medium"
                         title="Restore all uncommitted changes"
@@ -153,9 +162,10 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
                     )}
                     {onRevert && !isUncommitted && execution.after_commit_hash && execution.after_commit_hash !== 'UNCOMMITTED' && (
                       <button
+                        type="button"
                         onClick={(e) => { e.stopPropagation(); onRevert(execution.after_commit_hash!); }}
-                        className="text-[10px] p-0.5 rounded text-text-muted hover:text-status-error hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100"
-                        title="Revert this commit"
+                        className="text-[10px] p-0.5 rounded text-text-muted hover:text-status-error hover:bg-status-error/10 transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                        aria-label="Revert this commit"
                       >
                         <RotateCcw className="w-2.5 h-2.5" />
                       </button>

--- a/frontend/src/components/FilePathAutocomplete.tsx
+++ b/frontend/src/components/FilePathAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useId } from 'react';
 import { FileText, Folder, Zap } from 'lucide-react';
 
 interface FileItem {
@@ -44,6 +44,7 @@ const FilePathAutocomplete: React.FC<FilePathAutocompleteProps> = ({
   onBlur,
   style
 }) => {
+  const listboxId = useId();
   const [suggestions, setSuggestions] = useState<FileItem[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -417,7 +418,14 @@ const FilePathAutocomplete: React.FC<FilePathAutocompleteProps> = ({
     placeholder,
     className,
     disabled,
-    style
+    style,
+    role: 'combobox' as const,
+    'aria-autocomplete': 'list' as const,
+    'aria-expanded': showSuggestions && suggestions.length > 0,
+    'aria-controls': listboxId,
+    'aria-activedescendant': showSuggestions && suggestions[selectedIndex]
+      ? `${listboxId}-option-${selectedIndex}`
+      : undefined,
   };
 
   return (
@@ -438,7 +446,10 @@ const FilePathAutocomplete: React.FC<FilePathAutocompleteProps> = ({
       
       {showSuggestions && suggestions.length > 0 && (
         <div
+          id={listboxId}
           ref={dropdownRef}
+          role="listbox"
+          aria-label={activePattern?.type === 'slash' ? 'Slash commands' : 'Files'}
           className="absolute z-50 max-h-60 overflow-auto rounded-md bg-surface-secondary py-1 shadow-lg ring-1 ring-black ring-opacity-5 border border-border-primary"
           style={{
             minWidth: Math.min(300, dropdownPosition?.maxWidth || 300) + 'px',
@@ -458,13 +469,19 @@ const FilePathAutocomplete: React.FC<FilePathAutocompleteProps> = ({
 
             return (
               <div
+                id={`${listboxId}-option-${index}`}
                 key={suggestion.path}
+                role="option"
+                aria-selected={index === selectedIndex}
                 className={`flex items-center px-4 py-2.5 cursor-pointer min-w-0 transition-colors ${
                   index === selectedIndex
                     ? 'bg-interactive text-on-interactive'
                     : 'text-text-secondary hover:bg-surface-hover'
                 }`}
-                onClick={() => selectSuggestion(suggestion)}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  selectSuggestion(suggestion);
+                }}
                 onMouseEnter={() => setSelectedIndex(index)}
               >
                 {isSlashCommand ? (

--- a/frontend/src/components/GitHistoryGraph.tsx
+++ b/frontend/src/components/GitHistoryGraph.tsx
@@ -102,9 +102,11 @@ const CommitRow = memo(function CommitRow({
   const date = new Date(entry.committerDate);
   const dateStr = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   const hasStats = entry.filesChanged != null && entry.filesChanged > 0;
+  const Row = onClick ? 'button' : 'div';
 
   const row = (
-      <div
+      <Row
+        {...(onClick ? { type: 'button' as const } : {})}
         className={`flex items-stretch gap-1.5 w-full text-left rounded-sm min-w-0 ${layout === 'wide' ? (onClick ? 'hover:bg-surface-secondary cursor-pointer transition-colors' : '') : `hover:bg-surface-secondary ${onClick ? 'cursor-pointer' : 'cursor-default'} transition-colors`}`}
         onClick={onClick ? () => onClick(entry.hash) : undefined}
       >
@@ -178,7 +180,7 @@ const CommitRow = memo(function CommitRow({
             </>
           )}
         </div>
-      </div>
+      </Row>
   );
 
   if (layout === 'wide') return row;

--- a/frontend/src/components/GitStatusIndicator.tsx
+++ b/frontend/src/components/GitStatusIndicator.tsx
@@ -325,17 +325,8 @@ const GitStatusIndicator: React.FC<GitStatusIndicatorProps> = React.memo(({ gitS
     ariaLabel = `Behind by ${primaryCount} commit${primaryCount !== 1 ? 's' : ''}`;
   }
 
-  return (
-    <span 
-      className={`inline-flex items-center ${primaryCount > 0 ? 'justify-center gap-0.5' : 'justify-center'} w-[5.5ch] ${sizeConfig.padding} ${sizeConfig.text} rounded-md border ${config.bgColor} ${config.color} border-gray-300 dark:border-gray-600 ${(onClick || sessionId) ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`}
-      title={tooltipContent}
-      onClick={handleClick}
-      aria-label={ariaLabel}
-      data-testid={sessionId ? `session-${sessionId}-git-status` : 'git-status'}
-      data-git-state={gitStatus.state}
-      data-git-ahead={gitStatus.ahead}
-      data-git-behind={gitStatus.behind}
-    >
+  const content = (
+    <>
       <span className="flex-shrink-0">
         {config.icon}
       </span>
@@ -344,6 +335,26 @@ const GitStatusIndicator: React.FC<GitStatusIndicatorProps> = React.memo(({ gitS
           {primaryCount > 9 ? '★' : primaryCount}
         </span>
       )}
+    </>
+  );
+
+  const className = `inline-flex items-center ${primaryCount > 0 ? 'justify-center gap-0.5' : 'justify-center'} w-[5.5ch] ${sizeConfig.padding} ${sizeConfig.text} rounded-md border ${config.bgColor} ${config.color} border-gray-300 dark:border-gray-600 ${(onClick || sessionId) ? 'cursor-pointer hover:opacity-80 transition-opacity' : ''}`;
+  const dataProps = {
+    title: tooltipContent,
+    'aria-label': ariaLabel,
+    'data-testid': sessionId ? `session-${sessionId}-git-status` : 'git-status',
+    'data-git-state': gitStatus.state,
+    'data-git-ahead': gitStatus.ahead,
+    'data-git-behind': gitStatus.behind,
+  };
+
+  return onClick || sessionId ? (
+    <button type="button" className={className} onClick={handleClick} {...dataProps}>
+      {content}
+    </button>
+  ) : (
+    <span className={className} {...dataProps}>
+      {content}
     </span>
   );
 });

--- a/frontend/src/components/Help.tsx
+++ b/frontend/src/components/Help.tsx
@@ -70,7 +70,7 @@ interface HelpProps {
 export default function Help({ isOpen, onClose }: HelpProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl" showCloseButton={false}>
-      <ModalHeader>Pane Help</ModalHeader>
+      <ModalHeader title="Pane Help" />
       <ModalBody>
         <div className="space-y-8">
             {/* Quick Start */}

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -126,10 +126,10 @@ function OpenProjectCard({
   return (
     <Dropdown
       trigger={
-        <div className={actionCardClassName}>
+        <button type="button" className={actionCardClassName}>
           <FolderOpenIcon className="w-8 h-8 text-text-secondary" />
           <span className="text-sm font-medium text-text-primary">Open Project</span>
-        </div>
+        </button>
       }
       items={projects.map(project => ({
         id: String(project.id),
@@ -340,6 +340,7 @@ export function HomePage() {
               <div className="flex items-center gap-2">
                 <button
                   type="button"
+                  aria-label="Decrease UI scale"
                   onClick={() => void handleScaleChange(-0.1)}
                   disabled={uiScale <= 0.8}
                   className="rounded-md bg-surface-tertiary p-1 hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-40"
@@ -349,6 +350,7 @@ export function HomePage() {
                 <span className="w-10 text-center text-sm text-text-secondary">{uiScale.toFixed(1)}x</span>
                 <button
                   type="button"
+                  aria-label="Increase UI scale"
                   onClick={() => void handleScaleChange(0.1)}
                   disabled={uiScale >= 1.5}
                   className="rounded-md bg-surface-tertiary p-1 hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-40"

--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -134,6 +134,7 @@ export function SupportPaneDialog({ isOpen, onClose }: SupportPaneDialogProps) {
 
   return (
     <Modal
+      ariaLabel="Support Pane"
       isOpen={isOpen}
       onClose={onClose}
       size="sm"
@@ -314,6 +315,7 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
 
   return (
     <Modal
+      ariaLabel="Get Started with Pane"
       isOpen={isOpen}
       onClose={() => {}}
       size="md"

--- a/frontend/src/components/PaneChatView.tsx
+++ b/frontend/src/components/PaneChatView.tsx
@@ -8,6 +8,7 @@ import { PanelContainer } from './panels/PanelContainer';
 import { Button } from './ui/Button';
 import { ClaudeIcon, OpenAIIcon } from './ui/BrandIcons';
 import { cn } from '../utils/cn';
+import { LiveRegion } from './ui/LiveRegion';
 
 const PANE_CHAT_AGENT_OPTIONS: Array<{
   id: PaneChatAgent;
@@ -23,6 +24,7 @@ export function PaneChatView() {
   const [isLoading, setIsLoading] = useState(true);
   const [switchingAgent, setSwitchingAgent] = useState<PaneChatAgent | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [statusAnnouncement, setStatusAnnouncement] = useState('');
 
   const loadPaneChat = useCallback(async () => {
     setIsLoading(true);
@@ -52,6 +54,7 @@ export function PaneChatView() {
 
     setSwitchingAgent(agent);
     setError(null);
+    setStatusAnnouncement(`Switching Pane Chat to ${agent === 'claude' ? 'Claude' : 'Codex'}`);
 
     try {
       const response = await API.paneChat.setAgent(agent);
@@ -59,6 +62,7 @@ export function PaneChatView() {
         throw new Error(response.error || 'Failed to switch Pane Chat agent');
       }
       setState(response.data);
+      setStatusAnnouncement(`Pane Chat is now using ${agent === 'claude' ? 'Claude' : 'Codex'}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to switch Pane Chat agent');
     } finally {
@@ -69,8 +73,8 @@ export function PaneChatView() {
   if (isLoading && !state) {
     return (
       <div className="flex-1 flex items-center justify-center bg-bg-primary text-text-secondary">
-        <div className="flex items-center gap-2 text-sm">
-          <RefreshCw className="h-4 w-4 animate-spin" />
+        <div role="status" aria-live="polite" className="flex items-center gap-2 text-sm">
+          <RefreshCw aria-hidden="true" className="h-4 w-4 animate-spin" />
           <span>Opening Pane Chat...</span>
         </div>
       </div>
@@ -83,7 +87,7 @@ export function PaneChatView() {
         <div className="max-w-md text-center">
           <Terminal className="mx-auto mb-3 h-8 w-8 text-text-tertiary" />
           <h2 className="text-base font-semibold text-text-primary">Pane Chat did not open</h2>
-          <p className="mt-2 text-sm text-text-secondary">{error ?? 'Unknown error'}</p>
+          <p role="alert" className="mt-2 text-sm text-text-secondary">{error ?? 'Unknown error'}</p>
           <Button
             type="button"
             variant="secondary"
@@ -101,45 +105,49 @@ export function PaneChatView() {
 
   return (
     <div className="pane-chat-shell flex-1 flex flex-col overflow-hidden bg-bg-primary">
+      <LiveRegion>{statusAnnouncement}</LiveRegion>
       <div className="flex h-11 flex-shrink-0 items-center justify-between border-b border-border-primary px-4">
         <div className="flex min-w-0 items-center gap-2">
           <Terminal className="h-4 w-4 flex-shrink-0 text-text-tertiary" />
           <h1 className="truncate text-sm font-semibold text-text-primary">Pane Chat</h1>
           {error && (
-            <span className="truncate text-xs text-status-error">{error}</span>
+            <span role="alert" className="truncate text-xs text-status-error">{error}</span>
           )}
         </div>
-        <div
-          role="tablist"
-          aria-label="Pane Chat agent"
+        <fieldset
           className="flex h-8 flex-shrink-0 items-center rounded-md border border-border-secondary bg-surface-secondary p-0.5"
         >
+          <legend className="sr-only">Pane Chat agent</legend>
           {PANE_CHAT_AGENT_OPTIONS.map((option) => {
             const Icon = switchingAgent === option.id ? RefreshCw : option.icon;
             const selected = state.agent === option.id;
 
             return (
-              <button
+              <label
                 key={option.id}
-                type="button"
-                role="tab"
-                aria-selected={selected}
-                aria-label={`Use ${option.label} for Pane Chat`}
-                disabled={switchingAgent !== null}
-                onClick={() => void handleAgentChange(option.id)}
                 className={cn(
-                  'inline-flex h-7 min-w-[76px] items-center justify-center gap-1.5 rounded px-2 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-interactive disabled:cursor-not-allowed disabled:opacity-70',
+                  'relative inline-flex h-7 min-w-[76px] cursor-pointer items-center justify-center gap-1.5 rounded px-2 text-xs font-medium transition-colors focus-within:ring-2 focus-within:ring-interactive',
+                  switchingAgent !== null && 'cursor-not-allowed opacity-70',
                   selected
                     ? 'bg-bg-primary text-text-primary shadow-sm'
                     : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
                 )}
               >
+                <input
+                  type="radio"
+                  name="pane-chat-agent"
+                  value={option.id}
+                  checked={selected}
+                  disabled={switchingAgent !== null}
+                  onChange={() => void handleAgentChange(option.id)}
+                  className="sr-only"
+                />
                 <Icon className={cn('h-3.5 w-3.5', switchingAgent === option.id && 'animate-spin')} />
                 <span>{option.label}</span>
-              </button>
+              </label>
             );
           })}
-        </div>
+        </fieldset>
       </div>
 
       <SessionProvider session={state.session}>

--- a/frontend/src/components/PaneChatView.tsx
+++ b/frontend/src/components/PaneChatView.tsx
@@ -138,7 +138,7 @@ export function PaneChatView() {
                   name="pane-chat-agent"
                   value={option.id}
                   checked={selected}
-                  disabled={switchingAgent !== null}
+                  aria-disabled={switchingAgent !== null || undefined}
                   onChange={() => void handleAgentChange(option.id)}
                   className="sr-only"
                 />

--- a/frontend/src/components/PermissionDialog.tsx
+++ b/frontend/src/components/PermissionDialog.tsx
@@ -138,17 +138,12 @@ export const PermissionDialog: React.FC<PermissionDialogProps> = ({ request, onR
 
   return (
     <Modal isOpen={true} onClose={() => handleDeny()} size="lg" showCloseButton={false}>
-      <ModalHeader onClose={() => handleDeny()}>
-        <div className="flex items-center gap-3">
-          <Shield className={`w-6 h-6 ${isHighRisk(request.toolName) ? 'text-status-error' : 'text-status-warning'}`} />
-          <div className="flex-1">
-            <h2 className="text-xl font-semibold text-text-primary">Permission Required</h2>
-            <p className="text-sm text-text-secondary mt-1">
-              Claude wants to {getToolDescription(request.toolName)} in session: {session?.name || request.sessionId}
-            </p>
-          </div>
-        </div>
-      </ModalHeader>
+      <ModalHeader
+        title="Permission Required"
+        icon={<Shield className={`w-6 h-6 ${isHighRisk(request.toolName) ? 'text-status-error' : 'text-status-warning'}`} />}
+        description={<>Claude wants to {getToolDescription(request.toolName)} in session: {session?.name || request.sessionId}</>}
+        onClose={() => handleDeny()}
+      />
         
       <ModalBody className="space-y-6">
           <div>

--- a/frontend/src/components/ProjectDashboard.tsx
+++ b/frontend/src/components/ProjectDashboard.tsx
@@ -12,6 +12,7 @@ import { MultiOriginStatus } from './dashboard/MultiOriginStatus';
 import { StatusSummaryCards } from './dashboard/StatusSummaryCards';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
+import { LiveRegion } from './ui/LiveRegion';
 
 interface ProjectDashboardProps {
   projectId: number;
@@ -25,6 +26,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
   const [error, setError] = useState<string | null>(null);
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
   const [filterType, setFilterType] = useState<'all' | 'stale' | 'changes' | 'pr'>('all');
+  const [statusAnnouncement, setStatusAnnouncement] = useState('');
   const [isProgressive] = useState(true); // Use progressive loading by default
   const pendingSessionUpdatesRef = useRef<Map<string, SessionBranchInfo>>(new Map());
 
@@ -65,6 +67,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
       if (cachedData) {
         setDashboardData(cachedData);
         setLastRefreshTime(new Date(Date.now() - 30000)); // Show it was from cache
+        setStatusAnnouncement('Dashboard loaded from cache');
         return;
       }
     }
@@ -72,6 +75,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
     setIsLoading(!dashboardData); // Only show loading on initial load
     setIsRefreshing(!!dashboardData); // Show refreshing if we already have data
     setError(null);
+    setStatusAnnouncement(dashboardData ? 'Refreshing dashboard' : 'Loading dashboard');
     
     try {
       if (useProgressive && isProgressive) {
@@ -83,6 +87,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
           setLastRefreshTime(new Date());
           // Cache the data
           dashboardCache.set(projectId, response.data);
+          setStatusAnnouncement('Dashboard updated');
         } else {
           setError(response.error || 'Failed to fetch project status');
         }
@@ -95,6 +100,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
           setLastRefreshTime(new Date());
           // Cache the data
           dashboardCache.set(projectId, response.data);
+          setStatusAnnouncement('Dashboard updated');
         } else {
           setError(response.error || 'Failed to fetch project status');
         }
@@ -210,15 +216,15 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
     };
     
     return (
-      <tr key={session.sessionId} className={`hover:bg-surface-hover ${staleClass} cursor-pointer`} onClick={handleSessionClick}>
+      <tr key={session.sessionId} className={`hover:bg-surface-hover ${staleClass}`}>
         <td className="px-4 py-3 text-sm">
-          <div className="flex items-center gap-2">
+          <button type="button" className="flex w-full items-center gap-2 text-left" onClick={handleSessionClick}>
             <GitBranch className="w-4 h-4 text-text-tertiary" />
             <div>
               <div className="font-medium text-text-primary">{session.sessionName}</div>
               <div className="text-text-tertiary text-xs">{session.branchName}</div>
             </div>
-          </div>
+          </button>
         </td>
         <td className="px-4 py-3 text-sm text-text-secondary">
           <code className="text-xs bg-surface-secondary px-1 py-0.5 rounded">
@@ -268,7 +274,6 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-interactive hover:text-interactive-hover"
-              onClick={(e) => e.stopPropagation()}
             >
               <GitPullRequest className="w-4 h-4" />
               <span>#{session.pullRequest.number}</span>
@@ -308,13 +313,14 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
 
   if (error) {
     return (
-      <div className="p-6 bg-status-error/10 rounded-lg">
+      <div role="alert" className="p-6 bg-status-error/10 rounded-lg">
         <div className="flex items-center gap-2 text-status-error">
           <AlertCircle className="w-5 h-5" />
           <span className="font-medium">Error loading dashboard</span>
         </div>
         <p className="mt-1 text-sm text-status-error/80">{error}</p>
         <button
+          type="button"
           onClick={() => fetchDashboardData(false)}
           className="mt-3 px-3 py-1 text-sm bg-status-error text-text-on-status-error rounded hover:bg-status-error-hover"
         >
@@ -325,11 +331,12 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
   }
 
   if (isLoading && !dashboardData) {
-    return <ProjectDashboardSkeleton />;
+    return <div><LiveRegion>{statusAnnouncement}</LiveRegion><ProjectDashboardSkeleton /></div>;
   }
 
   return (
     <Card className="flex flex-col h-full">
+      <LiveRegion>{statusAnnouncement}</LiveRegion>
       <div className="px-6 py-4 border-b border-border-primary">
         <div className="flex items-center justify-between">
           <div>

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -747,7 +747,7 @@ function SessionRow({
           className="absolute inset-0 z-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-interactive"
         />
       </Tooltip>
-      <div className="relative z-10 pointer-events-none contents">
+      <div className="pointer-events-none contents">
         <SessionRowContent
           session={session}
           gs={gs}
@@ -761,7 +761,7 @@ function SessionRow({
           rowLayout={rowLayout}
         />
 
-        <div className="pointer-events-auto flex flex-shrink-0 items-center gap-0.5">
+        <div className="relative z-10 pointer-events-auto flex flex-shrink-0 items-center gap-0.5">
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onArchive(); }}

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, useId } from 'react';
 import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { useSessionStore } from '../stores/sessionStore';
@@ -434,19 +434,10 @@ export function ProjectSessionList({
               {/* Project header */}
               <div
                 className={cn(
-                  "group/project flex items-center gap-1.5 pl-3 pr-2 py-1.5 hover:bg-surface-hover transition-colors cursor-pointer",
+                  "group/project relative flex items-center gap-1.5 pl-3 pr-2 py-1.5 hover:bg-surface-hover transition-colors",
                   dragOverProjectId === project.id && dragProjectId !== project.id && "bg-interactive/20",
                   dragProjectId === project.id && "opacity-50"
                 )}
-                onClick={() => toggleProject(project.id)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    toggleProject(project.id);
-                  }
-                }}
                 draggable
                 onDragStart={(e) => handleProjectDragStart(e, project.id)}
                 onDragOver={(e) => handleProjectDragOver(e, project.id)}
@@ -457,27 +448,35 @@ export function ProjectSessionList({
                 <Tooltip
                   content={<span className="text-[10px] text-text-tertiary font-mono break-all">{project.path}</span>}
                   side="right"
-                  className="min-w-0 flex-1"
                 >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-1.5 min-w-0">
-                      <span className="min-w-0 truncate text-xs font-semibold text-text-primary">{project.name}</span>
-                      <span className={cn(
-                        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
-                        projectActivity === 'active'
-                          ? 'bg-status-info opacity-100 duration-150'
-                          : 'bg-text-muted/20 opacity-40 duration-[3s]'
-                      )} />
-                    </div>
-                  </div>
+                  <button
+                    type="button"
+                    onClick={() => toggleProject(project.id)}
+                    aria-expanded={isExpanded}
+                    aria-controls={`project-sessions-${project.id}`}
+                    aria-label={`${isExpanded ? 'Collapse' : 'Expand'} repository ${project.name}`}
+                    className="absolute inset-0 z-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-interactive"
+                  />
                 </Tooltip>
+                <div className="relative z-10 pointer-events-none flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className="min-w-0 truncate text-xs font-semibold text-text-primary">{project.name}</span>
+                    <span className={cn(
+                      "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
+                      projectActivity === 'active'
+                        ? 'bg-status-info opacity-100 duration-150'
+                        : 'bg-text-muted/20 opacity-40 duration-[3s]'
+                    )} />
+                  </div>
+                </div>
                 <div
-                  className="flex-shrink-0 opacity-0 group-hover/project:opacity-100 transition-opacity ml-auto"
-                  onClick={(e) => e.stopPropagation()}
+                  className="relative z-10 flex-shrink-0 opacity-0 group-hover/project:opacity-100 group-focus-within/project:opacity-100 transition-opacity ml-auto"
                 >
                   <Dropdown
                     trigger={
                       <button
+                        type="button"
+                        aria-label={`Repository actions for ${project.name}`}
                         className="p-1 rounded text-text-muted hover:text-text-tertiary hover:bg-surface-hover transition-colors"
                       >
                         <MoreHorizontal className="w-3.5 h-3.5" />
@@ -489,19 +488,20 @@ export function ProjectSessionList({
                   />
                 </div>
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     handleNewSession(project);
                   }}
-                  className="flex-shrink-0 p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-surface-hover transition-colors"
-                  title="New workspace"
+                  className="relative z-10 inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-text-tertiary hover:text-text-primary hover:bg-surface-hover transition-colors"
+                  aria-label={`New pane in ${project.name}`}
                 >
                   <Plus className="w-3.5 h-3.5" />
                 </button>
               </div>
 
               {isExpanded && projectSessions.length > 0 && (
-                <div className="mt-0.5">
+                <div id={`project-sessions-${project.id}`} className="mt-0.5">
                   {projectSessions.map((session) => (
                     <SessionRow
                       key={session.id}
@@ -722,32 +722,32 @@ function SessionRow({
   const dels = (gs?.commitDeletions ?? 0) + (gs?.deletions ?? 0);
   const hasDiff = adds > 0 || dels > 0;
   const showActivity = sessionActivity === 'active';
+  const accessibleName = displayName || gs?.prTitle || session.name || 'Untitled';
 
   return (
-    <Tooltip
-      content={<SessionDetailTooltip session={session} gitStatus={localGitStatus} showName={false} showDiffStats={false} globalIndex={globalIndex} />}
-      side="right"
-      className="block w-full"
-      interactive
+    <div
+      className={cn(
+        'group/session relative w-full text-left pl-2 pr-2 transition-colors flex items-center gap-1',
+        rowLayout === 'single' ? 'py-1.5' : 'py-2',
+        isActive
+          ? 'bg-interactive/30 border-l-4 border-interactive'
+          : 'hover:bg-surface-hover border-l-4 border-transparent'
+      )}
     >
-      <div
-        className={cn(
-          'group/session relative w-full text-left pl-2 pr-2 transition-colors flex items-center gap-1 cursor-pointer',
-          rowLayout === 'single' ? 'py-1.5' : 'py-2',
-          isActive
-            ? 'bg-interactive/30 border-l-4 border-interactive'
-            : 'hover:bg-surface-hover border-l-4 border-transparent'
-        )}
-        onClick={onClick}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onClick();
-          }
-        }}
+      <Tooltip
+        content={<SessionDetailTooltip session={session} gitStatus={localGitStatus} showName={false} showDiffStats={false} globalIndex={globalIndex} />}
+        side="right"
+        interactive
       >
+        <button
+          type="button"
+          onClick={onClick}
+          aria-current={isActive ? 'page' : undefined}
+          aria-label={accessibleName}
+          className="absolute inset-0 z-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-interactive"
+        />
+      </Tooltip>
+      <div className="relative z-10 pointer-events-none contents">
         <SessionRowContent
           session={session}
           gs={gs}
@@ -755,23 +755,25 @@ function SessionRow({
           hasDiff={hasDiff}
           adds={adds}
           dels={dels}
-          displayName={displayName}
+          displayName={accessibleName}
           showActivity={showActivity}
           showUnviewedCompleted={hasUnviewedCompletedActivity && !isActive && !showActivity}
           rowLayout={rowLayout}
         />
 
-        <div className="flex flex-shrink-0 items-center gap-0.5">
+        <div className="pointer-events-auto flex flex-shrink-0 items-center gap-0.5">
           <button
+            type="button"
             onClick={(e) => { e.stopPropagation(); onArchive(); }}
             className="inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-text-muted hover:text-status-error hover:bg-surface-hover transition-all opacity-0 group-hover/session:opacity-100"
             title="Archive"
-            aria-label="Archive pane"
+            aria-label={`Archive ${accessibleName}`}
           >
             <Archive className="w-3.5 h-3.5" />
           </button>
 
           <button
+            type="button"
             onClick={(e) => { e.stopPropagation(); onTogglePinned(); }}
             className={`inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded transition-all ${
               session.isFavorite
@@ -779,19 +781,20 @@ function SessionRow({
                 : 'text-text-muted hover:text-text-tertiary hover:bg-surface-hover opacity-0 group-hover/session:opacity-100'
             }`}
             title={session.isFavorite ? 'Unpin' : 'Pin'}
-            aria-label={session.isFavorite ? 'Unpin pane' : 'Pin pane'}
+            aria-label={`${session.isFavorite ? 'Unpin' : 'Pin'} ${accessibleName}`}
           >
             <Pin className="w-3.5 h-3.5 rotate-45" />
           </button>
         </div>
       </div>
-    </Tooltip>
+    </div>
   );
 }
 
 // --- Archived Sessions panel (pinned to sidebar bottom) ---
 
 export function ArchivedSessions() {
+  const archivedContentId = useId();
   const [showArchived, setShowArchived] = useState(false);
   const [archivedProjects, setArchivedProjects] = useState<Array<Project & { sessions: Session[] }>>([]);
   const [expandedArchivedProjects, setExpandedArchivedProjects] = useState<Set<number>>(new Set());
@@ -852,7 +855,10 @@ export function ArchivedSessions() {
   return (
     <div className="border-t border-border-primary">
       <button
+        type="button"
         onClick={toggleArchived}
+        aria-expanded={showArchived}
+        aria-controls={archivedContentId}
         className="w-full flex items-center gap-2 px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
       >
         {showArchived ? (
@@ -870,7 +876,7 @@ export function ArchivedSessions() {
       </button>
 
       {showArchived && (
-        <div className="pb-2 max-h-[40vh] overflow-y-auto">
+        <div id={archivedContentId} className="pb-2 max-h-[40vh] overflow-y-auto">
           {isLoadingArchived ? (
             <div className="px-4 py-2 space-y-2 animate-pulse">
               {[1, 2, 3].map(i => (
@@ -887,7 +893,10 @@ export function ArchivedSessions() {
               return (
                 <div key={`archived-${project.id}`}>
                   <button
+                    type="button"
                     onClick={() => toggleArchivedProject(project.id)}
+                    aria-expanded={isExpanded}
+                    aria-controls={`archived-project-${project.id}`}
                     className="w-full flex items-center gap-2 px-6 py-1.5 text-xs text-text-tertiary hover:text-text-secondary hover:bg-surface-hover transition-colors"
                   >
                     {isExpanded ? (
@@ -898,21 +907,18 @@ export function ArchivedSessions() {
                     <span className="truncate">{project.name}</span>
                     <span className="ml-auto text-text-muted text-[10px]">{project.sessions.length}</span>
                   </button>
-                  {isExpanded && project.sessions.map(session => (
+                  {isExpanded && <div id={`archived-project-${project.id}`}>{project.sessions.map(session => (
                     <div
                       key={session.id}
-                      className="group/archived flex items-center gap-1 pl-10 pr-1 py-1.5 hover:bg-surface-hover transition-colors cursor-pointer"
-                      onClick={() => handleSessionClick(session.id)}
-                      role="button"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          handleSessionClick(session.id);
-                        }
-                      }}
+                      className="group/archived relative flex items-center gap-1 pl-10 pr-1 py-1.5 hover:bg-surface-hover transition-colors"
                     >
-                      <div className="flex-1 text-left min-w-0">
+                      <button
+                        type="button"
+                        onClick={() => handleSessionClick(session.id)}
+                        aria-label={`Open archived pane ${session.name || 'Untitled'}`}
+                        className="absolute inset-0 z-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-interactive"
+                      />
+                      <div className="relative z-10 pointer-events-none flex-1 text-left min-w-0">
                         <div className="flex items-center gap-2 min-w-0">
                           <Archive className="w-3 h-3 flex-shrink-0 text-text-muted" />
                           <span className="text-xs text-text-tertiary truncate">
@@ -921,14 +927,15 @@ export function ArchivedSessions() {
                         </div>
                       </div>
                       <button
+                        type="button"
                         onClick={(e) => { e.stopPropagation(); handleRestoreSession(session.id); }}
-                        className="flex-shrink-0 p-1 rounded text-text-muted hover:text-status-success hover:bg-surface-hover transition-all opacity-0 group-hover/archived:opacity-100"
-                        title="Restore"
+                        className="relative z-10 flex-shrink-0 p-1 rounded text-text-muted hover:text-status-success hover:bg-surface-hover transition-all opacity-0 group-hover/archived:opacity-100 group-focus-within/archived:opacity-100"
+                        aria-label={`Restore ${session.name || 'Untitled'}`}
                       >
                         <ArchiveRestore className="w-3 h-3" />
                       </button>
                     </div>
-                  ))}
+                  ))}</div>}
                 </div>
               );
             })

--- a/frontend/src/components/ProjectSettings.tsx
+++ b/frontend/src/components/ProjectSettings.tsx
@@ -126,8 +126,7 @@ export default function ProjectSettings({ project, isOpen, onClose, onUpdate, on
         title="Project Settings" 
         icon={<Settings className="w-5 h-5" />}
         onClose={onClose}
-      >
-        <div className="flex items-center gap-2">
+        actions={
           <Button
             onClick={handleSave}
             disabled={isSaving || !name || !path}
@@ -139,8 +138,8 @@ export default function ProjectSettings({ project, isOpen, onClose, onUpdate, on
           >
             Save Changes
           </Button>
-        </div>
-      </ModalHeader>
+        }
+      />
 
       <ModalBody>
         {error && (

--- a/frontend/src/components/PromptDetailModal.tsx
+++ b/frontend/src/components/PromptDetailModal.tsx
@@ -4,6 +4,7 @@ import { formatDistanceToNow } from '../utils/formatters';
 import { formatDuration, getTimeDifference, isValidTimestamp, parseTimestamp } from '../utils/timestampUtils';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { IconButton } from './ui/IconButton';
+import { LiveRegion } from './ui/LiveRegion';
 
 interface PromptMarker {
   id: number;
@@ -60,18 +61,16 @@ export function PromptDetailModal({ prompt, promptIndex, onClose }: PromptDetail
 
   return (
     <Modal isOpen={true} onClose={onClose} size="lg" showCloseButton={false}>
-      <ModalHeader onClose={onClose}>
-        <div className="flex items-center justify-between flex-1 pr-2">
-          <div className="flex items-center space-x-3">
-            <h2 className="text-lg font-semibold text-text-primary">
-              Prompt #{promptIndex + 1}
-            </h2>
-            <div className="flex items-center space-x-2 text-sm text-text-tertiary">
-              <span>{formatDistanceToNow(parseTimestamp(prompt.timestamp))} ago</span>
-              <span className="text-text-tertiary">•</span>
-              <span className="font-medium">{calculateDuration()}</span>
-            </div>
+      <ModalHeader
+        title={`Prompt #${promptIndex + 1}`}
+        description={
+          <div className="flex items-center space-x-2 text-sm text-text-tertiary">
+            <span>{formatDistanceToNow(parseTimestamp(prompt.timestamp))} ago</span>
+            <span aria-hidden="true">&middot;</span>
+            <span className="font-medium">{calculateDuration()}</span>
           </div>
+        }
+        actions={
           <IconButton
             onClick={handleCopy}
             variant="ghost"
@@ -79,8 +78,9 @@ export function PromptDetailModal({ prompt, promptIndex, onClose }: PromptDetail
             aria-label="Copy prompt"
             icon={copied ? <Check className="h-4 w-4 text-status-success" /> : <Copy className="h-4 w-4" />}
           />
-        </div>
-      </ModalHeader>
+        }
+        onClose={onClose}
+      />
 
       <ModalBody>
         <pre className="whitespace-pre-wrap font-mono text-sm text-text-primary bg-surface-primary p-4 rounded-md border border-border-secondary">
@@ -94,6 +94,7 @@ export function PromptDetailModal({ prompt, promptIndex, onClose }: PromptDetail
           <span>Double-click any prompt to view details</span>
         </div>
       </ModalFooter>
+      <LiveRegion>{copied ? 'Prompt copied to clipboard' : ''}</LiveRegion>
     </Modal>
   );
 }

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -6,6 +6,7 @@ import { useHotkey } from '../hooks/useHotkey';
 import { useHotkeyStore } from '../stores/hotkeyStore';
 import { HomePage } from './HomePage';
 import { PaneChatView } from './PaneChatView';
+import { LiveRegion } from './ui/LiveRegion';
 import '@xterm/xterm/css/xterm.css';
 import { useSessionView } from '../hooks/useSessionView';
 import { DetailPanel } from './DetailPanel';
@@ -125,6 +126,16 @@ export const SessionView = memo(() => {
     // Otherwise look in regular sessions
     return state.sessions.find(session => session.id === state.activeSessionId);
   });
+  const lastAnnouncedSessionStateRef = useRef<string | null>(activeSession?.status ?? null);
+  const [sessionStatusAnnouncement, setSessionStatusAnnouncement] = useState('');
+
+  useEffect(() => {
+    if (!activeSession || lastAnnouncedSessionStateRef.current === activeSession.status) return;
+    lastAnnouncedSessionStateRef.current = activeSession.status;
+    setSessionStatusAnnouncement(
+      `${activeSession.name || 'Pane'} is ${activeSession.status}${activeSession.statusMessage ? `: ${activeSession.statusMessage}` : ''}`,
+    );
+  }, [activeSession?.id, activeSession?.name, activeSession?.status, activeSession?.statusMessage]);
 
   // Panel store state and actions
   const {
@@ -1717,6 +1728,9 @@ export const SessionView = memo(() => {
   
   return (
     <div className="pane-session-shell flex-1 flex flex-col overflow-hidden bg-bg-primary">
+      <LiveRegion mode={activeSession.status === 'error' ? 'assertive' : 'polite'}>
+        {sessionStatusAnnouncement}
+      </LiveRegion>
       {/* SINGLE SessionProvider wraps everything */}
       <SessionProvider session={activeSession} gitBranchActions={branchActions} isMerging={hook.isMerging} gitCommands={hook.gitCommands} onOpenIDEWithCommand={handleOpenIDEWithCommand} onConfigureIDE={() => setShowProjectSettings(true)} onSetTracking={handleOpenSetTracking} trackingBranch={currentUpstream} configuredIDECommand={sessionProject?.open_ide_command} isRemoteMode={isRemoteMode}>
 
@@ -1937,10 +1951,10 @@ export const SessionView = memo(() => {
                         {/* Custom command pills */}
                         {customCommands.map((cmd, index) => {
                           const shortcutDisplay = hotkeyDisplay(`add-tool-custom-${index}`);
-                          const pill = (
-                            <span
-                              key={`shortcut-${index}`}
-                              className="group/pill inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-[11px] font-medium text-text-tertiary border border-border-primary hover:bg-surface-hover hover:text-text-secondary transition-colors whitespace-nowrap flex-shrink-0 cursor-pointer"
+                          const commandButton = (
+                            <button
+                              type="button"
+                              className="inline-flex items-center gap-1 pl-2 py-0.5 text-[11px] font-medium text-text-tertiary hover:text-text-secondary whitespace-nowrap"
                               onClick={() => handlePanelCreate('terminal', {
                                 initialCommand: cmd.command,
                                 title: cmd.name
@@ -1949,20 +1963,28 @@ export const SessionView = memo(() => {
                             >
                               {getCliBrandIcon(cmd.command, 'w-3 h-3') || <TerminalSquare className="w-3 h-3" />}
                               {cmd.name.length > 13 ? cmd.name.slice(0, 13) + '…' : cmd.name}
+                            </button>
+                          );
+                          return (
+                            <span
+                              key={`shortcut-${index}`}
+                              className="group/pill inline-flex items-center gap-0 pr-1 rounded-full text-text-tertiary border border-border-primary hover:bg-surface-hover transition-colors whitespace-nowrap flex-shrink-0"
+                            >
+                              {shortcutDisplay ? (
+                                <Tooltip content={<Kbd>{shortcutDisplay}</Kbd>} side="top">
+                                  {commandButton}
+                                </Tooltip>
+                              ) : commandButton}
                               <button
-                                className="p-0.5 rounded-full opacity-0 group-hover/pill:opacity-100 hover:bg-surface-tertiary hover:text-text-primary transition-all"
-                                onClick={(e) => { e.stopPropagation(); deleteCustomCommand(index); }}
-                                title="Remove shortcut"
+                                type="button"
+                                className="p-0.5 rounded-full opacity-0 group-hover/pill:opacity-100 group-focus-within/pill:opacity-100 hover:bg-surface-tertiary hover:text-text-primary transition-all"
+                                onClick={() => deleteCustomCommand(index)}
+                                aria-label={`Remove ${cmd.name} shortcut`}
                               >
                                 <X className="w-2.5 h-2.5" />
                               </button>
                             </span>
                           );
-                          return shortcutDisplay ? (
-                            <Tooltip key={`shortcut-${index}`} content={<Kbd>{shortcutDisplay}</Kbd>} side="top">
-                              {pill}
-                            </Tooltip>
-                          ) : pill;
                         })}
                       </div>
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -217,9 +217,12 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
     startActive();
   }, [refresh, startActive]);
 
-  const closeResourcePopover = useCallback(() => {
+  const closeResourcePopover = useCallback((restoreFocus = false) => {
     setShowResourcePopover(false);
     stopActive();
+    if (restoreFocus) {
+      requestAnimationFrame(() => resourceMenuButtonRef.current?.focus());
+    }
   }, [stopActive]);
 
   const toggleResourceSection = useCallback((id: string) => {
@@ -272,6 +275,12 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
   useEffect(() => {
     if (!showResourcePopover) return;
 
+    const focusFrame = requestAnimationFrame(() => {
+      resourcePopoverRef.current
+        ?.querySelector<HTMLElement>('button:not(:disabled), [tabindex="0"]')
+        ?.focus();
+    });
+
     const handleClickOutside = (event: MouseEvent) => {
       const target = event.target as Node;
       if (
@@ -284,6 +293,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
 
     const timer = setTimeout(() => document.addEventListener('mousedown', handleClickOutside), 0);
     return () => {
+      cancelAnimationFrame(focusFrame);
       clearTimeout(timer);
       document.removeEventListener('mousedown', handleClickOutside);
     };
@@ -293,7 +303,10 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
     if (!showResourcePopover) return;
 
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeResourcePopover();
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeResourcePopover(true);
+      }
     };
 
     document.addEventListener('keydown', handleEscape);
@@ -665,21 +678,22 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
             </Tooltip>
             {version && (
               <div className="flex items-center justify-center gap-1.5 text-xs text-text-tertiary truncate">
-                <span
-                  className="cursor-pointer hover:text-text-secondary transition-colors"
+                <button
+                  type="button"
+                  className="hover:text-text-secondary transition-colors"
                   onClick={onAboutClick}
-                  title="Click to view version details"
+                  aria-label={`About Pane version ${version}`}
                 >
                   v{version}{worktreeName && ` \u00b7 ${worktreeName}`}{gitCommit && ` \u00b7 ${gitCommit}`}
-                </span>
+                </button>
                 <span className="text-border-primary">&middot;</span>
-                <span
-                  className="cursor-pointer hover:text-text-secondary transition-colors"
+                <button
+                  type="button"
+                  className="hover:text-text-secondary transition-colors"
                   onClick={onDocsClick}
-                  title="Open documentation"
                 >
                   Docs
-                </span>
+                </button>
               </div>
             )}
           </div>
@@ -689,6 +703,10 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
       {showResourcePopover && createPortal(
         <div
           ref={resourcePopoverRef}
+          role="dialog"
+          aria-label="Resource Usage"
+          aria-busy={resourceLoading}
+          tabIndex={-1}
           className="bg-surface-primary border border-border-subtle/60 rounded-lg shadow-dropdown-elevated backdrop-blur-sm animate-dropdown-enter overflow-hidden w-[320px] max-w-[calc(100vw-16px)]"
           style={resourcePopoverStyle}
         >
@@ -697,12 +715,13 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
               Resource Usage
             </span>
             <button
+              type="button"
               onClick={handleResourceRefresh}
               className="p-1 rounded text-text-tertiary hover:text-text-primary hover:bg-surface-hover transition-colors"
               disabled={resourceLoading}
               aria-label="Refresh resource usage"
             >
-              <RefreshCw className={`w-3.5 h-3.5 ${resourceLoading ? 'animate-spin' : ''}`} />
+              <RefreshCw aria-hidden="true" className={`w-3.5 h-3.5 ${resourceLoading ? 'animate-spin' : ''}`} />
             </button>
           </div>
 
@@ -724,7 +743,10 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
               <div className="max-h-[400px] overflow-y-auto">
                 <div className="border-b border-border-secondary">
                   <button
+                    type="button"
                     onClick={() => toggleResourceSection('pane-app')}
+                    aria-expanded={expandedResourceSections.has('pane-app')}
+                    aria-controls="resource-pane-app-processes"
                     className="flex items-center justify-between w-full px-3 py-1.5 hover:bg-surface-hover transition-colors"
                   >
                     <div className="flex items-center gap-1.5">
@@ -738,7 +760,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                       <span>{formatMemory(electronTotalMem)}</span>
                     </div>
                   </button>
-                  {expandedResourceSections.has('pane-app') && snapshot.electronProcesses.map(p => (
+                  {expandedResourceSections.has('pane-app') && <div id="resource-pane-app-processes">{snapshot.electronProcesses.map(p => (
                     <div key={p.pid} className="flex items-center justify-between px-3 py-1 pl-8">
                       <span className="text-xs text-text-secondary">{p.label}</span>
                       <div className="flex items-center gap-3 text-xs text-text-tertiary font-mono">
@@ -746,13 +768,16 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                         <span>{formatMemory(p.memoryMB)}</span>
                       </div>
                     </div>
-                  ))}
+                  ))}</div>}
                 </div>
 
                 {snapshot.sessions.map(sess => (
                   <div key={sess.sessionId} className="border-b border-border-secondary">
                     <button
+                      type="button"
                       onClick={() => toggleResourceSection(sess.sessionId)}
+                      aria-expanded={expandedResourceSections.has(sess.sessionId)}
+                      aria-controls={`resource-session-${sess.sessionId}`}
                       className="flex items-center justify-between w-full px-3 py-1.5 hover:bg-surface-hover transition-colors"
                     >
                       <div className="flex items-center gap-1.5 min-w-0">
@@ -766,7 +791,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                         <span>{formatMemory(sess.totalMemoryMB)}</span>
                       </div>
                     </button>
-                    {expandedResourceSections.has(sess.sessionId) && sess.children.map(child => (
+                    {expandedResourceSections.has(sess.sessionId) && <div id={`resource-session-${sess.sessionId}`}>{sess.children.map(child => (
                       <div key={child.pid} className="flex items-center justify-between px-3 py-1 pl-8">
                         <span className="text-xs text-text-secondary truncate">{child.name}</span>
                         <div className="flex items-center gap-3 text-xs text-text-tertiary font-mono flex-shrink-0 ml-2">
@@ -774,7 +799,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                           <span>{formatMemory(child.memoryMB)}</span>
                         </div>
                       </div>
-                    ))}
+                    ))}</div>}
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/Button';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { isMac } from '../utils/platformUtils';
+import { LiveRegion } from './ui/LiveRegion';
 
 interface UpdateDialogProps {
   isOpen: boolean;
@@ -300,6 +301,16 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     return formatBytes(bytesPerSecond) + '/s';
   };
   const isUpdateBusy = updateState === 'checking' || updateState === 'available' || updateState === 'downloading' || updateState === 'installing';
+  const progressMilestone = downloadProgress ? Math.floor(downloadProgress.percent / 10) * 10 : 0;
+  const statusAnnouncement = message ?? ({
+    idle: '',
+    checking: 'Checking for updates',
+    available: 'Update available',
+    downloading: `Downloading update: ${progressMilestone}%`,
+    downloaded: 'Update downloaded',
+    installing: 'Installing update',
+    error: '',
+  } satisfies Record<UpdateState, string>)[updateState];
 
   const renderMacUpdateActions = () => (
     <div className="space-y-4">
@@ -371,12 +382,12 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       closeOnEscape={!isUpdateBusy}
       closeOnOverlayClick={!isUpdateBusy}
     >
-      <ModalHeader onClose={isUpdateBusy ? undefined : onClose}>
-        <div className="flex items-center gap-3">
-          <Download className="w-6 h-6 text-interactive" />
-          <h2 className="text-xl font-semibold text-text-primary">Software Update</h2>
-        </div>
-      </ModalHeader>
+      <LiveRegion>{statusAnnouncement}</LiveRegion>
+      <ModalHeader
+        title="Software Update"
+        icon={<Download className="w-6 h-6 text-interactive" />}
+        onClose={isUpdateBusy ? undefined : onClose}
+      />
 
       <ModalBody className="space-y-6">
           {versionInfo && (
@@ -551,7 +562,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                 )}
 
                 {/* Error Details */}
-                <div className="bg-status-error/10 border border-status-error/30 rounded-lg p-4">
+              <div role="alert" className="bg-status-error/10 border border-status-error/30 rounded-lg p-4">
                   <div className="flex items-start gap-3">
                     <AlertCircle className="w-5 h-5 text-status-error mt-0.5" />
                     <div className="flex-1">

--- a/frontend/src/components/panels/PanelGroupView.tsx
+++ b/frontend/src/components/panels/PanelGroupView.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-import { PanelTabStrip } from './PanelTabStrip';
+import { getPanelTabId, getPanelTabPanelId, PanelTabStrip } from './PanelTabStrip';
 import { PanelContainer } from './PanelContainer';
 import type { ToolPanel, PanelGroupNode } from '../../../../shared/types/panels';
 import { dropZoneFor, subsetInsertIndex, type DropZone } from '../../utils/panelLayout';
@@ -190,10 +190,10 @@ export const PanelGroupView: React.FC<PanelGroupViewProps> = React.memo(({
           show (e.g. the primary group holding only permanent tabs). */}
       {multiGroup && stripPanels.length > 0 && (
         <div
-          role="tablist"
           className="flex-shrink-0 flex justify-center bg-bg-chrome border-b border-border-primary px-2 py-0.5"
         >
           <PanelTabStrip
+            idNamespace={group.id}
             panels={stripPanels}
             activePanelId={group.activePanelId}
             onPanelSelect={onPanelSelect}
@@ -217,10 +217,16 @@ export const PanelGroupView: React.FC<PanelGroupViewProps> = React.memo(({
         {orderedPanels.map(panel => {
           const isActiveTab = panel.id === group.activePanelId;
           const keepAlive = panel.type === 'terminal';
+          const panelTabNamespace = !multiGroup || panel.metadata?.permanent === true ? 'top' : group.id;
           if (!isActiveTab && !keepAlive) return null;
           return (
             <div
               key={panel.id}
+              id={getPanelTabPanelId(panelTabNamespace, panel.id)}
+              role="tabpanel"
+              aria-labelledby={getPanelTabId(panelTabNamespace, panel.id)}
+              aria-hidden={!isActiveTab}
+              inert={!isActiveTab ? true : undefined}
               className="absolute inset-0"
               style={{
                 display: isActiveTab ? 'block' : 'none',

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -80,6 +80,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   const { config, fetchConfig, updateConfig } = useConfigStore();
   const [showDropdown, setShowDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const addToolButtonRef = useRef<HTMLButtonElement>(null);
   const dropdownMenuRef = useRef<HTMLDivElement>(null);
   const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
   // Rename state moved to PanelTabStrip
@@ -258,6 +259,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
       case 'Escape':
         e.preventDefault();
         setShowDropdown(false);
+        requestAnimationFrame(() => addToolButtonRef.current?.focus());
         break;
       case 'Tab':
         // Allow tab to close dropdown and move to next element
@@ -400,8 +402,6 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
       {/* Flex container */}
       <div
         className="relative flex items-center min-h-[var(--panel-tab-height)] px-2"
-        role="tablist"
-        aria-label="Panel Tabs"
         onDragOver={tabsInGroups && isTabDragging ? () => setDragOverBar(true) : undefined}
         onDragLeave={tabsInGroups && isTabDragging ? () => setDragOverBar(false) : undefined}
       >
@@ -427,6 +427,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
             disabled then because the strip shows a subset and the 1-9 indexes
             would lie. */}
         <PanelTabStrip
+          idNamespace="top"
           panels={primaryGroupPanels ?? sortedPanels}
           activePanelId={primaryGroupActivePanelId !== undefined ? primaryGroupActivePanelId : (activePanel?.id ?? null)}
           onPanelSelect={handlePanelClick}
@@ -446,6 +447,8 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
         <div className="relative h-[var(--panel-tab-height)] flex items-center flex-shrink-0" ref={dropdownRef}>
           <Tooltip content={hotkeyDisplay('open-add-tool') ? <Kbd>{hotkeyDisplay('open-add-tool')}</Kbd> : undefined} side="bottom">
             <button
+              ref={addToolButtonRef}
+              type="button"
               className="inline-flex items-center h-[var(--panel-tab-height)] px-3 text-sm text-text-tertiary hover:text-text-primary hover:bg-surface-hover rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle"
               onClick={() => setShowDropdown(!showDropdown)}
               onKeyDown={(e) => {
@@ -547,41 +550,40 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 const currentRefIndex = refIndex++;
                 const shortcutDisplay = hotkeyDisplay(`add-tool-custom-${index}`);
                 return (
-                <button
-                  key={`custom-${index}`}
-                  ref={(el) => { dropdownItemsRef.current[currentRefIndex] = el; }}
-                  role="menuitem"
-                  className={menuItemClass}
-                  onClick={() => handleAddPanel('terminal', {
-                    initialCommand: cmd.command,
-                    title: cmd.name
-                  })}
-                  onKeyDown={(e) => {
-                    // Delete or Backspace removes the custom command
-                    if (e.key === 'Delete' || e.key === 'Backspace') {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      deleteCustomCommand(index);
-                    }
-                  }}
-                  title={`${cmd.name} (Delete/Backspace to remove)`}
-                >
-                  {getCliBrandIcon(cmd.command, 'w-4 h-4 flex-shrink-0 mt-0.5') || <TerminalSquare className="w-4 h-4 flex-shrink-0 mt-0.5" />}
-                  <span className="ml-2 flex-1 min-w-0">
-                    <span className="block truncate">{cmd.name}</span>
-                    {shortcutDisplay && <Kbd size="xs" variant="muted" className="mt-1 origin-left scale-[0.7]">{shortcutDisplay}</Kbd>}
-                  </span>
+                <div key={`custom-${index}`} role="none" className="flex items-center">
                   <button
-                    className="p-0.5 ml-1 rounded hover:bg-surface-hover text-text-muted hover:text-text-primary transition-colors flex-shrink-0"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      deleteCustomCommand(index);
+                    ref={(el) => { dropdownItemsRef.current[currentRefIndex] = el; }}
+                    type="button"
+                    role="menuitem"
+                    className={menuItemClass}
+                    onClick={() => handleAddPanel('terminal', {
+                      initialCommand: cmd.command,
+                      title: cmd.name
+                    })}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Delete' || e.key === 'Backspace') {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        deleteCustomCommand(index);
+                      }
                     }}
-                    title="Remove shortcut"
+                    title={`${cmd.name} (Delete/Backspace to remove)`}
+                  >
+                    {getCliBrandIcon(cmd.command, 'w-4 h-4 flex-shrink-0 mt-0.5') || <TerminalSquare className="w-4 h-4 flex-shrink-0 mt-0.5" />}
+                    <span className="ml-2 flex-1 min-w-0">
+                      <span className="block truncate">{cmd.name}</span>
+                      {shortcutDisplay && <Kbd size="xs" variant="muted" className="mt-1 origin-left scale-[0.7]">{shortcutDisplay}</Kbd>}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className="p-1 mr-2 rounded hover:bg-surface-hover text-text-muted hover:text-text-primary transition-colors flex-shrink-0"
+                    onClick={() => deleteCustomCommand(index)}
+                    aria-label={`Remove ${cmd.name} shortcut`}
                   >
                     <X className="w-3 h-3" />
                   </button>
-                </button>
+                </div>
               );})}
               {/* Add Custom Command input */}
               {availablePanelTypes.includes('terminal') && (
@@ -666,10 +668,12 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 </span>
               } side="bottom">
               <button
+                type="button"
+                aria-label={resolvedRunScript ? `Run ${resolvedRunScript.command}` : 'Set up run script'}
                 className="inline-flex items-center justify-center h-[var(--panel-tab-height)] px-2.5 rounded text-text-tertiary hover:text-status-success hover:bg-surface-hover transition-colors flex-shrink-0"
                 onClick={handleRunDevServer}
               >
-                <Play className="w-4 h-4" />
+                <Play aria-hidden="true" className="w-4 h-4" />
               </button>
             </Tooltip>
           )}

--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -126,6 +126,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
   const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const editInputRef = useRef<HTMLInputElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
   const [stripDropIndex, setStripDropIndex] = useState<number | null>(null);
   const [rovingPanelId, setRovingPanelId] = useState<string | null>(activePanelId ?? panels[0]?.id ?? null);
   const previousActivePanelIdRef = useRef(activePanelId);
@@ -207,7 +208,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
       const preferredTarget = focusTarget
         ? document.getElementById(getPanelTabId(idNamespace, focusTarget.id))
         : null;
-      const fallbackTarget = document.querySelector<HTMLElement>('[role="tab"][tabindex="0"]');
+      const fallbackTarget = stripRef.current?.querySelector<HTMLElement>('[role="tab"][tabindex="0"]');
       (preferredTarget ?? fallbackTarget)?.focus();
     });
   }, [getPanelTabPresentation, idNamespace, onPanelClose, panels]);
@@ -321,16 +322,22 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
 
   return (
     <div
+      ref={stripRef}
       className={cn(
         "flex items-center overflow-x-auto scrollbar-none min-w-0",
         compact ? "max-w-full" : "flex-1",
       )}
       onDragLeave={handleStripDragLeave}
     >
+      {/* Drag/drop requires tabs to remain siblings, so this semantic tablist
+          owns the rendered tab buttons instead of wrapping them. */}
       <div
         role="tablist"
         aria-label="Panel tabs"
-        aria-owns={panels.map((panel) => getPanelTabId(idNamespace, panel.id)).join(' ')}
+        aria-owns={panels
+          .filter((panel) => panel.id !== editingPanelId)
+          .map((panel) => getPanelTabId(idNamespace, panel.id))
+          .join(' ') || undefined}
         className="contents"
       />
       {panels.map((panel, index) => {
@@ -383,13 +390,13 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
               compact
                 ? cn(
                     "h-6 text-[11px]",
-                    isPermanent ? "px-2" : "px-2 pr-5",
+                    isPermanent ? "px-2" : "px-2 pr-7",
                   )
                 : cn(
                     "h-[var(--panel-tab-height)]",
                     isCompactTab
-                      ? cn("min-w-[5rem] text-xs", isPermanent ? "px-2" : "px-2 pr-6")
-                      : cn("min-w-[8rem] text-sm", isPermanent ? "px-3" : "px-3 pr-7"),
+                      ? cn("min-w-[5rem] text-xs", isPermanent ? "px-2" : "px-2 pr-8")
+                      : cn("min-w-[8rem] text-sm", isPermanent ? "px-3" : "px-3 pr-8"),
                   ),
               isActive
                 ? "text-text-primary"
@@ -420,6 +427,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
               <input
                 ref={setEditInputRefCallback}
                 type="text"
+                aria-label={`Rename ${displayTitle}`}
                 value={editingTitle}
                 onChange={(e) => setEditingTitle(e.target.value)}
                 onKeyDown={handleRenameKeyDown}
@@ -456,7 +464,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
                 type="button"
                 aria-label={`Close ${displayTitle}`}
                 className={cn(
-                  "absolute z-20 top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity transition-colors text-text-muted hover:bg-surface-hover hover:text-status-error focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle",
+                  "absolute z-20 top-1/2 inline-flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded opacity-0 group-hover:opacity-100 transition-opacity transition-colors text-text-muted hover:bg-surface-hover hover:text-status-error focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle",
                   compact ? "right-1" : "right-1.5",
                 )}
                 onClick={(e) => handlePanelClose(e, panel)}

--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -5,7 +5,7 @@
  * (via PanelGroupView) so there is one tab-rendering implementation.
  */
 
-import React, { useCallback, useState, useRef, useMemo } from 'react';
+import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
 import { X, Terminal, GitBranch, FileCode, FolderTree, BarChart3, Globe } from 'lucide-react';
 import { cn } from '../../utils/cn';
 import { ToolPanel, ToolPanelType, LogsPanelState } from '../../../../shared/types/panels';
@@ -56,6 +56,20 @@ export interface PanelTabStripProps {
   draggedPanelId?: string | null;
   /** Optional per-panel title/disabled presentation override. */
   getPanelTabPresentation?: PanelTabPresentationResolver;
+  /** Stable group/strip namespace used for tab and tabpanel relationships. */
+  idNamespace: string;
+}
+
+function safeDomId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+export function getPanelTabId(namespace: string, panelId: string): string {
+  return `panel-tab-${safeDomId(namespace)}-${safeDomId(panelId)}`;
+}
+
+export function getPanelTabPanelId(namespace: string, panelId: string): string {
+  return `panel-content-${safeDomId(namespace)}-${safeDomId(panelId)}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -106,13 +120,27 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
   isTabDragging = false,
   draggedPanelId = null,
   getPanelTabPresentation,
+  idNamespace,
 }) => {
   const compact = variant === 'compact';
   const [editingPanelId, setEditingPanelId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const editInputRef = useRef<HTMLInputElement>(null);
   const [stripDropIndex, setStripDropIndex] = useState<number | null>(null);
+  const [rovingPanelId, setRovingPanelId] = useState<string | null>(activePanelId ?? panels[0]?.id ?? null);
+  const previousActivePanelIdRef = useRef(activePanelId);
   const getPanelActivityStatus = usePanelStore(s => s.getPanelActivityStatus);
+
+  useEffect(() => {
+    const activePanelChanged = previousActivePanelIdRef.current !== activePanelId;
+    previousActivePanelIdRef.current = activePanelId;
+    setRovingPanelId((current) => {
+      if (activePanelChanged && panels.some((panel) => panel.id === activePanelId)) return activePanelId;
+      if (current && panels.some((panel) => panel.id === current)) return current;
+      if (panels.some((panel) => panel.id === activePanelId)) return activePanelId;
+      return panels[0]?.id ?? null;
+    });
+  }, [activePanelId, panels]);
 
   const hotkeys = useHotkeyStore(s => s.hotkeys);
   const hotkeyDisplay = useCallback((id: string) => {
@@ -170,8 +198,19 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
         return;
       }
     }
+    const panelIndex = panels.findIndex((candidate) => candidate.id === panel.id);
+    const isFocusable = (candidate: ToolPanel) => !getPanelTabPresentation?.(candidate)?.disabled;
+    const focusTarget = panels.slice(panelIndex + 1).find(isFocusable)
+      ?? panels.slice(0, panelIndex).reverse().find(isFocusable);
     onPanelClose(panel);
-  }, [onPanelClose]);
+    requestAnimationFrame(() => {
+      const preferredTarget = focusTarget
+        ? document.getElementById(getPanelTabId(idNamespace, focusTarget.id))
+        : null;
+      const fallbackTarget = document.querySelector<HTMLElement>('[role="tab"][tabindex="0"]');
+      (preferredTarget ?? fallbackTarget)?.focus();
+    });
+  }, [getPanelTabPresentation, idNamespace, onPanelClose, panels]);
 
   // --- Drag handlers ---
   const handleDragStart = useCallback((e: React.DragEvent, panelId: string) => {
@@ -247,6 +286,39 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
     );
   }, [shortcutHintsEnabled, panels, hotkeyDisplay]);
 
+  const handleTabKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const currentPanel = panels[index];
+    if (!currentPanel) return;
+    const currentDisabled = getPanelTabPresentation?.(currentPanel)?.disabled === true;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (!currentDisabled) onPanelSelect(currentPanel);
+      return;
+    }
+
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+
+    const navigableIndexes = panels.map((_, panelIndex) => panelIndex);
+    if (navigableIndexes.length === 0) return;
+
+    event.preventDefault();
+    const currentPosition = navigableIndexes.indexOf(index);
+    let targetIndex: number;
+    if (event.key === 'Home') targetIndex = navigableIndexes[0];
+    else if (event.key === 'End') targetIndex = navigableIndexes[navigableIndexes.length - 1];
+    else {
+      const step = event.key === 'ArrowRight' ? 1 : -1;
+      const start = currentPosition >= 0 ? currentPosition : 0;
+      targetIndex = navigableIndexes[(start + step + navigableIndexes.length) % navigableIndexes.length];
+    }
+
+    const targetPanel = panels[targetIndex];
+    setRovingPanelId(targetPanel.id);
+    if (!getPanelTabPresentation?.(targetPanel)?.disabled) onPanelSelect(targetPanel);
+    requestAnimationFrame(() => document.getElementById(getPanelTabId(idNamespace, targetPanel.id))?.focus());
+  }, [getPanelTabPresentation, idNamespace, onPanelSelect, panels]);
+
   return (
     <div
       className={cn(
@@ -255,6 +327,12 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
       )}
       onDragLeave={handleStripDragLeave}
     >
+      <div
+        role="tablist"
+        aria-label="Panel tabs"
+        aria-owns={panels.map((panel) => getPanelTabId(idNamespace, panel.id)).join(' ')}
+        className="contents"
+      />
       {panels.map((panel, index) => {
         const isPermanent = panel.metadata?.permanent === true;
         const isEditing = editingPanelId === panel.id;
@@ -266,6 +344,36 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
         const isDragged = panel.id === draggedPanelId;
         const isCompactTab = panel.type === 'diff' || panel.type === 'explorer' || panel.type === 'browser';
         const shortcutHint = shortcutHints[index];
+        const tabId = getPanelTabId(idNamespace, panel.id);
+        const tabPanelId = getPanelTabPanelId(idNamespace, panel.id);
+        const tooltipContent = presentation?.disabledReason || shortcutHint ? (
+          <span className="flex flex-col items-start gap-1">
+            <span className="text-text-secondary">{presentation?.disabledReason ?? displayTitle}</span>
+            {shortcutHint && (
+              <Kbd size="xs" variant="muted" className="origin-left scale-[0.8]">{shortcutHint}</Kbd>
+            )}
+          </span>
+        ) : null;
+
+        const tabButton = !isEditing ? (
+          <button
+            id={tabId}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-disabled={isDisabled || undefined}
+            aria-controls={tabPanelId}
+            aria-label={displayTitle}
+            tabIndex={panel.id === rovingPanelId ? 0 : -1}
+            onFocus={() => setRovingPanelId(panel.id)}
+            onClick={() => { if (!isDisabled) onPanelSelect(panel); }}
+            onDoubleClick={(event) => {
+              if (!isDisabled && !isPermanent && !isDiffPanel) handleStartRename(event, panel);
+            }}
+            onKeyDown={(event) => handleTabKeyDown(event, index)}
+            className="absolute inset-0 z-0 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-focus-ring-subtle"
+          />
+        ) : null;
 
         const tab = (
           <div
@@ -295,24 +403,10 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
             onDragEnd={handleDragEnd}
             onDragOver={(e) => handleStripDragOver(e, index)}
             onDrop={handleStripDrop}
-            onClick={() => !isEditing && !isDisabled && onPanelSelect(panel)}
-            onDoubleClick={(e) => {
-              if (!isEditing && !isPermanent && !isDiffPanel) {
-                handleStartRename(e, panel);
-              }
-            }}
-            role="tab"
-            aria-selected={isActive}
-            aria-disabled={isDisabled || undefined}
-            tabIndex={isActive && !isDisabled ? 0 : -1}
-            onKeyDown={(e) => {
-              if (isEditing || isDisabled) return;
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onPanelSelect(panel);
-              }
-            }}
           >
+            {tooltipContent && tabButton ? (
+              <Tooltip content={tooltipContent} side="bottom">{tabButton}</Tooltip>
+            ) : tabButton}
             {/* Strip drop indicator line. Between-tab boundaries render as the
                 next tab's left edge; only the strip's end renders a right edge. */}
             {isTabDragging && stripDropIndex === index && (
@@ -331,7 +425,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
                 onKeyDown={handleRenameKeyDown}
                 onBlur={handleRenameSubmit}
                 className={cn(
-                  "px-1 bg-bg-primary border border-border-primary rounded outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus text-text-primary",
+                  "relative z-20 px-1 bg-bg-primary border border-border-primary rounded outline-none focus:border-border-focus focus:ring-1 focus:ring-border-focus text-text-primary",
                   compact ? "text-[11px]" : "text-sm",
                 )}
                 onClick={(e) => e.stopPropagation()}
@@ -339,7 +433,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
               />
             ) : (
               <span className={cn(
-                "inline-flex items-center justify-center min-w-0",
+                "relative z-10 pointer-events-none inline-flex items-center justify-center min-w-0",
                 compact ? "gap-1" : "gap-2",
               )}>
                 {panel.type === 'terminal' && (
@@ -359,8 +453,10 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
 
             {!isPermanent && !isEditing && (
               <button
+                type="button"
+                aria-label={`Close ${displayTitle}`}
                 className={cn(
-                  "absolute top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity transition-colors text-text-muted hover:bg-surface-hover hover:text-status-error focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle",
+                  "absolute z-20 top-1/2 -translate-y-1/2 p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity transition-colors text-text-muted hover:bg-surface-hover hover:text-status-error focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle",
                   compact ? "right-1" : "right-1.5",
                 )}
                 onClick={(e) => handlePanelClose(e, panel)}
@@ -376,26 +472,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
           <div className="h-4 w-px bg-border-primary mx-1 flex-shrink-0" aria-hidden="true" />
         ) : null;
 
-        const tooltipContent = presentation?.disabledReason || shortcutHint ? (
-          <span className="flex flex-col items-start gap-1">
-            <span className="text-text-secondary">{presentation?.disabledReason ?? displayTitle}</span>
-            {shortcutHint && (
-              <Kbd size="xs" variant="muted" className="origin-left scale-[0.8]">{shortcutHint}</Kbd>
-            )}
-          </span>
-        ) : null;
-
-        return tooltipContent ? (
-          <React.Fragment key={panel.id}>
-            <Tooltip
-              content={tooltipContent}
-              side="bottom"
-            >
-              {tab}
-            </Tooltip>
-            {divider}
-          </React.Fragment>
-        ) : <React.Fragment key={panel.id}>{tab}{divider}</React.Fragment>;
+        return <React.Fragment key={panel.id}>{tab}{divider}</React.Fragment>;
       })}
       {/* Trailing drop target: the strip's empty space appends after the last tab */}
       {isTabDragging && (

--- a/frontend/src/components/panels/SetupTasksPanel.tsx
+++ b/frontend/src/components/panels/SetupTasksPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useId } from 'react';
 import { CheckCircle2, Circle, ChevronRight, GitBranch, FileCode } from 'lucide-react';
 import { useSession } from '../../contexts/SessionContext';
 import { panelApi } from '../../services/panelApi';
@@ -23,6 +23,7 @@ interface SetupTasksPanelProps {
 }
 
 const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) => {
+  const disclosureIdPrefix = useId();
   const sessionContext = useSession();
   const [tasksStatus, setTasksStatus] = useState<Record<string, boolean>>({});
   const [isChecking, setIsChecking] = useState(false);
@@ -363,6 +364,7 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
           {setupTasks.map(task => {
             const isComplete = tasksStatus[task.id] || false;
             const isExpanded = expandedTask === task.id;
+            const disclosureId = `${disclosureIdPrefix}-${task.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
 
             return (
               <div
@@ -376,7 +378,10 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
                 `}
               >
                 <button
+                  type="button"
                   onClick={() => setExpandedTask(isExpanded ? null : task.id)}
+                  aria-expanded={isExpanded}
+                  aria-controls={disclosureId}
                   className="w-full px-4 py-3 flex items-center gap-3 hover:bg-surface-hover transition-colors rounded-t-lg"
                 >
                   {/* Status icon */}
@@ -414,7 +419,7 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
 
                 {/* Expanded content */}
                 {isExpanded && (
-                  <div className="px-4 pb-4 border-t border-border-secondary">
+                  <div id={disclosureId} className="px-4 pb-4 border-t border-border-secondary">
                     <p className="mt-3 text-sm text-text-secondary">
                       {task.description}
                     </p>

--- a/frontend/src/components/panels/diff/DiffViewer.tsx
+++ b/frontend/src/components/panels/diff/DiffViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, memo, forwardRef, useImperativeHandle, useRef, useCallback } from 'react';
+import { useState, useEffect, useMemo, memo, forwardRef, useImperativeHandle, useRef, useCallback, useId } from 'react';
 import { DiffView, DiffModeEnum } from '@git-diff-view/react';
 import type { DiffHighlighter } from '@git-diff-view/shiki';
 import { getDiffViewHighlighter } from '@git-diff-view/shiki';
@@ -40,6 +40,7 @@ const FileAccordion = memo<FileAccordionProps>(({
   highlighter,
   onOpenInEditor,
 }) => {
+  const contentId = useId();
   const hasHunks = file.rawDiff.includes('@@');
   const diffData = useMemo(() => {
     if (!isExpanded || file.isBinary || !hasHunks) return null;
@@ -53,11 +54,16 @@ const FileAccordion = memo<FileAccordionProps>(({
   return (
     <div id={`file-${index}`} className="border-b border-border-primary">
       {/* Clickable header */}
-      <div
-        className="group px-4 py-2.5 bg-surface-secondary hover:bg-surface-hover cursor-pointer transition-colors flex items-center justify-between"
-        onClick={onToggle}
-      >
-        <div className="flex items-center gap-2 min-w-0">
+      <div className="group relative px-4 py-2.5 bg-surface-secondary hover:bg-surface-hover transition-colors flex items-center justify-between">
+        <button
+          type="button"
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} diff for ${file.path}`}
+          onClick={onToggle}
+          className="absolute inset-0 z-0 rounded focus:outline-none focus:ring-2 focus:ring-inset focus:ring-interactive"
+        />
+        <div className="relative z-10 pointer-events-none flex items-center gap-2 min-w-0">
           {isExpanded
             ? <ChevronDown className="w-4 h-4 flex-shrink-0 text-text-tertiary" />
             : <ChevronRight className="w-4 h-4 flex-shrink-0 text-text-tertiary" />}
@@ -76,7 +82,7 @@ const FileAccordion = memo<FileAccordionProps>(({
           )}
         </div>
 
-        <div className="flex items-center gap-2 flex-shrink-0">
+        <div className="relative z-10 pointer-events-none flex items-center gap-2 flex-shrink-0">
           {file.additions > 0 && (
             <span className="text-xs text-status-success font-semibold">+{file.additions}</span>
           )}
@@ -85,9 +91,10 @@ const FileAccordion = memo<FileAccordionProps>(({
           )}
           {file.type !== 'deleted' && onOpenInEditor ? (
             <button
+              type="button"
               onClick={(e) => { e.stopPropagation(); onOpenInEditor(file.path); }}
-              title="Open in Editor"
-              className="p-1 rounded hover:bg-surface-hover opacity-0 group-hover:opacity-100 transition-opacity"
+              aria-label={`Open ${file.path} in Editor`}
+              className="pointer-events-auto p-1 rounded hover:bg-surface-hover opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
             >
               <ExternalLink className="w-3.5 h-3.5 text-text-tertiary" />
             </button>
@@ -99,7 +106,7 @@ const FileAccordion = memo<FileAccordionProps>(({
 
       {/* Expanded content */}
       {isExpanded && (
-        <div className="border-t border-border-primary">
+        <div id={contentId} className="border-t border-border-primary">
           {file.isBinary ? (
             <div className="p-4 text-text-secondary text-sm">Binary file</div>
           ) : diffData && diffData.hunks.length > 0 ? (

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -16,6 +16,7 @@ import { isMac, isWindows } from '../../../utils/platformUtils';
 import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
 import { TerminalPopover, PopoverButton } from '../../terminal/TerminalPopover';
 import { useConfigStore } from '../../../stores/configStore';
+import { LiveRegion } from '../../ui/LiveRegion';
 
 interface FileItem {
   name: string;
@@ -760,6 +761,7 @@ function HeadlessFileTree({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
+      <LiveRegion>{uploadStatus ?? ''}</LiveRegion>
       <div className="flex items-center justify-between p-2 border-b border-border-primary">
         <span className="text-sm font-medium text-text-primary">Files</span>
         <div className="flex gap-1">
@@ -852,7 +854,7 @@ function HeadlessFileTree({
         </div>
       )}
       {error && (
-        <div className="px-3 py-2 bg-status-error/20 text-status-error text-sm border-b border-status-error/30">
+        <div role="alert" className="px-3 py-2 bg-status-error/20 text-status-error text-sm border-b border-status-error/30">
           {error}
         </div>
       )}
@@ -865,15 +867,15 @@ function HeadlessFileTree({
       {searchQuery && (
         <div className="flex-1 overflow-auto">
           {getFilteredFiles().map(file => (
-            <div
+            <button
+              type="button"
               key={file.path}
-              className={`flex items-center px-2 py-1 hover:bg-surface-hover cursor-pointer group ${
+              disabled={file.isDirectory}
+              className={`flex w-full items-center px-2 py-1 text-left hover:bg-surface-hover group disabled:cursor-default ${
                 selectedPath === file.path ? 'bg-interactive' : ''
               }`}
               style={{ paddingLeft: '8px' }}
-              onClick={() => {
-                if (!file.isDirectory) onFileSelect(file);
-              }}
+              onClick={() => onFileSelect(file)}
               onContextMenu={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -891,7 +893,7 @@ function HeadlessFileTree({
               <span className="text-xs text-text-tertiary ml-2 truncate max-w-[120px]">
                 {file.path}
               </span>
-            </div>
+            </button>
           ))}
           {getFilteredFiles().length === 0 && (
             <div className="p-4 text-text-secondary text-sm">No matching files</div>
@@ -926,11 +928,13 @@ function HeadlessFileTree({
           const isExpanded = item.isExpanded();
           const isItemSelected = item.isSelected();
           const isOpenFile = selectedPath === data.path && !isFolder;
+          const treeItemProps = item.getProps();
 
           return (
             <div
               key={item.getId()}
-              {...item.getProps()}
+              {...treeItemProps}
+              role={treeItemProps.role}
               ref={(element) => {
                 if (element) itemElementRefs.current.set(data.path, element);
                 else itemElementRefs.current.delete(data.path);
@@ -1680,7 +1684,7 @@ export function FileEditor({
               </div>
             </div>
             {error && (
-              <div className="px-4 py-2 bg-status-error/20 text-status-error text-sm">
+              <div role="alert" className="px-4 py-2 bg-status-error/20 text-status-error text-sm">
                 Error: {error}
               </div>
             )}

--- a/frontend/src/components/panels/logPanel/LogsView.tsx
+++ b/frontend/src/components/panels/logPanel/LogsView.tsx
@@ -3,6 +3,7 @@ import { Search, X, Download, Trash2, ChevronUp, ChevronDown, Filter, Copy, Chec
 import { cn } from '../../../utils/cn';
 import AnsiToHtml from 'ansi-to-html';
 import { useTheme } from '../../../contexts/ThemeContext';
+import { LiveRegion } from '../../ui/LiveRegion';
 
 interface LogEntry {
   timestamp: string;
@@ -235,6 +236,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
 
   return (
     <div className="h-full flex flex-col bg-bg-primary relative">
+      <LiveRegion>{copied ? 'Logs copied to clipboard' : ''}</LiveRegion>
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 bg-surface-secondary border-b border-border-primary">
         <div className="text-sm text-text-secondary">

--- a/frontend/src/components/session/CommitMessageDialog.tsx
+++ b/frontend/src/components/session/CommitMessageDialog.tsx
@@ -37,14 +37,13 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
   const isProcessing = isMerging || isMergingAndArchiving;
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl">
-      <ModalHeader>
-        {dialogType === 'commit'
+      <ModalHeader
+        title={dialogType === 'commit'
           ? 'Commit Changes'
           : dialogType === 'squash'
             ? `Merge to ${gitCommands?.comparisonBaseBranch || 'Main'}`
-            : `Rebase from ${gitCommands?.comparisonBaseBranch || 'Main'}`
-        }
-      </ModalHeader>
+            : `Rebase from ${gitCommands?.comparisonBaseBranch || 'Main'}`}
+      />
       
       <ModalBody>
           <div className="space-y-4">
@@ -141,4 +140,4 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
       </ModalFooter>
     </Modal>
   );
-}; 
+};

--- a/frontend/src/components/session/FolderArchiveDialog.tsx
+++ b/frontend/src/components/session/FolderArchiveDialog.tsx
@@ -20,12 +20,10 @@ export const FolderArchiveDialog: React.FC<FolderArchiveDialogProps> = ({
 }) => {
   return (
     <Modal isOpen={isOpen} onClose={onCancel} size="md">
-      <ModalHeader>
-        <div className="flex items-center gap-2">
-          <FolderArchive className="w-5 h-5 text-text-secondary" />
-          Archive Folder?
-        </div>
-      </ModalHeader>
+      <ModalHeader
+        title="Archive Folder?"
+        icon={<FolderArchive className="w-5 h-5 text-text-secondary" />}
+      />
 
       <ModalBody>
         <p className="text-text-secondary">

--- a/frontend/src/components/session/GitErrorDialog.tsx
+++ b/frontend/src/components/session/GitErrorDialog.tsx
@@ -25,12 +25,11 @@ export const GitErrorDialog: React.FC<GitErrorDialogProps> = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl">
-      <ModalHeader className="bg-status-error/10">
-        <div className="flex items-center space-x-3">
-          <AlertCircle className="w-6 h-6 text-status-error" />
-          <span className="text-status-error">{errorDetails.title}</span>
-        </div>
-      </ModalHeader>
+      <ModalHeader
+        title={errorDetails.title}
+        icon={<AlertCircle className="w-6 h-6 text-status-error" />}
+        className="bg-status-error/10"
+      />
 
       <ModalBody>
           <div className="space-y-6">
@@ -168,4 +167,4 @@ export const GitErrorDialog: React.FC<GitErrorDialogProps> = ({
       </ModalFooter>
     </Modal>
   );
-}; 
+};

--- a/frontend/src/components/terminal/InterceptorDropdown.tsx
+++ b/frontend/src/components/terminal/InterceptorDropdown.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../utils/cn';
 import { Kbd } from '../ui/Kbd';
 import type { TerminalSuggestion, PasteMode } from '../../services/terminalInterceptor/types';
 import { LINE_COUNT_PRESETS } from '../../services/terminalInterceptor/types';
+import { LiveRegion } from '../ui/LiveRegion';
 
 interface InterceptorDropdownProps {
   visible: boolean;
@@ -70,9 +71,15 @@ export const InterceptorDropdown: React.FC<InterceptorDropdownProps> = ({
     selectedItemRef.current.scrollIntoView({ block: 'nearest' });
   }, [selectedIndex, visible]);
 
-  if (!visible) return null;
+  const selectedTerminal = terminals[selectedIndex];
+  const announcement = visible && selectedTerminal
+    ? `${selectedTerminal.title}, ${formatPresetLabel(LINE_COUNT_PRESETS[lineCountPresetIndex])} lines, ${pasteMode} mode`
+    : '';
 
-  return createPortal(
+  return (
+    <>
+      <LiveRegion>{announcement}</LiveRegion>
+      {visible && createPortal(
     <div
       ref={containerRef}
       className={cn(
@@ -200,6 +207,8 @@ export const InterceptorDropdown: React.FC<InterceptorDropdownProps> = ({
       </div>
     </div>,
     document.body
+      )}
+    </>
   );
 };
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -21,6 +21,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     loadingText,
     icon,
     disabled,
+    'aria-busy': ariaBusy,
     children,
     ...props 
   }, ref) => {
@@ -53,10 +54,13 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           className
         )}
         disabled={disabled || loading}
+        aria-busy={ariaBusy ?? loading}
         {...props}
       >
         {loading && (
           <svg 
+            aria-hidden="true"
+            focusable="false"
             className="animate-spin -ml-1 mr-2 h-4 w-4" 
             xmlns="http://www.w3.org/2000/svg" 
             fill="none" 
@@ -77,7 +81,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             />
           </svg>
         )}
-        {icon && !loading && <span className="mr-2">{icon}</span>}
+        {icon && !loading && <span className="mr-2" aria-hidden="true">{icon}</span>}
         {loading && loadingText ? loadingText : children}
       </button>
     );

--- a/frontend/src/components/ui/CopyableField.tsx
+++ b/frontend/src/components/ui/CopyableField.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Check, Copy } from 'lucide-react';
+import { LiveRegion } from './LiveRegion';
 
 export function CopyableField({ icon: Icon, value, mono }: { icon: React.FC<{ className?: string }>; value: string; mono?: boolean }) {
   const [copied, setCopied] = useState(false);
@@ -11,17 +12,21 @@ export function CopyableField({ icon: Icon, value, mono }: { icon: React.FC<{ cl
   }, [value]);
 
   return (
-    <button
-      onClick={handleCopy}
-      className="flex items-center gap-1.5 w-full text-left rounded px-0.5 -mx-0.5 hover:bg-surface-hover transition-colors group"
-    >
-      <Icon className="w-3 h-3 text-text-tertiary flex-shrink-0" />
-      <span className={`text-text-secondary truncate flex-1 ${mono ? 'font-mono' : ''}`}>{value}</span>
-      {copied ? (
-        <Check className="w-2.5 h-2.5 text-status-success flex-shrink-0" />
-      ) : (
-        <Copy className="w-2.5 h-2.5 text-text-tertiary flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
-      )}
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="flex items-center gap-1.5 w-full text-left rounded px-0.5 -mx-0.5 hover:bg-surface-hover transition-colors group"
+      >
+        <span aria-hidden="true"><Icon className="w-3 h-3 text-text-tertiary flex-shrink-0" /></span>
+        <span className={`text-text-secondary truncate flex-1 ${mono ? 'font-mono' : ''}`}>{value}</span>
+        {copied ? (
+          <Check aria-hidden="true" className="w-2.5 h-2.5 text-status-success flex-shrink-0" />
+        ) : (
+          <Copy aria-hidden="true" className="w-2.5 h-2.5 text-text-tertiary flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+        )}
+      </button>
+      <LiveRegion>{copied ? 'Copied to clipboard' : ''}</LiveRegion>
+    </>
   );
 }

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useRef, useEffect, ReactNode, CSSProperties } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, useId, ReactNode, CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
+import { Slot } from '@radix-ui/react-slot';
 import { cn } from '../../utils/cn';
 import { formatKeyDisplay } from '../../utils/hotkeyUtils';
 import { Kbd } from './Kbd';
 import { initialActiveIndex } from './dropdownNavigation';
+import { usePortalContainer } from '../../contexts/PortalContainerContext';
 
 export interface DropdownItem {
   id: string;
@@ -21,7 +23,7 @@ export interface DropdownItem {
 
 export interface DropdownProps {
   // Trigger element
-  trigger: ReactNode;
+  trigger: React.ReactElement;
   triggerClassName?: string;
   
   // Items
@@ -94,12 +96,15 @@ export function Dropdown({
   const [isOpen, setIsOpen] = useState(false);
   const [actualPosition, setActualPosition] = useState<'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'>('bottom-right');
   const [activeIndex, setActiveIndex] = useState(-1);
+  const menuId = useId();
+  const portalContainer = usePortalContainer();
   const dropdownRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLElement>(null);
 
   const handleToggle = () => {
     const newState = !isOpen;
+    setActiveIndex(newState ? initialActiveIndex(items, selectedId) : -1);
     setIsOpen(newState);
     onOpenChange?.(newState);
   };
@@ -145,7 +150,7 @@ export function Dropdown({
 
   // Roving tabindex: DOM focus follows the active item. If there are no regular
   // items, focus the first footer control so footer-only menus remain usable.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isOpen) return;
     const controls = getMenuControls(contentRef.current);
     const target = controls[activeIndex] ?? controls[0];
@@ -282,36 +287,33 @@ export function Dropdown({
   return (
     <div ref={dropdownRef} className={cn('relative', className)} style={style}>
       {/* Trigger */}
-      <div
+      <Slot
         ref={triggerRef}
         onClick={handleToggle}
         className={triggerClassName}
-        // Make trigger focusable for keyboard navigation
-        tabIndex={0}
         aria-haspopup="menu"
         aria-expanded={isOpen}
+        aria-controls={isOpen ? menuId : undefined}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleToggle();
-          } else if (e.key === 'ArrowDown' && !isOpen) {
+          if (e.key === 'ArrowDown' && !isOpen) {
             e.preventDefault();
             handleToggle();
           }
         }}
       >
         {trigger}
-      </div>
+      </Slot>
 
       {/* Dropdown Menu - rendered via portal to escape overflow clipping */}
       {isOpen && createPortal(
         <div
+          id={menuId}
           ref={contentRef}
           role="menu"
           aria-orientation="vertical"
           onKeyDown={handleMenuKeyDown}
           className={cn(
-            'z-[10000]',
+            'z-[10000] pointer-events-auto',
             'bg-surface-primary rounded-md shadow-dropdown-elevated',
             'border border-border-subtle/60',
             'backdrop-blur-sm',
@@ -418,7 +420,7 @@ export function Dropdown({
               )}
             </div>
         </div>,
-        document.body
+        portalContainer ?? document.body
       )}
     </div>
   );

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { cn } from '../../utils/cn';
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -18,9 +18,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     fullWidth = false,
     icon,
     id,
+    'aria-describedby': ariaDescribedBy,
+    'aria-invalid': ariaInvalid,
     ...props 
   }, ref) => {
-    const inputId = id || `input-${Math.random().toString(36).substr(2, 9)}`;
+    const generatedId = useId();
+    const inputId = id || `input-${generatedId}`;
+    const messageId = error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined;
+    const describedBy = [ariaDescribedBy, messageId].filter(Boolean).join(' ') || undefined;
     
     const baseStyles = 'px-input-x py-input-y bg-bg-primary text-text-primary placeholder:text-text-muted border rounded-input transition-all duration-normal focus:outline-none focus:ring-1 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50';
 
@@ -56,8 +61,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
               icon && 'pl-10',
               className
             )}
-            aria-invalid={!!error}
-            aria-describedby={error ? `${inputId}-error` : helperText ? `${inputId}-helper` : undefined}
+            aria-invalid={ariaInvalid ?? !!error}
+            aria-describedby={describedBy}
             {...props}
           />
         </div>
@@ -94,9 +99,14 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     helperText,
     fullWidth = false,
     id,
+    'aria-describedby': ariaDescribedBy,
+    'aria-invalid': ariaInvalid,
     ...props 
   }, ref) => {
-    const textareaId = id || `textarea-${Math.random().toString(36).substr(2, 9)}`;
+    const generatedId = useId();
+    const textareaId = id || `textarea-${generatedId}`;
+    const messageId = error ? `${textareaId}-error` : helperText ? `${textareaId}-helper` : undefined;
+    const describedBy = [ariaDescribedBy, messageId].filter(Boolean).join(' ') || undefined;
     
     const baseStyles = 'px-input-x py-input-y bg-bg-primary text-text-primary placeholder:text-text-muted border rounded-input transition-all duration-normal focus:outline-none focus:ring-1 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 resize-none';
 
@@ -125,8 +135,8 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             widthStyles,
             className
           )}
-          aria-invalid={!!error}
-          aria-describedby={error ? `${textareaId}-error` : helperText ? `${textareaId}-helper` : undefined}
+          aria-invalid={ariaInvalid ?? !!error}
+          aria-describedby={describedBy}
           {...props}
         />
         {error && (
@@ -158,7 +168,8 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     id,
     ...props 
   }, ref) => {
-    const checkboxId = id || `checkbox-${Math.random().toString(36).substr(2, 9)}`;
+    const generatedId = useId();
+    const checkboxId = id || `checkbox-${generatedId}`;
     
     return (
       <label htmlFor={checkboxId} className="flex items-center space-x-2 cursor-pointer">

--- a/frontend/src/components/ui/LiveRegion.tsx
+++ b/frontend/src/components/ui/LiveRegion.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { cn } from '../../utils/cn';
+
+interface LiveRegionProps {
+  mode?: 'polite' | 'assertive';
+  atomic?: boolean;
+  visuallyHidden?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+export function LiveRegion({
+  mode = 'polite',
+  atomic = true,
+  visuallyHidden = true,
+  className,
+  children,
+}: LiveRegionProps) {
+  return (
+    <div
+      role={mode === 'assertive' ? 'alert' : 'status'}
+      aria-live={mode}
+      aria-atomic={atomic}
+      aria-relevant="additions text"
+      className={cn(visuallyHidden && 'sr-only', className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,6 +1,8 @@
-import React, { createContext, useContext, useEffect, useId, useRef } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
 import { cn } from '../../utils/cn';
 import { X } from 'lucide-react';
+import { PortalContainerProvider } from '../../contexts/PortalContainerContext';
 
 export interface ModalProps {
   isOpen: boolean;
@@ -10,14 +12,17 @@ export interface ModalProps {
   closeOnOverlayClick?: boolean;
   closeOnEscape?: boolean;
   showCloseButton?: boolean;
-  ariaLabel?: string;
   className?: string;
+  ariaLabel?: string;
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+  restoreFocusOnClose?: boolean;
 }
 
-const ModalTitleContext = createContext<string | undefined>(undefined);
-const modalStack: HTMLDivElement[] = [];
-let openModalCount = 0;
-let originalBodyOverflow = '';
+function canReceiveFocus(element: HTMLElement | null): element is HTMLElement {
+  if (!element?.isConnected) return false;
+  if (element.matches(':disabled, [aria-disabled="true"]')) return false;
+  return true;
+}
 
 export const Modal: React.FC<ModalProps> = ({
   isOpen,
@@ -27,186 +32,106 @@ export const Modal: React.FC<ModalProps> = ({
   closeOnOverlayClick = true,
   closeOnEscape = true,
   showCloseButton = true,
-  ariaLabel,
   className,
+  ariaLabel,
+  initialFocusRef,
+  restoreFocusOnClose = true,
 }) => {
-  const modalRef = useRef<HTMLDivElement>(null);
-  const mouseDownTargetRef = useRef<EventTarget | null>(null);
-  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
-  const titleId = useId();
-  
-  // Handle escape key
-  useEffect(() => {
-    if (!isOpen || !closeOnEscape) return;
-    
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !e.defaultPrevented && modalStack.at(-1) === modalRef.current) {
-        onClose();
-      }
-    };
-    
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onClose, closeOnEscape]);
-  
-  // Lock body scroll when modal is open
-  useEffect(() => {
-    if (!isOpen) return;
-    if (openModalCount === 0) originalBodyOverflow = document.body.style.overflow;
-    openModalCount += 1;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      openModalCount = Math.max(0, openModalCount - 1);
-      if (openModalCount === 0) document.body.style.overflow = originalBodyOverflow;
-    };
-  }, [isOpen]);
-  
-  // Focus management and restoration.
-  useEffect(() => {
-    if (!isOpen) return;
+  const contentRef = useRef<HTMLDivElement>(null);
+  const openerRef = useRef<HTMLElement | null>(null);
+  const didRestoreRef = useRef(false);
+  const restoreFocusRef = useRef(restoreFocusOnClose);
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
 
-    previouslyFocusedRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    const modal = modalRef.current;
-    const previousModal = modalStack.at(-1);
-    if (previousModal) {
-      previousModal.inert = true;
-      previousModal.setAttribute('aria-hidden', 'true');
+  restoreFocusRef.current = restoreFocusOnClose;
+
+  const restoreOpener = () => {
+    if (didRestoreRef.current || !restoreFocusRef.current) return;
+
+    const activeModal = document.activeElement?.closest('[aria-modal="true"]');
+    if (activeModal && activeModal !== contentRef.current) return;
+
+    const opener = openerRef.current;
+    if (canReceiveFocus(opener)) {
+      didRestoreRef.current = true;
+      opener.focus();
     }
-    if (modal) modalStack.push(modal);
-    const keepFocusInTopModal = (event: FocusEvent) => {
-      const target = event.target;
-      if (
-        !modal
-        || modalStack.at(-1) !== modal
-        || !(target instanceof HTMLElement)
-        || modal.contains(target)
-        || target.closest('[data-radix-popper-content-wrapper]')
-      ) return;
-      const firstFocusable = modal.querySelector<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      (firstFocusable ?? modal).focus();
-    };
-    document.addEventListener('focusin', keepFocusInTopModal);
-    const timer = setTimeout(() => {
-      const firstFocusable = modalRef.current?.querySelector<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      (firstFocusable ?? modalRef.current)?.focus();
-    }, 50);
+  };
 
-    return () => {
-      clearTimeout(timer);
-      document.removeEventListener('focusin', keepFocusInTopModal);
-      const index = modal ? modalStack.lastIndexOf(modal) : -1;
-      if (index >= 0) modalStack.splice(index, 1);
-      const nextModal = modalStack.at(-1);
-      if (nextModal) {
-        nextModal.inert = false;
-        nextModal.removeAttribute('aria-hidden');
-      }
-      window.setTimeout(() => previouslyFocusedRef.current?.focus(), 0);
-    };
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    openerRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    didRestoreRef.current = false;
   }, [isOpen]);
-  
-  if (!isOpen) return null;
   
   const sizeClasses = {
     sm: 'max-w-md',
     md: 'max-w-lg',
     lg: 'max-w-2xl',
     xl: 'max-w-4xl',
-    full: 'max-w-full mx-4',
-  };
-  
-  const handleOverlayMouseDown = (e: React.MouseEvent) => {
-    // Store where the mouse down occurred
-    mouseDownTargetRef.current = e.target;
-  };
-  
-  const handleOverlayClick = (e: React.MouseEvent) => {
-    // If click target was removed from DOM (e.g. portal dropdown closed), don't close
-    if (e.target instanceof Node && !document.body.contains(e.target)) return;
-
-    // Check if the click target is the modal content or its children
-    const modalContent = modalRef.current;
-    const isClickInsideModal = modalContent && e.target && e.target instanceof Node && modalContent.contains(e.target);
-    
-    // Only close if:
-    // 1. closeOnOverlayClick is enabled
-    // 2. The click is not inside the modal content
-    // 3. The mousedown also started outside the modal content
-    if (closeOnOverlayClick && !isClickInsideModal) {
-      const wasMouseDownInsideModal = modalContent && mouseDownTargetRef.current && mouseDownTargetRef.current instanceof Node && modalContent.contains(mouseDownTargetRef.current);
-      if (!wasMouseDownInsideModal) {
-        onClose();
-      }
-    }
-    // Reset the ref after handling
-    mouseDownTargetRef.current = null;
-  };
-
-  const handleModalKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab' || modalStack.at(-1) !== modalRef.current) return;
-    const focusable = Array.from(modalRef.current?.querySelectorAll<HTMLElement>(
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ) ?? []).filter((element) => element.offsetParent !== null);
-    if (focusable.length === 0) {
-      event.preventDefault();
-      modalRef.current?.focus();
-      return;
-    }
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    if (event.shiftKey && document.activeElement === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault();
-      first.focus();
-    }
+    full: 'max-w-full',
   };
   
   return (
-    <div
-      className="fixed inset-0 z-modal-backdrop flex items-center justify-center p-4 overflow-y-auto"
-      onMouseDown={handleOverlayMouseDown}
-      onClick={handleOverlayClick}
-    >
-      {/* Backdrop */}
-      <div className="fixed inset-0 bg-modal-overlay backdrop-blur-sm pointer-events-none" aria-hidden="true" />
-      
-      {/* Modal */}
-      <div
-        ref={modalRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabel ? undefined : titleId}
-        tabIndex={-1}
-        onKeyDown={handleModalKeyDown}
-        className={cn(
-          'relative bg-bg-primary rounded-modal shadow-modal w-full max-h-[90vh] overflow-hidden flex flex-col',
-          sizeClasses[size],
-          'animate-fadeIn',
-          className
-        )}
-      >
-        {showCloseButton && (
-          <div className="absolute top-4 right-4 z-10">
-            <button
-              type="button"
-              aria-label="Close modal"
-              onClick={onClose}
-              className="text-text-tertiary hover:text-text-secondary transition-colors p-1 rounded"
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-modal-backdrop bg-modal-overlay backdrop-blur-sm" />
+        <Dialog.Content
+          ref={contentRef}
+          aria-modal="true"
+          aria-describedby={undefined}
+          className={cn(
+            'fixed inset-0 z-modal m-auto h-fit w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] outline-none',
+            sizeClasses[size],
+          )}
+          onOpenAutoFocus={(event) => {
+            const target = initialFocusRef?.current ?? null;
+            if (canReceiveFocus(target)) {
+              event.preventDefault();
+              target.focus();
+            }
+          }}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            restoreOpener();
+          }}
+          onEscapeKeyDown={(event) => {
+            if (!closeOnEscape) event.preventDefault();
+          }}
+          onPointerDownOutside={(event) => {
+            if (!closeOnOverlayClick) event.preventDefault();
+          }}
+        >
+          {ariaLabel && <Dialog.Title className="sr-only">{ariaLabel}</Dialog.Title>}
+          <PortalContainerProvider value={portalContainer}>
+            <div
+              className={cn(
+                'relative bg-bg-primary rounded-modal shadow-modal w-full max-h-[calc(100vh-2rem)] overflow-hidden flex flex-col animate-fadeIn',
+                className,
+              )}
             >
-              <X className="h-5 w-5" />
-            </button>
-          </div>
-        )}
-        <ModalTitleContext.Provider value={titleId}>{children}</ModalTitleContext.Provider>
-      </div>
-    </div>
+              {showCloseButton && (
+                <div className="absolute top-4 right-4 z-10">
+                  <button
+                    type="button"
+                    aria-label="Close modal"
+                    onClick={onClose}
+                    className="text-text-tertiary hover:text-text-secondary transition-colors p-1 rounded"
+                  >
+                    <X className="h-5 w-5" aria-hidden="true" />
+                  </button>
+                </div>
+              )}
+              {children}
+            </div>
+            <div ref={setPortalContainer} className="fixed inset-0 pointer-events-none" />
+          </PortalContainerProvider>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 
@@ -214,15 +139,15 @@ Modal.displayName = 'Modal';
 
 // Modal Header component
 export interface ModalHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
-  title?: string;
+  title: string;
   icon?: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
   onClose?: () => void;
-  children?: React.ReactNode;
 }
 
 export const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
-  ({ className, title, icon, onClose, children, ...props }, ref) => {
-    const titleId = useContext(ModalTitleContext);
+  ({ className, title, icon, description, actions, onClose, ...props }, ref) => {
     return (
       <div
         ref={ref}
@@ -232,21 +157,29 @@ export const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
         )}
         {...props}
       >
-        <div className="flex items-center gap-2">
-          {icon && <div className="text-text-secondary">{icon}</div>}
-          <h2 id={titleId} className="text-heading-2 text-text-primary">
-            {title || children}
-          </h2>
+        <div className="flex min-w-0 items-center gap-2">
+          {icon && <div className="text-text-secondary" aria-hidden="true">{icon}</div>}
+          <div className="min-w-0">
+            <Dialog.Title className="text-heading-2 text-text-primary">
+              {title}
+            </Dialog.Title>
+            {description && <div className="mt-1 text-sm text-text-secondary">{description}</div>}
+          </div>
         </div>
-        {onClose && (
-          <button
-            type="button"
-            aria-label="Close modal"
-            onClick={onClose}
-            className="text-text-tertiary hover:text-text-secondary transition-colors"
-          >
-            <X className="w-5 h-5" />
-          </button>
+        {(actions || onClose) && (
+          <div className="ml-4 flex flex-shrink-0 items-center gap-2">
+            {actions}
+            {onClose && (
+              <button
+                type="button"
+                aria-label="Close modal"
+                onClick={onClose}
+                className="text-text-tertiary hover:text-text-secondary transition-colors"
+              >
+                <X className="w-5 h-5" aria-hidden="true" />
+              </button>
+            )}
+          </div>
         )}
       </div>
     );

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import { cn } from '../../utils/cn';
+import { usePortalContainer } from '../../contexts/PortalContainerContext';
 
 const Select = SelectPrimitive.Root;
 
@@ -78,39 +79,43 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 const SelectContent = forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden',
-        'rounded-md',
-        'bg-surface-primary',
-        'border border-border-subtle',
-        'shadow-lg',
-        'data-[state=open]:animate-fade-in data-[state=open]:animate-zoom-in-95',
-        'transition-all duration-200',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-        className
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+>(({ className, children, position = 'popper', ...props }, ref) => {
+  const portalContainer = usePortalContainer();
+
+  return (
+    <SelectPrimitive.Portal container={portalContainer ?? undefined}>
+      <SelectPrimitive.Content
+        ref={ref}
         className={cn(
-          'p-1',
+          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden',
+          'rounded-md',
+          'bg-surface-primary',
+          'border border-border-subtle',
+          'shadow-lg',
+          'data-[state=open]:animate-fade-in data-[state=open]:animate-zoom-in-95',
+          'transition-all duration-200',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+});
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = forwardRef<

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useId } from 'react';
 import { cn } from '../../utils/cn';
 
 interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
@@ -10,12 +10,29 @@ interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, error, label, description, helperText, fullWidth, id, ...props }, ref) => {
+  ({
+    className,
+    error,
+    label,
+    description,
+    helperText,
+    fullWidth = false,
+    id,
+    'aria-describedby': ariaDescribedBy,
+    'aria-invalid': ariaInvalid,
+    ...props
+  }, ref) => {
+    const generatedId = useId();
+    const textareaId = id || `textarea-${generatedId}`;
+    const visibleMessage = error || description || helperText;
+    const messageId = visibleMessage ? `${textareaId}-${error ? 'error' : 'help'}` : undefined;
+    const describedBy = [ariaDescribedBy, messageId].filter(Boolean).join(' ') || undefined;
+
     return (
-      <div className="w-full">
+      <div className={cn(fullWidth && 'w-full')}>
         {label && (
           <label 
-            htmlFor={id}
+            htmlFor={textareaId}
             className="block text-sm font-medium text-text-primary mb-2"
           >
             {label}
@@ -23,7 +40,9 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
         
         <textarea
-          id={id}
+          id={textareaId}
+          aria-describedby={describedBy}
+          aria-invalid={ariaInvalid ?? !!error}
           className={cn(
             'w-full px-3 py-2 rounded-md border transition-colors',
             'text-text-primary placeholder-text-tertiary',
@@ -39,19 +58,19 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         />
         
         {error && (
-          <p className="mt-2 text-sm text-status-error">
+          <p id={messageId} role="alert" className="mt-2 text-sm text-status-error">
             {error}
           </p>
         )}
         
         {description && !error && (
-          <p className="mt-2 text-sm text-text-tertiary">
+          <p id={messageId} className="mt-2 text-sm text-text-tertiary">
             {description}
           </p>
         )}
         
         {helperText && !error && !description && (
-          <p className="mt-2 text-sm text-text-tertiary">
+          <p id={messageId} className="mt-2 text-sm text-text-tertiary">
             {helperText}
           </p>
         )}

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -1,13 +1,15 @@
-import React, { useState, useRef, useCallback, useLayoutEffect } from 'react';
+import React, { useState, useRef, useCallback, useEffect, useId, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { Slot } from '@radix-ui/react-slot';
 import { cn } from '../../utils/cn';
+import { usePortalContainer } from '../../contexts/PortalContainerContext';
 
-export interface TooltipProps {
+export interface TooltipProps extends Omit<React.HTMLAttributes<HTMLElement>, 'children' | 'content'> {
   content: React.ReactNode;
-  children: React.ReactNode;
+  children: React.ReactElement;
   side?: 'top' | 'bottom' | 'left' | 'right';
   className?: string;
-  /** When true, the tooltip stays open when hovered and allows interaction (clicks, selection) */
+  /** When true, the tooltip stays open when hovered so rich text can be selected. */
   interactive?: boolean;
   /** Delay in ms before showing the tooltip (default: 400) */
   delay?: number;
@@ -15,24 +17,32 @@ export interface TooltipProps {
 
 const GAP = 6;
 
-export const Tooltip: React.FC<TooltipProps> = ({
+export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
   content,
   children,
   side = 'top',
   className,
   interactive = false,
   delay = 400,
-}) => {
-  const [isHovered, setIsHovered] = useState(false);
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  onBlur,
+  onKeyDown,
+  ...triggerProps
+}, forwardedRef) => {
+  const [isOpen, setIsOpen] = useState(false);
   const [style, setStyle] = useState<React.CSSProperties>({ visibility: 'hidden' });
-  const triggerRef = useRef<HTMLDivElement>(null);
+  const tooltipId = useId();
+  const portalContainer = usePortalContainer();
+  const triggerRef = useRef<HTMLElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const showTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Compute position after the tooltip DOM element mounts so we can measure it
   useLayoutEffect(() => {
-    if (!isHovered || !triggerRef.current || !tooltipRef.current) return;
+    if (!isOpen || !triggerRef.current || !tooltipRef.current) return;
 
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const tipRect = tooltipRef.current.getBoundingClientRect();
@@ -65,7 +75,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
     top = Math.max(margin, Math.min(top, window.innerHeight - tipRect.height - margin));
 
     setStyle({ top, left, visibility: 'visible', opacity: 1 });
-  }, [isHovered, side]);
+  }, [isOpen, side]);
 
   const cancelHide = useCallback(() => {
     if (hideTimeout.current) {
@@ -87,11 +97,11 @@ export const Tooltip: React.FC<TooltipProps> = ({
     if (delay > 0) {
       showTimeout.current = setTimeout(() => {
         setStyle({ visibility: 'hidden' });
-        setIsHovered(true);
+        setIsOpen(true);
       }, delay);
     } else {
       setStyle({ visibility: 'hidden' });
-      setIsHovered(true);
+      setIsOpen(true);
     }
   }, [cancelHide, cancelShow, delay]);
 
@@ -99,11 +109,27 @@ export const Tooltip: React.FC<TooltipProps> = ({
     cancelShow();
     if (interactive) {
       // Small delay so user can move mouse from trigger to tooltip
-      hideTimeout.current = setTimeout(() => setIsHovered(false), 100);
+      hideTimeout.current = setTimeout(() => setIsOpen(false), 100);
     } else {
-      setIsHovered(false);
+      setIsOpen(false);
     }
   }, [interactive, cancelShow]);
+
+  const dismiss = useCallback(() => {
+    cancelHide();
+    cancelShow();
+    setIsOpen(false);
+  }, [cancelHide, cancelShow]);
+
+  useEffect(() => () => {
+    cancelHide();
+    cancelShow();
+  }, [cancelHide, cancelShow]);
+
+  const existingDescription = (children.props as { 'aria-describedby'?: string })['aria-describedby'];
+  const describedBy = [existingDescription, isOpen ? tooltipId : undefined]
+    .filter(Boolean)
+    .join(' ') || undefined;
 
   const arrowBorder: Record<string, string> = {
     top: 'border-l-transparent border-r-transparent border-b-transparent border-t-bg-tertiary',
@@ -119,21 +145,55 @@ export const Tooltip: React.FC<TooltipProps> = ({
     right: { left: -8, top: '50%', transform: 'translateY(-50%)' },
   };
 
-  return (
-    <div
-      ref={triggerRef}
-      className={cn('relative inline-block', className)}
-      onMouseEnter={show}
-      onMouseLeave={hide}
-    >
-      {children}
+  const setTriggerRef = useCallback((node: HTMLElement | null) => {
+    triggerRef.current = node;
+    if (typeof forwardedRef === 'function') forwardedRef(node);
+    else if (forwardedRef) forwardedRef.current = node;
+  }, [forwardedRef]);
 
-      {isHovered && createPortal(
+  return (
+    <>
+      <Slot
+        {...triggerProps}
+        ref={setTriggerRef}
+        className={className}
+        aria-describedby={describedBy}
+        onMouseEnter={(event) => {
+          onMouseEnter?.(event);
+          if (!event.defaultPrevented) show();
+        }}
+        onMouseLeave={(event) => {
+          onMouseLeave?.(event);
+          if (!event.defaultPrevented) hide();
+        }}
+        onFocus={(event) => {
+          onFocus?.(event);
+          if (!event.defaultPrevented) show();
+        }}
+        onBlur={(event) => {
+          onBlur?.(event);
+          if (!event.defaultPrevented) hide();
+        }}
+        onKeyDown={(event) => {
+          onKeyDown?.(event);
+          if (event.defaultPrevented) return;
+          if (event.key === 'Escape' && isOpen) {
+            event.preventDefault();
+            event.stopPropagation();
+            dismiss();
+          }
+        }}
+      >
+        {children}
+      </Slot>
+
+      {isOpen && createPortal(
         <div
+          id={tooltipId}
           ref={tooltipRef}
           className={cn(
             'fixed z-tooltip px-3 py-1.5 text-sm text-text-primary bg-bg-tertiary border border-border-primary rounded-lg shadow-lg transition-opacity duration-150',
-            interactive ? 'whitespace-normal' : 'whitespace-nowrap pointer-events-none'
+            interactive ? 'whitespace-normal pointer-events-auto' : 'whitespace-nowrap pointer-events-none'
           )}
           style={style}
           role="tooltip"
@@ -146,10 +206,10 @@ export const Tooltip: React.FC<TooltipProps> = ({
             style={arrowStyle[side]}
           />
         </div>,
-        document.body
+        portalContainer ?? document.body
       )}
-    </div>
+    </>
   );
-};
+});
 
 Tooltip.displayName = 'Tooltip';

--- a/frontend/src/contexts/PortalContainerContext.tsx
+++ b/frontend/src/contexts/PortalContainerContext.tsx
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+const PortalContainerContext = createContext<HTMLElement | null>(null);
+
+export const PortalContainerProvider = PortalContainerContext.Provider;
+
+export function usePortalContainer(): HTMLElement | null {
+  return useContext(PortalContainerContext);
+}

--- a/frontend/src/remote/RemotePwaApp.tsx
+++ b/frontend/src/remote/RemotePwaApp.tsx
@@ -190,7 +190,15 @@ export function RemotePwaApp() {
   }, [loadAffordances, refreshProjects]);
 
   const connectCode = useCallback(async (code: string) => {
-    const profile = decodeRemoteConnectionCode(code);
+    setLastError(null);
+    let profile: RemotePaneConnectionProfile;
+    try {
+      profile = decodeRemoteConnectionCode(code);
+    } catch (error) {
+      setLastError(error instanceof Error ? error.message : 'Invalid remote Pane connection code');
+      throw error;
+    }
+
     forgetProfilesForBaseUrl(profile.baseUrl, setSavedProfiles);
     await connectProfile(profile);
   }, [connectProfile]);

--- a/frontend/src/remote/RemotePwaApp.tsx
+++ b/frontend/src/remote/RemotePwaApp.tsx
@@ -1,10 +1,16 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
 import type { ToolPanel } from '../../../shared/types/panels';
 import type { RemotePaneConnectionProfile, RemotePaneConnectionStatus, RemotePwaAffordances } from '../../../shared/types/remoteDaemon';
 import type { Session } from '../types/session';
 import { RemoteConnectionScreen } from './components/RemoteConnectionScreen';
 import { RemoteCreateSessionDialog } from './components/RemoteCreateSessionDialog';
-import { RemotePanelTabs, type RemoteTerminalCreateOptions } from './components/RemotePanelTabs';
+import {
+  getRemotePanelTabId,
+  getRemotePanelTabPanelId,
+  RemotePanelTabs,
+  type RemoteTerminalCreateOptions,
+} from './components/RemotePanelTabs';
 import { RemoteSessionList } from './components/RemoteSessionList';
 import { RemoteSidebar } from './components/RemoteSidebar';
 import { RemoteStatusBar } from './components/RemoteStatusBar';
@@ -59,6 +65,19 @@ export function RemotePwaApp() {
   const [affordancesLoading, setAffordancesLoading] = useState(false);
   const [sidebarActionSessionId, setSidebarActionSessionId] = useState<string | null>(null);
   const [createSessionProject, setCreateSessionProject] = useState<RemoteProjectWithSessions | null>(null);
+  const [mountedTerminalPanelIds, setMountedTerminalPanelIds] = useState<string[]>([]);
+  const sidebarOpenerRef = useRef<HTMLElement | null>(null);
+  const createSessionOpenerRef = useRef<HTMLElement | null>(null);
+
+  const openSidebar = useCallback(() => {
+    sidebarOpenerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    setSidebarOpen(true);
+  }, []);
+
+  const openCreateSession = useCallback((project: RemoteProjectWithSessions) => {
+    createSessionOpenerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    setCreateSessionProject(project);
+  }, []);
 
   const projects = useRemoteSessionStore(state => state.projects);
   const selectedSessionId = useRemoteSessionStore(state => state.selectedSessionId);
@@ -85,7 +104,19 @@ export function RemotePwaApp() {
     () => selectedPanels.filter(panel => panel.type === 'terminal'),
     [selectedPanels],
   );
-  const selectedPanel = terminalPanels.find(panel => panel.id === selectedPanelId) ?? terminalPanels[0] ?? null;
+  const selectedPanel = selectedPanels.find(panel => panel.id === selectedPanelId) ?? selectedPanels[0] ?? null;
+
+  useEffect(() => {
+    if (!selectedPanel || selectedPanel.type !== 'terminal') return;
+    setMountedTerminalPanelIds(previous => previous.includes(selectedPanel.id)
+      ? previous
+      : [...previous, selectedPanel.id]);
+  }, [selectedPanel]);
+
+  useEffect(() => {
+    const currentPanelIds = new Set(terminalPanels.map(panel => panel.id));
+    setMountedTerminalPanelIds(previous => previous.filter(panelId => currentPanelIds.has(panelId)));
+  }, [terminalPanels]);
 
   const refreshProjects = useCallback(async (runtime: RemoteRuntimeAdapter | null = adapter) => {
     if (!runtime) return null;
@@ -117,9 +148,7 @@ export function RemotePwaApp() {
         runtime.getActivePanel(sessionId).catch(() => null),
       ]);
       setPanels(sessionId, panels);
-      const activeTerminalPanel = activePanel?.type === 'terminal' ? activePanel : null;
-      const firstTerminalPanel = panels.find(panel => panel.type === 'terminal') ?? null;
-      setSelectedPanel(activeTerminalPanel?.id ?? firstTerminalPanel?.id ?? null);
+      setSelectedPanel(activePanel?.id ?? panels[0]?.id ?? null);
       setLastError(null);
     } catch (error) {
       setLastError(error instanceof Error ? error.message : 'Failed to load remote panels');
@@ -329,29 +358,40 @@ export function RemotePwaApp() {
 
   return (
     <div className="flex h-dvh min-h-dvh w-full overflow-hidden bg-bg-primary text-text-primary">
-      {sidebarOpen && (
-        <div className="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true" aria-label="Remote panes">
-          <button
-            type="button"
-            className="absolute inset-0 bg-black/60"
-            aria-label="Close remote panes"
-            onClick={() => setSidebarOpen(false)}
-          />
-          <RemoteSidebar
-            projects={projects}
-            selectedSessionId={selectedSessionId}
-            loading={loading}
-            actionSessionId={sidebarActionSessionId}
-            onSelectSession={selectRemoteSession}
-            onTogglePinned={toggleRemotePinnedSession}
-            onArchiveSession={archiveRemoteSession}
-            onCreateSession={setCreateSessionProject}
-            onRefresh={() => { void refreshProjects(adapter); }}
-            onClose={() => setSidebarOpen(false)}
-            className="absolute inset-y-0 left-0 flex w-[min(22rem,calc(100vw-2rem))] max-w-full shadow-2xl"
-          />
-        </div>
-      )}
+      <Dialog.Root open={sidebarOpen} onOpenChange={setSidebarOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 md:hidden" />
+          <Dialog.Content
+            aria-describedby={undefined}
+            onCloseAutoFocus={(event) => {
+              event.preventDefault();
+              requestAnimationFrame(() => {
+                if (document.activeElement?.closest('[aria-modal="true"]')) return;
+                if (sidebarOpenerRef.current?.isConnected) sidebarOpenerRef.current.focus();
+              });
+            }}
+            className="fixed inset-y-0 left-0 z-50 w-[min(22rem,calc(100vw-2rem))] max-w-full shadow-2xl outline-none md:hidden"
+          >
+            <Dialog.Title className="sr-only">Remote panes</Dialog.Title>
+            <RemoteSidebar
+              projects={projects}
+              selectedSessionId={selectedSessionId}
+              loading={loading}
+              actionSessionId={sidebarActionSessionId}
+              onSelectSession={selectRemoteSession}
+              onTogglePinned={toggleRemotePinnedSession}
+              onArchiveSession={archiveRemoteSession}
+              onCreateSession={(project) => {
+                setSidebarOpen(false);
+                openCreateSession(project);
+              }}
+              onRefresh={() => { void refreshProjects(adapter); }}
+              onClose={() => setSidebarOpen(false)}
+              className="flex h-full w-full shadow-2xl"
+            />
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
 
       <RemoteSidebar
         projects={projects}
@@ -361,7 +401,7 @@ export function RemotePwaApp() {
         onSelectSession={selectRemoteSession}
         onTogglePinned={toggleRemotePinnedSession}
         onArchiveSession={archiveRemoteSession}
-        onCreateSession={setCreateSessionProject}
+        onCreateSession={openCreateSession}
         onRefresh={() => { void refreshProjects(adapter); }}
         className="hidden w-80 shrink-0 md:flex"
       />
@@ -372,11 +412,11 @@ export function RemotePwaApp() {
           lastError={lastError}
           lastSeenAt={lastSeenAt}
           onDisconnect={disconnect}
-          onOpenSidebar={() => setSidebarOpen(true)}
+          onOpenSidebar={openSidebar}
         />
 
         <RemotePanelTabs
-          panels={terminalPanels}
+          panels={selectedPanels}
           selectedPanelId={selectedPanel?.id ?? null}
           creating={creatingTerminal}
           customCommands={affordances.customCommands}
@@ -386,25 +426,48 @@ export function RemotePwaApp() {
 
         <RemoteSessionList
           session={selectedSession}
-          panels={terminalPanels}
+          panels={selectedPanels}
           onCreateTerminal={createTerminal}
         />
 
-        {selectedSession && selectedPanel?.type === 'terminal' && (
-          <RemoteTerminalPanel
-            adapter={adapter}
-            panel={selectedPanel}
-            sessionId={selectedSession.id}
-            connectionStatus={connectionStatus}
-            shortcuts={affordances.terminalShortcuts}
-            shortcutsLoading={affordancesLoading}
-            voiceTranscription={affordances.voiceTranscription}
-            onRefreshShortcuts={() => { void loadAffordances(adapter); }}
-          />
-        )}
+        {selectedSession && terminalPanels
+          .filter(panel => panel.id === selectedPanel?.id || mountedTerminalPanelIds.includes(panel.id))
+          .map(panel => {
+            const selected = panel.id === selectedPanel?.id;
+            return (
+              <div
+                key={panel.id}
+                id={getRemotePanelTabPanelId(panel.id)}
+                role="tabpanel"
+                aria-labelledby={getRemotePanelTabId(panel.id)}
+                hidden={!selected}
+                tabIndex={0}
+                className={selected ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : undefined}
+              >
+                <RemoteTerminalPanel
+                  adapter={adapter}
+                  panel={panel}
+                  sessionId={selectedSession.id}
+                  connectionStatus={connectionStatus}
+                  shortcuts={affordances.terminalShortcuts}
+                  shortcutsLoading={affordancesLoading}
+                  voiceTranscription={affordances.voiceTranscription}
+                  onRefreshShortcuts={() => { void loadAffordances(adapter); }}
+                />
+              </div>
+            );
+          })}
 
         {selectedSession && selectedPanel && selectedPanel.type !== 'terminal' && (
-          <UnsupportedPanel session={selectedSession} panel={selectedPanel} />
+          <div
+            id={getRemotePanelTabPanelId(selectedPanel.id)}
+            role="tabpanel"
+            aria-labelledby={getRemotePanelTabId(selectedPanel.id)}
+            tabIndex={0}
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          >
+            <UnsupportedPanel session={selectedSession} panel={selectedPanel} />
+          </div>
         )}
       </section>
 
@@ -412,6 +475,8 @@ export function RemotePwaApp() {
         <RemoteCreateSessionDialog
           adapter={adapter}
           project={createSessionProject}
+          restoreFocusRef={createSessionOpenerRef}
+          fallbackFocusRef={sidebarOpenerRef}
           onClose={() => setCreateSessionProject(null)}
           onCreated={(sessionName) => handleRemoteSessionCreated(createSessionProject.id, sessionName)}
         />

--- a/frontend/src/remote/RemotePwaApp.tsx
+++ b/frontend/src/remote/RemotePwaApp.tsx
@@ -3,7 +3,10 @@ import * as Dialog from '@radix-ui/react-dialog';
 import type { ToolPanel } from '../../../shared/types/panels';
 import type { RemotePaneConnectionProfile, RemotePaneConnectionStatus, RemotePwaAffordances } from '../../../shared/types/remoteDaemon';
 import type { Session } from '../types/session';
-import { RemoteConnectionScreen } from './components/RemoteConnectionScreen';
+import {
+  RemoteConnectionScreen,
+  type RemoteConnectionErrorKind,
+} from './components/RemoteConnectionScreen';
 import { RemoteCreateSessionDialog } from './components/RemoteCreateSessionDialog';
 import {
   getRemotePanelTabId,
@@ -57,6 +60,7 @@ export function RemotePwaApp() {
   const [activeProfile, setActiveProfile] = useState<RemotePaneConnectionProfile | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<RemotePaneConnectionStatus>('local');
   const [lastError, setLastError] = useState<string | null>(null);
+  const [connectionErrorKind, setConnectionErrorKind] = useState<RemoteConnectionErrorKind | null>(null);
   const [lastSeenAt, setLastSeenAt] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [creatingTerminal, setCreatingTerminal] = useState(false);
@@ -171,6 +175,7 @@ export function RemotePwaApp() {
     const runtime = new RemoteRuntimeAdapter(profile);
     setConnectionStatus('connecting');
     setLastError(null);
+    setConnectionErrorKind(null);
 
     try {
       await runtime.connect();
@@ -185,17 +190,20 @@ export function RemotePwaApp() {
       setActiveProfile(null);
       setConnectionStatus('local');
       setLastError(error instanceof Error ? error.message : 'Failed to connect to remote Pane');
+      setConnectionErrorKind('connection');
       throw error;
     }
   }, [loadAffordances, refreshProjects]);
 
   const connectCode = useCallback(async (code: string) => {
     setLastError(null);
+    setConnectionErrorKind(null);
     let profile: RemotePaneConnectionProfile;
     try {
       profile = decodeRemoteConnectionCode(code);
     } catch (error) {
       setLastError(error instanceof Error ? error.message : 'Invalid remote Pane connection code');
+      setConnectionErrorKind('connection-code');
       throw error;
     }
 
@@ -209,6 +217,7 @@ export function RemotePwaApp() {
     setActiveProfile(null);
     setConnectionStatus('local');
     setLastError(null);
+    setConnectionErrorKind(null);
     setLastSeenAt(null);
     setAffordances(EMPTY_AFFORDANCES);
     setAffordancesLoading(false);
@@ -357,6 +366,7 @@ export function RemotePwaApp() {
       <RemoteConnectionScreen
         savedProfiles={savedProfiles}
         error={lastError}
+        errorKind={connectionErrorKind}
         onConnectCode={connectCode}
         onConnectProfile={connectProfile}
         onForgetProfile={forgetProfile}

--- a/frontend/src/remote/components/RemoteConnectionScreen.tsx
+++ b/frontend/src/remote/components/RemoteConnectionScreen.tsx
@@ -30,6 +30,9 @@ export function RemoteConnectionScreen({
   const canReadClipboard = typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.readText);
   const mobileInstallPlatform = getMobileInstallPlatform();
   const connectionErrorId = useId();
+  const showConnectionTroubleshooting = Boolean(
+    error && !/^(Connection code|Invalid remote Pane connection code)/.test(error),
+  );
 
   useEffect(() => {
     if (savedProfiles.length > 0) {
@@ -177,10 +180,10 @@ export function RemoteConnectionScreen({
             />
 
             {(error || clipboardError) && (
-              <div id={connectionErrorId} role="alert" className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-600">
+              <div id={connectionErrorId} role="alert" className="mt-3 rounded-md border border-status-error/30 bg-status-error/10 px-3 py-2 text-sm text-status-error">
                 <p>{error || clipboardError}</p>
-                {error && (
-                  <p className="mt-2 text-xs text-red-500/90">
+                {showConnectionTroubleshooting && (
+                  <p className="mt-2 text-xs text-status-error">
                     If this profile uses Tailscale, install or open Tailscale on this device, sign in to the same tailnet as the host, then retry.
                   </p>
                 )}
@@ -192,7 +195,7 @@ export function RemoteConnectionScreen({
                 type="submit"
                 disabled={isConnecting || (!code.trim() && !canReadClipboard)}
                 aria-busy={isConnecting && connectingProfileId === null}
-                className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-interactive px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:py-2"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-interactive px-4 py-2.5 text-sm font-semibold text-text-on-interactive transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:py-2"
               >
                 {code.trim() ? <ArrowRight className="h-4 w-4" aria-hidden="true" /> : <ClipboardPaste className="h-4 w-4" aria-hidden="true" />}
                 {isConnecting ? 'Connecting...' : code.trim() ? 'Import & Connect' : 'Paste & Connect'}
@@ -215,7 +218,7 @@ export function RemoteConnectionScreen({
                           onClick={() => { void handleProfileConnect(profile); }}
                           disabled={isConnecting}
                           aria-busy={connectingProfileId === profile.id}
-                          className="min-w-0 flex-1 rounded-md bg-interactive px-3 py-2 text-sm font-semibold text-white hover:opacity-90 sm:flex-none sm:py-1.5"
+                          className="min-w-0 flex-1 rounded-md bg-interactive px-3 py-2 text-sm font-semibold text-text-on-interactive hover:opacity-90 sm:flex-none sm:py-1.5"
                         >
                           Connect
                         </button>

--- a/frontend/src/remote/components/RemoteConnectionScreen.tsx
+++ b/frontend/src/remote/components/RemoteConnectionScreen.tsx
@@ -4,10 +4,12 @@ import type { RemotePaneConnectionProfile } from '../../../../shared/types/remot
 
 type ConnectionScreenMode = 'menu' | 'connect';
 type MobileInstallPlatform = 'ios' | 'android' | 'mobile';
+export type RemoteConnectionErrorKind = 'connection-code' | 'connection';
 
 interface RemoteConnectionScreenProps {
   savedProfiles: RemotePaneConnectionProfile[];
   error: string | null;
+  errorKind: RemoteConnectionErrorKind | null;
   onConnectCode: (code: string) => Promise<void>;
   onConnectProfile: (profile: RemotePaneConnectionProfile) => Promise<void>;
   onForgetProfile: (profileId: string) => void;
@@ -16,6 +18,7 @@ interface RemoteConnectionScreenProps {
 export function RemoteConnectionScreen({
   savedProfiles,
   error,
+  errorKind,
   onConnectCode,
   onConnectProfile,
   onForgetProfile,
@@ -30,9 +33,7 @@ export function RemoteConnectionScreen({
   const canReadClipboard = typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.readText);
   const mobileInstallPlatform = getMobileInstallPlatform();
   const connectionErrorId = useId();
-  const showConnectionTroubleshooting = Boolean(
-    error && !/^(Connection code|Invalid remote Pane connection code)/.test(error),
-  );
+  const showConnectionTroubleshooting = Boolean(error && errorKind === 'connection');
 
   useEffect(() => {
     if (savedProfiles.length > 0) {

--- a/frontend/src/remote/components/RemoteConnectionScreen.tsx
+++ b/frontend/src/remote/components/RemoteConnectionScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState, type FormEvent } from 'react';
 import { ArrowLeft, ArrowRight, BookOpen, ClipboardPaste, Download, Monitor, Smartphone, Trash2 } from 'lucide-react';
 import type { RemotePaneConnectionProfile } from '../../../../shared/types/remoteDaemon';
 
@@ -22,12 +22,14 @@ export function RemoteConnectionScreen({
 }: RemoteConnectionScreenProps) {
   const [code, setCode] = useState('');
   const [isConnecting, setIsConnecting] = useState(false);
+  const [connectingProfileId, setConnectingProfileId] = useState<string | null>(null);
   const [clipboardError, setClipboardError] = useState<string | null>(null);
   const [mode, setMode] = useState<ConnectionScreenMode>(() => (
     savedProfiles.length > 0 ? 'connect' : 'menu'
   ));
   const canReadClipboard = typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.readText);
   const mobileInstallPlatform = getMobileInstallPlatform();
+  const connectionErrorId = useId();
 
   useEffect(() => {
     if (savedProfiles.length > 0) {
@@ -61,6 +63,25 @@ export function RemoteConnectionScreen({
     }
   };
 
+  const submitConnectionCode = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void handleSubmit();
+  };
+
+  const handleProfileConnect = async (profile: RemotePaneConnectionProfile) => {
+    setIsConnecting(true);
+    setConnectingProfileId(profile.id);
+    setClipboardError(null);
+    try {
+      await onConnectProfile(profile);
+    } catch {
+      // The parent owns the visible error state.
+    } finally {
+      setIsConnecting(false);
+      setConnectingProfileId(null);
+    }
+  };
+
   const showFirstRunMenu = savedProfiles.length === 0 && mode === 'menu';
   const showBackToMenu = savedProfiles.length === 0 && mode === 'connect';
 
@@ -69,7 +90,7 @@ export function RemoteConnectionScreen({
       <section className="w-full max-w-sm sm:max-w-2xl">
         <div className="mb-6 flex items-start gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-surface-secondary text-interactive">
-            <Monitor className="h-5 w-5" />
+            <Monitor className="h-5 w-5" aria-hidden="true" />
           </div>
           <div className="min-w-0">
             <h1 className="text-xl font-semibold text-text-primary">Remote Pane</h1>
@@ -91,14 +112,14 @@ export function RemoteConnectionScreen({
               >
                 <div>
                   <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md bg-surface-secondary text-interactive">
-                    <ClipboardPaste className="h-5 w-5" />
+                    <ClipboardPaste className="h-5 w-5" aria-hidden="true" />
                   </div>
                   <h2 className="text-base font-semibold text-text-primary">Connect with a code</h2>
                   <p className="mt-2 text-sm leading-5 text-text-secondary">Paste a pane-remote:// code from an existing remote host.</p>
                 </div>
                 <span className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-interactive">
                   Open connection form
-                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
                 </span>
               </button>
 
@@ -110,27 +131,34 @@ export function RemoteConnectionScreen({
               >
                 <div>
                   <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-md bg-surface-secondary text-interactive">
-                    <BookOpen className="h-5 w-5" />
+                    <BookOpen className="h-5 w-5" aria-hidden="true" />
                   </div>
                   <h2 className="text-base font-semibold text-text-primary">Set up a remote host</h2>
                   <p className="mt-2 text-sm leading-5 text-text-secondary">Run Pane on a VM, WSL box, server, or desktop and create a connection code.</p>
                 </div>
                 <span className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-interactive">
                   Open setup guide
-                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
                 </span>
               </a>
             </div>
           </div>
         ) : (
-          <div className="rounded-lg border border-border-primary bg-surface-primary p-5 shadow-lg sm:p-6">
+          <form
+            onSubmit={submitConnectionCode}
+            aria-busy={isConnecting}
+            className="rounded-lg border border-border-primary bg-surface-primary p-5 shadow-lg sm:p-6"
+          >
+            <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+              {isConnecting ? connectingProfileId ? 'Connecting to saved profile' : 'Connecting to remote Pane' : ''}
+            </div>
             {showBackToMenu && (
               <button
                 type="button"
                 onClick={() => setMode('menu')}
                 className="mb-4 inline-flex items-center gap-2 text-sm font-medium text-text-secondary hover:text-text-primary"
               >
-                <ArrowLeft className="h-4 w-4" />
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
                 Back
               </button>
             )}
@@ -142,12 +170,14 @@ export function RemoteConnectionScreen({
               id="connection-code"
               value={code}
               onChange={event => setCode(event.target.value)}
+              aria-invalid={Boolean(error || clipboardError)}
+              aria-describedby={error || clipboardError ? connectionErrorId : undefined}
               placeholder="pane-remote://..."
               className="ph-no-capture min-h-32 max-h-52 w-full resize-y rounded-md border border-border-primary bg-bg-secondary p-3 font-mono text-sm text-text-primary outline-none transition-colors placeholder:text-text-muted focus:border-border-focus"
             />
 
             {(error || clipboardError) && (
-              <div className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-600">
+              <div id={connectionErrorId} role="alert" className="mt-3 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-600">
                 <p>{error || clipboardError}</p>
                 {error && (
                   <p className="mt-2 text-xs text-red-500/90">
@@ -159,12 +189,12 @@ export function RemoteConnectionScreen({
 
             <div className="mt-4 flex justify-stretch sm:justify-end">
               <button
-                type="button"
-                onClick={handleSubmit}
+                type="submit"
                 disabled={isConnecting || (!code.trim() && !canReadClipboard)}
+                aria-busy={isConnecting && connectingProfileId === null}
                 className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-interactive px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto sm:py-2"
               >
-                {code.trim() ? <ArrowRight className="h-4 w-4" /> : <ClipboardPaste className="h-4 w-4" />}
+                {code.trim() ? <ArrowRight className="h-4 w-4" aria-hidden="true" /> : <ClipboardPaste className="h-4 w-4" aria-hidden="true" />}
                 {isConnecting ? 'Connecting...' : code.trim() ? 'Import & Connect' : 'Paste & Connect'}
               </button>
             </div>
@@ -182,7 +212,9 @@ export function RemoteConnectionScreen({
                       <div className="flex shrink-0 items-center gap-2">
                         <button
                           type="button"
-                          onClick={() => { void onConnectProfile(profile).catch(() => {}); }}
+                          onClick={() => { void handleProfileConnect(profile); }}
+                          disabled={isConnecting}
+                          aria-busy={connectingProfileId === profile.id}
                           className="min-w-0 flex-1 rounded-md bg-interactive px-3 py-2 text-sm font-semibold text-white hover:opacity-90 sm:flex-none sm:py-1.5"
                         >
                           Connect
@@ -190,10 +222,11 @@ export function RemoteConnectionScreen({
                         <button
                           type="button"
                           onClick={() => onForgetProfile(profile.id)}
+                          disabled={isConnecting}
                           className="rounded-md p-2 text-text-tertiary hover:bg-surface-hover hover:text-text-primary"
                           aria-label={`Forget ${profile.label}`}
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Trash2 className="h-4 w-4" aria-hidden="true" />
                         </button>
                       </div>
                     </div>
@@ -201,7 +234,7 @@ export function RemoteConnectionScreen({
                 </div>
               </div>
             )}
-          </div>
+          </form>
         )}
       </section>
     </main>
@@ -215,12 +248,12 @@ function MobileInstallPrompt({ platform }: { platform: MobileInstallPlatform }) 
     <div className="rounded-lg border border-border-primary bg-surface-primary p-4 shadow-lg">
       <div className="flex gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-surface-secondary text-interactive">
-          <Smartphone className="h-5 w-5" />
+          <Smartphone className="h-5 w-5" aria-hidden="true" />
         </div>
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <h2 className="text-base font-semibold text-text-primary">Install Remote Pane</h2>
-            <Download className="h-4 w-4 text-interactive" />
+            <Download className="h-4 w-4 text-interactive" aria-hidden="true" />
           </div>
           <ol className="mt-2 list-inside list-decimal space-y-1 text-sm leading-5 text-text-secondary">
             {steps.map(step => (

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -227,7 +227,9 @@ export function RemoteCreateSessionDialog({
               if (target?.isConnected) target.focus();
             });
           }}
-          onEscapeKeyDown={(event) => { if (submitting) event.preventDefault(); }}
+          onEscapeKeyDown={(event) => {
+            if (submitting || branchOpen) event.preventDefault();
+          }}
           onPointerDownOutside={(event) => { if (submitting) event.preventDefault(); }}
         >
           <form
@@ -404,7 +406,7 @@ export function RemoteCreateSessionDialog({
             type="submit"
             disabled={loadingBranches || submitting || !baseBranch}
             aria-busy={submitting}
-            className="rounded-md bg-interactive px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-interactive-hover disabled:cursor-not-allowed disabled:opacity-60"
+            className="rounded-md bg-interactive px-5 py-2 text-sm font-semibold text-text-on-interactive transition-colors hover:bg-interactive-hover disabled:cursor-not-allowed disabled:opacity-60"
           >
             {submitting ? 'Creating...' : 'Create'}
           </button>

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, GitBranch, GitFork, Pin, Search, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type FormEvent, type RefObject } from 'react';
 import { generatePaneName, sanitizePaneName } from '../../utils/paneName';
 import type { RemoteBranchInfo, RemoteProjectWithSessions, RemoteRuntimeAdapter } from '../runtime/remoteRuntimeAdapter';
 
@@ -13,6 +14,8 @@ const REMOTE_START_PINNED_PREFERENCE_KEY = 'pane.remoteCreateSession.startPinned
 interface RemoteCreateSessionDialogProps {
   adapter: RemoteRuntimeAdapter;
   project: RemoteProjectWithSessions;
+  restoreFocusRef: RefObject<HTMLElement | null>;
+  fallbackFocusRef?: RefObject<HTMLElement | null>;
   onClose: () => void;
   onCreated: (sessionName: string) => Promise<void>;
 }
@@ -20,6 +23,8 @@ interface RemoteCreateSessionDialogProps {
 export function RemoteCreateSessionDialog({
   adapter,
   project,
+  restoreFocusRef,
+  fallbackFocusRef,
   onClose,
   onCreated,
 }: RemoteCreateSessionDialogProps) {
@@ -33,8 +38,17 @@ export function RemoteCreateSessionDialog({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [branchOpen, setBranchOpen] = useState(false);
+  const [activeBranchIndex, setActiveBranchIndex] = useState(0);
+  const [announcement, setAnnouncement] = useState('');
   const [userEditedName, setUserEditedName] = useState(false);
   const branchDropdownRef = useRef<HTMLDivElement>(null);
+  const branchInputRef = useRef<HTMLInputElement>(null);
+  const branchListboxId = useId();
+  const branchIdPrefix = useId();
+  const branchHelpId = useId();
+  const nameHelpId = useId();
+  const errorId = useId();
+  const paneNameInvalid = error === 'Pane name is required.';
 
   const existingNames = useMemo(() => new Set((project.sessions ?? []).map(session => session.name)), [project.sessions]);
 
@@ -56,6 +70,18 @@ export function RemoteCreateSessionDialog({
       setPaneName(generatePaneName(branchName, existingNames, branches));
     }
   }, [branches, existingNames, userEditedName]);
+
+  useEffect(() => {
+    setActiveBranchIndex(0);
+  }, [branchSearch]);
+
+  useEffect(() => {
+    if (loadingBranches) {
+      setAnnouncement('Loading branches');
+    } else if (!error) {
+      setAnnouncement(`${branches.length} ${branches.length === 1 ? 'branch' : 'branches'} available`);
+    }
+  }, [branches.length, error, loadingBranches]);
 
   useEffect(() => {
     let cancelled = false;
@@ -109,6 +135,43 @@ export function RemoteCreateSessionDialog({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [branchOpen]);
 
+  const handleBranchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!branchOpen) {
+        setBranchOpen(true);
+        return;
+      }
+      if (filteredBranches.length === 0) return;
+      const direction = event.key === 'ArrowDown' ? 1 : -1;
+      setActiveBranchIndex(previous => (previous + direction + filteredBranches.length) % filteredBranches.length);
+      return;
+    }
+    if (event.key === 'Home' && branchOpen) {
+      event.preventDefault();
+      setActiveBranchIndex(0);
+      return;
+    }
+    if (event.key === 'End' && branchOpen) {
+      event.preventDefault();
+      setActiveBranchIndex(Math.max(0, filteredBranches.length - 1));
+      return;
+    }
+    if (event.key === 'Enter' && branchOpen) {
+      const branch = filteredBranches[activeBranchIndex];
+      if (branch) {
+        event.preventDefault();
+        setSelectedBranch(branch.name);
+      }
+      return;
+    }
+    if (event.key === 'Escape' && branchOpen) {
+      event.preventDefault();
+      setBranchOpen(false);
+      setBranchSearch('');
+    }
+  };
+
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     if (loadingBranches || submitting) return;
@@ -123,6 +186,7 @@ export function RemoteCreateSessionDialog({
       return;
     }
 
+    setAnnouncement(`Creating ${cleanedName}`);
     setSubmitting(true);
     setError(null);
     try {
@@ -147,21 +211,35 @@ export function RemoteCreateSessionDialog({
   };
 
   return (
-    <div className="fixed inset-0 z-[70] flex items-end bg-black/65 p-0 sm:items-center sm:justify-center sm:p-6" role="dialog" aria-modal="true" aria-label={`New Pane in ${project.name}`}>
-      <button
-        type="button"
-        className="absolute inset-0"
-        aria-label="Close new pane dialog"
-        onClick={() => {
-          if (!submitting) onClose();
-        }}
-      />
-      <form
-        onSubmit={handleSubmit}
-        className="relative z-10 flex max-h-[92dvh] w-full flex-col overflow-hidden rounded-t-xl border border-border-primary bg-surface-primary shadow-2xl sm:max-w-xl sm:rounded-xl"
-      >
+    <Dialog.Root open onOpenChange={(open) => { if (!open && !submitting) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[70] bg-black/65" />
+        <Dialog.Content
+          asChild
+          aria-describedby={undefined}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            requestAnimationFrame(() => {
+              if (document.activeElement?.closest('[aria-modal="true"]')) return;
+              const target = restoreFocusRef.current?.isConnected
+                ? restoreFocusRef.current
+                : fallbackFocusRef?.current;
+              if (target?.isConnected) target.focus();
+            });
+          }}
+          onEscapeKeyDown={(event) => { if (submitting) event.preventDefault(); }}
+          onPointerDownOutside={(event) => { if (submitting) event.preventDefault(); }}
+        >
+          <form
+            onSubmit={handleSubmit}
+            aria-busy={loadingBranches || submitting}
+            className="fixed inset-x-0 bottom-0 z-[71] flex max-h-[92dvh] w-full flex-col overflow-hidden rounded-t-xl border border-border-primary bg-surface-primary shadow-2xl outline-none sm:inset-auto sm:left-1/2 sm:top-1/2 sm:max-w-xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl"
+          >
+            <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">{announcement}</div>
         <div className="flex shrink-0 items-center justify-between border-b border-border-primary px-5 py-4">
-          <h2 className="min-w-0 truncate text-lg font-semibold text-text-primary">New Pane in {project.name}</h2>
+          <Dialog.Title asChild>
+            <h2 className="min-w-0 truncate text-lg font-semibold text-text-primary">New Pane in {project.name}</h2>
+          </Dialog.Title>
           <button
             type="button"
             onClick={onClose}
@@ -169,53 +247,67 @@ export function RemoteCreateSessionDialog({
             className="ml-3 rounded-md p-2 text-text-tertiary hover:bg-surface-hover hover:text-text-primary"
             aria-label="Close"
           >
-            <X className="h-4 w-4" />
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto">
           <section className="border-b border-border-primary p-5">
             <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-text-primary">
-              <GitBranch className="h-4 w-4 text-text-tertiary" />
+              <GitBranch className="h-4 w-4 text-text-tertiary" aria-hidden="true" />
               <label htmlFor="remote-create-branch">Base Branch</label>
             </div>
             <div ref={branchDropdownRef} className="relative">
-              <button
-                id="remote-create-branch"
-                type="button"
-                disabled={loadingBranches || branches.length === 0}
-                onClick={() => setBranchOpen(previous => !previous)}
-                className="flex h-12 w-full items-center justify-between gap-3 rounded-md border border-border-primary bg-surface-secondary px-3 text-left text-text-primary disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <span className="truncate">{loadingBranches ? 'Loading branches...' : baseBranch || 'No branches found'}</span>
-                <ChevronDown className="h-4 w-4 shrink-0 text-text-tertiary" />
-              </button>
+              <div className="flex h-12 w-full items-center gap-2 rounded-md border border-border-primary bg-surface-secondary px-3 focus-within:border-interactive focus-within:ring-2 focus-within:ring-interactive">
+                <Search className="h-4 w-4 shrink-0 text-text-tertiary" aria-hidden="true" />
+                <input
+                  ref={branchInputRef}
+                  id="remote-create-branch"
+                  disabled={loadingBranches || branches.length === 0}
+                  role="combobox"
+                  aria-autocomplete="list"
+                  aria-expanded={branchOpen}
+                  aria-controls={branchOpen ? branchListboxId : undefined}
+                  aria-activedescendant={branchOpen && filteredBranches[activeBranchIndex]
+                    ? `${branchIdPrefix}-${activeBranchIndex}`
+                    : undefined}
+                  aria-describedby={branchHelpId}
+                  value={branchOpen ? branchSearch : baseBranch}
+                  onFocus={() => setBranchOpen(true)}
+                  onClick={() => setBranchOpen(true)}
+                  onChange={(event) => {
+                    setBranchSearch(event.target.value);
+                    setBranchOpen(true);
+                  }}
+                  onKeyDown={handleBranchKeyDown}
+                  className="min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-muted disabled:cursor-not-allowed disabled:opacity-60"
+                  placeholder={loadingBranches ? 'Loading branches...' : 'Search branches'}
+                />
+                <ChevronDown className="h-4 w-4 shrink-0 text-text-tertiary" aria-hidden="true" />
+              </div>
 
               {branchOpen && (
                 <div className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-md border border-border-primary bg-surface-primary shadow-xl">
-                  <div className="flex items-center gap-2 border-b border-border-primary px-3 py-2">
-                    <Search className="h-4 w-4 shrink-0 text-text-tertiary" />
-                    <input
-                      value={branchSearch}
-                      onChange={(event) => setBranchSearch(event.target.value)}
-                      autoFocus
-                      className="h-8 min-w-0 flex-1 bg-transparent text-sm text-text-primary outline-none placeholder:text-text-muted"
-                      placeholder="Search branches"
-                    />
-                  </div>
-                  <div className="max-h-56 overflow-y-auto py-1">
-                    {filteredBranches.map(branch => (
-                      <button
+                  <div id={branchListboxId} role="listbox" aria-label="Base branches" className="max-h-56 overflow-y-auto py-1">
+                    {filteredBranches.map((branch, index) => (
+                      <div
                         key={branch.name}
-                        type="button"
-                        onClick={() => setSelectedBranch(branch.name)}
+                        id={`${branchIdPrefix}-${index}`}
+                        role="option"
+                        aria-selected={branch.name === baseBranch}
+                        onPointerDown={(event) => {
+                          event.preventDefault();
+                          setSelectedBranch(branch.name);
+                          branchInputRef.current?.focus();
+                        }}
+                        onPointerMove={() => setActiveBranchIndex(index)}
                         className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-surface-hover ${
-                          branch.name === baseBranch ? 'text-text-primary' : 'text-text-secondary'
+                          index === activeBranchIndex ? 'bg-surface-hover text-text-primary' : branch.name === baseBranch ? 'text-text-primary' : 'text-text-secondary'
                         }`}
                       >
                         <span className="truncate">{branch.name}</span>
                         {branch.isCurrent && <span className="shrink-0 text-xs text-text-tertiary">current</span>}
-                      </button>
+                      </div>
                     ))}
                     {filteredBranches.length === 0 && (
                       <div className="px-3 py-3 text-sm text-text-secondary">No branches match.</div>
@@ -224,13 +316,15 @@ export function RemoteCreateSessionDialog({
                 </div>
               )}
             </div>
-            <p className="mt-2 text-xs text-text-tertiary">Remote branches will track their remote for git pull/push.</p>
+            <p id={branchHelpId} className="mt-2 text-xs text-text-tertiary">Remote branches will track their remote for git pull/push.</p>
           </section>
 
           <section className="border-b border-border-primary p-5">
             <label htmlFor="remote-create-name" className="mb-2 block text-sm font-semibold text-text-primary">Pane Name</label>
             <input
               id="remote-create-name"
+              aria-describedby={`${nameHelpId}${paneNameInvalid ? ` ${errorId}` : ''}`}
+              aria-invalid={paneNameInvalid}
               value={paneName}
               onChange={(event) => {
                 setPaneName(event.target.value);
@@ -239,13 +333,13 @@ export function RemoteCreateSessionDialog({
               className="h-12 w-full rounded-md border border-border-primary bg-surface-secondary px-3 text-text-primary outline-none focus:border-interactive focus:ring-2 focus:ring-interactive"
               placeholder="pane-name"
             />
-            <p className="mt-2 text-xs text-text-tertiary">Auto-filled from branch. Edit to customize.</p>
+            <p id={nameHelpId} className="mt-2 text-xs text-text-tertiary">Auto-filled from branch. Edit to customize.</p>
           </section>
 
           <section className="border-b border-border-primary p-5">
             <label className="flex items-center justify-between gap-4">
               <span className="flex min-w-0 gap-3">
-                <Pin className="mt-1 h-4 w-4 shrink-0 text-text-tertiary" />
+                <Pin className="mt-1 h-4 w-4 shrink-0 text-text-tertiary" aria-hidden="true" />
                 <span className="min-w-0">
                   <span className="block text-sm font-semibold text-text-primary">Start pinned</span>
                   <span className="mt-1 block text-sm text-text-secondary">Show this pane in the pinned section immediately.</span>
@@ -271,7 +365,7 @@ export function RemoteCreateSessionDialog({
           <section className="p-5">
             <label className="flex items-center justify-between gap-4">
               <span className="flex min-w-0 gap-3">
-                <GitFork className="mt-1 h-4 w-4 shrink-0 text-text-tertiary" />
+                <GitFork className="mt-1 h-4 w-4 shrink-0 text-text-tertiary" aria-hidden="true" />
                 <span className="min-w-0">
                   <span className="block text-sm font-semibold text-text-primary">Use worktree</span>
                   <span className="mt-1 block text-sm text-text-secondary">Run in an isolated git worktree.</span>
@@ -291,7 +385,7 @@ export function RemoteCreateSessionDialog({
           </section>
 
           {error && (
-            <div className="mx-5 mb-5 rounded-md border border-status-error/40 bg-status-error/10 p-3 text-sm text-status-error">
+            <div id={errorId} role="alert" className="mx-5 mb-5 rounded-md border border-status-error/40 bg-status-error/10 p-3 text-sm text-status-error">
               {error}
             </div>
           )}
@@ -309,13 +403,16 @@ export function RemoteCreateSessionDialog({
           <button
             type="submit"
             disabled={loadingBranches || submitting || !baseBranch}
+            aria-busy={submitting}
             className="rounded-md bg-interactive px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-interactive-hover disabled:cursor-not-allowed disabled:opacity-60"
           >
             {submitting ? 'Creating...' : 'Create'}
           </button>
         </div>
-      </form>
-    </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 

--- a/frontend/src/remote/components/RemotePanelTabs.tsx
+++ b/frontend/src/remote/components/RemotePanelTabs.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Plus, TerminalSquare } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { RemotePwaCustomCommand } from '../../../../shared/types/remoteDaemon';
 import type { ToolPanel } from '../../../../shared/types/panels';
@@ -29,6 +29,10 @@ export function RemotePanelTabs({
 }: RemotePanelTabsProps) {
   const [showAddMenu, setShowAddMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const addTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const addMenuId = useId();
 
   useEffect(() => {
     if (!showAddMenu) return;
@@ -43,26 +47,82 @@ export function RemotePanelTabs({
     return () => window.removeEventListener('pointerdown', closeOnPointerDown);
   }, [showAddMenu]);
 
+  useEffect(() => {
+    if (!showAddMenu) return;
+    const frame = window.requestAnimationFrame(() => menuItemRefs.current[0]?.focus());
+    return () => window.cancelAnimationFrame(frame);
+  }, [showAddMenu]);
+
   const addTerminal = (options?: RemoteTerminalCreateOptions) => {
     onCreateTerminal(options);
     setShowAddMenu(false);
   };
 
+  const selectTabAt = (index: number) => {
+    const panel = panels[index];
+    if (!panel) return;
+    onSelectPanel(panel.id);
+    tabRefs.current[index]?.focus();
+  };
+
+  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex: number | null = null;
+    if (event.key === 'ArrowRight') nextIndex = (index + 1) % panels.length;
+    if (event.key === 'ArrowLeft') nextIndex = (index - 1 + panels.length) % panels.length;
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = panels.length - 1;
+    if (nextIndex === null) return;
+    event.preventDefault();
+    selectTabAt(nextIndex);
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const items = menuItemRefs.current.filter((item): item is HTMLButtonElement => Boolean(item));
+    const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
+    let nextIndex: number | null = null;
+
+    if (event.key === 'ArrowDown') nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
+    if (event.key === 'ArrowUp') nextIndex = currentIndex < 0 ? items.length - 1 : (currentIndex - 1 + items.length) % items.length;
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = items.length - 1;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setShowAddMenu(false);
+      addTriggerRef.current?.focus();
+      return;
+    }
+    if (event.key === 'Tab') {
+      setShowAddMenu(false);
+      return;
+    }
+    if (nextIndex !== null && items[nextIndex]) {
+      event.preventDefault();
+      items[nextIndex].focus();
+    }
+  };
+
   return (
     <div className="flex min-h-12 shrink-0 items-end gap-2 border-b border-border-primary bg-bg-secondary px-2 pt-2">
-      <div className="flex min-w-0 flex-1 items-end gap-1 overflow-x-auto">
-        {panels.map(panel => (
+      <div className="flex min-w-0 flex-1 items-end gap-1 overflow-x-auto" role="tablist" aria-label="Remote tool panels">
+        {panels.map((panel, index) => (
           <button
             key={panel.id}
+            ref={(element) => { tabRefs.current[index] = element; }}
             type="button"
+            role="tab"
+            id={getRemotePanelTabId(panel.id)}
+            aria-selected={selectedPanelId === panel.id}
+            aria-controls={getRemotePanelTabPanelId(panel.id)}
+            tabIndex={selectedPanelId === panel.id || (!selectedPanelId && index === 0) ? 0 : -1}
             onClick={() => onSelectPanel(panel.id)}
+            onKeyDown={(event) => handleTabKeyDown(event, index)}
             className={`relative flex h-10 max-w-[min(12rem,55vw)] shrink-0 items-center gap-2 rounded-t-lg border px-3 text-sm font-medium shadow-sm transition-colors ${
               selectedPanelId === panel.id
                 ? 'border-border-primary border-b-bg-primary bg-bg-primary text-text-primary shadow-[0_-1px_0_rgba(255,255,255,0.04)_inset]'
                 : 'border-border-secondary bg-surface-primary text-text-secondary hover:border-border-primary hover:bg-surface-hover hover:text-text-primary'
             }`}
           >
-            <TerminalSquare className="h-4 w-4 shrink-0" />
+            <TerminalSquare className="h-4 w-4 shrink-0" aria-hidden="true" />
             <span className="truncate">{panel.title}</span>
           </button>
         ))}
@@ -70,31 +130,38 @@ export function RemotePanelTabs({
 
       <div ref={menuRef} className="relative shrink-0">
         <button
+          ref={addTriggerRef}
           type="button"
           onClick={() => setShowAddMenu(value => !value)}
           disabled={creating}
           className="mb-1.5 flex h-8 shrink-0 items-center gap-1 rounded-md border border-border-secondary bg-surface-primary px-2 text-sm font-medium text-text-secondary shadow-sm hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 sm:px-3"
           aria-haspopup="menu"
           aria-expanded={showAddMenu}
+          aria-controls={showAddMenu ? addMenuId : undefined}
           aria-label="Add tool"
         >
-          <Plus className="h-4 w-4" />
+          <Plus className="h-4 w-4" aria-hidden="true" />
           <span className="hidden sm:inline">Add Tool</span>
-          <ChevronDown className="hidden h-3 w-3 sm:block" />
+          <ChevronDown className="hidden h-3 w-3 sm:block" aria-hidden="true" />
         </button>
 
         {showAddMenu && (
           <div
+            id={addMenuId}
             className="absolute right-0 top-full z-30 mt-2 w-[min(20rem,calc(100vw-1rem))] overflow-hidden rounded-lg border border-border-primary bg-surface-primary shadow-dropdown"
             role="menu"
+            aria-label="Add tool"
+            onKeyDown={handleMenuKeyDown}
           >
             <AddToolMenuItem
+              buttonRef={(element) => { menuItemRefs.current[0] = element; }}
               icon={<TerminalSquare className="h-4 w-4" />}
               title="Terminal"
               description="Start a shell on the remote host"
               onClick={() => addTerminal()}
             />
             <AddToolMenuItem
+              buttonRef={(element) => { menuItemRefs.current[1] = element; }}
               icon={<ClaudeIcon className="h-4 w-4" />}
               title="Claude Code"
               description="Run claude --dangerously-skip-permissions"
@@ -104,6 +171,7 @@ export function RemotePanelTabs({
               })}
             />
             <AddToolMenuItem
+              buttonRef={(element) => { menuItemRefs.current[2] = element; }}
               icon={<OpenAIIcon className="h-4 w-4" />}
               title="Codex"
               description="Run codex --yolo"
@@ -115,6 +183,7 @@ export function RemotePanelTabs({
             {customCommands.map((command, index) => (
               <AddToolMenuItem
                 key={`${command.name}-${index}`}
+                buttonRef={(element) => { menuItemRefs.current[index + 3] = element; }}
                 icon={getCliBrandIcon(command.command, 'h-4 w-4') ?? <TerminalSquare className="h-4 w-4" />}
                 title={command.name}
                 description={command.command}
@@ -132,11 +201,13 @@ export function RemotePanelTabs({
 }
 
 function AddToolMenuItem({
+  buttonRef,
   icon,
   title,
   description,
   onClick,
 }: {
+  buttonRef: (element: HTMLButtonElement | null) => void;
   icon: ReactNode;
   title: string;
   description: string;
@@ -144,16 +215,30 @@ function AddToolMenuItem({
 }) {
   return (
     <button
+      ref={buttonRef}
       type="button"
       role="menuitem"
+      tabIndex={-1}
       onClick={onClick}
       className="flex w-full items-start gap-3 px-3 py-2.5 text-left text-sm text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
     >
-      <span className="mt-0.5 shrink-0 text-text-tertiary">{icon}</span>
+      <span className="mt-0.5 shrink-0 text-text-tertiary" aria-hidden="true">{icon}</span>
       <span className="min-w-0">
         <span className="block font-medium text-text-primary">{title}</span>
         <span className="block truncate text-xs text-text-tertiary">{description}</span>
       </span>
     </button>
   );
+}
+
+function toDomId(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+export function getRemotePanelTabId(panelId: string): string {
+  return `remote-panel-tab-${toDomId(panelId)}`;
+}
+
+export function getRemotePanelTabPanelId(panelId: string): string {
+  return `remote-panel-tabpanel-${toDomId(panelId)}`;
 }

--- a/frontend/src/remote/components/RemoteStatusBar.tsx
+++ b/frontend/src/remote/components/RemoteStatusBar.tsx
@@ -1,4 +1,5 @@
 import { LogOut, Menu } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import type { RemotePaneConnectionProfile, RemotePaneConnectionStatus } from '../../../../shared/types/remoteDaemon';
 
 interface RemoteStatusBarProps {
@@ -21,9 +22,32 @@ export function RemoteStatusBar({
   const connected = status === 'connected';
   const statusLabel = getStatusLabel(status);
   const title = connected ? profile.label : `${statusLabel} ${profile.label}`;
+  const [announcement, setAnnouncement] = useState('');
+  const previousAnnouncementRef = useRef('');
+
+  useEffect(() => {
+    const nextAnnouncement = status === 'error' && lastError
+      ? `${statusLabel} ${profile.label}. ${lastError}`
+      : `${statusLabel} ${profile.label}`;
+    if (nextAnnouncement !== previousAnnouncementRef.current) {
+      previousAnnouncementRef.current = nextAnnouncement;
+      setAnnouncement(nextAnnouncement);
+    }
+  }, [lastError, profile.label, status, statusLabel]);
 
   return (
-    <div className="flex min-h-14 shrink-0 items-center justify-between gap-2 border-b border-border-primary bg-surface-primary px-3 py-2 sm:px-4">
+    <div
+      className="flex min-h-14 shrink-0 items-center justify-between gap-2 border-b border-border-primary bg-surface-primary px-3 py-2 sm:px-4"
+      aria-busy={status === 'connecting' || status === 'reconnecting'}
+    >
+      <div
+        className="sr-only"
+        role={status === 'error' ? 'alert' : 'status'}
+        aria-live={status === 'error' ? 'assertive' : 'polite'}
+        aria-atomic="true"
+      >
+        {announcement}
+      </div>
       <div className="flex min-w-0 items-center gap-2 sm:gap-3">
         <button
           type="button"
@@ -31,9 +55,9 @@ export function RemoteStatusBar({
           className="rounded-md p-2 text-text-secondary hover:bg-surface-hover hover:text-text-primary md:hidden"
           aria-label="Open remote panes"
         >
-          <Menu className="h-5 w-5" />
+          <Menu className="h-5 w-5" aria-hidden="true" />
         </button>
-        <span className={`flex h-2.5 w-2.5 shrink-0 rounded-full ${connected ? 'bg-status-success' : status === 'error' ? 'bg-status-error' : 'bg-status-warning'}`} />
+        <span aria-hidden="true" className={`flex h-2.5 w-2.5 shrink-0 rounded-full ${connected ? 'bg-status-success' : status === 'error' ? 'bg-status-error' : 'bg-status-warning'}`} />
         <div className="min-w-0">
           <p className="truncate text-sm font-semibold text-text-primary">{title}</p>
           <p className="truncate text-xs text-text-tertiary">
@@ -45,9 +69,10 @@ export function RemoteStatusBar({
       <button
         type="button"
         onClick={onDisconnect}
+        aria-label="Disconnect"
         className="inline-flex shrink-0 items-center gap-2 rounded-md border border-border-primary px-2.5 py-2 text-sm font-medium text-text-secondary hover:bg-surface-hover hover:text-text-primary sm:px-3 sm:py-1.5"
       >
-        <LogOut className="h-4 w-4 sm:hidden" />
+        <LogOut className="h-4 w-4 sm:hidden" aria-hidden="true" />
         <span className="hidden sm:inline">Disconnect</span>
       </button>
     </div>

--- a/frontend/src/remote/components/RemoteTerminalScrollJoystick.tsx
+++ b/frontend/src/remote/components/RemoteTerminalScrollJoystick.tsx
@@ -19,7 +19,7 @@ export function RemoteTerminalScrollJoystick({
   onScrollToBottom,
 }: RemoteTerminalScrollJoystickProps) {
   const [offset, setOffset] = useState(0);
-  const trackRef = useRef<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLInputElement | null>(null);
   const offsetRef = useRef(0);
   const activeRef = useRef(false);
   const animationFrameRef = useRef<number | null>(null);
@@ -74,6 +74,23 @@ export function RemoteTerminalScrollJoystick({
     animationFrameRef.current = window.requestAnimationFrame(tick);
   }, []);
 
+  const applyKeyboardOffset = useCallback((nextOffset: number) => {
+    const clampedOffset = clamp(nextOffset, -MAX_OFFSET, MAX_OFFSET);
+    if (Math.abs(clampedOffset) <= DEAD_ZONE) {
+      stopScrolling();
+      return;
+    }
+
+    offsetRef.current = clampedOffset;
+    setOffset(clampedOffset);
+    activeRef.current = true;
+    lineRemainderRef.current = 0;
+    lastFrameTimeRef.current = null;
+    if (animationFrameRef.current === null) {
+      animationFrameRef.current = window.requestAnimationFrame(tick);
+    }
+  }, [stopScrolling, tick]);
+
   const updateOffset = useCallback((clientY: number) => {
     const track = trackRef.current;
     if (!track) {
@@ -86,11 +103,12 @@ export function RemoteTerminalScrollJoystick({
     setOffset(nextOffset);
   }, []);
 
-  const startScrolling = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+  const startScrolling = useCallback((event: React.PointerEvent<HTMLInputElement>) => {
     if (disabled) {
       return;
     }
 
+    event.currentTarget.focus();
     event.preventDefault();
     event.currentTarget.setPointerCapture(event.pointerId);
     activeRef.current = true;
@@ -103,7 +121,7 @@ export function RemoteTerminalScrollJoystick({
     }
   }, [disabled, tick, updateOffset]);
 
-  const moveScrolling = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+  const moveScrolling = useCallback((event: React.PointerEvent<HTMLInputElement>) => {
     if (!activeRef.current) {
       return;
     }
@@ -112,58 +130,82 @@ export function RemoteTerminalScrollJoystick({
     updateOffset(event.clientY);
   }, [updateOffset]);
 
-  const finishScrolling = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+  const finishScrolling = useCallback((event: React.PointerEvent<HTMLInputElement>) => {
     if (event.currentTarget.hasPointerCapture(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId);
     }
     stopScrolling();
   }, [stopScrolling]);
 
-  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
     if (disabled) {
       return;
     }
 
-    if (event.key === 'ArrowUp') {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
       event.preventDefault();
-      onScrollLines(-4);
-    } else if (event.key === 'ArrowDown') {
+      applyKeyboardOffset(offsetRef.current - 12);
+    } else if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
       event.preventDefault();
-      onScrollLines(4);
+      applyKeyboardOffset(offsetRef.current + 12);
     } else if (event.key === 'PageUp') {
       event.preventDefault();
-      onScrollLines(-24);
+      applyKeyboardOffset(offsetRef.current - 24);
     } else if (event.key === 'PageDown') {
       event.preventDefault();
-      onScrollLines(24);
+      applyKeyboardOffset(offsetRef.current + 24);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      applyKeyboardOffset(-MAX_OFFSET);
     } else if (event.key === 'End') {
       event.preventDefault();
+      stopScrolling();
       onScrollToBottom();
+    } else if (event.key === 'Escape' || event.key === '0') {
+      event.preventDefault();
+      stopScrolling();
     }
-  }, [disabled, onScrollLines, onScrollToBottom]);
+  }, [applyKeyboardOffset, disabled, onScrollToBottom, stopScrolling]);
 
   useEffect(() => stopScrolling, [stopScrolling]);
 
+  const roundedOffset = Math.round(offset);
+  const scrollSpeed = Math.round((Math.abs(roundedOffset) / MAX_OFFSET) * 100);
+  const valueText = scrollSpeed === 0
+    ? 'Neutral'
+    : `${scrollSpeed}% ${roundedOffset < 0 ? 'up' : 'down'}`;
+
   return (
     <div className="pointer-events-none absolute right-2 top-1/2 z-30 -translate-y-1/2 md:hidden">
-      <div
-        ref={trackRef}
-        role="button"
-        tabIndex={disabled ? -1 : 0}
-        aria-disabled={disabled}
-        aria-label="Smooth terminal scroll"
-        title="Drag to scroll"
-        onPointerDown={startScrolling}
-        onPointerMove={moveScrolling}
-        onPointerUp={finishScrolling}
-        onPointerCancel={finishScrolling}
-        onLostPointerCapture={stopScrolling}
-        onKeyDown={handleKeyDown}
-        className={`pointer-events-auto relative h-40 w-11 touch-none select-none rounded-full border border-white/10 bg-black/45 shadow-lg outline-none backdrop-blur transition-colors focus-visible:ring-2 focus-visible:ring-interactive ${disabled ? 'opacity-50' : ''}`}
-      >
+      <div className={`pointer-events-auto relative h-40 w-11 rounded-full border border-white/10 bg-black/45 shadow-lg backdrop-blur transition-colors focus-within:ring-2 focus-within:ring-interactive ${disabled ? 'opacity-50' : ''}`}>
+        <input
+          ref={trackRef}
+          type="range"
+          min={-MAX_OFFSET}
+          max={MAX_OFFSET}
+          step={1}
+          value={roundedOffset}
+          disabled={disabled}
+          aria-label="Terminal scroll direction and speed"
+          aria-orientation="vertical"
+          aria-valuetext={valueText}
+          title="Drag to scroll"
+          onChange={(event) => {
+            applyKeyboardOffset(Number(event.target.value));
+          }}
+          onPointerDown={startScrolling}
+          onPointerMove={moveScrolling}
+          onPointerUp={finishScrolling}
+          onPointerCancel={finishScrolling}
+          onLostPointerCapture={stopScrolling}
+          onBlur={stopScrolling}
+          onKeyDown={handleKeyDown}
+          className="absolute inset-0 z-10 h-full w-full cursor-ns-resize touch-none opacity-0 disabled:cursor-not-allowed"
+        />
         <div className="absolute bottom-4 left-1/2 top-4 w-px -translate-x-1/2 bg-white/15" />
         <div
-          className="absolute left-1/2 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-surface-secondary/95 text-text-secondary shadow-md transition-colors"
+          aria-hidden="true"
+          className="pointer-events-none absolute left-1/2 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-surface-secondary/95 text-text-secondary shadow-md transition-colors"
           style={{ transform: `translate(-50%, calc(-50% + ${offset}px))` }}
         >
           <ChevronsUpDown className="h-5 w-5" />

--- a/frontend/src/styles/tokens/colors.css
+++ b/frontend/src/styles/tokens/colors.css
@@ -124,7 +124,7 @@
   --owl-600: #3d2528;
   --owl-500: #5c3a3e;
   --owl-400: #7d5558;
-  --owl-300: #a07578;
+  --owl-300: #a5797c;
   --owl-200: #c49a9e;
   --owl-100: #e8cdd0;
 
@@ -195,12 +195,12 @@
   --color-border-focus: rgb(88 166 255);
 
   /* Semantic Tokens - Interactive */
-  --color-interactive-primary: rgb(47 129 247);   /* GitHub #2f81f7 */
-  --color-interactive-hover: rgb(56 139 253);
-  --color-interactive-active: rgb(88 166 255);
+  --color-interactive-primary: rgb(31 111 235);   /* #1f6feb - AA with white text */
+  --color-interactive-hover: rgb(26 95 208);
+  --color-interactive-active: rgb(11 79 194);
   --color-interactive-text: rgb(88 166 255);      /* GitHub #58a6ff */
   --color-focus-ring: rgb(88 166 255);
-  --color-interactive-rgb: 47 129 247;
+  --color-interactive-rgb: 31 111 235;
 
   /* High-contrast interactive text for dark backgrounds */
   --color-text-interactive-on-dark: rgb(88 166 255);

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "ws": "^8.20.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@electron/rebuild": "^4.0.1",
     "@playwright/test": "^1.52.0",
     "concurrently": "^9.1.0",

--- a/playwright.ci.minimal.config.ts
+++ b/playwright.ci.minimal.config.ts
@@ -5,8 +5,8 @@ const devServerPort = getPlaywrightPort();
 
 export default defineConfig({
   testDir: './tests',
-  // Only run smoke tests and health check in CI
-  testMatch: ['smoke.spec.ts', 'health-check.spec.ts'],
+  // Keep the fast startup checks and the maintained accessibility journeys in CI.
+  testMatch: ['smoke.spec.ts', 'health-check.spec.ts', 'accessibility.spec.ts'],
   // Reduce timeout for CI
   timeout: 20 * 1000,
   expect: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^8.20.1
         version: 8.20.1
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.10.2
+        version: 4.12.1(playwright-core@1.54.1)
       '@electron/rebuild':
         specifier: ^4.0.1
         version: 4.0.1
@@ -247,6 +250,9 @@ importers:
       eslint:
         specifier: ^9.17.0
         version: 9.31.0(jiti@2.6.0)
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.31.0(jiti@2.6.0))
       eslint-plugin-react-hooks:
         specifier: ^5.1.0
         version: 5.2.0(eslint@9.31.0(jiti@2.6.0))
@@ -422,6 +428,11 @@ packages:
   '@anthropic-ai/sdk@0.60.0':
     resolution: {integrity: sha512-9zu/TXaUy8BZhXedDtt1wT3H4LOlpKDO1/ftiFpeR3N1PCr3KJFKkxxlQWWt1NNp08xSwUNJ3JNY8yhl8av6eQ==}
     hasBin: true
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -2432,6 +2443,30 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-includes@3.1.9:
+    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flat@1.3.3:
+    resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
+    engines: {node: '>= 0.4'}
+
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
+    engines: {node: '>= 0.4'}
+
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
@@ -2440,6 +2475,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -2447,6 +2485,10 @@ packages:
   async-exit-hook@2.0.1:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
+
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -2468,8 +2510,20 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
   axios@1.12.2:
     resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -2563,6 +2617,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -2948,6 +3006,21 @@ packages:
   dagre-d3-es@7.0.11:
     resolution: {integrity: sha512-tvlJLyQf834SylNKax8Wkzco/1ias1OPw8DcUMDE7oUIoSEW25riQVuiu/0OWEFqT0cxHT3Pa9/D82Jr47IONw==}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-view-buffer@1.0.2:
+    resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-length@1.0.2:
+    resolution: {integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==}
+    engines: {node: '>= 0.4'}
+
+  data-view-byte-offset@1.0.1:
+    resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
+    engines: {node: '>= 0.4'}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -3140,6 +3213,14 @@ packages:
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
+  es-abstract-get@1.0.0:
+    resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
+    engines: {node: '>= 0.4'}
+
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
+    engines: {node: '>= 0.4'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -3155,8 +3236,20 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es-shim-unscopables@1.1.0:
+    resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
+    engines: {node: '>= 0.4'}
+
+  es-to-primitive@1.3.4:
+    resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
 
   es6-error@4.1.1:
@@ -3186,6 +3279,12 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
@@ -3378,6 +3477,10 @@ packages:
       debug:
         optional: true
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -3440,6 +3543,17 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function.prototype.name@1.2.0:
+    resolution: {integrity: sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==}
+    engines: {node: '>= 0.4'}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -3471,6 +3585,10 @@ packages:
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
+
+  get-symbol-description@1.1.0:
+    resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
+    engines: {node: '>= 0.4'}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -3536,12 +3654,20 @@ packages:
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.2.0:
+    resolution: {integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==}
+    engines: {node: '>= 0.4'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3553,6 +3679,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-html@9.0.5:
@@ -3666,6 +3796,10 @@ packages:
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
 
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
@@ -3699,24 +3833,64 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-async-function@2.1.1:
+    resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-data-view@1.0.2:
+    resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-document.all@1.0.0:
+    resolution: {integrity: sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-finalizationregistry@1.1.1:
+    resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
+    engines: {node: '>= 0.4'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -3732,6 +3906,18 @@ packages:
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-negative-zero@2.0.3:
+    resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -3743,13 +3929,52 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
+
   is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
 
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakref@1.1.1:
+    resolution: {integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isbinaryfile@4.0.10:
     resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
@@ -3854,6 +4079,10 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  jsx-ast-utils@3.3.5:
+    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
+    engines: {node: '>=4.0'}
+
   katex@0.16.22:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
@@ -3870,6 +4099,13 @@ packages:
   langium@3.3.1:
     resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
     engines: {node: '>=16.0.0'}
+
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -4381,6 +4617,18 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
+    engines: {node: '>= 0.4'}
+
+  object.values@1.2.1:
+    resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
+    engines: {node: '>= 0.4'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4417,6 +4665,10 @@ packages:
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
+
+  own-keys@1.0.1:
+    resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
+    engines: {node: '>= 0.4'}
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -4571,6 +4823,10 @@ packages:
 
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -4799,6 +5055,10 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  reflect.getprototypeof@1.0.10:
+    resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
+    engines: {node: '>= 0.4'}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -4807,6 +5067,10 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -4897,8 +5161,20 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
+    engines: {node: '>=0.4'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-push-apply@1.0.0:
+    resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
+    engines: {node: '>= 0.4'}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -4944,6 +5220,18 @@ packages:
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
     engines: {node: '>= 18'}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
+  set-proto@1.0.0:
+    resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -5094,6 +5382,10 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -5101,6 +5393,22 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trim@1.2.11:
+    resolution: {integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimend@1.0.10:
+    resolution: {integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==}
+    engines: {node: '>= 0.4'}
+
+  string.prototype.trimstart@1.0.8:
+    resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
+    engines: {node: '>= 0.4'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -5303,6 +5611,22 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-length@1.0.3:
+    resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-byte-offset@1.0.4:
+    resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
+    engines: {node: '>= 0.4'}
+
+  typed-array-length@1.0.8:
+    resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
+    engines: {node: '>= 0.4'}
+
   typescript-eslint@8.37.0:
     resolution: {integrity: sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5321,6 +5645,10 @@ packages:
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
+
+  unbox-primitive@1.1.0:
+    resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
+    engines: {node: '>= 0.4'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -5594,6 +5922,22 @@ packages:
   when-exit@2.1.4:
     resolution: {integrity: sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==}
 
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-builtin-type@1.2.1:
+    resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
+
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -5735,6 +6079,11 @@ snapshots:
       '@img/sharp-win32-x64': 0.33.5
 
   '@anthropic-ai/sdk@0.60.0': {}
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.54.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.54.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -7701,15 +8050,61 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.2: {}
+
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-includes@3.1.9:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      is-string: 1.1.1
+      math-intrinsics: 1.1.0
+
+  array.prototype.flat@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-shim-unscopables: 1.1.0
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
+
   assert-plus@1.0.0:
     optional: true
 
   assertion-error@2.0.1: {}
 
+  ast-types-flow@0.0.8: {}
+
   astral-regex@2.0.0:
     optional: true
 
   async-exit-hook@2.0.1: {}
+
+  async-function@1.0.0: {}
 
   async@3.2.6: {}
 
@@ -7732,6 +8127,12 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  axe-core@4.12.1: {}
+
   axios@1.12.2:
     dependencies:
       follow-redirects: 1.15.9
@@ -7739,6 +8140,8 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
 
@@ -7908,6 +8311,13 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
 
   call-bound@1.0.4:
     dependencies:
@@ -8312,6 +8722,26 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.21
 
+  damerau-levenshtein@1.0.8: {}
+
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   date-fns@4.1.0: {}
 
   dayjs@1.11.13: {}
@@ -8349,14 +8779,12 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
   delaunator@5.0.1:
     dependencies:
@@ -8531,6 +8959,70 @@ snapshots:
 
   err-code@2.0.3: {}
 
+  es-abstract-get@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      is-callable: 1.2.7
+      object-inspect: 1.13.4
+
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.4
+      function.prototype.name: 1.2.0
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.11
+      string.prototype.trimend: 1.0.10
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.8
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.22
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -8541,12 +9033,29 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
   es-set-tostringtag@2.1.0:
     dependencies:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-shim-unscopables@1.1.0:
+    dependencies:
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.4:
+    dependencies:
+      es-abstract-get: 1.0.0
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   es6-error@4.1.1:
     optional: true
@@ -8613,6 +9122,25 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.31.0(jiti@2.6.0)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.9
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.12.1
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.31.0(jiti@2.6.0)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-react-hooks@5.2.0(eslint@9.31.0(jiti@2.6.0)):
     dependencies:
@@ -8849,6 +9377,10 @@ snapshots:
 
   follow-redirects@1.15.9: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8913,6 +9445,22 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  function.prototype.name@1.2.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+      hasown: 2.0.4
+      is-callable: 1.2.7
+      is-document.all: 1.0.0
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -8946,6 +9494,12 @@ snapshots:
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.3
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
 
   github-from-package@0.0.0: {}
 
@@ -9010,7 +9564,6 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
 
   gopd@1.2.0: {}
 
@@ -9034,12 +9587,17 @@ snapshots:
 
   hachure-fill@0.5.2: {}
 
+  has-bigints@1.1.0: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-    optional: true
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -9048,6 +9606,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -9191,6 +9753,12 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
@@ -9227,19 +9795,71 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
 
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-decimal@2.0.1: {}
+
+  is-document.all@1.0.0:
+    dependencies:
+      call-bound: 1.0.4
 
   is-extglob@2.1.1: {}
 
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
 
   is-glob@4.0.3:
     dependencies:
@@ -9251,15 +9871,65 @@ snapshots:
 
   is-lambda@1.0.1: {}
 
+  is-map@2.0.3: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
   is-stream@1.1.0: {}
 
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
+
   is-unicode-supported@0.1.0: {}
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
 
   isbinaryfile@4.0.10: {}
 
@@ -9360,6 +10030,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsx-ast-utils@3.3.5:
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.flat: 1.3.3
+      object.assign: 4.1.7
+      object.values: 1.2.1
+
   katex@0.16.22:
     dependencies:
       commander: 8.3.0
@@ -9379,6 +10056,12 @@ snapshots:
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
+
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
 
   layout-base@1.0.2: {}
 
@@ -10110,8 +10793,30 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.1
+
+  object.values@1.2.1:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
 
   on-finished@2.4.1:
     dependencies:
@@ -10158,6 +10863,12 @@ snapshots:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
 
   p-cancelable@2.1.1: {}
 
@@ -10285,6 +10996,8 @@ snapshots:
     dependencies:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.5.6):
     dependencies:
@@ -10532,6 +11245,17 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -10541,6 +11265,15 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
 
   remark-gfm@4.0.1:
     dependencies:
@@ -10681,7 +11414,26 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
   safe-buffer@5.2.1: {}
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
 
@@ -10733,6 +11485,28 @@ snapshots:
       send: 1.2.0
     transitivePeerDependencies:
       - supports-color
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
 
@@ -10920,6 +11694,11 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -10931,6 +11710,36 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+
+  string.prototype.trim@1.2.11:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      has-property-descriptors: 1.0.2
+      safe-regex-test: 1.1.0
+
+  string.prototype.trimend@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
 
   string_decoder@1.3.0:
     dependencies:
@@ -11155,6 +11964,39 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.1
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typescript-eslint@8.37.0(eslint@9.31.0(jiti@2.6.0))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.37.0(@typescript-eslint/parser@8.37.0(eslint@9.31.0(jiti@2.6.0))(typescript@5.8.3))(eslint@9.31.0(jiti@2.6.0))(typescript@5.8.3)
@@ -11171,6 +12013,13 @@ snapshots:
   ufo@1.6.1: {}
 
   uint8array-extras@1.5.0: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
 
@@ -11410,6 +12259,47 @@ snapshots:
   web-vitals@5.1.0: {}
 
   when-exit@2.1.4: {}
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.2.0
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.22
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@1.3.1:
     dependencies:

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -70,6 +70,59 @@ const panels = [
   },
 ];
 
+const remoteSession = {
+  ...session,
+  id: 'remote-accessibility-session',
+  name: 'Remote accessibility pane',
+  worktreePath: '/tmp/remote-accessibility-fixture/remote-accessibility-pane',
+  projectId: 2,
+};
+
+const remoteProject = {
+  ...project,
+  id: 2,
+  name: 'Remote accessibility fixture',
+  path: '/tmp/remote-accessibility-fixture',
+  sessions: [remoteSession],
+};
+
+const remotePanels = [{
+  ...panels[1],
+  id: 'remote-accessibility-explorer',
+  sessionId: remoteSession.id,
+}];
+
+const remoteAffordances = {
+  terminalShortcuts: [],
+  customCommands: [],
+  voiceTranscription: {
+    availableModes: [],
+    defaultMode: 'streaming',
+    configured: {
+      cleanup: false,
+      recorded: false,
+      streaming: false,
+      fal: false,
+      deepgram: false,
+      openRouter: false,
+    },
+    modes: {
+      streaming: {
+        label: 'Live',
+        priceLabel: '~$0.462/hr ASR + cleanup',
+        latencyLabel: 'Realtime text while speaking',
+        recommended: true,
+      },
+      recorded: {
+        label: 'Batch',
+        priceLabel: '~$0.084/hr full pipeline',
+        latencyLabel: 'Text appears after stop',
+        recommended: false,
+      },
+    },
+  },
+};
+
 async function openDesktop(page: Page): Promise<void> {
   await installElectronApiMock(page, {
     initialProjects: [project],
@@ -80,6 +133,87 @@ async function openDesktop(page: Page): Promise<void> {
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
   await expect(page.locator('[data-testid="sidebar"]').first()).toBeVisible({ timeout: 10_000 });
   await expect(page.getByText('Something went wrong')).toHaveCount(0);
+}
+
+async function openConnectedRemote(page: Page): Promise<void> {
+  await page.addInitScript((profile) => {
+    window.localStorage.setItem('pane.remotePwa.savedProfiles', JSON.stringify([profile]));
+
+    class MockEventSource {
+      onopen: ((event: Event) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(readonly url: string) {
+        window.setTimeout(() => this.onopen?.(new Event('open')), 0);
+      }
+
+      addEventListener(): void {}
+      removeEventListener(): void {}
+      close(): void {}
+    }
+
+    Object.defineProperty(window, 'EventSource', {
+      configurable: true,
+      value: MockEventSource,
+    });
+  }, {
+    id: 'qa-host',
+    label: 'QA host',
+    baseUrl: 'http://qa-pane.test/remote/browser',
+    token: 'qa-token-12345678',
+    transport: 'http+sse',
+  });
+
+  await page.route('http://qa-pane.test/**', async (route) => {
+    const request = route.request();
+    if (request.method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      return;
+    }
+
+    const body = JSON.parse(request.postData() ?? '{}') as { channel?: string };
+    let result: unknown = null;
+    switch (body.channel) {
+      case 'sessions:get-all-with-projects':
+        result = [remoteProject];
+        break;
+      case 'panels:list':
+        result = remotePanels;
+        break;
+      case 'panels:getActive':
+        result = remotePanels[0];
+        break;
+      case 'remote:pwa-affordances':
+        result = remoteAffordances;
+        break;
+      case 'projects:list-branches':
+        result = [
+          { name: 'origin/main', isCurrent: false, hasWorktree: false, isRemote: true },
+          { name: 'main', isCurrent: true, hasWorktree: false, isRemote: false },
+        ];
+        break;
+      case 'projects:detect-branch':
+        result = 'main';
+        break;
+      default:
+        await route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: false, error: { message: `Unexpected channel: ${body.channel ?? 'unknown'}` } }),
+        });
+        return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, result }),
+    });
+  });
+
+  await page.goto('/remote.html', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: 'Connect', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Remote accessibility pane' })).toBeVisible({ timeout: 10_000 });
 }
 
 test('Home and About are axe-clean and the modal contains and restores focus', async ({ page }) => {
@@ -118,6 +252,16 @@ test('Home and About are axe-clean and the modal contains and restores focus', a
   await expect(themeTrigger).toBeFocused();
 });
 
+test('Night Owl recent-pane metadata remains axe-clean', async ({ page }) => {
+  await openDesktop(page);
+
+  const themeTrigger = page.getByRole('button', { name: /\(sharp\)|\(rounded\)|OLED|Dusk|Forge|Ember|Aurora|Night Owl|Terracotta/ }).last();
+  await themeTrigger.click();
+  await page.getByRole('menuitemradio', { name: 'Night Owl', exact: true }).click();
+  await expect(themeTrigger).toHaveText(/Night Owl/);
+  await expectNoAxeViolations(page);
+});
+
 test('seeded Create Pane dialog is keyboard reachable and axe-clean', async ({ page }) => {
   await openDesktop(page);
 
@@ -128,7 +272,18 @@ test('seeded Create Pane dialog is keyboard reachable and axe-clean', async ({ p
 
   const dialog = page.getByRole('dialog', { name: /New Pane in Accessibility fixture/i });
   await expect(dialog).toBeVisible();
-  await expect(page.getByRole('combobox', { name: /Base Branch/i })).toBeVisible();
+  const branchCombobox = page.getByRole('combobox', { name: /Base Branch/i });
+  await expect(branchCombobox).toBeVisible();
+  await branchCombobox.click();
+  await expect(page.getByRole('listbox', { name: 'Branches' })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeVisible();
+  await expect(page.getByRole('listbox', { name: 'Branches' })).toBeHidden();
+  await expect(branchCombobox).toBeFocused();
+
+  await page.getByRole('button', { name: 'Advanced' }).click();
+  await expect(page.getByRole('switch', { name: 'Start pinned' })).toBeVisible();
+  await expect(page.getByRole('switch', { name: 'Use worktree' })).toBeVisible();
   await expectNoAxeViolations(page);
 });
 
@@ -178,6 +333,30 @@ test('Pane Chat agent choice uses native radio semantics', async ({ page }) => {
 test('disconnected Remote Pane screen is axe-clean', async ({ page }) => {
   await page.goto('/remote.html', { waitUntil: 'domcontentloaded', timeout: 30_000 });
   await expect(page.getByRole('heading', { name: 'Remote Pane' })).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByRole('button', { name: /Connect with a code/i })).toBeVisible();
+  await page.getByRole('button', { name: /Connect with a code/i }).click();
+  const codeInput = page.getByLabel('Connection Code');
+  await codeInput.fill('pane-remote://not-json');
   await expectNoAxeViolations(page);
+  await page.getByRole('button', { name: 'Import & Connect' }).click();
+  await expect(page.getByRole('alert')).toContainText('Connection code is not valid');
+  await expect(page.getByRole('alert')).not.toContainText('Tailscale');
+  await expect(codeInput).toHaveAttribute('aria-invalid', 'true');
+  await expectNoAxeViolations(page);
+});
+
+test('connected Remote Create Pane keeps its dialog open on branch Escape and is axe-clean', async ({ page }) => {
+  await openConnectedRemote(page);
+
+  await page.getByRole('button', { name: 'New pane in Remote accessibility fixture' }).click();
+  const dialog = page.getByRole('dialog', { name: 'New Pane in Remote accessibility fixture' });
+  await expect(dialog).toBeVisible();
+
+  const branchCombobox = page.getByRole('combobox', { name: 'Base Branch' });
+  await branchCombobox.click();
+  await expect(page.getByRole('listbox', { name: 'Base branches' })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeVisible();
+  await expect(page.getByRole('listbox', { name: 'Base branches' })).toBeHidden();
+  await expect(branchCombobox).toBeFocused();
+  await expectNoAxeViolations(page, { include: '[role="dialog"]' });
 });

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -123,8 +123,12 @@ const remoteAffordances = {
   },
 };
 
-async function openDesktop(page: Page): Promise<void> {
+async function openDesktop(
+  page: Page,
+  options: { paneChatAgentChangeDelayMs?: number } = {},
+): Promise<void> {
   await installElectronApiMock(page, {
+    ...options,
     initialProjects: [project],
     initialSessions: [session],
     initialPanels: panels,
@@ -298,6 +302,20 @@ test('seeded pane exposes separate compound actions and arrow-keyed panel tabs',
   await expect(archiveButton).toBeAttached();
   await expect(pinButton).toBeAttached();
   await expect(paneButton.locator('button, a, [role="button"]')).toHaveCount(0);
+  await archiveButton.click();
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & {
+      __paneTestElectronMock: { getSessionDeleteCalls: () => string[] };
+    }
+  ).__paneTestElectronMock.getSessionDeleteCalls())).toEqual([session.id]);
+  await expect(paneButton).not.toHaveAttribute('aria-current', 'page');
+  await pinButton.click();
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & {
+      __paneTestElectronMock: { getSessionFavoriteToggleCalls: () => string[] };
+    }
+  ).__paneTestElectronMock.getSessionFavoriteToggleCalls())).toEqual([session.id]);
+  await expect(paneButton).not.toHaveAttribute('aria-current', 'page');
   await paneButton.click();
 
   const explorerTab = page.getByRole('tab', { name: /^Explorer/ }).first();
@@ -314,11 +332,21 @@ test('seeded pane exposes separate compound actions and arrow-keyed panel tabs',
   await expect(dashboardTab).toHaveCount(0);
   await expect(explorerTab).toBeFocused();
 
+  const explorerTabId = await explorerTab.getAttribute('id');
+  expect(explorerTabId).not.toBeNull();
+  await explorerTab.dblclick();
+  const panelTablist = page.locator('[role="tablist"][aria-label="Panel tabs"]').first();
+  await expect.poll(async () => (
+    (await panelTablist.getAttribute('aria-owns'))?.split(' ').includes(explorerTabId!) ?? false
+  )).toBe(false);
+  await expectNoAxeViolations(page, { include: '.pane-session-shell' });
+  await page.keyboard.press('Escape');
+
   await expectNoAxeViolations(page, { include: '.pane-session-shell' });
 });
 
 test('Pane Chat agent choice uses native radio semantics', async ({ page }) => {
-  await openDesktop(page);
+  await openDesktop(page, { paneChatAgentChangeDelayMs: 200 });
 
   await page.getByRole('button', { name: 'Pane Chat' }).click();
   const radios = page.getByRole('radio');
@@ -326,6 +354,7 @@ test('Pane Chat agent choice uses native radio semantics', async ({ page }) => {
   await expect(page.getByRole('radio', { checked: true })).toHaveCount(1);
   await radios.first().focus();
   await page.keyboard.press('ArrowRight');
+  await expect(radios.nth(1)).toBeFocused();
   await expect(radios.nth(1)).toBeChecked();
   await expectNoAxeViolations(page, { include: '.pane-chat-shell' });
 });

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test, type Page } from '@playwright/test';
+import { expectNoAxeViolations } from './axeTest';
+import { installElectronApiMock } from './electronApiMock';
+
+const project = {
+  id: 1,
+  name: 'Accessibility fixture',
+  path: '/tmp/accessibility-fixture',
+  active: true,
+  created_at: new Date(0).toISOString(),
+  updated_at: new Date(0).toISOString(),
+};
+
+const session = {
+  id: 'accessibility-session',
+  name: 'Accessibility pane',
+  worktreePath: '/tmp/accessibility-fixture/accessibility-pane',
+  prompt: 'Verify the accessible UI',
+  status: 'stopped',
+  createdAt: new Date(0).toISOString(),
+  lastActivity: new Date(0).toISOString(),
+  output: [],
+  jsonMessages: [],
+  isRunning: false,
+  permissionMode: 'ignore',
+  projectId: project.id,
+  displayOrder: 0,
+  isFavorite: false,
+  toolType: 'none',
+  archived: false,
+};
+
+const panels = [
+  {
+    id: 'accessibility-terminal',
+    sessionId: session.id,
+    type: 'terminal',
+    title: 'Terminal',
+    state: { isActive: true, hasBeenViewed: true, customState: { isInitialized: false } },
+    metadata: {
+      createdAt: new Date(0).toISOString(),
+      lastActiveAt: new Date(0).toISOString(),
+      position: 0,
+      permanent: true,
+    },
+  },
+  {
+    id: 'accessibility-explorer',
+    sessionId: session.id,
+    type: 'explorer',
+    title: 'Explorer',
+    state: { isActive: false, hasBeenViewed: true },
+    metadata: {
+      createdAt: new Date(0).toISOString(),
+      lastActiveAt: new Date(0).toISOString(),
+      position: 1,
+    },
+  },
+  {
+    id: 'accessibility-dashboard',
+    sessionId: session.id,
+    type: 'dashboard',
+    title: 'Dashboard',
+    state: { isActive: false, hasBeenViewed: true },
+    metadata: {
+      createdAt: new Date(0).toISOString(),
+      lastActiveAt: new Date(0).toISOString(),
+      position: 2,
+    },
+  },
+];
+
+async function openDesktop(page: Page): Promise<void> {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [session],
+    initialPanels: panels,
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await expect(page.locator('[data-testid="sidebar"]').first()).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+}
+
+test('Home and About are axe-clean and the modal contains and restores focus', async ({ page }) => {
+  await openDesktop(page);
+  await expectNoAxeViolations(page);
+
+  const aboutButton = page.getByRole('button', { name: /About Pane version/i });
+  await expect(aboutButton).toBeVisible();
+  await aboutButton.focus();
+  await aboutButton.click();
+
+  const dialog = page.getByRole('dialog', { name: 'About Pane' });
+  await expect(dialog).toBeVisible();
+  await expect.poll(() => page.evaluate(() => (
+    document.activeElement?.closest('[role="dialog"]') !== null
+  ))).toBe(true);
+
+  for (let index = 0; index < 8; index += 1) {
+    await page.keyboard.press('Tab');
+    await expect.poll(() => page.evaluate(() => (
+      document.activeElement?.closest('[role="dialog"]') !== null
+    ))).toBe(true);
+  }
+
+  await expectNoAxeViolations(page);
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+  await expect(aboutButton).toBeFocused();
+
+  const themeTrigger = page.getByRole('button', { name: /\(sharp\)|\(rounded\)|OLED|Dusk|Forge|Ember|Aurora|Night Owl|Terracotta/ }).last();
+  await themeTrigger.focus();
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('menu')).toBeVisible();
+  await expect(page.locator('[role="menuitemradio"]:focus')).toHaveCount(1);
+  await page.keyboard.press('Escape');
+  await expect(themeTrigger).toBeFocused();
+});
+
+test('seeded Create Pane dialog is keyboard reachable and axe-clean', async ({ page }) => {
+  await openDesktop(page);
+
+  await page.getByRole('button', { name: /^Expand repository Accessibility fixture$/ }).click();
+  const newPaneButton = page.getByRole('button', { name: /New (workspace|pane)/i }).first();
+  await expect(newPaneButton).toBeVisible();
+  await newPaneButton.click();
+
+  const dialog = page.getByRole('dialog', { name: /New Pane in Accessibility fixture/i });
+  await expect(dialog).toBeVisible();
+  await expect(page.getByRole('combobox', { name: /Base Branch/i })).toBeVisible();
+  await expectNoAxeViolations(page);
+});
+
+test('seeded pane exposes separate compound actions and arrow-keyed panel tabs', async ({ page }) => {
+  await openDesktop(page);
+
+  await page.getByRole('button', { name: /^Expand repository Accessibility fixture$/ }).click();
+  const paneButton = page.getByRole('button', { name: 'Accessibility pane', exact: true });
+  await expect(paneButton).toBeVisible();
+  const archiveButton = page.getByRole('button', { name: /Archive Accessibility pane/i });
+  const pinButton = page.getByRole('button', { name: /Pin Accessibility pane/i });
+  await expect(archiveButton).toBeAttached();
+  await expect(pinButton).toBeAttached();
+  await expect(paneButton.locator('button, a, [role="button"]')).toHaveCount(0);
+  await paneButton.click();
+
+  const explorerTab = page.getByRole('tab', { name: /^Explorer/ }).first();
+  const dashboardTab = page.getByRole('tab', { name: /^Dashboard/ }).first();
+  await expect(explorerTab).toHaveAttribute('aria-selected', 'true');
+  await explorerTab.focus();
+  await page.keyboard.press('ArrowRight');
+  await expect(dashboardTab).toBeFocused();
+  await expect(dashboardTab).toHaveAttribute('aria-selected', 'true');
+  await page.keyboard.press('Tab');
+  const closeDashboard = page.getByRole('button', { name: 'Close Dashboard' });
+  await expect(closeDashboard).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(dashboardTab).toHaveCount(0);
+  await expect(explorerTab).toBeFocused();
+
+  await expectNoAxeViolations(page, { include: '.pane-session-shell' });
+});
+
+test('Pane Chat agent choice uses native radio semantics', async ({ page }) => {
+  await openDesktop(page);
+
+  await page.getByRole('button', { name: 'Pane Chat' }).click();
+  const radios = page.getByRole('radio');
+  await expect(radios).toHaveCount(2);
+  await expect(page.getByRole('radio', { checked: true })).toHaveCount(1);
+  await radios.first().focus();
+  await page.keyboard.press('ArrowRight');
+  await expect(radios.nth(1)).toBeChecked();
+  await expectNoAxeViolations(page, { include: '.pane-chat-shell' });
+});
+
+test('disconnected Remote Pane screen is axe-clean', async ({ page }) => {
+  await page.goto('/remote.html', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await expect(page.getByRole('heading', { name: 'Remote Pane' })).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByRole('button', { name: /Connect with a code/i })).toBeVisible();
+  await expectNoAxeViolations(page);
+});

--- a/tests/axeTest.ts
+++ b/tests/axeTest.ts
@@ -1,0 +1,54 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page } from '@playwright/test';
+
+const WCAG_TAGS = [
+  'wcag2a',
+  'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
+  'wcag22aa',
+];
+
+function formatViolations(
+  violations: Awaited<ReturnType<AxeBuilder['analyze']>>['violations'],
+): string {
+  return violations.map((violation) => {
+    const targets = violation.nodes
+      .map((node) => node.target.join(' > '))
+      .join('\n    ');
+
+    return [
+      `${violation.id}: ${violation.help}`,
+      `  ${violation.helpUrl}`,
+      `  Targets:\n    ${targets}`,
+    ].join('\n');
+  }).join('\n\n');
+}
+
+export async function expectNoAxeViolations(
+  page: Page,
+  options: { include?: string } = {},
+): Promise<void> {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-delay: 0s !important;
+        animation-duration: 0.001ms !important;
+        transition-delay: 0s !important;
+        transition-duration: 0.001ms !important;
+      }
+    `,
+  });
+  await page.waitForTimeout(20);
+
+  let builder = new AxeBuilder({ page }).withTags(WCAG_TAGS);
+  if (options.include) {
+    builder = builder.include(options.include);
+  }
+
+  const results = await builder.analyze();
+  expect(
+    results.violations,
+    `Expected no WCAG A/AA violations.\n\n${formatViolations(results.violations)}`,
+  ).toEqual([]);
+}

--- a/tests/dropdown-keyboard-nav.spec.ts
+++ b/tests/dropdown-keyboard-nav.spec.ts
@@ -22,22 +22,6 @@ async function dismissStartupDialogs(page: Page) {
   }
 }
 
-async function clickDomNode(locator: ReturnType<Page['locator']>) {
-  await locator.evaluate((node: HTMLElement) => node.click());
-}
-
-async function openSettings(page: Page) {
-  const collapseSidebarButton = page.getByRole('button', { name: 'Collapse sidebar' });
-  await expect(collapseSidebarButton).toBeVisible({ timeout: 5000 });
-  await collapseSidebarButton.click();
-
-  const settingsButton = page.getByRole('button', { name: 'Settings' }).first();
-  await expect(settingsButton).toBeVisible({ timeout: 5000 });
-  await clickDomNode(settingsButton);
-
-  await expect(page.getByText('Pane Settings')).toBeVisible({ timeout: 5000 });
-}
-
 test.describe('Dropdown keyboard navigation', () => {
   test('footer-only dropdown focuses and activates its footer action', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
@@ -60,15 +44,13 @@ test.describe('Dropdown keyboard navigation', () => {
   test('theme dropdown is navigable with arrow keys and Enter', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
     await dismissStartupDialogs(page);
-    await openSettings(page);
 
-    // The Appearance section is expanded by default; open the theme dropdown.
-    // Scope to the settings form: HomePage underneath also renders a theme picker.
     const trigger = page
-      .locator('#settings-form [aria-haspopup="menu"]')
+      .locator('[aria-haspopup="menu"]')
       .filter({ hasText: 'Light (rounded)' });
     await expect(trigger).toBeVisible({ timeout: 5000 });
-    await trigger.click();
+    await trigger.focus();
+    await page.keyboard.press('Enter');
 
     const menu = page.getByRole('menu');
     await expect(menu).toBeVisible({ timeout: 5000 });
@@ -92,7 +74,7 @@ test.describe('Dropdown keyboard navigation', () => {
     // Menu closes and the theme is applied.
     await expect(page.getByRole('menu')).toHaveCount(0);
     await expect(
-      page.locator('#settings-form').getByText('Forge', { exact: true }),
+      page.getByRole('button', { name: /Forge/ }),
     ).toBeVisible();
     await expect.poll(async () =>
       page.evaluate(() => document.documentElement.classList.contains('forge')),
@@ -104,13 +86,13 @@ test.describe('Dropdown keyboard navigation', () => {
   test('Escape closes the dropdown without changing the theme', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
     await dismissStartupDialogs(page);
-    await openSettings(page);
 
     const trigger = page
-      .locator('#settings-form [aria-haspopup="menu"]')
+      .locator('[aria-haspopup="menu"]')
       .filter({ hasText: 'Light (rounded)' });
     await expect(trigger).toBeVisible({ timeout: 5000 });
-    await trigger.click();
+    await trigger.focus();
+    await page.keyboard.press('Enter');
 
     await expect(page.getByRole('menu')).toBeVisible({ timeout: 5000 });
 

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -16,6 +16,10 @@ type ElectronApiMockOptions = {
   configGetFailures?: number;
   notificationsSupported?: boolean;
   mainAnalyticsEvents?: AnalyticsMainEvent[];
+  initialProjects?: Array<Record<string, unknown>>;
+  initialSessions?: Array<Record<string, unknown>>;
+  initialPanels?: Array<Record<string, unknown>>;
+  activeProjectId?: number | null;
 };
 
 export async function installElectronApiMock(page: Page, options: ElectronApiMockOptions = {}) {
@@ -154,7 +158,12 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         started: false,
       };
     };
-    let mockSessions: Array<Record<string, unknown>> = [];
+    let mockProjects = clone(mockOptions.initialProjects ?? []);
+    let mockSessions = clone(mockOptions.initialSessions ?? []);
+    let mockPanels = clone(mockOptions.initialPanels ?? []);
+    let mockActiveProjectId = mockOptions.activeProjectId === undefined
+      ? (mockProjects.find((project) => project.active === true)?.id as number | undefined) ?? null
+      : mockOptions.activeProjectId;
     let cloudDisconnectError: string | null = null;
     let configGetCount = 0;
     let nextConfigUpdateError: string | null = null;
@@ -381,7 +390,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
       }),
       panels: namespace({
-        getSessionPanels: () => success([]),
+        getSessionPanels: (sessionId: string) => success(
+          clone(mockPanels.filter((panel) => panel.sessionId === sessionId)),
+        ),
         shouldAutoCreate: () => success(false),
       }),
       permissions: namespace({
@@ -396,8 +407,24 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
       }),
       projects: namespace({
-        getAll: () => success([]),
-        getActive: () => success(null),
+        getAll: () => success(clone(mockProjects.map((project) => ({
+          ...project,
+          active: mockActiveProjectId === null
+            ? false
+            : project.id === mockActiveProjectId,
+        })))),
+        getActive: () => success(clone(
+          mockProjects.find((project) => project.id === mockActiveProjectId) ?? null,
+        )),
+        activate: (projectId: string) => {
+          mockActiveProjectId = Number(projectId);
+          return success();
+        },
+        detectBranch: () => success('main'),
+        listBranches: () => success([
+          { name: 'origin/main', isCurrent: false, hasWorktree: false, isRemote: true },
+          { name: 'main', isCurrent: true, hasWorktree: false, isRemote: false },
+        ]),
         refreshGitStatus: () => success(),
       }),
       prompts: namespace({
@@ -682,6 +709,13 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         setSessions(sessions: Array<Record<string, unknown>>) {
           mockSessions = clone(sessions);
+        },
+        setProjects(projects: Array<Record<string, unknown>>, activeProjectId: number | null = null) {
+          mockProjects = clone(projects);
+          mockActiveProjectId = activeProjectId;
+        },
+        setPanels(panels: Array<Record<string, unknown>>) {
+          mockPanels = clone(panels);
         },
         getSessionsReadCount() {
           return sessionsGetCount;

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -20,6 +20,7 @@ type ElectronApiMockOptions = {
   initialSessions?: Array<Record<string, unknown>>;
   initialPanels?: Array<Record<string, unknown>>;
   activeProjectId?: number | null;
+  paneChatAgentChangeDelayMs?: number;
 };
 
 export async function installElectronApiMock(page: Page, options: ElectronApiMockOptions = {}) {
@@ -171,6 +172,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     let remainingConfigGetFailures = mockOptions.configGetFailures ?? 0;
     const configUpdates: Array<Record<string, unknown>> = [];
     const preferenceWrites: Array<{ key: string; value: string }> = [];
+    const sessionDeleteCalls: string[] = [];
+    const sessionFavoriteToggleCalls: string[] = [];
     let sessionsGetCount = 0;
 
     const subscribe = (channel: string, callback: (...args: unknown[]) => void) => {
@@ -384,7 +387,10 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       }),
       paneChat: namespace({
         getOrCreate: () => success(createPaneChatState()),
-        setAgent: (agent: 'claude' | 'codex') => {
+        setAgent: async (agent: 'claude' | 'codex') => {
+          if (mockOptions.paneChatAgentChangeDelayMs) {
+            await new Promise((resolve) => setTimeout(resolve, mockOptions.paneChatAgentChangeDelayMs));
+          }
           configState.defaultOrchestratorAgent = agent === 'codex' ? 'codex' : 'claude';
           return success(createPaneChatState());
         },
@@ -441,6 +447,14 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         stopActive: () => success(),
       }),
       sessions: namespace({
+        delete: (sessionId: string) => {
+          sessionDeleteCalls.push(sessionId);
+          return success();
+        },
+        toggleFavorite: (sessionId: string) => {
+          sessionFavoriteToggleCalls.push(sessionId);
+          return success();
+        },
         getAll: () => {
           sessionsGetCount += 1;
           return success(clone(mockSessions));
@@ -719,6 +733,12 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         getSessionsReadCount() {
           return sessionsGetCount;
+        },
+        getSessionDeleteCalls() {
+          return clone(sessionDeleteCalls);
+        },
+        getSessionFavoriteToggleCalls() {
+          return clone(sessionFavoriteToggleCalls);
         },
       },
     });


### PR DESCRIPTION
## Summary

- replace non-semantic desktop and Remote Pane interactions with keyboard-operable controls and complete composite-widget behavior
- move dialogs, nested portals, tooltips, dropdowns, and selects onto shared accessible focus and portal contracts
- add deliberate live-region announcements for meaningful progress, errors, and connection changes
- enforce selected `jsx-a11y` rules and add maintained Playwright/axe journeys to minimal CI

## Scope

Direct Settings dialog implementation work is intentionally excluded because it is being handled separately. This PR does not modify `frontend/src/components/Settings.tsx`; it only preserves Settings compatibility through shared Modal and Select contracts.

Refs #323

## Testing

- `pnpm typecheck`
- `pnpm lint` (0 errors; 167 existing warnings)
- `pnpm --filter frontend test` (83 passed)
- `pnpm run build:frontend`
- `pnpm test:ci:minimal` (26 passed, including 7 axe journeys)
- `pnpm test -- tests/settings.spec.ts` (15 passed)
- `pnpm test -- tests/dropdown-keyboard-nav.spec.ts` (3 passed)
- rendered axe pass across all 12 themes, including seeded Night Owl recent-pane metadata
- About dialog desktop and 200%-equivalent reflow/scroll verification
- disconnected Remote Pane mobile verification at 390x844

The connected Remote Pane path was not exercised against a live host; automated QA covers it through a route-mocked host and covers the disconnected journey through the Electron API mock. No visual redesign is included.

<!-- codex-pr-test-automation-summary -->
## Automated manual QA

**Status: Passed and ready for review.**

- Tested commit `2efe26af36b35a175c7eef0fabf14ca556e6f74a` with marker `agent-e2e-pr-329-20260713-fixed`.
- All first-pass findings are resolved: branch-list Escape ownership, Advanced switch names, Remote button contrast, Night Owl metadata contrast, and malformed-code feedback.
- Maintained accessibility journeys: 7/7 passed; minimal CI: 26/26; frontend unit tests: 83/83; typecheck, lint, and production frontend build passed.
- GitHub Actions: 16/16 checks passed across smoke, main-process, and Runpane wrapper matrices.
- Connected Remote Pane used a strict route-mocked host. A live-host smoke remains useful but is not blocking this accessibility QA result.
- [Detailed findings and screenshot evidence](https://github.com/dcouple/Pane/pull/329#issuecomment-4961618205)

| Desktop Create Pane | Connected Remote Pane |
| --- | --- |
| <img src="https://x0.at/wGGE.png" width="420" alt="Desktop Create Pane after accessibility fixes"> | <img src="https://x0.at/xY9v.png" width="420" alt="Connected Remote Create Pane after accessibility fixes"> |
<!-- /codex-pr-test-automation-summary -->
