### PR TITLE
Fix packaged headless terminal dependencies

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -6387,7 +6387,7 @@ For more information, please refer to <http://unlicense.org>
 ================================================================================
 
 Package: Pane
-Version: 2.4.26
+Version: 2.4.27
 Author: [object Object]
 License: AGPL-3.0
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "@anthropic-ai/sdk": "^0.60.0",
     "@lydell/node-pty": "1.2.0-beta.3",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/headless": "^6.0.0",
     "better-sqlite3-multiple-ciphers": "^12.6.2",
     "bull": "^4.16.3",
     "chokidar": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.16.0
+      '@xterm/addon-serialize':
+        specifier: ^0.14.0
+        version: 0.14.0
+      '@xterm/headless':
+        specifier: ^6.0.0
+        version: 6.0.0
       better-sqlite3-multiple-ciphers:
         specifier: ^12.6.2
         version: 12.6.2


### PR DESCRIPTION
## Summary

- declare the headless xterm runtime packages in the root Electron app manifest
- regenerate the lockfile's root importer and `NOTICES`
- ensure Electron Builder includes the modules required by `terminalPanelManager`

## Why

PR #336 added `@xterm/headless` and `@xterm/addon-serialize` to `main/package.json`, which is sufficient for workspace development and tests. The packaged application is rooted at the repository-level `package.json`, however, so Electron Builder omitted those runtime modules from the Linux AppImage. The v2.4.27 release's packaged headless smoke test then hung after Electron failed during module loading.

## Testing

- `pnpm install`
- `pnpm build` (frontend, main, and universal macOS Electron package)
- inspected packaged `app.asar` and confirmed both `/node_modules/@xterm/headless` and `/node_modules/@xterm/addon-serialize`
- ran the packaged `Pane.app/Contents/MacOS/Pane --remote-setup ... --no-install-service`; it printed the connection configuration and exited successfully

## Release Note

The v2.4.27 workflow was cancelled after its Linux packaged-headless smoke test exposed this missing dependency. Cut v2.4.28 after merge.
