### PR TITLE
feat: keep computer awake while sessions are active

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -7,6 +7,7 @@ import { useNavigationStore } from '../stores/navigationStore';
 import { API } from '../utils/api';
 import { Dropdown } from './ui/Dropdown';
 import { Badge } from './ui/Badge';
+import { Toggle } from './ui/Toggle';
 import { AddProjectDialog } from './AddProjectDialog';
 import { CloneFromGitHubDialog } from './CloneFromGitHubDialog';
 import { formatDistanceToNow, isValidTimestamp } from '../utils/timestampUtils';
@@ -358,6 +359,18 @@ export function HomePage() {
                   <ChevronUp className="w-4 h-4" />
                 </button>
               </div>
+            </div>
+
+            <div
+              className="flex items-center justify-between rounded-lg bg-surface-secondary p-4"
+              title="Prevents the system from idle-sleeping while any session is active. The display can still turn off; closing the lid or choosing Sleep still sleeps the machine."
+            >
+              <span className="text-text-primary">Keep Awake</span>
+              <Toggle
+                checked={config?.keepAwakeWhileSessionsActive !== false}
+                aria-label="Keep computer awake while sessions are active"
+                onChange={(value) => void updateConfig({ keepAwakeWhileSessionsActive: value }).catch(() => {})}
+              />
             </div>
 
             {platform === 'win32' && (

--- a/frontend/src/components/settings/catalog.tsx
+++ b/frontend/src/components/settings/catalog.tsx
@@ -30,8 +30,8 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategoryDefinition[] = [
     label: 'General',
     description: 'Startup and application updates.',
     icon: Settings,
-    settingIds: ['automatic-updates', 'check-updates-now', 'start-on-login'],
-    aliases: ['startup', 'updates', 'login'],
+    settingIds: ['automatic-updates', 'check-updates-now', 'start-on-login', 'keep-awake'],
+    aliases: ['startup', 'updates', 'login', 'sleep', 'caffeinate', 'awake', 'power'],
   },
   {
     id: 'appearance',

--- a/frontend/src/components/settings/categories/GeneralSettings.tsx
+++ b/frontend/src/components/settings/categories/GeneralSettings.tsx
@@ -74,6 +74,21 @@ export function GeneralSettings({ persistence }: { persistence: SettingsPersiste
           />
         </SettingRow>
       </SettingsSection>
+
+      <SettingsSection title="Power" description="System sleep behavior while sessions are active.">
+        <SettingRow
+          settingId="keep-awake"
+          label="Keep computer awake while sessions are active"
+          description="Prevents the system from idle-sleeping while any session is active. The display can still turn off; closing the lid or choosing Sleep still sleeps the machine."
+          saveState={persistence.saveStates['keep-awake']}
+        >
+          <ImmediateToggle
+            label="Keep computer awake while sessions are active"
+            value={config.keepAwakeWhileSessionsActive !== false}
+            onSave={(value) => persistence.saveConfig('keep-awake', { keepAwakeWhileSessionsActive: value })}
+          />
+        </SettingRow>
+      </SettingsSection>
     </SettingsPage>
   );
 }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -75,6 +75,8 @@ export interface AppConfig {
   autoCheckUpdates?: boolean;
   // Start Pane automatically when the user logs in
   autoStartOnBoot?: boolean;
+  // Keep the computer awake while any session is active
+  keepAwakeWhileSessionsActive?: boolean;
   // Stravu MCP integration
   stravuApiKey?: string;
   stravuServerUrl?: string;
@@ -157,6 +159,7 @@ export interface UpdateConfigRequest {
   defaultOrchestratorAgent?: PaneChatAgent;
   autoCheckUpdates?: boolean;
   autoStartOnBoot?: boolean;
+  keepAwakeWhileSessionsActive?: boolean;
   stravuApiKey?: string;
   stravuServerUrl?: string;
   theme?: AppConfig['theme'];

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -17,6 +17,7 @@ export type SettingsSettingId =
   | 'automatic-updates'
   | 'check-updates-now'
   | 'start-on-login'
+  | 'keep-awake'
   | 'theme'
   | 'ui-scale'
   | 'sidebar-pane-rows'

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -2979,6 +2979,15 @@ export class DatabaseService {
       .all() as Session[];
   }
 
+  getPowerSaveSnapshotSessions(options?: { includeHidden?: boolean }): Session[] {
+    const hiddenClause = options?.includeHidden ? "" : "WHERE (is_hidden = 0 OR is_hidden IS NULL)";
+    return this.db
+      .prepare(
+        `SELECT * FROM sessions ${hiddenClause} ORDER BY created_at DESC`,
+      )
+      .all() as Session[];
+  }
+
   getArchivedSessions(projectId?: number, options?: { includeHidden?: boolean }): Session[] {
     const hiddenClause = options?.includeHidden ? "" : " AND (is_hidden = 0 OR is_hidden IS NULL)";
     if (projectId !== undefined) {

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -87,6 +87,7 @@ import { createPaneDaemonHost, type PaneDaemonHost } from './daemon/bootstrap';
 import { remotePaneClientController } from './daemon/client/remotePaneClient';
 import { startHeadlessPaneProcess } from './daemon/startHeadless';
 import { runRemoteSetupCli } from './daemon/setupRemoteHostCli';
+import { PowerSaveManager } from './services/powerSaveManager';
 
 export let mainWindow: BrowserWindow | null = null;
 
@@ -186,6 +187,7 @@ let versionChecker: VersionChecker;
 let archiveProgressManager: ArchiveProgressManager;
 let analyticsManager: AnalyticsManager;
 let paneDaemonHost: PaneDaemonHost | null = null;
+let powerSaveManager: PowerSaveManager | null = null;
 
 // ptyHost supervisor — forked as an Electron UtilityProcess on app ready,
 // but only when the `usePtyHost` setting is enabled (default: off). When
@@ -984,6 +986,8 @@ async function initializeServices() {
   logger = services.logger as Logger;
   archiveProgressManager = services.archiveProgressManager as ArchiveProgressManager;
   analyticsManager = services.analyticsManager as AnalyticsManager;
+  powerSaveManager = new PowerSaveManager(configManager, sessionManager);
+  powerSaveManager.sync();
 
   ipcMain.handle('analytics:get-identity', async () => {
     try {
@@ -1319,6 +1323,9 @@ if (launchRemoteSetup) {
     // User chose to quit anyway
     archiveProgressManager.clearAll();
   }
+
+  powerSaveManager?.dispose();
+  powerSaveManager = null;
 
   // Safety net: force exit if graceful shutdown takes too long
   // Placed after the dialog so user interaction time isn't counted

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -55,6 +55,7 @@ export class ConfigManager extends EventEmitter {
       defaultModel: 'sonnet',
       defaultOrchestratorAgent: DEFAULT_PANE_CHAT_AGENT,
       autoStartOnBoot: true,
+      keepAwakeWhileSessionsActive: true,
       stravuApiKey: undefined,
       stravuServerUrl: '', // Stravu integration disabled
       notifications: {

--- a/main/src/services/powerSaveManager.test.ts
+++ b/main/src/services/powerSaveManager.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppConfig } from '../types/config';
+import type { Session } from '../types/session';
+
+const powerSaveBlocker = vi.hoisted(() => ({
+  start: vi.fn(() => 42),
+  stop: vi.fn(),
+  isStarted: vi.fn(() => true),
+}));
+
+vi.mock('electron', () => ({ powerSaveBlocker }));
+
+import { ConfigManager } from './configManager';
+import { PowerSaveManager } from './powerSaveManager';
+
+class ConfigManagerStub extends EventEmitter {
+  private config: AppConfig = { keepAwakeWhileSessionsActive: true };
+
+  getConfig(): AppConfig {
+    return { ...this.config };
+  }
+
+  setKeepAwake(enabled: boolean): void {
+    this.config = { ...this.config, keepAwakeWhileSessionsActive: enabled };
+    this.emit('config-updated', this.getConfig());
+  }
+}
+
+class SessionManagerStub extends EventEmitter {}
+
+function createSession(
+  id: string,
+  status: Session['status'],
+  overrides: Partial<Session> = {},
+): Session {
+  return {
+    id,
+    name: id,
+    worktreePath: `/tmp/${id}`,
+    prompt: '',
+    status,
+    createdAt: new Date(),
+    output: [],
+    jsonMessages: [],
+    ...overrides,
+  };
+}
+
+describe('PowerSaveManager', () => {
+  let configManager: ConfigManagerStub;
+  let sessionManager: SessionManagerStub;
+  let manager: PowerSaveManager;
+
+  beforeEach(() => {
+    powerSaveBlocker.start.mockClear();
+    powerSaveBlocker.stop.mockClear();
+    powerSaveBlocker.isStarted.mockClear();
+    configManager = new ConfigManagerStub();
+    sessionManager = new SessionManagerStub();
+    manager = new PowerSaveManager(configManager, sessionManager);
+  });
+
+  afterEach(() => {
+    manager.dispose();
+  });
+
+  it.each<Session['status']>(['initializing', 'ready', 'running', 'waiting'])(
+    'starts exactly one app-suspension blocker for an active %s session',
+    status => {
+      sessionManager.emit('session-created', createSession('session-1', status));
+      sessionManager.emit('session-updated', createSession('session-1', status));
+
+      expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+      expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-app-suspension');
+      expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
+    },
+  );
+
+  it('tracks an active main-repo session solely from events', () => {
+    sessionManager.emit(
+      'session-created',
+      createSession('main-repo-session', 'running', { isMainRepo: true }),
+    );
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-app-suspension');
+  });
+
+  it.each<Session['status']>(['stopped', 'error'])(
+    'stops when the last active session reaches %s',
+    status => {
+      sessionManager.emit('session-created', createSession('session-1', 'running'));
+      sessionManager.emit('session-updated', createSession('session-1', status));
+
+      expect(powerSaveBlocker.stop).toHaveBeenCalledTimes(1);
+      expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
+    },
+  );
+
+  it('stays held until every active session has stopped', () => {
+    sessionManager.emit('session-created', createSession('session-1', 'running'));
+    sessionManager.emit('session-created', createSession('session-2', 'waiting'));
+    sessionManager.emit('session-updated', createSession('session-1', 'stopped'));
+
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
+
+    sessionManager.emit('session-updated', createSession('session-2', 'stopped'));
+    expect(powerSaveBlocker.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays held across a running to waiting to running flap', () => {
+    sessionManager.emit('session-created', createSession('session-1', 'running'));
+    sessionManager.emit('session-updated', createSession('session-1', 'waiting'));
+    sessionManager.emit('session-updated', createSession('session-1', 'running'));
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
+  });
+
+  it('stops when the last active session is archived', () => {
+    sessionManager.emit('session-created', createSession('session-1', 'ready'));
+    sessionManager.emit('session-deleted', { id: 'session-1' });
+
+    expect(powerSaveBlocker.stop).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
+  });
+
+  it('acquires and releases for interrupted-session status events', () => {
+    sessionManager.emit('session-updated', createSession('resumed-session', 'running'));
+    sessionManager.emit('session-updated', createSession('resumed-session', 'stopped'));
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops immediately when disabled and remains stopped for later active sessions', () => {
+    sessionManager.emit('session-created', createSession('session-1', 'running'));
+
+    configManager.setKeepAwake(false);
+    sessionManager.emit('session-updated', createSession('session-1', 'stopped'));
+    sessionManager.emit('session-created', createSession('session-2', 'running'));
+
+    expect(powerSaveBlocker.stop).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds session statuses from the sessions-loaded event', () => {
+    sessionManager.emit('sessions-loaded', [
+      createSession('stopped-session', 'stopped'),
+      createSession('active-session', 'waiting'),
+    ]);
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults keep-awake to enabled for a fresh ConfigManager', () => {
+    const freshConfigManager = new ConfigManager();
+
+    expect(freshConfigManager.getConfig().keepAwakeWhileSessionsActive).toBe(true);
+  });
+});

--- a/main/src/services/powerSaveManager.test.ts
+++ b/main/src/services/powerSaveManager.test.ts
@@ -27,7 +27,15 @@ class ConfigManagerStub extends EventEmitter {
   }
 }
 
-class SessionManagerStub extends EventEmitter {}
+class SessionManagerStub extends EventEmitter {
+  constructor(private readonly snapshotSessions: Session[] = []) {
+    super();
+  }
+
+  getPowerSaveSnapshotSessions(): Session[] {
+    return this.snapshotSessions;
+  }
+}
 
 function createSession(
   id: string,
@@ -152,6 +160,60 @@ describe('PowerSaveManager', () => {
     ]);
 
     expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a tracked active main-repo session held when sessions-loaded omits it', () => {
+    sessionManager.emit(
+      'session-created',
+      createSession('main-repo-session', 'running', { isMainRepo: true }),
+    );
+
+    sessionManager.emit('sessions-loaded', [
+      createSession('ordinary-session', 'stopped'),
+    ]);
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
+  });
+
+  it('does not reacquire for an archived running update after prior deletion', () => {
+    sessionManager.emit('session-deleted', { id: 'archived-session' });
+    sessionManager.emit(
+      'session-updated',
+      createSession('archived-session', 'running', { archived: true }),
+    );
+
+    expect(powerSaveBlocker.start).not.toHaveBeenCalled();
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
+  });
+
+  it('drops a previously active session when a late archived running update arrives', () => {
+    sessionManager.emit('session-created', createSession('archived-session', 'running'));
+    sessionManager.emit(
+      'session-updated',
+      createSession('archived-session', 'running', { archived: true }),
+    );
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds active sessions from the construction snapshot before any event', () => {
+    manager.dispose();
+    powerSaveBlocker.start.mockClear();
+    powerSaveBlocker.stop.mockClear();
+
+    sessionManager = new SessionManagerStub([
+      createSession('main-repo-session', 'running', { isMainRepo: true }),
+      createSession('archived-session', 'running', { archived: true }),
+      createSession('stopped-session', 'stopped'),
+    ]);
+    manager = new PowerSaveManager(configManager, sessionManager);
+    manager.sync();
+
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+    expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-app-suspension');
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
   });
 
   it('defaults keep-awake to enabled for a fresh ConfigManager', () => {

--- a/main/src/services/powerSaveManager.ts
+++ b/main/src/services/powerSaveManager.ts
@@ -1,0 +1,83 @@
+import { powerSaveBlocker } from 'electron';
+import type { EventEmitter } from 'events';
+import type { AppConfig } from '../types/config';
+import type { Session } from '../types/session';
+
+const ACTIVE_SESSION_STATUSES = new Set<Session['status']>([
+  'initializing',
+  'ready',
+  'running',
+  'waiting',
+]);
+
+interface PowerSaveConfigSource extends EventEmitter {
+  getConfig(): AppConfig;
+}
+
+type PowerSaveSessionSource = EventEmitter;
+
+export class PowerSaveManager {
+  private readonly statuses = new Map<string, Session['status']>();
+  private blockerId: number | null = null;
+
+  private readonly handleSessionsLoaded = (sessions: Session[]): void => {
+    this.statuses.clear();
+    for (const session of sessions) {
+      this.statuses.set(session.id, session.status);
+    }
+    this.sync();
+  };
+
+  private readonly handleSessionChanged = (session: Session): void => {
+    this.statuses.set(session.id, session.status);
+    this.sync();
+  };
+
+  private readonly handleSessionDeleted = (session: Pick<Session, 'id'>): void => {
+    this.statuses.delete(session.id);
+    this.sync();
+  };
+
+  private readonly handleConfigUpdated = (): void => {
+    this.sync();
+  };
+
+  constructor(
+    private readonly configManager: PowerSaveConfigSource,
+    private readonly sessionManager: PowerSaveSessionSource,
+  ) {
+    this.sessionManager.on('sessions-loaded', this.handleSessionsLoaded);
+    this.sessionManager.on('session-created', this.handleSessionChanged);
+    this.sessionManager.on('session-updated', this.handleSessionChanged);
+    this.sessionManager.on('session-deleted', this.handleSessionDeleted);
+    this.configManager.on('config-updated', this.handleConfigUpdated);
+  }
+
+  sync(): void {
+    const enabled = this.configManager.getConfig().keepAwakeWhileSessionsActive !== false;
+    const hasActiveSession = Array.from(this.statuses.values()).some(status =>
+      ACTIVE_SESSION_STATUSES.has(status)
+    );
+    const shouldBlockSleep = enabled && hasActiveSession;
+
+    if (shouldBlockSleep && this.blockerId === null) {
+      this.blockerId = powerSaveBlocker.start('prevent-app-suspension');
+    } else if (!shouldBlockSleep && this.blockerId !== null) {
+      powerSaveBlocker.stop(this.blockerId);
+      this.blockerId = null;
+    }
+  }
+
+  dispose(): void {
+    this.sessionManager.removeListener('sessions-loaded', this.handleSessionsLoaded);
+    this.sessionManager.removeListener('session-created', this.handleSessionChanged);
+    this.sessionManager.removeListener('session-updated', this.handleSessionChanged);
+    this.sessionManager.removeListener('session-deleted', this.handleSessionDeleted);
+    this.configManager.removeListener('config-updated', this.handleConfigUpdated);
+
+    if (this.blockerId !== null) {
+      powerSaveBlocker.stop(this.blockerId);
+      this.blockerId = null;
+    }
+  }
+}

--- a/main/src/services/powerSaveManager.ts
+++ b/main/src/services/powerSaveManager.ts
@@ -14,27 +14,28 @@ interface PowerSaveConfigSource extends EventEmitter {
   getConfig(): AppConfig;
 }
 
-type PowerSaveSessionSource = EventEmitter;
+interface PowerSaveSessionSource extends EventEmitter {
+  getPowerSaveSnapshotSessions(): Session[];
+}
 
 export class PowerSaveManager {
-  private readonly statuses = new Map<string, Session['status']>();
+  private readonly activeSessionIds = new Set<string>();
   private blockerId: number | null = null;
 
   private readonly handleSessionsLoaded = (sessions: Session[]): void => {
-    this.statuses.clear();
     for (const session of sessions) {
-      this.statuses.set(session.id, session.status);
+      this.retainIfActive(session);
     }
     this.sync();
   };
 
   private readonly handleSessionChanged = (session: Session): void => {
-    this.statuses.set(session.id, session.status);
+    this.retainIfActive(session);
     this.sync();
   };
 
   private readonly handleSessionDeleted = (session: Pick<Session, 'id'>): void => {
-    this.statuses.delete(session.id);
+    this.activeSessionIds.delete(session.id);
     this.sync();
   };
 
@@ -51,13 +52,15 @@ export class PowerSaveManager {
     this.sessionManager.on('session-updated', this.handleSessionChanged);
     this.sessionManager.on('session-deleted', this.handleSessionDeleted);
     this.configManager.on('config-updated', this.handleConfigUpdated);
+
+    for (const session of this.sessionManager.getPowerSaveSnapshotSessions()) {
+      this.retainIfActive(session);
+    }
   }
 
   sync(): void {
     const enabled = this.configManager.getConfig().keepAwakeWhileSessionsActive !== false;
-    const hasActiveSession = Array.from(this.statuses.values()).some(status =>
-      ACTIVE_SESSION_STATUSES.has(status)
-    );
+    const hasActiveSession = this.activeSessionIds.size > 0;
     const shouldBlockSleep = enabled && hasActiveSession;
 
     if (shouldBlockSleep && this.blockerId === null) {
@@ -66,6 +69,15 @@ export class PowerSaveManager {
       powerSaveBlocker.stop(this.blockerId);
       this.blockerId = null;
     }
+  }
+
+  private retainIfActive(session: Session): void {
+    if (!session.archived && ACTIVE_SESSION_STATUSES.has(session.status)) {
+      this.activeSessionIds.add(session.id);
+      return;
+    }
+
+    this.activeSessionIds.delete(session.id);
   }
 
   dispose(): void {

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -1905,14 +1905,14 @@ export class SessionManager extends EventEmitter {
       }
 
       // Update session status to running
-      this.db.updateSession(sessionId, { status: 'running' });
+      this.updateSession(sessionId, { status: 'running' });
       console.log(`[SessionManager] Resumed session ${sessionId}: ${resumedPanelCount} panels`);
     }
   }
 
   async dismissInterruptedSessions(sessionIds: string[]): Promise<void> {
     for (const sessionId of sessionIds) {
-      this.db.updateSession(sessionId, { status: 'stopped' });
+      this.updateSession(sessionId, { status: 'stopped' });
     }
     console.log(`[SessionManager] Dismissed ${sessionIds.length} interrupted sessions`);
   }

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -292,6 +292,11 @@ export class SessionManager extends EventEmitter {
     return dbSessions.map(this.convertDbSessionToSession.bind(this));
   }
 
+  getPowerSaveSnapshotSessions(): Session[] {
+    const dbSessions = this.db.getPowerSaveSnapshotSessions();
+    return dbSessions.map(this.convertDbSessionToSession.bind(this));
+  }
+
   getSessionsForProject(projectId: number): Session[] {
     const dbSessions = this.db.getAllSessions(projectId);
     return dbSessions.map(this.convertDbSessionToSession.bind(this));
@@ -1912,6 +1917,12 @@ export class SessionManager extends EventEmitter {
 
   async dismissInterruptedSessions(sessionIds: string[]): Promise<void> {
     for (const sessionId of sessionIds) {
+      const dbSession = this.db.getSession(sessionId);
+      if (!dbSession) {
+        console.warn(`[SessionManager] Session ${sessionId} not found for dismiss`);
+        continue;
+      }
+
       this.updateSession(sessionId, { status: 'stopped' });
     }
     console.log(`[SessionManager] Dismissed ${sessionIds.length} interrupted sessions`);

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -75,6 +75,8 @@ export interface AppConfig {
   autoCheckUpdates?: boolean;
   // Start Pane automatically when the user logs in
   autoStartOnBoot?: boolean;
+  // Prevent idle sleep while Pane sessions are active
+  keepAwakeWhileSessionsActive?: boolean;
   // Stravu MCP integration
   stravuApiKey?: string;
   stravuServerUrl?: string;
@@ -153,6 +155,7 @@ export interface UpdateConfigRequest {
   defaultOrchestratorAgent?: PaneChatAgent;
   autoCheckUpdates?: boolean;
   autoStartOnBoot?: boolean;
+  keepAwakeWhileSessionsActive?: boolean;
   stravuApiKey?: string;
   stravuServerUrl?: string;
   theme?: 'light' | 'light-rounded' | 'dark' | 'oled' | 'dusk' | 'dusk-oled' | 'forge' | 'ember' | 'aurora' | 'night-owl' | 'night-owl-oled' | 'terracotta';

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -112,6 +112,18 @@ test.describe('Settings', () => {
     expect(writes.preferences).toContainEqual({ key: 'sidebar_pane_row_layout', value: 'two-row' });
   });
 
+  test('persists the keep-awake toggle to config', async ({ page }) => {
+    await bootSettings(page, { initialConfig: { keepAwakeWhileSessionsActive: true } });
+
+    await page.getByRole('switch', { name: 'Keep computer awake while sessions are active' }).click();
+    await expect(page.getByText('Saved', { exact: true })).toBeVisible();
+
+    const updates = await page.evaluate(() => (
+      window as typeof window & { __paneTestElectronMock: SettingsMock }
+    ).__paneTestElectronMock.getConfigUpdates());
+    expect(updates).toContainEqual({ keepAwakeWhileSessionsActive: false });
+  });
+
   test('announces a failed save and restores the authoritative value', async ({ page }) => {
     await bootSettings(page, { initialConfig: { autoCheckUpdates: true } });
     await page.evaluate(() => {


### PR DESCRIPTION
# Summary

Pane's core promise is unattended parallel agent runs — but on Linux and Windows nothing stops the OS from idle-sleeping mid-run (PTYs freeze, overnight runs die silently), and on macOS survival depends on each CLI's private `caffeinate` behavior (Claude Code cycles `caffeinate -i -t 300`; Codex holds `caffeinate -dimsu`). Pane now owns this guarantee tool-agnostically: **while any session is in an active status (`initializing`/`ready`/`running`/`waiting`), the main process holds one Electron `powerSaveBlocker('prevent-app-suspension')`** — released the moment the last active session ends or the setting is turned off.

Done means: a default-on **"Keep computer awake while sessions are active"** toggle on Settings → General (new Power section); the system never idle-sleeps while a session is active on macOS/Windows/Linux; the display still sleeps normally; zero blocker held when idle or disabled.

Design decisions (from the work item):
- **D1** `prevent-app-suspension` only — never `prevent-display-sleep` (the Claude-Desktop-on-Windows screen-burn mistake), no `caffeinate` spawning, no per-OS code.
- **D2** Event-sourced status map in `PowerSaveManager` (seeded by `sessions-loaded`, updated by `session-created`/`session-updated`/`session-deleted`) — deliberately **not** `getAllSessions()`, whose SQL excludes main-repo sessions, and not a literal ref-count (drift-proof). A `running → waiting → running` flap keeps the blocker held (no stop/start cycle).
- **D3** Global config `keepAwakeWhileSessionsActive`, default **on**; disabling releases immediately.
- **D4** Toggle copy says "sessions are active" (terminal-only panes are documented out of scope) and names the lid-close limitation.
- **Addendum (post-QA):** the toggle is also surfaced on the Home page's Preferences card (under Theme / UI Scale) so it's reachable where users land — commit `bdad083`.

Also fixed en route: interrupted-session resume/dismiss wrote status straight to the DB without emitting `session-updated` (`sessionManager.ts`); they now route through `updateSession()` like every other status write.

# Visual overview

The feature's entire UI footprint is one new row on Settings → General; everything else is an invisible OS-level wake assertion tied to session lifecycle.

| Before | After (shipped, default on) |
|---|---|
| ![Settings General before](https://github.com/dcouple/Pane/releases/download/qa-assets/332-settings-before.png) | ![Settings General after](https://github.com/dcouple/Pane/releases/download/qa-assets/332-settings-after.png) |

Flipping the toggle (renderer persistence proof — "Saved" indicator, value recorded at the config boundary):

![Toggle flipped with Saved indicator](https://github.com/dcouple/Pane/releases/download/qa-assets/332-toggle-flipped-saved.png)

Also on the Home page's Preferences card (post-QA addendum, default on, same config field):

![Home page Keep Awake toggle](https://github.com/dcouple/Pane/releases/download/qa-assets/332-home-preferences.png)

Runtime behavior (AC6, isolated dev instance): session active → `pid 54790(Electron): NoIdleSleepAssertion named: "Electron"` appears in `pmset -g assertions` the same second; `sessions:stop` → assertion gone at t+1s.

# Verification

| AC | Criterion | Evidence |
|---|---|---|
| AC1 | 0→1 active sessions starts exactly one `prevent-app-suspension` blocker (incl. main-repo sessions) | Unit suite (Node 22): `Tests 14 passed (14)` — `✓ starts exactly one app-suspension blocker for an active running session`, `✓ tracks an active main-repo session solely from events`; duplicate events asserted `toHaveBeenCalledTimes(1)` |
| AC2 | Last active session leaving the set stops the blocker; `running↔waiting` flap keeps it held | `✓ stops when the last active session reaches stopped / error / is archived`, `✓ stays held across a running to waiting to running flap` (zero `stop` calls), `✓ acquires and releases for interrupted-session status events` |
| AC3 | Disable mid-hold stops immediately; no restart while disabled | `✓ stops immediately when disabled and remains stopped for later active sessions` |
| AC4 | Fresh config defaults to enabled | `✓ defaults keep-awake to enabled for a fresh ConfigManager`; AC6 run's fresh isolated config contained `"keepAwakeWhileSessionsActive": true` on disk |
| AC5 | Toggle on Settings → General persists without restart | Playwright vs mocked electron API: `16 passed`, incl. `persists the keep-awake toggle to config`; independent browser-driven flip recorded `CONFIG_UPDATES=[{"keepAwakeWhileSessionsActive":false}]` with "Saved" shown |
| AC6 | Live macOS: Electron-owned `NoIdleSleepAssertion` while active, gone after stop | Isolated dev instance (fresh `PANE_DIR`): session active at 01:02:44 → same-second `pid 54790(Electron): NoIdleSleepAssertion named: "Electron"`; held 5+ min through `waiting`; after `sessions:stop` → `t+1s status=stopped electron-assertions="(none)"` (remaining `caffeinate` assertions belong to unrelated CLI processes) |

Build gate: workspace `typecheck` clean, `lint` 0 errors, `build:main` succeeds.

# Manual tests

**Must**
- [x] With the toggle on, start a Claude session and confirm `pmset -g assertions` (macOS) shows a `NoIdleSleepAssertion` owned by the Pane/Electron process (not `caffeinate`) — core promise of the feature
- [x] Stop that session and confirm the Electron-owned assertion disappears within seconds — no leaked wake lock (the Linux-inhibitor-leak failure mode)
- [x] Toggle the setting off while a session is active → assertion released immediately; back on → re-acquired

**Important**
- [x] Settings → General shows the new Power section; toggle is ON by default on a fresh install
- [x] Flip the toggle → "Saved" appears and `~/.pane/config.json` gains `"keepAwakeWhileSessionsActive": false` without an app restart
- [x] Two concurrent sessions: stopping one keeps the assertion held; stopping both releases it
- [x] A session sitting in `waiting` (needs your input) keeps the machine awake — intended behavior, documented in the item
- [ ] Resume an interrupted session from the resume dialog → it acquires the blocker (this path's status write was fixed to emit events) — left to human: needs a genuinely interrupted session staged; event path covered by unit test
- [ ] Quit the app via Cmd+Q with an active session → assertion gone after quit; cancelling quit at the archive-tasks "Wait" dialog keeps the blocker held — left to human: the cancel branch needs the native dialog
- [x] App restart with no sessions running → no Electron assertion at idle
- [ ] Linux: `systemd-inhibit --list` shows an inhibitor from Pane while a session is active — left to human: no Linux machine in this run
- [ ] Windows: `powercfg /requests` shows a SYSTEM request from Pane while a session is active — left to human: no Windows machine in this run

**Nice**
- [ ] Display still sleeps normally while the blocker is held (only *system* sleep is prevented) — left to human: needs a real display-sleep wait; mechanism guarantees it (`prevent-app-suspension`, never `prevent-display-sleep`)
- [x] Terminal-only panes (no AI tool) do not hold the blocker — documented out-of-scope, verified as such in AC6 round 1

Areas not affected: all other settings pages, session lifecycle behavior (create/stop/archive semantics unchanged — only an added listener), diff/editor/terminal panels, run scripts, display-sleep behavior.

# Residual risks

- Linux and Windows behavior rides Electron's `powerSaveBlocker` abstraction (logind inhibitor / `SetThreadExecutionState`) — verified empirically on macOS only in this run; the two platform Manual-test items above cover the gap.
- Hidden sessions are not tracked by the blocker (documented plan assumption; one-line change if ever wrong).
