### PR TITLE
Fix Shift+Enter in fullscreen CLI panels

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -11,6 +11,7 @@ import { TerminalPanelProps } from '../../types/panelComponents';
 import { useHotkeyStore } from '../../stores/hotkeyStore';
 import { renderLog, devLog } from '../../utils/console';
 import { getTerminalTheme } from '../../utils/terminalTheme';
+import { resolveTerminalKeyHandling } from '../../utils/terminalKeyHandling';
 import { isMac } from '../../utils/platformUtils';
 import { FileEdit, FolderOpen } from 'lucide-react';
 import { useTerminalLinks } from '../terminal/hooks/useTerminalLinks';
@@ -762,24 +763,22 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             return false;
           }
 
-          // When a TUI app is running, pass most keys through to the PTY
-          // but still let Ctrl/Cmd+V use the browser's native paste path
-          if (tuiActiveRef.current) {
-            if (ctrlOrMeta && e.key.toLowerCase() === 'v') return false;
-            return true;
-          }
+          const terminalKeyDecision = resolveTerminalKeyHandling(e, {
+            isTuiActive: tuiActiveRef.current,
+            isCliPanel: isCliPanelRef.current,
+          });
 
-          // Shift+Enter: emit the same sequence as Alt+Enter (\x1b\r = ESC+CR)
-          // xterm.js ignores shiftKey on Enter, so Shift+Enter = Enter by default.
-          // Alt+Enter natively sends \x1b\r which CLI tools recognize as "insert newline".
-          // Block both keydown and keyup to fully suppress xterm's default \r.
-          // Guard: skip when Ctrl/Cmd is held so Ctrl+Shift+Enter chords are not swallowed.
-          if (e.shiftKey && !ctrlOrMeta && e.key === 'Enter') {
+          // Shift+Enter sends the same ESC+CR sequence as Alt+Enter for CLI
+          // composers. In fullscreen agent TUIs this must run before generic
+          // passthrough, while ordinary TUIs still receive Shift+Enter directly.
+          if (terminalKeyDecision.action === 'send-input') {
             if (e.type === 'keydown') {
-              window.electronAPI.invoke('terminal:input', panel.id, '\x1b\r');
+              window.electronAPI.invoke('terminal:input', panel.id, terminalKeyDecision.input);
             }
             return false;
           }
+          if (terminalKeyDecision.action === 'block') return false;
+          if (terminalKeyDecision.action === 'pass-through') return true;
 
           // Ctrl/Cmd+1-9: switch sessions
           if (ctrlOrMeta && e.key >= '1' && e.key <= '9') return false;

--- a/frontend/src/utils/terminalKeyHandling.test.ts
+++ b/frontend/src/utils/terminalKeyHandling.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveTerminalKeyHandling,
+  TERMINAL_MULTILINE_NEWLINE_SEQUENCE,
+  type TerminalKeyLike,
+} from './terminalKeyHandling';
+
+const key = (overrides: Partial<TerminalKeyLike>): TerminalKeyLike => ({
+  key: 'a',
+  shiftKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  ...overrides,
+});
+
+describe('resolveTerminalKeyHandling', () => {
+  it('sends the multiline sequence for Shift+Enter outside TUI mode', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'Enter', shiftKey: true }),
+      { isTuiActive: false, isCliPanel: false },
+    )).toEqual({ action: 'send-input', input: TERMINAL_MULTILINE_NEWLINE_SEQUENCE });
+  });
+
+  it('sends the multiline sequence for CLI agent panels in TUI mode', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'Enter', shiftKey: true }),
+      { isTuiActive: true, isCliPanel: true },
+    )).toEqual({ action: 'send-input', input: TERMINAL_MULTILINE_NEWLINE_SEQUENCE });
+  });
+
+  it('passes Shift+Enter through for ordinary TUI apps', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'Enter', shiftKey: true }),
+      { isTuiActive: true, isCliPanel: false },
+    )).toEqual({ action: 'pass-through' });
+  });
+
+  it('does not swallow Ctrl+Shift+Enter chords', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'Enter', shiftKey: true, ctrlKey: true }),
+      { isTuiActive: true, isCliPanel: true },
+    )).toEqual({ action: 'pass-through' });
+  });
+
+  it('blocks Cmd/Ctrl+V in TUI mode so native paste can run', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'v', metaKey: true }),
+      { isTuiActive: true, isCliPanel: true },
+    )).toEqual({ action: 'block' });
+  });
+
+  it('passes Ctrl+C through in TUI mode so fullscreen apps can handle interrupts', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'c', ctrlKey: true }),
+      { isTuiActive: true, isCliPanel: true },
+    )).toEqual({ action: 'pass-through' });
+  });
+
+  it('continues to later terminal shortcut handling outside TUI mode', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: '1', metaKey: true }),
+      { isTuiActive: false, isCliPanel: true },
+    )).toEqual({ action: 'continue' });
+  });
+});

--- a/frontend/src/utils/terminalKeyHandling.ts
+++ b/frontend/src/utils/terminalKeyHandling.ts
@@ -1,0 +1,41 @@
+export const TERMINAL_MULTILINE_NEWLINE_SEQUENCE = '\x1b\r';
+
+export type TerminalKeyHandlingDecision =
+  | { action: 'continue' }
+  | { action: 'pass-through' }
+  | { action: 'block' }
+  | { action: 'send-input'; input: string };
+
+export interface TerminalKeyHandlingState {
+  isTuiActive: boolean;
+  isCliPanel: boolean;
+}
+
+export interface TerminalKeyLike {
+  key: string;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+}
+
+export function resolveTerminalKeyHandling(
+  event: TerminalKeyLike,
+  state: TerminalKeyHandlingState,
+): TerminalKeyHandlingDecision {
+  const ctrlOrMeta = event.ctrlKey || event.metaKey;
+  const shiftEnter = event.shiftKey && !ctrlOrMeta && event.key === 'Enter';
+
+  if (shiftEnter && (!state.isTuiActive || state.isCliPanel)) {
+    return { action: 'send-input', input: TERMINAL_MULTILINE_NEWLINE_SEQUENCE };
+  }
+
+  if (state.isTuiActive) {
+    if (ctrlOrMeta && event.key.toLowerCase() === 'v') {
+      return { action: 'block' };
+    }
+
+    return { action: 'pass-through' };
+  }
+
+  return { action: 'continue' };
+}


### PR DESCRIPTION
## Summary

- keep Shift+Enter as Pane's multiline composer shortcut for Claude/Codex terminal panels even when the agent is in fullscreen/alternate-screen TUI mode
- preserve raw key passthrough for ordinary fullscreen TUIs, including Ctrl+C and other app-owned keys
- extract terminal key handling into a focused helper with regression coverage

Closes #331

## Testing

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter frontend test` (90 passed)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter frontend typecheck`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter frontend lint` (0 errors, existing 167 warnings)
- manual dev smoke with `PANE_DIR=~/.pane_test pnpm dev`: confirmed Shift+Enter inserts a newline in fullscreen CLI agent mode

## Notes

The fix intentionally does not release the full Pane shortcut list inside arbitrary fullscreen TUIs. Ctrl/Cmd+V remains a native paste exception, Ctrl+C passes through to the fullscreen app/agent, and Shift+Enter is scoped to CLI agent panels.
