### PR TITLE
Fix terminal restoration and TUI redraws

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -135,6 +135,7 @@ The following packages are licensed under the MIT license:
   - @xterm/addon-unicode11 (0.9.0) - The xterm.js authors
   - @xterm/addon-web-links (0.12.0) - The xterm.js authors
   - @xterm/addon-webgl (0.19.0) - The xterm.js authors
+  - @xterm/headless (6.0.0)
   - @xterm/xterm (6.0.0)
   - 7zip-bin (5.2.0)
   - accepts (2.0.0)
@@ -6386,7 +6387,7 @@ For more information, please refer to <http://unlicense.org>
 ================================================================================
 
 Package: Pane
-Version: 2.4.22
+Version: 2.4.26
 Author: [object Object]
 License: AGPL-3.0
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -21,6 +21,7 @@ import { SelectionPopover } from '../terminal/SelectionPopover';
 import { useTerminalSearch } from '../../hooks/useTerminalSearch';
 import { TerminalSearchOverlay } from '../terminal/TerminalSearchOverlay';
 import type { TerminalPanelState } from '../../../../shared/types/panels';
+import { selectTerminalRestoreContent } from '../../utils/terminalRestore';
 import { TerminalInterceptor } from '../../services/terminalInterceptor/TerminalInterceptor';
 import { createAtTerminalHandler } from '../../services/terminalInterceptor/handlers/atTerminalHandler';
 import { InterceptorDropdown } from '../terminal/InterceptorDropdown';
@@ -153,6 +154,17 @@ function waitForNextPaint(): Promise<void> {
  * UNMOUNT (session switch / panel close): serialize a final snapshot, then
  * dispose WebGL, addons, and the xterm instance. Remounts restore from
  * `terminal:getState` (capped payload) and replay once into a fresh xterm.
+ * This differs intentionally from terminal clients that retain every renderer
+ * and its DOM node for every session: Pane bounds renderer memory, listeners,
+ * WebGL resources, and duplicate output parsing to the mounted top-level Pane
+ * session. Tool tabs inside that session are still kept mounted as described
+ * above. The main-process PTY and headless emulator remain authoritative, so
+ * background agents keep running and local-control screen reads remain correct
+ * without a renderer per session. The tradeoff is that remounting exposes
+ * foreground-TUI redraw assumptions hidden by retained-DOM designs. Restoring
+ * cells recreates terminal state but cannot make the application recompute its
+ * layout, which is why activation finishes with a timed real PTY size
+ * transition and return.
  */
 export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActive, autoFocus = true }) => {
   renderLog('[TerminalPanel] Component rendering, panel:', panel.id, 'isActive:', isActive);
@@ -489,7 +501,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     onStep,
   } = useTerminalSearch(xtermRef);
 
-  const resizePtyToFit = useCallback(() => {
+  const resizePtyToFit = useCallback(async (force = false): Promise<void> => {
     if (!fitAddonRef.current || !terminalRef.current) return;
     // Guard before fit(): the renderer grid is the damage point, not just the IPC.
     // Width only: wrap junk is a cols problem, and a stacked pane at Allotment's
@@ -503,12 +515,20 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       Number.isInteger(dimensions.cols) && Number.isInteger(dimensions.rows) &&
       dimensions.cols >= MIN_PTY_COLS && dimensions.rows >= MIN_PTY_ROWS
     ) {
-      window.electronAPI.invoke('terminal:resize', panel.id, dimensions.cols, dimensions.rows);
+      await window.electronAPI.invoke(
+        'terminal:resize',
+        panel.id,
+        dimensions.cols,
+        dimensions.rows,
+        { force },
+      );
     }
   }, [panel.id]);
 
-  // Full-depth refresh: normal shells reset+replay main's raw scrollback at the
-  // settled width; live TUIs (alt-screen) repaint via resize instead. Runs on
+  // Full-depth refresh: normal buffers reset+replay main's raw scrollback at the
+  // settled width; alternate buffers preserve their live model. Both paths end
+  // with a forced PTY resize so foreground applications redraw even when the
+  // dimensions did not change. Runs on
   // every panel activation (load-bearing for paint correctness across the
   // hide→show renderer swap — see the component lifecycle doc), on battery-
   // saver activations, after sustained-blur WebGL teardown, and from the manual
@@ -546,7 +566,11 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
       const state = await window.electronAPI.invoke('terminal:getState', panel.id);
       if (state?.isAlternateScreen) {
-        resizePtyToFit();
+        // Renderer refresh alone cannot repair an application frame that was
+        // restored before the visible grid settled. Main turns this forced resize
+        // into a one-column transition and back so the foreground app receives a
+        // real resize notification even when the settled dimensions are unchanged.
+        await resizePtyToFit(true);
         if (terminal.rows > 0) {
           terminal.refresh(0, terminal.rows - 1);
         }
@@ -555,13 +579,16 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       }
 
       // Fit first so reset+replay lands at the settled width, not a stale/tiny grid
-      resizePtyToFit();
+      await resizePtyToFit();
       terminal.reset();
-      const finishRefresh = () => {
+      const finishRefresh = async () => {
         restoreScrollPosition();
         // The old post-replay fit() invalidated WebGL via a dims change; after reordering
         // that fit is a same-size no-op, so an explicit refresh is needed for WebGL redraw
         if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
+        // Claude's default renderer can remain in the normal buffer while still
+        // needing the same application redraw as a fullscreen alternate-buffer TUI.
+        await resizePtyToFit(true);
       };
 
       if (state?.scrollbackBuffer) {
@@ -571,16 +598,15 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             ? state.scrollbackBuffer.join('\n')
             : '';
         if (content) {
-          await new Promise<void>(resolve => {
+          await new Promise<void>((resolve, reject) => {
             terminal.write(content, () => {
-              finishRefresh();
-              resolve();
+              void finishRefresh().then(resolve, reject);
             });
           });
           return;
         }
       }
-      finishRefresh();
+      await finishRefresh();
     } catch (e) {
       console.warn('[TerminalPanel] Failed to refresh terminal:', e);
     }
@@ -598,7 +624,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     const buffer = terminal.buffer.active;
     const distanceFromBottom = Math.max(0, buffer.baseY - buffer.viewportY);
     const wasNearBottom = isNearBottomRef.current || distanceFromBottom <= NEAR_BOTTOM_THRESHOLD_ROWS;
-    resizePtyToFit();
+    void resizePtyToFit();
     if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
     if (wasNearBottom) {
       terminal.scrollToBottom();
@@ -686,9 +712,9 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // Terminal is already initialized, get its state to restore scrollback
           console.log('[TerminalPanel] Restoring terminal state from backend...');
           const terminalState = await window.electronAPI.invoke('terminal:getState', panel.id);
-          if (terminalState && (terminalState.scrollbackBuffer || terminalState.serializedBuffer)) {
+          if (terminalState && selectTerminalRestoreContent(terminalState)) {
             // We'll restore this to the terminal after it's created
-            console.log('[TerminalPanel] Found restore state — scrollback:', !!terminalState.scrollbackBuffer, 'serialized:', !!terminalState.serializedBuffer);
+            console.log('[TerminalPanel] Found terminal restore state');
             // Store for restoration after terminal is created - LOCAL to this initialization
             terminalStateForThisPanel = terminalState;
           }
@@ -1014,33 +1040,14 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // 30 s interval was removed to stop hidden panels from doing a full
           // buffer walk + IPC payload once per half-minute for no visible gain.
 
-          // Restore scrollback if we have saved state FOR THIS PANEL
-          // When the PTY is alive (initialized === true), always prefer raw scrollback
-          // because it accumulates all PTY output in real-time — the serialized snapshot
-          // is frozen at the moment the component last unmounted and misses any output
-          // that arrived while the panel wasn't displayed.
-          // The serialized snapshot is only more valuable for app restart scenarios
-          // (PTY gone, raw buffer lost) where it preserves formatting.
+          // Restore the active buffer for this panel. Full-screen TUIs render in
+          // xterm's alternate buffer, so normal shell scrollback is not a valid
+          // representation while alternate-screen mode is active.
           if (terminalStateForThisPanel) {
-            // Raw scrollback: always current when PTY is alive, contains full ANSI codes
-            if (terminalStateForThisPanel.scrollbackBuffer) {
-              let restoredContent: string;
-              if (typeof terminalStateForThisPanel.scrollbackBuffer === 'string') {
-                restoredContent = terminalStateForThisPanel.scrollbackBuffer;
-                console.log('[TerminalPanel] Restoring', restoredContent.length, 'chars of scrollback (raw, live PTY)');
-              } else if (Array.isArray(terminalStateForThisPanel.scrollbackBuffer)) {
-                restoredContent = terminalStateForThisPanel.scrollbackBuffer.join('\n');
-                console.log('[TerminalPanel] Restoring', terminalStateForThisPanel.scrollbackBuffer.length, 'lines of scrollback (raw, live PTY)');
-              } else {
-                restoredContent = '';
-              }
-              if (restoredContent) {
-                terminal.write(restoredContent);
-              }
-            } else if (terminalStateForThisPanel.serializedBuffer) {
-              // Fallback: serialized snapshot (for when raw scrollback is empty/unavailable)
-              console.log('[TerminalPanel] Restoring serialized snapshot for panel', panel.id);
-              terminal.write(terminalStateForThisPanel.serializedBuffer);
+            const restore = selectTerminalRestoreContent(terminalStateForThisPanel);
+            if (restore) {
+              console.log('[TerminalPanel] Restoring', restore.content.length, 'chars from', restore.source);
+              terminal.write(restore.content);
             }
             // Force WebGL renderer to redraw after buffer content changes.
             // Without this, macOS WebGL canvas shows stale/stuttered content until
@@ -1481,7 +1488,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           const debouncedResize = () => {
             if (resizeTimer) clearTimeout(resizeTimer);
             resizeTimer = setTimeout(() => {
-              if (!disposed) resizePtyToFit();
+              if (!disposed) void resizePtyToFit();
             }, 150);
           };
 

--- a/frontend/src/utils/terminalRestore.test.ts
+++ b/frontend/src/utils/terminalRestore.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { selectTerminalRestoreContent } from './terminalRestore';
+
+describe('selectTerminalRestoreContent', () => {
+  it('prefers the authoritative serialized state for an active alternate screen', () => {
+    expect(selectTerminalRestoreContent({
+      isAlternateScreen: true,
+      scrollbackBuffer: 'claude --resume session-id',
+      alternateScreenBuffer: '\x1b[?1049hagent output',
+      serializedBuffer: '\x1b[?1049hserialized agent screen',
+    })).toEqual({
+      content: '\x1b[?1049hserialized agent screen',
+      source: 'serialized',
+    });
+  });
+
+  it('falls back to captured alternate-screen bytes for older state payloads', () => {
+    expect(selectTerminalRestoreContent({
+      isAlternateScreen: true,
+      scrollbackBuffer: 'shell output',
+      alternateScreenBuffer: '\x1b[?1049hagent output',
+    })).toEqual({
+      content: '\x1b[?1049hagent output',
+      source: 'alternateScreen',
+    });
+  });
+
+  it('keeps normal shell restoration on scrollback', () => {
+    expect(selectTerminalRestoreContent({
+      isAlternateScreen: false,
+      scrollbackBuffer: ['first', 'second'],
+      serializedBuffer: 'old snapshot',
+    })).toEqual({ content: 'first\nsecond', source: 'scrollback' });
+  });
+});

--- a/frontend/src/utils/terminalRestore.ts
+++ b/frontend/src/utils/terminalRestore.ts
@@ -1,0 +1,35 @@
+import type { TerminalPanelState } from '../../../shared/types/panels';
+
+export type TerminalRestoreSource = 'alternateScreen' | 'scrollback' | 'serialized';
+
+export interface TerminalRestoreContent {
+  content: string;
+  source: TerminalRestoreSource;
+}
+
+function normalizeScrollback(scrollback: TerminalPanelState['scrollbackBuffer']): string {
+  if (typeof scrollback === 'string') return scrollback;
+  if (Array.isArray(scrollback)) return scrollback.join('\n');
+  return '';
+}
+
+/** Select the buffer that represents the live terminal's active screen. */
+export function selectTerminalRestoreContent(state: TerminalPanelState): TerminalRestoreContent | null {
+  if (state.isAlternateScreen) {
+    if (state.serializedBuffer) {
+      return { content: state.serializedBuffer, source: 'serialized' };
+    }
+    if (state.alternateScreenBuffer) {
+      return { content: state.alternateScreenBuffer, source: 'alternateScreen' };
+    }
+  }
+
+  const scrollback = normalizeScrollback(state.scrollbackBuffer);
+  if (scrollback) {
+    return { content: scrollback, source: 'scrollback' };
+  }
+  if (state.serializedBuffer) {
+    return { content: state.serializedBuffer, source: 'serialized' };
+  }
+  return null;
+}

--- a/main/package.json
+++ b/main/package.json
@@ -21,6 +21,8 @@
     "@anthropic-ai/sdk": "^0.60.0",
     "@lydell/node-pty": "1.2.0-beta.3",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/headless": "^6.0.0",
     "better-sqlite3-multiple-ciphers": "^12.6.2",
     "bull": "^4.16.3",
     "chokidar": "^5.0.0",

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -602,8 +602,13 @@ export function registerPanelHandlers(
     return terminalPanelManager.writeToTerminal(panelId, data);
   });
   
-  commandRegistry.register('terminal:resize', async (panelId: string, cols: number, rows: number) => {
-    return terminalPanelManager.resizeTerminal(panelId, cols, rows);
+  commandRegistry.register('terminal:resize', async (
+    panelId: string,
+    cols: number,
+    rows: number,
+    options?: { force?: boolean },
+  ) => {
+    return terminalPanelManager.resizeTerminal(panelId, cols, rows, options);
   });
   
   commandRegistry.register('terminal:getState', async (panelId: string) => {

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -22,6 +22,7 @@ vi.mock('../services/terminalPanelManager', () => ({
     initializeTerminal: vi.fn(),
     isTerminalInitialized: vi.fn(),
     getTerminalSnapshot: vi.fn(),
+    waitForTerminalState: vi.fn(),
     getTerminalScrollback: vi.fn(),
     writeToTerminal: vi.fn(),
   },
@@ -867,7 +868,8 @@ describe('runpane IPC handlers', () => {
     vi.mocked(terminalPanelManager.getTerminalSnapshot).mockReturnValue({
       initialized: true,
       scrollbackBuffer: 'old\n',
-      alternateScreenBuffer: 'one\ntwo\nthree',
+      alternateScreenBuffer: '\x1b[Hstale cursor-addressed bytes',
+      screenText: 'one\ntwo\nthree',
       isAlternateScreen: true,
       activityStatus: 'idle',
       lastActivityTime: '2026-01-01T00:02:00.000Z',

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -386,10 +386,10 @@ export function registerRunpaneHandlers(
   });
 
   commandRegistry.register('runpane:panels:screen', async (request: unknown): Promise<RunpanePanelScreenResult> => {
-    return withRunpaneAction(services, 'panels:screen', {}, () => {
+    return withRunpaneAction(services, 'panels:screen', {}, async () => {
       const normalized = parsePanelScreenRequest(request);
       const panel = resolveTerminalPanel(normalized.panelId);
-      return buildPanelScreenResult(panel, normalized.limit ?? DEFAULT_PANEL_SCREEN_LIMIT);
+      return await buildPanelScreenResult(panel, normalized.limit ?? DEFAULT_PANEL_SCREEN_LIMIT);
     }, result => ({
       paneId: result.paneId,
       panelId: result.panelId,
@@ -774,7 +774,8 @@ function resolveTerminalPanel(panelId: string): ToolPanel {
   return panel;
 }
 
-function buildPanelScreenResult(panel: ToolPanel, limit: number): RunpanePanelScreenResult {
+async function buildPanelScreenResult(panel: ToolPanel, limit: number): Promise<RunpanePanelScreenResult> {
+  await terminalPanelManager.waitForTerminalState(panel.id);
   const liveSnapshot = terminalPanelManager.getTerminalSnapshot(panel.id);
   const customState = getTerminalCustomState(panel);
   const state = panelStateSummary(panel, liveSnapshot, customState);
@@ -800,6 +801,12 @@ function selectPanelScreenText(
   customState: TerminalPanelState,
 ): { source: RunpanePanelScreenSource; rawText: string } {
   if (snapshot) {
+    if (snapshot.screenText !== undefined) {
+      return {
+        source: snapshot.isAlternateScreen ? 'alternateScreen' : 'scrollback',
+        rawText: snapshot.screenText,
+      };
+    }
     if (snapshot.isAlternateScreen && snapshot.alternateScreenBuffer) {
       return { source: 'alternateScreen', rawText: snapshot.alternateScreenBuffer };
     }
@@ -877,11 +884,11 @@ async function waitForPanel(panel: ToolPanel, request: RunpanePanelWaitRequest):
   const startedAt = Date.now();
   const timeoutMs = request.timeoutMs ?? DEFAULT_PANEL_WAIT_TIMEOUT_MS;
   const intervalMs = request.intervalMs ?? DEFAULT_PANEL_WAIT_INTERVAL_MS;
-  let lastScreen = buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
+  let lastScreen = await buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
   let condition = request.condition ?? defaultWaitCondition(lastScreen.state);
 
   while (Date.now() - startedAt <= timeoutMs) {
-    lastScreen = buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
+    lastScreen = await buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
     condition = request.condition ?? defaultWaitCondition(lastScreen.state);
     const blocked = detectPanelBlocker(lastScreen.text, lastScreen.state.agentType, panel.id);
     const matched = isWaitConditionMatched(condition, lastScreen, request.contains, blocked);
@@ -1020,7 +1027,7 @@ async function submitComposerForPanel(
   panel: ToolPanel,
   strategy: RunpanePanelSubmitComposerStrategy | undefined,
 ): Promise<RunpanePanelSubmitComposerResult> {
-  const beforeScreen = buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
+  const beforeScreen = await buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
   const state = beforeScreen.state;
   const submit = resolveComposerSubmit(strategy, state.agentType);
   terminalPanelManager.writeToTerminal(panel.id, submit.input);
@@ -1057,7 +1064,7 @@ async function verifyComposerSubmitted(
 
   while (Date.now() - startedAt <= DEFAULT_COMPOSER_VERIFY_TIMEOUT_MS) {
     await sleep(DEFAULT_COMPOSER_VERIFY_INTERVAL_MS);
-    latestScreen = buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
+    latestScreen = await buildPanelScreenResult(panel, DEFAULT_PANEL_SCREEN_LIMIT);
 
     if (latestScreen.state.activityStatus === 'active') {
       return { ok: true, verifiedSubmitted: true };

--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ConfigManager } from './configManager';
 import { resetPaneRuntimeForTests, setPaneRuntime } from '../core/runtime';
 import { createFlowControlRecord, disposeFlowControlRecord, type FlowControlRecord } from '../ptyHost/flowControl';
+import { TerminalStateEmulator } from './terminalStateEmulator';
 
 vi.mock('@lydell/node-pty', () => ({}));
 
@@ -37,8 +38,11 @@ import { panelManager } from './panelManager';
 
 type TerminalUnderTest = {
   pty: {
+    cols: number;
+    rows: number;
     pause: ReturnType<typeof vi.fn>;
     resume: ReturnType<typeof vi.fn>;
+    resize: ReturnType<typeof vi.fn>;
     write: ReturnType<typeof vi.fn>;
   };
   isPtyHost: boolean;
@@ -46,6 +50,7 @@ type TerminalUnderTest = {
   sessionId: string;
   scrollbackBuffer: string;
   alternateScreenBuffer: string;
+  screenEmulator?: TerminalStateEmulator;
   commandHistory: string[];
   currentCommand: string;
   lastActivity: Date;
@@ -76,6 +81,17 @@ type VisibilityAccess = {
 type SnapshotAccess = {
   terminals: Map<string, TerminalUnderTest>;
   getTerminalSnapshot(panelId: string): ReturnType<TerminalPanelManager['getTerminalSnapshot']>;
+  getTerminalState(panelId: string): ReturnType<TerminalPanelManager['getTerminalState']>;
+};
+
+type ResizeAccess = {
+  terminals: Map<string, TerminalUnderTest>;
+  resizeTerminal(
+    panelId: string,
+    cols: number,
+    rows: number,
+    options?: { force?: boolean },
+  ): Promise<void>;
 };
 
 type InitialInputAccess = {
@@ -94,8 +110,11 @@ type LaunchCommandAccess = {
 function createTerminal(overrides: Partial<TerminalUnderTest> = {}): TerminalUnderTest {
   return {
     pty: {
+      cols: 80,
+      rows: 24,
       pause: vi.fn(),
       resume: vi.fn(),
+      resize: vi.fn(),
       write: vi.fn(),
     },
     isPtyHost: false,
@@ -119,6 +138,33 @@ function createTerminal(overrides: Partial<TerminalUnderTest> = {}): TerminalUnd
     ...overrides,
   };
 }
+
+describe('TerminalPanelManager terminal resize', () => {
+  afterEach(() => {
+    vi.mocked(panelManager.getPanel).mockReset();
+    vi.mocked(panelManager.updatePanel).mockReset();
+    vi.useRealTimers();
+  });
+
+  it('deduplicates ordinary same-size resizes but holds an actual redraw transition', async () => {
+    vi.useFakeTimers();
+    const manager = new TerminalPanelManager() as unknown as ResizeAccess;
+    const terminal = createTerminal({ outputBuffer: '' });
+    manager.terminals.set(terminal.panelId, terminal);
+
+    await manager.resizeTerminal(terminal.panelId, 80, 24);
+    expect(terminal.pty.resize).not.toHaveBeenCalled();
+
+    const redraw = manager.resizeTerminal(terminal.panelId, 80, 24, { force: true });
+    expect(terminal.pty.resize).toHaveBeenNthCalledWith(1, 79, 24);
+    expect(terminal.pty.resize).toHaveBeenCalledTimes(1);
+
+    await vi.runAllTimersAsync();
+    await redraw;
+    expect(terminal.pty.resize).toHaveBeenNthCalledWith(2, 80, 24);
+    disposeFlowControlRecord(terminal.flowControl);
+  });
+});
 
 function createConfigManagerStub(): ConfigManager {
   return {
@@ -303,11 +349,15 @@ describe('TerminalPanelManager hidden output delivery', () => {
     disposeFlowControlRecord(terminal.flowControl);
   });
 
-  it('returns live terminal snapshots for daemon reads', () => {
+  it('returns emulated live screen and restore state for daemon and renderer reads', async () => {
     const manager = new TerminalPanelManager() as unknown as SnapshotAccess;
+    const screenEmulator = new TerminalStateEmulator(40, 5);
+    screenEmulator.write('\x1b[?1049h\x1b[Hagent screen');
+    await screenEmulator.waitForIdle();
     const terminal = createTerminal({
       scrollbackBuffer: 'scrollback',
       alternateScreenBuffer: 'screen',
+      screenEmulator,
       isAlternateScreen: true,
       activityStatus: 'active',
       currentCommand: 'codex',
@@ -340,6 +390,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
       initialized: true,
       scrollbackBuffer: 'scrollback',
       alternateScreenBuffer: 'screen',
+      screenText: 'agent screen',
       isAlternateScreen: true,
       activityStatus: 'active',
       currentCommand: 'codex',
@@ -348,6 +399,13 @@ describe('TerminalPanelManager hidden output delivery', () => {
       agentType: 'codex',
       agentSessionId: 'agent-session-1',
     });
+    const restoreState = await manager.getTerminalState(terminal.panelId);
+    expect(restoreState).toMatchObject({
+      isAlternateScreen: true,
+      scrollbackBuffer: 'scrollback',
+    });
+    expect(restoreState?.serializedBuffer).toContain('\x1b[?1049h');
+    screenEmulator.dispose();
     disposeFlowControlRecord(terminal.flowControl);
   });
 

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -17,6 +17,7 @@ import {
   onAck as flowControlOnAck,
   onPtyBytes as flowControlOnPtyBytes,
 } from '../ptyHost/flowControl';
+import { TerminalStateEmulator } from './terminalStateEmulator';
 
 const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI flicker
 const OUTPUT_BATCH_INTERVAL_HIDDEN = 250; // ms — background / hidden cadence to cut IPC wake-up cost
@@ -26,6 +27,10 @@ const MAX_CONCURRENT_SPAWNS = 3;
 const IDLE_THRESHOLD_MS = 30_000; // 30s — mark panel idle after no PTY output
 const MAX_SCROLLBACK_BUFFER_SIZE = 500_000; // 500KB of normal shell history
 const MAX_ALTERNATE_SCREEN_BUFFER_SIZE = 100_000; // 100KB of recent TUI redraw state
+const MIN_PTY_COLS = 20;
+const MIN_PTY_ROWS = 5;
+const FORCED_REDRAW_TRANSITION_MS = 50;
+const FORCED_REDRAW_SETTLE_MS = 80;
 // Formal ceiling for the raw-ANSI scrollback shipped on restore/getState replay. Peer consensus:
 // Orca (TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT) and Superset (MAX_HISTORY_SCROLLBACK_BYTES) both use
 // 512 * 1024. Above the 500KB live trim, so it does not reduce today's payload — the measurable win
@@ -44,6 +49,8 @@ export interface TerminalPanelSnapshot {
   initialized: true;
   scrollbackBuffer: string;
   alternateScreenBuffer: string;
+  /** Plain text for the current emulated viewport. */
+  screenText?: string;
   isAlternateScreen: boolean;
   activityStatus: 'active' | 'idle';
   lastActivityTime: string;
@@ -157,6 +164,8 @@ interface TerminalProcess {
   sessionId: string;
   scrollbackBuffer: string;
   alternateScreenBuffer: string;
+  /** Authoritative xterm-compatible model of the live PTY byte stream. */
+  screenEmulator?: TerminalStateEmulator;
   commandHistory: string[];
   currentCommand: string;
   lastActivity: Date;
@@ -897,6 +906,7 @@ export class TerminalPanelManager {
       sessionId: panel.sessionId,
       scrollbackBuffer: '',
       alternateScreenBuffer: '',
+      screenEmulator: new TerminalStateEmulator(spawnCols, spawnRows),
       commandHistory: [],
       currentCommand: '',
       lastActivity: new Date(),
@@ -1132,6 +1142,7 @@ export class TerminalPanelManager {
       // Strip \x1b[2J inside DEC 2026 sync blocks before xterm.js sees the data
       const filtered = this.filterSyncBlockClears(terminal, data);
       this.captureCodexSessionId(terminal, filtered);
+      terminal.screenEmulator?.write(filtered);
 
       // Keep TUI redraw traffic separate from durable shell scrollback. Full-screen
       // apps emit high-volume cursor/clear sequences that are useful only as a
@@ -1217,6 +1228,7 @@ export class TerminalPanelManager {
       );
 
       // Clean up
+      terminal.screenEmulator?.dispose();
       this.terminals.delete(terminal.panelId);
       this.visibleViewersByPanel.delete(terminal.panelId);
 
@@ -1279,7 +1291,12 @@ export class TerminalPanelManager {
     terminal.lastActivity = new Date();
   }
   
-  resizeTerminal(panelId: string, cols: number, rows: number): void {
+  async resizeTerminal(
+    panelId: string,
+    cols: number,
+    rows: number,
+    options: { force?: boolean } = {},
+  ): Promise<void> {
     const terminal = this.terminals.get(panelId);
     if (!terminal) {
       console.warn(`[TerminalPanelManager] Terminal ${panelId} not found for resize`);
@@ -1287,18 +1304,40 @@ export class TerminalPanelManager {
     }
 
     // Reject non-integers (NaN/Infinity/floats) and mid-layout garbage
-    if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols < 20 || rows < 5) {
+    if (
+      !Number.isInteger(cols) ||
+      !Number.isInteger(rows) ||
+      cols < MIN_PTY_COLS ||
+      rows < MIN_PTY_ROWS
+    ) {
       console.warn(`[TerminalPanelManager] Rejecting invalid resize ${cols}x${rows} for ${panelId}`);
       return;
     }
 
-    // Dedupe: avoids ConPTY repaints and redundant WINCH redraws
-    if (terminal.pty.cols === cols && terminal.pty.rows === rows) {
+    const isSameSize = terminal.pty.cols === cols && terminal.pty.rows === rows;
+    // Normal layout traffic stays deduplicated. A forced redraw must make the
+    // kernel observe an actual size transition; repeating TIOCSWINSZ with the
+    // same dimensions is not guaranteed to signal the foreground process group.
+    if (!options.force && isSameSize) {
       return;
     }
 
     try {
+      if (options.force && isSameSize) {
+        const redrawCols = cols > MIN_PTY_COLS ? cols - 1 : cols + 1;
+        terminal.pty.resize(redrawCols, rows);
+        // Give the foreground process time to observe the intermediate grid.
+        // Back-to-back TIOCSWINSZ calls can collapse into a single pending signal.
+        await new Promise(resolve => setTimeout(resolve, FORCED_REDRAW_TRANSITION_MS));
+      }
       terminal.pty.resize(cols, rows);
+      terminal.screenEmulator?.resize(cols, rows);
+      if (options.force) {
+        // Let the final application redraw reach our output batch before the
+        // renderer removes its activation mask.
+        await new Promise(resolve => setTimeout(resolve, FORCED_REDRAW_SETTLE_MS));
+        this.flushOutputBuffer(terminal);
+      }
     } catch (err) {
       // A resize failure does not mean the pty died; onExit owns cleanup
       console.warn(`[TerminalPanelManager] Failed to resize terminal ${panelId}:`, err);
@@ -1326,6 +1365,8 @@ export class TerminalPanelManager {
     
     const panel = panelManager.getPanel(panelId);
     if (!panel) return;
+
+    await terminal.screenEmulator?.waitForIdle();
     
     // Get current working directory (if possible)
     let cwd = (panel.state.customState && 'cwd' in panel.state.customState) ? panel.state.customState.cwd : undefined;
@@ -1351,11 +1392,13 @@ export class TerminalPanelManager {
       cwd: cwd,
       scrollbackBuffer: terminal.scrollbackBuffer,
       alternateScreenBuffer: terminal.alternateScreenBuffer,
-      isAlternateScreen: terminal.isAlternateScreen,
+      isAlternateScreen: terminal.screenEmulator?.isAlternateScreen ?? terminal.isAlternateScreen,
       commandHistory: terminal.commandHistory.slice(-100), // Keep last 100 commands
       lastActivityTime: terminal.lastActivity.toISOString(),
       lastActiveCommand: terminal.currentCommand,
-      serializedBuffer: this.serializedBuffers.get(panelId),
+      serializedBuffer: terminal.screenEmulator?.isAlternateScreen
+        ? terminal.screenEmulator.serializeForRestore()
+        : this.serializedBuffers.get(panelId),
       ...(terminal.codexAgentSessionId
         ? { agentType: 'codex' as const, agentSessionId: terminal.codexAgentSessionId }
         : {})
@@ -1427,25 +1470,36 @@ export class TerminalPanelManager {
     }
   }
   
-  getTerminalState(panelId: string): TerminalPanelState | null {
+  async getTerminalState(panelId: string): Promise<TerminalPanelState | null> {
     const terminal = this.terminals.get(panelId);
     if (!terminal) return null;
 
+    await terminal.screenEmulator?.waitForIdle();
+
     const cappedScrollback = this.trimAnsiSafe(terminal.scrollbackBuffer, MAX_RESTORE_PAYLOAD_SIZE);
+    const isAlternateScreen = terminal.screenEmulator?.isAlternateScreen ?? terminal.isAlternateScreen;
     return {
       isInitialized: true,
       cwd: process.cwd(), // Simplified - would need platform-specific implementation
       shellType: process.env.SHELL || 'bash',
       scrollbackBuffer: cappedScrollback,
       alternateScreenBuffer: terminal.alternateScreenBuffer,
-      isAlternateScreen: terminal.isAlternateScreen,
+      isAlternateScreen,
       commandHistory: terminal.commandHistory,
       lastActivityTime: terminal.lastActivity.toISOString(),
       lastActiveCommand: terminal.currentCommand,
-      // Omit the serialized snapshot when raw scrollback exists — the frontend prefers raw whenever
-      // the PTY is alive; the snapshot is only consulted on app-restart (empty raw scrollback).
-      serializedBuffer: cappedScrollback.length > 0 ? undefined : this.serializedBuffers.get(panelId)
+      // An active alternate screen cannot be reconstructed from normal shell
+      // scrollback. Serialize the authoritative live model for renderer remounts.
+      serializedBuffer: isAlternateScreen
+        ? terminal.screenEmulator?.serializeForRestore()
+        : cappedScrollback.length > 0
+          ? undefined
+          : this.serializedBuffers.get(panelId)
     };
+  }
+
+  async waitForTerminalState(panelId: string): Promise<void> {
+    await this.terminals.get(panelId)?.screenEmulator?.waitForIdle();
   }
 
   getTerminalSnapshot(panelId: string): TerminalPanelSnapshot | null {
@@ -1460,7 +1514,8 @@ export class TerminalPanelManager {
       initialized: true,
       scrollbackBuffer: terminal.scrollbackBuffer,
       alternateScreenBuffer: terminal.alternateScreenBuffer,
-      isAlternateScreen: terminal.isAlternateScreen,
+      screenText: terminal.screenEmulator?.getScreenText(),
+      isAlternateScreen: terminal.screenEmulator?.isAlternateScreen ?? terminal.isAlternateScreen,
       activityStatus: terminal.activityStatus,
       lastActivityTime: terminal.lastActivity.toISOString(),
       currentCommand: terminal.currentCommand,
@@ -1475,6 +1530,7 @@ export class TerminalPanelManager {
     const terminal = this.terminals.get(panelId);
     if (terminal) {
       terminal.scrollbackBuffer = '';
+      terminal.screenEmulator?.clearScrollback();
     }
     this.serializedBuffers.delete(panelId);
 
@@ -1520,6 +1576,7 @@ export class TerminalPanelManager {
       terminal.idleTimer = null;
     }
     this.flushOutputBuffer(terminal);
+    terminal.screenEmulator?.dispose();
 
     // Kill the PTY process
     try {
@@ -1618,6 +1675,7 @@ export class TerminalPanelManager {
       const panel = panelManager.getPanel(panelId);
       if (!panel) {
         console.warn(`[ptyHost] respawnAll: panel ${panelId} no longer exists, skipping`);
+        terminal.screenEmulator?.dispose();
         this.terminals.delete(panelId);
         this.visibleViewersByPanel.delete(panelId);
         continue;
@@ -1654,6 +1712,7 @@ export class TerminalPanelManager {
         clearTimeout(terminal.idleTimer);
         terminal.idleTimer = null;
       }
+      terminal.screenEmulator?.dispose();
       this.terminals.delete(panelId);
       this.visibleViewersByPanel.delete(panelId);
     }
@@ -1699,7 +1758,9 @@ export class TerminalPanelManager {
   getAltScreenState(panelId: string): { isAlternateScreen: boolean } | null {
     const terminal = this.terminals.get(panelId);
     if (!terminal) return null;
-    return { isAlternateScreen: terminal.isAlternateScreen };
+    return {
+      isAlternateScreen: terminal.screenEmulator?.isAlternateScreen ?? terminal.isAlternateScreen,
+    };
   }
 
   saveSerializedSnapshot(panelId: string, serializedData: string): void {
@@ -1762,6 +1823,7 @@ export class TerminalPanelManager {
           terminal.idleTimer = null;
         }
         this.flushOutputBuffer(terminal);
+        terminal.screenEmulator?.dispose();
 
         terminal.pty.kill();
       } catch (error) {

--- a/main/src/services/terminalStateEmulator.test.ts
+++ b/main/src/services/terminalStateEmulator.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { TerminalStateEmulator } from './terminalStateEmulator';
+
+describe('TerminalStateEmulator', () => {
+  it('renders cursor-addressed alternate-screen output as a coherent screen', async () => {
+    const emulator = new TerminalStateEmulator(20, 5);
+
+    emulator.write('\x1b[?1049h\x1b[2J\x1b[HClaude\x1b[2;1Hanswer\rworking');
+    await emulator.waitForIdle();
+
+    expect(emulator.isAlternateScreen).toBe(true);
+    expect(emulator.getScreenText()).toBe('Claude\nworking');
+    const serialized = emulator.serializeForRestore();
+    expect(serialized).toContain('\x1b[?1049h');
+
+    const restored = new TerminalStateEmulator(20, 5);
+    restored.write(serialized);
+    await restored.waitForIdle();
+    expect(restored.isAlternateScreen).toBe(true);
+    expect(restored.getScreenText()).toBe('Claude\nworking');
+    restored.dispose();
+    emulator.dispose();
+  });
+
+  it('restores the normal screen after leaving the alternate buffer', async () => {
+    const emulator = new TerminalStateEmulator(20, 5);
+
+    emulator.write('shell prompt\r\n$ claude');
+    emulator.write('\x1b[?1049h\x1b[Hagent response');
+    await emulator.waitForIdle();
+    expect(emulator.getScreenText()).toBe('agent response');
+
+    emulator.write('\x1b[?1049l');
+    await emulator.waitForIdle();
+
+    expect(emulator.isAlternateScreen).toBe(false);
+    expect(emulator.getScreenText()).toBe('shell prompt\n$ claude');
+    emulator.dispose();
+  });
+
+  it('tracks terminal resizes', async () => {
+    const emulator = new TerminalStateEmulator(10, 2);
+    emulator.write('1234567890abc');
+    await emulator.waitForIdle();
+
+    emulator.resize(20, 2);
+    expect(emulator.getScreenText()).toContain('1234567890');
+    emulator.dispose();
+  });
+
+  it('includes active input modes in restore serialization', async () => {
+    const emulator = new TerminalStateEmulator(20, 5);
+    emulator.write('\x1b[?1h\x1b[?1004h\x1b[?2004h');
+    await emulator.waitForIdle();
+
+    const serialized = emulator.serializeForRestore();
+    expect(serialized).toContain('\x1b[?1h');
+    expect(serialized).toContain('\x1b[?1004h');
+    expect(serialized).toContain('\x1b[?2004h');
+    emulator.dispose();
+  });
+});

--- a/main/src/services/terminalStateEmulator.ts
+++ b/main/src/services/terminalStateEmulator.ts
@@ -1,0 +1,103 @@
+import { SerializeAddon } from '@xterm/addon-serialize';
+import { Terminal } from '@xterm/headless';
+
+const HEADLESS_SCROLLBACK_LINES = 2500;
+
+/**
+ * Maintains an xterm-compatible terminal model for state restoration and
+ * local-control screen reads. PTY output parsing is asynchronous, so callers
+ * that need a coherent snapshot must await waitForIdle first.
+ */
+export class TerminalStateEmulator {
+  private readonly terminal: Terminal;
+  private readonly serializeAddon = new SerializeAddon();
+  private pendingWrites = 0;
+  private idleResolvers: Array<() => void> = [];
+  private disposed = false;
+  private finalIsAlternateScreen = false;
+  private finalSerializedBuffer = '';
+  private finalScreenText = '';
+
+  constructor(cols: number, rows: number) {
+    this.terminal = new Terminal({
+      cols,
+      rows,
+      scrollback: HEADLESS_SCROLLBACK_LINES,
+      allowProposedApi: true,
+    });
+    this.terminal.loadAddon(this.serializeAddon);
+  }
+
+  write(data: string): void {
+    if (!data || this.disposed) return;
+
+    this.pendingWrites += 1;
+    this.terminal.write(data, () => {
+      if (this.disposed) return;
+      this.pendingWrites -= 1;
+      if (this.pendingWrites === 0) {
+        const resolvers = this.idleResolvers;
+        this.idleResolvers = [];
+        for (const resolve of resolvers) resolve();
+      }
+    });
+  }
+
+  waitForIdle(): Promise<void> {
+    if (this.pendingWrites === 0) return Promise.resolve();
+    return new Promise(resolve => this.idleResolvers.push(resolve));
+  }
+
+  resize(cols: number, rows: number): void {
+    if (this.disposed) return;
+    this.terminal.resize(cols, rows);
+  }
+
+  get isAlternateScreen(): boolean {
+    return this.disposed
+      ? this.finalIsAlternateScreen
+      : this.terminal.buffer.active.type === 'alternate';
+  }
+
+  /** Serialize the visible normal buffer and, when active, the alternate buffer. */
+  serializeForRestore(): string {
+    return this.disposed
+      ? this.finalSerializedBuffer
+      : this.serializeAddon.serialize({ scrollback: 0 });
+  }
+
+  /** Return plain text for the currently visible viewport. */
+  getScreenText(): string {
+    if (this.disposed) return this.finalScreenText;
+
+    const buffer = this.terminal.buffer.active;
+    const lines: string[] = [];
+    const end = buffer.viewportY + this.terminal.rows;
+
+    for (let index = buffer.viewportY; index < end; index += 1) {
+      lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+    }
+
+    while (lines.length > 0 && lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+
+  clearScrollback(): void {
+    this.terminal.clear();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.finalIsAlternateScreen = this.isAlternateScreen;
+    this.finalSerializedBuffer = this.serializeForRestore();
+    this.finalScreenText = this.getScreenText();
+    this.disposed = true;
+    this.terminal.dispose();
+    const resolvers = this.idleResolvers;
+    this.idleResolvers = [];
+    this.pendingWrites = 0;
+    for (const resolve of resolvers) resolve();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.16.0
+      '@xterm/addon-serialize':
+        specifier: ^0.14.0
+        version: 0.14.0
+      '@xterm/headless':
+        specifier: ^6.0.0
+        version: 6.0.0
       better-sqlite3-multiple-ciphers:
         specifier: ^12.6.2
         version: 12.6.2
@@ -2334,6 +2340,9 @@ packages:
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
+
+  '@xterm/headless@6.0.0':
+    resolution: {integrity: sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -7910,6 +7919,8 @@ snapshots:
   '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/addon-webgl@0.19.0': {}
+
+  '@xterm/headless@6.0.0': {}
 
   '@xterm/xterm@6.0.0': {}
 


### PR DESCRIPTION
## Summary

- model every live PTY with headless xterm so alternate-screen state and RunPane screen reads remain authoritative when the renderer unmounts
- restore the active terminal buffer instead of replaying normal shell history over a live TUI
- force a timed one-column PTY resize transition on activation and manual refresh so foreground TUIs emit a canonical redraw
- document Pane's renderer lifecycle and cover terminal modes, restoration selection, RunPane screen output, and forced redraw behavior

Fixes #324.

## Why

Pane disposes renderer-side xterm/WebGL resources when a top-level session unmounts while keeping its PTY alive. Reconstructing only from normal scrollback restored the wrong buffer for full-screen and cursor-addressed applications. Even after restoring the correct cells, Claude's TUI could retain a frame computed for the previous renderer geometry until a real window resize delivered a resize notification.

The main process now owns an xterm-compatible screen model. Renderer activation restores that authoritative state, then performs a real PTY size transition and return so the foreground application redraws at the settled dimensions. `runpane panels screen` reads the same model and no longer sees the launch command in place of the agent screen.

## Testing

- `pnpm lint` (passes; existing warning baseline only)
- `pnpm typecheck`
- `pnpm --filter main test -- --run` (41 files, 339 tests)
- `pnpm --filter frontend test` (8 files, 93 tests)
- `pnpm build:frontend`
- `pnpm build:main`
- `pnpm --filter runpane build`
- manually reproduced with Claude default and fullscreen TUI modes in an isolated `PANE_DIR`; switching panes and tabs now restores and redraws correctly without a physical window resize

## Dependency Notes

- adds `@xterm/headless` and `@xterm/addon-serialize` to the main process
- regenerates `NOTICES`
