### PR TITLE
Add permanent deletion for archived panes

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -802,7 +802,12 @@ export function ArchivedSessions() {
   const [hasLoadedArchived, setHasLoadedArchived] = useState(false);
 
   const setActiveSession = useSessionStore(s => s.setActiveSession);
+  const activeSessionId = useSessionStore(s => s.activeSessionId);
   const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
+  const archivedSessionCount = useMemo(
+    () => archivedProjects.reduce((sum, project) => sum + project.sessions.length, 0),
+    [archivedProjects],
+  );
 
   const loadArchivedSessions = useCallback(async () => {
     try {
@@ -847,6 +852,56 @@ export function ArchivedSessions() {
     }
   };
 
+  const handlePermanentDeleteSession = async (session: Session) => {
+    const sessionName = session.name || 'Untitled';
+    const confirmed = window.confirm(
+      `Permanently delete archived pane "${sessionName}"?\n\nThis removes it from Pane history and cannot be undone.`,
+    );
+    if (!confirmed) return;
+
+    try {
+      const response = await API.sessions.permanentDelete(session.id);
+      if (!response.success) {
+        console.error('Failed to permanently delete session:', response.error);
+        return;
+      }
+      if (activeSessionId === session.id) {
+        await setActiveSession(null);
+        navigateToSessions();
+      }
+      loadArchivedSessions();
+    } catch (e) {
+      console.error('Failed to permanently delete session:', e);
+    }
+  };
+
+  const handlePermanentDeleteAllArchived = async () => {
+    if (archivedSessionCount === 0) return;
+
+    const confirmed = window.confirm(
+      `Permanently delete all ${archivedSessionCount} archived panes?\n\nThis removes them from Pane history and cannot be undone.`,
+    );
+    if (!confirmed) return;
+
+    try {
+      const response = await API.sessions.permanentDeleteArchived();
+      if (!response.success) {
+        console.error('Failed to permanently delete archived sessions:', response.error);
+        return;
+      }
+      const deletedActiveSession = archivedProjects.some(project =>
+        project.sessions.some(session => session.id === activeSessionId),
+      );
+      if (deletedActiveSession) {
+        await setActiveSession(null);
+        navigateToSessions();
+      }
+      loadArchivedSessions();
+    } catch (e) {
+      console.error('Failed to permanently delete archived sessions:', e);
+    }
+  };
+
   const handleSessionClick = (sessionId: string) => {
     setActiveSession(sessionId);
     navigateToSessions();
@@ -854,26 +909,39 @@ export function ArchivedSessions() {
 
   return (
     <div className="border-t border-border-primary">
-      <button
-        type="button"
-        onClick={toggleArchived}
-        aria-expanded={showArchived}
-        aria-controls={archivedContentId}
-        className="w-full flex items-center gap-2 px-4 py-2 text-[11px] font-semibold uppercase tracking-wider text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
-      >
-        {showArchived ? (
-          <ChevronDown className="w-3 h-3 flex-shrink-0" />
-        ) : (
-          <ChevronRight className="w-3 h-3 flex-shrink-0" />
+      <div className="group/archived-header flex items-center hover:bg-surface-hover focus-within:bg-surface-hover transition-colors">
+        <button
+          type="button"
+          onClick={toggleArchived}
+          aria-expanded={showArchived}
+          aria-controls={archivedContentId}
+          className="min-w-0 flex-1 flex items-center gap-2 py-2 pl-3 pr-1 text-[11px] font-semibold uppercase tracking-wider text-text-secondary hover:text-text-primary transition-colors"
+        >
+          {showArchived ? (
+            <ChevronDown className="w-3 h-3 flex-shrink-0" />
+          ) : (
+            <ChevronRight className="w-3 h-3 flex-shrink-0" />
+          )}
+          <Archive className="w-3 h-3 flex-shrink-0" />
+          <span>Archived</span>
+        </button>
+        {hasLoadedArchived && archivedSessionCount > 0 && (
+          <button
+            type="button"
+            onClick={handlePermanentDeleteAllArchived}
+            className="flex-shrink-0 p-1 rounded text-text-muted hover:text-status-error hover:bg-surface-hover transition-all opacity-0 group-hover/archived-header:opacity-100 group-focus-within/archived-header:opacity-100"
+            title="Permanently delete all archived panes"
+            aria-label="Permanently delete all archived panes"
+          >
+            <Trash2 className="w-3 h-3" />
+          </button>
         )}
-        <Archive className="w-3 h-3 flex-shrink-0" />
-        <span>Archived</span>
-        {hasLoadedArchived && archivedProjects.length > 0 && (
-          <span className="ml-auto text-[10px] text-text-muted font-normal tabular-nums">
-            {archivedProjects.reduce((sum, p) => sum + p.sessions.length, 0)}
+        {hasLoadedArchived && archivedSessionCount > 0 && (
+          <span className="w-8 pr-3 text-right text-[10px] text-text-muted font-normal tabular-nums">
+            {archivedSessionCount}
           </span>
         )}
-      </button>
+      </div>
 
       {showArchived && (
         <div id={archivedContentId} className="pb-2 max-h-[40vh] overflow-y-auto">
@@ -884,7 +952,7 @@ export function ArchivedSessions() {
               ))}
             </div>
           ) : archivedProjects.length === 0 ? (
-            <div className="px-6 py-3 text-xs text-text-tertiary">
+            <div className="px-5 py-3 text-xs text-text-tertiary">
               No archived panes
             </div>
           ) : (
@@ -897,7 +965,7 @@ export function ArchivedSessions() {
                     onClick={() => toggleArchivedProject(project.id)}
                     aria-expanded={isExpanded}
                     aria-controls={`archived-project-${project.id}`}
-                    className="w-full flex items-center gap-2 px-6 py-1.5 text-xs text-text-tertiary hover:text-text-secondary hover:bg-surface-hover transition-colors"
+                    className="w-full flex items-center gap-2 pl-5 pr-4 py-1.5 text-xs text-text-tertiary hover:text-text-secondary hover:bg-surface-hover transition-colors"
                   >
                     {isExpanded ? (
                       <ChevronDown className="w-3 h-3 flex-shrink-0" />
@@ -910,7 +978,7 @@ export function ArchivedSessions() {
                   {isExpanded && <div id={`archived-project-${project.id}`}>{project.sessions.map(session => (
                     <div
                       key={session.id}
-                      className="group/archived relative flex items-center gap-1 pl-10 pr-1 py-1.5 hover:bg-surface-hover transition-colors"
+                      className="group/archived relative flex items-center gap-1 pl-8 pr-1 py-1.5 hover:bg-surface-hover transition-colors"
                     >
                       <button
                         type="button"
@@ -930,9 +998,19 @@ export function ArchivedSessions() {
                         type="button"
                         onClick={(e) => { e.stopPropagation(); handleRestoreSession(session.id); }}
                         className="relative z-10 flex-shrink-0 p-1 rounded text-text-muted hover:text-status-success hover:bg-surface-hover transition-all opacity-0 group-hover/archived:opacity-100 group-focus-within/archived:opacity-100"
+                        title={`Restore ${session.name || 'Untitled'}`}
                         aria-label={`Restore ${session.name || 'Untitled'}`}
                       >
                         <ArchiveRestore className="w-3 h-3" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); handlePermanentDeleteSession(session); }}
+                        className="relative z-10 flex-shrink-0 p-1 rounded text-text-muted hover:text-status-error hover:bg-surface-hover transition-all opacity-0 group-hover/archived:opacity-100 group-focus-within/archived:opacity-100"
+                        title={`Permanently delete ${session.name || 'Untitled'}`}
+                        aria-label={`Permanently delete ${session.name || 'Untitled'}`}
+                      >
+                        <Trash2 className="w-3 h-3" />
                       </button>
                     </div>
                   ))}</div>}

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -101,6 +101,8 @@ interface ElectronAPI {
     get: (sessionId: string) => Promise<IPCResponse>;
     create: (request: CreateSessionRequest) => Promise<IPCResponse>;
     delete: (sessionId: string) => Promise<IPCResponse>;
+    permanentDelete: (sessionId: string) => Promise<IPCResponse>;
+    permanentDeleteArchived: () => Promise<IPCResponse<{ deletedCount: number }>>;
     sendInput: (sessionId: string, input: string) => Promise<IPCResponse>;
     continue: (sessionId: string, prompt?: string, model?: string) => Promise<IPCResponse>;
     getOutput: (sessionId: string, limit?: number) => Promise<IPCResponse>;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -106,6 +106,16 @@ export class API {
       return window.electronAPI.sessions.delete(sessionId);
     },
 
+    async permanentDelete(sessionId: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.sessions.permanentDelete(sessionId);
+    },
+
+    async permanentDeleteArchived() {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.sessions.permanentDeleteArchived();
+    },
+
     async sendInput(sessionId: string, input: string) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.sessions.sendInput(sessionId, input);

--- a/main/src/database/database.hidden-sessions.test.ts
+++ b/main/src/database/database.hidden-sessions.test.ts
@@ -64,3 +64,88 @@ describe('hidden sessions', () => {
     db.close();
   });
 });
+
+describe('permanent archived session deletion', () => {
+  it('only permanently deletes sessions after they are archived', () => {
+    const { db, tempDir } = createTestDatabase();
+    const project = db.createProject('Repo', path.join(tempDir, 'repo'));
+
+    db.createSession({
+      id: 'active-session',
+      name: 'Active Session',
+      initial_prompt: '',
+      worktree_name: 'active',
+      worktree_path: path.join(tempDir, 'repo-active'),
+      project_id: project.id,
+      tool_type: 'claude',
+    });
+    db.addSessionOutput('active-session', 'stdout', 'still here');
+
+    expect(db.deleteArchivedSessionPermanently('active-session')).toBe(false);
+    expect(db.getSession('active-session')).toBeDefined();
+    expect(db.getSessionOutputs('active-session')).toHaveLength(1);
+
+    db.archiveSession('active-session');
+
+    expect(db.deleteArchivedSessionPermanently('active-session')).toBe(true);
+    expect(db.getSession('active-session')).toBeUndefined();
+    expect(db.getSessionOutputs('active-session')).toHaveLength(0);
+
+    db.close();
+  });
+
+  it('bulk deletes visible archived sessions without deleting hidden archived sessions or active sessions', () => {
+    const { db, tempDir } = createTestDatabase();
+    const project = db.createProject('Repo', path.join(tempDir, 'repo'));
+
+    db.createSession({
+      id: 'archived-one',
+      name: 'Archived One',
+      initial_prompt: '',
+      worktree_name: 'archived-one',
+      worktree_path: path.join(tempDir, 'repo-archived-one'),
+      project_id: project.id,
+      tool_type: 'claude',
+    });
+    db.createSession({
+      id: 'archived-two',
+      name: 'Archived Two',
+      initial_prompt: '',
+      worktree_name: 'archived-two',
+      worktree_path: path.join(tempDir, 'repo-archived-two'),
+      project_id: project.id,
+      tool_type: 'claude',
+    });
+    db.createSession({
+      id: 'active-session',
+      name: 'Active Session',
+      initial_prompt: '',
+      worktree_name: 'active',
+      worktree_path: path.join(tempDir, 'repo-active'),
+      project_id: project.id,
+      tool_type: 'claude',
+    });
+    db.createSession({
+      id: 'hidden-archived',
+      name: 'Hidden Archived',
+      initial_prompt: '',
+      worktree_name: 'hidden',
+      worktree_path: tempDir,
+      project_id: null,
+      tool_type: 'none',
+      is_hidden: true,
+    });
+
+    db.archiveSession('archived-one');
+    db.archiveSession('archived-two');
+    db.archiveSession('hidden-archived');
+
+    expect(db.deleteArchivedSessionsPermanently()).toBe(2);
+    expect(db.getSession('archived-one')).toBeUndefined();
+    expect(db.getSession('archived-two')).toBeUndefined();
+    expect(db.getSession('active-session')).toBeDefined();
+    expect(db.getSession('hidden-archived')).toBeDefined();
+
+    db.close();
+  });
+});

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -3161,6 +3161,78 @@ export class DatabaseService {
     return result.changes > 0;
   }
 
+  private tableExists(tableName: string): boolean {
+    const row = this.db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get(tableName);
+    return row !== undefined;
+  }
+
+  private deleteSessionOwnedRows(sessionId: string): void {
+    const panelRows = this.db
+      .prepare("SELECT id FROM tool_panels WHERE session_id = ?")
+      .all(sessionId) as Array<{ id: string }>;
+
+    if (panelRows.length > 0 && this.tableExists("claude_panel_settings")) {
+      const deletePanelSettings = this.db.prepare(
+        "DELETE FROM claude_panel_settings WHERE panel_id = ?",
+      );
+      for (const panel of panelRows) {
+        deletePanelSettings.run(panel.id);
+      }
+    }
+
+    this.db.prepare("DELETE FROM execution_diffs WHERE session_id = ?").run(sessionId);
+    this.db.prepare("DELETE FROM prompt_markers WHERE session_id = ?").run(sessionId);
+    this.db.prepare("DELETE FROM conversation_messages WHERE session_id = ?").run(sessionId);
+    this.db.prepare("DELETE FROM session_outputs WHERE session_id = ?").run(sessionId);
+    this.db.prepare("DELETE FROM session_git_status_cache WHERE session_id = ?").run(sessionId);
+    this.db.prepare("DELETE FROM tool_panels WHERE session_id = ?").run(sessionId);
+  }
+
+  deleteArchivedSessionPermanently(id: string): boolean {
+    return this.transaction(() => {
+      const archivedSession = this.db
+        .prepare("SELECT id FROM sessions WHERE id = ? AND archived = 1")
+        .get(id);
+      if (!archivedSession) {
+        return false;
+      }
+
+      this.deleteSessionOwnedRows(id);
+      const result = this.db
+        .prepare("DELETE FROM sessions WHERE id = ? AND archived = 1")
+        .run(id);
+      return result.changes > 0;
+    });
+  }
+
+  deleteArchivedSessionsPermanently(): number {
+    return this.transaction(() => {
+      const rows = this.db
+        .prepare(
+          `
+          SELECT id FROM sessions
+          WHERE archived = 1
+            AND (is_main_repo = 0 OR is_main_repo IS NULL)
+            AND (is_hidden = 0 OR is_hidden IS NULL)
+        `,
+        )
+        .all() as Array<{ id: string }>;
+
+      let deletedCount = 0;
+      for (const row of rows) {
+        this.deleteSessionOwnedRows(row.id);
+        const result = this.db
+          .prepare("DELETE FROM sessions WHERE id = ? AND archived = 1")
+          .run(row.id);
+        deletedCount += result.changes;
+      }
+
+      return deletedCount;
+    });
+  }
+
   // Session output operations
   addSessionOutput(
     sessionId: string,

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -158,6 +158,8 @@ const SESSION_CHANNELS = [
   'sessions:get-archived-with-projects',
   'sessions:create',
   'sessions:delete',
+  'sessions:permanent-delete',
+  'sessions:permanent-delete-archived',
   'sessions:input',
   'sessions:get-or-create-main-repo',
   'sessions:continue',

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -35,6 +35,8 @@ const DAEMON_SESSION_CHANNELS = [
   'sessions:get-archived-with-projects',
   'sessions:create',
   'sessions:delete',
+  'sessions:permanent-delete',
+  'sessions:permanent-delete-archived',
   'sessions:input',
   'sessions:get-or-create-main-repo',
   'sessions:continue',
@@ -69,6 +71,17 @@ const DAEMON_SESSION_PANEL_CHANNELS = [
   'panels:send-input',
   'panels:continue',
 ] as const;
+
+type DatabaseSession = {
+  id: string;
+  name?: string | null;
+  archived?: boolean | number | null;
+  worktree_name?: string | null;
+  worktree_path?: string | null;
+  project_id?: number | null;
+  is_main_repo?: boolean | number | null;
+  created_at?: string | null;
+};
 
 export function registerSessionHandlers(
   ipcMain: IpcMain,
@@ -109,6 +122,74 @@ export function registerSessionHandlers(
   const attachCachedGitStatus = (session: Session): Session => {
     const cached = gitStatusManager.getCachedStatus(session.id)?.status;
     return cached ? { ...session, gitStatus: cached } : session;
+  };
+
+  const cleanupPermanentDeleteFiles = async (dbSession: DatabaseSession) => {
+    const sessionId = dbSession.id;
+
+    try {
+      await runCommandManager.stopRunCommands(sessionId);
+    } catch (err) {
+      console.error(`[Session IPC] stopRunCommands failed during permanent delete for ${sessionId}:`, err);
+    }
+
+    try {
+      const worktreeName = dbSession.worktree_name || '';
+      const projectId = dbSession.project_id;
+      const worktreePath = dbSession.worktree_path || '';
+      if (worktreeName && projectId && !dbSession.is_main_repo && worktreePath && existsSync(worktreePath)) {
+        const project = databaseService.getProject(projectId);
+        const ctx = sessionManager.getProjectContextByProjectId(projectId);
+        if (project && ctx) {
+          const sessionCreatedAt = dbSession.created_at ? new Date(dbSession.created_at) : undefined;
+          console.log(`[WorktreeAudit] remove_requested source="session-delete" permanentDelete=true sessionId=${JSON.stringify(sessionId)} projectId=${projectId} projectPath=${JSON.stringify(project.path)} worktreeName=${JSON.stringify(worktreeName)} worktreePath=${JSON.stringify(worktreePath)}`);
+          await worktreeManager.removeWorktree(
+            project.path,
+            worktreeName,
+            project.worktree_folder || undefined,
+            sessionCreatedAt,
+            ctx.pathResolver,
+            ctx.commandRunner,
+            {
+              source: 'session-delete',
+              sessionId,
+              projectId,
+            },
+          );
+        } else {
+          console.warn(`[WorktreeAudit] remove_skipped source="session-delete" permanentDelete=true sessionId=${JSON.stringify(sessionId)} projectId=${projectId} worktreeName=${JSON.stringify(worktreeName)} reason="missing_project_or_context"`);
+        }
+      }
+    } catch (err) {
+      console.error(`[Session IPC] Failed to remove worktree during permanent delete for ${sessionId}:`, err);
+    }
+
+    const artifactsDir = getAppSubdirectory('artifacts', sessionId);
+    if (existsSync(artifactsDir)) {
+      try {
+        await fs.rm(artifactsDir, { recursive: true, force: true });
+      } catch (err) {
+        console.error(`[Session IPC] Failed to remove artifacts during permanent delete for ${sessionId}:`, err);
+      }
+    }
+
+    for (const subdir of ['images', 'files'] as const) {
+      const dir = getAppSubdirectory(subdir);
+      if (!existsSync(dir)) continue;
+
+      try {
+        const allFiles = await fs.readdir(dir);
+        const sessionPrefix = `${sessionId}_`;
+        const sessionFiles = allFiles.filter(file => file.startsWith(sessionPrefix));
+        for (const file of sessionFiles) {
+          await fs.unlink(path.join(dir, file)).catch(() => {});
+        }
+      } catch (err) {
+        console.error(`[Session IPC] Failed to remove ${subdir} during permanent delete for ${sessionId}:`, err);
+      }
+    }
+
+    sessionImageCounters.delete(sessionId);
   };
 
   // Session management handlers
@@ -532,6 +613,74 @@ export function registerSessionHandlers(
     } catch (error) {
       console.error('Failed to delete session:', error);
       return { success: false, error: 'Failed to delete session' };
+    }
+  });
+
+  commandRegistry.register('sessions:permanent-delete', async (sessionId: string) => {
+    try {
+      const session = databaseService.getSession(sessionId);
+      if (!session) {
+        return { success: false, error: 'Session not found' };
+      }
+
+      if (!session.archived) {
+        return { success: false, error: 'Session must be archived before permanent deletion' };
+      }
+
+      try {
+        gitStatusManager.clearSessionCache(sessionId);
+      } catch (err) {
+        console.error(`[Session IPC] clearSessionCache failed for permanently deleted session ${sessionId}:`, err);
+      }
+
+      try {
+        await panelManager.cleanupSessionPanelsInMemory(sessionId);
+      } catch (err) {
+        console.error(`[Session IPC] cleanupSessionPanelsInMemory failed for permanently deleted session ${sessionId}:`, err);
+      }
+
+      await cleanupPermanentDeleteFiles(session as unknown as DatabaseSession);
+
+      const deleted = databaseService.deleteArchivedSessionPermanently(sessionId);
+      if (!deleted) {
+        return { success: false, error: 'Session not found or not archived' };
+      }
+
+      const allSessions = sessionManager.getAllSessions();
+      sessionManager.emit('sessions-loaded', allSessions);
+      return { success: true };
+    } catch (error) {
+      console.error('Failed to permanently delete session:', error);
+      return { success: false, error: 'Failed to permanently delete session' };
+    }
+  });
+
+  commandRegistry.register('sessions:permanent-delete-archived', async () => {
+    try {
+      const archivedSessions = databaseService.getArchivedSessions();
+      for (const session of archivedSessions) {
+        try {
+          gitStatusManager.clearSessionCache(session.id);
+        } catch (err) {
+          console.error(`[Session IPC] clearSessionCache failed for permanently deleted session ${session.id}:`, err);
+        }
+
+        try {
+          await panelManager.cleanupSessionPanelsInMemory(session.id);
+        } catch (err) {
+          console.error(`[Session IPC] cleanupSessionPanelsInMemory failed for permanently deleted session ${session.id}:`, err);
+        }
+
+        await cleanupPermanentDeleteFiles(session as unknown as DatabaseSession);
+      }
+
+      const deletedCount = databaseService.deleteArchivedSessionsPermanently();
+      const allSessions = sessionManager.getAllSessions();
+      sessionManager.emit('sessions-loaded', allSessions);
+      return { success: true, data: { deletedCount } };
+    } catch (error) {
+      console.error('Failed to permanently delete archived sessions:', error);
+      return { success: false, error: 'Failed to permanently delete archived sessions' };
     }
   });
 

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -137,7 +137,7 @@ export function registerSessionHandlers(
       const worktreeName = dbSession.worktree_name || '';
       const projectId = dbSession.project_id;
       const worktreePath = dbSession.worktree_path || '';
-      if (worktreeName && projectId && !dbSession.is_main_repo && worktreePath && existsSync(worktreePath)) {
+      if (worktreeName && projectId && !dbSession.is_main_repo && worktreePath) {
         const project = databaseService.getProject(projectId);
         const ctx = sessionManager.getProjectContextByProjectId(projectId);
         if (project && ctx) {

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -462,6 +462,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     get: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:get', sessionId),
     create: (request: CreateSessionRequest): Promise<IPCResponse> => invokeIpc('sessions:create', request),
     delete: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:delete', sessionId),
+    permanentDelete: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:permanent-delete', sessionId),
+    permanentDeleteArchived: (): Promise<IPCResponse> => invokeIpc('sessions:permanent-delete-archived'),
     sendInput: (sessionId: string, input: string): Promise<IPCResponse> => invokeIpc('sessions:input', sessionId, input),
     continue: (sessionId: string, prompt?: string, model?: string): Promise<IPCResponse> => invokeIpc('sessions:continue', sessionId, prompt, model),
     getOutput: (sessionId: string, limit?: number): Promise<IPCResponse> => invokeIpc('sessions:get-output', sessionId, limit),

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -451,6 +451,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           sessionDeleteCalls.push(sessionId);
           return success();
         },
+        permanentDelete: () => success(),
+        permanentDeleteArchived: () => success({ deletedCount: 0 }),
         toggleFavorite: (sessionId: string) => {
           sessionFavoriteToggleCalls.push(sessionId);
           return success();


### PR DESCRIPTION
## Summary
- add permanent delete actions for individual archived panes and all visible archived panes
- require confirmation before destructive archived-pane cleanup
- remove leftover worktrees/artifacts/files before dropping archived pane history
- add archived-only database deletion helpers and focused coverage

Closes #333

## Testing
- PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/parsas/.codex/tmp/arg0/codex-arg0A9D7rH:/Users/parsas/.composio:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/parsas/.composio:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/parsas/.local/bin:/Users/parsas/.yarn/bin:/Users/parsas/.config/yarn/global/node_modules/.bin:/Users/parsas/.local/bin pnpm --filter main typecheck
- PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/parsas/.codex/tmp/arg0/codex-arg0A9D7rH:/Users/parsas/.composio:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/parsas/.composio:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/parsas/.local/bin:/Users/parsas/.yarn/bin:/Users/parsas/.config/yarn/global/node_modules/.bin:/Users/parsas/.local/bin pnpm --filter frontend typecheck
- PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex-path:/Users/parsas/.codex/tmp/arg0/codex-arg0A9D7rH:/Users/parsas/.composio:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/parsas/.composio:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/parsas/.local/bin:/Users/parsas/.yarn/bin:/Users/parsas/.config/yarn/global/node_modules/.bin:/Users/parsas/.local/bin pnpm --filter main exec vitest run src/database/database.hidden-sessions.test.ts src/ipc/daemonRegistryBindings.test.ts