### PR TITLE
feat: add a setting to disable git commit attribution

### DIFF
--- a/frontend/src/components/settings/catalog.tsx
+++ b/frontend/src/components/settings/catalog.tsx
@@ -62,8 +62,8 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategoryDefinition[] = [
     label: 'Worktrees & Git',
     description: 'Defaults for commits, pull requests, and new worktrees.',
     icon: GitBranch,
-    settingIds: ['commit-footer', 'auto-rename-pr', 'worktree-file-sync'],
-    aliases: ['git', 'worktree', 'commit', 'pull request', 'pr'],
+    settingIds: ['commit-footer', 'git-attribution', 'auto-rename-pr', 'worktree-file-sync'],
+    aliases: ['git', 'worktree', 'commit', 'pull request', 'pr', 'attribution', 'committer', 'author'],
   },
   {
     id: 'notifications',

--- a/frontend/src/components/settings/categories/WorktreesGitSettings.tsx
+++ b/frontend/src/components/settings/categories/WorktreesGitSettings.tsx
@@ -58,6 +58,18 @@ export function WorktreesGitSettings({ persistence, onDirtyChange }: WorktreesGi
           />
         </SettingRow>
         <SettingRow
+          settingId="git-attribution"
+          label="Attribute commits to Pane"
+          description="Set the git committer to Pane on commits made through Pane, so they show as committed by Pane on GitHub. Turn off to use your own git identity. Applies to newly opened terminals and commands."
+          saveState={persistence.saveStates['git-attribution']}
+        >
+          <ImmediateToggle
+            label="Attribute commits to Pane"
+            value={config.gitAttributionEnabled !== false}
+            onSave={(value) => persistence.saveConfig('git-attribution', { gitAttributionEnabled: value })}
+          />
+        </SettingRow>
+        <SettingRow
           settingId="auto-rename-pr"
           label="Auto-rename panes to pull request titles"
           description="When Pane detects a pull request for a pane, use its title as the pane name."

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -111,6 +111,10 @@ export interface AppConfig {
   };
   // Pane commit footer setting (enabled by default)
   enableCommitFooter?: boolean;
+  // Inject Pane's git committer identity (GIT_COMMITTER_NAME/EMAIL) into commits
+  // made through Pane (enabled by default). Applies to newly spawned terminals
+  // and commands only — already-running processes keep their launch-time env.
+  gitAttributionEnabled?: boolean;
   // Agent-facing Pane context in repository instructions files
   agentContext?: {
     managedAgentsMd: boolean;
@@ -169,6 +173,7 @@ export interface UpdateConfigRequest {
   additionalPaths?: string[];
   sessionCreationPreferences?: AppConfig['sessionCreationPreferences'];
   enableCommitFooter?: boolean;
+  gitAttributionEnabled?: boolean;
   agentContext?: AppConfig['agentContext'];
   useInteractiveMode?: boolean;
   usePtyHost?: boolean;

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -31,6 +31,7 @@ export type SettingsSettingId =
   | 'agent-context'
   | 'claude-executable'
   | 'commit-footer'
+  | 'git-attribution'
   | 'auto-rename-pr'
   | 'worktree-file-sync'
   | 'notification-permission'

--- a/main/src/ipc/file.ts
+++ b/main/src/ipc/file.ts
@@ -6,7 +6,7 @@ import { glob } from 'glob';
 import type { PaneCommandRegistry } from '../daemon/commandRegistry';
 import type { AppServices } from './types';
 import type { Session } from '../types/session';
-import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
+import { getGitAttributionEnv } from '../utils/attribution';
 import { commandExecutor } from '../utils/commandExecutor';
 import { buildGitCommitCommand } from '../utils/shellEscape';
 import { revealInFileManager } from '../utils/revealInFileManager';
@@ -471,7 +471,7 @@ export function registerFileHandlers(
         await commandExecutor.execAsync(commitCommand, {
           cwd: session.worktreePath,
           timeout: 120_000,
-          env: { ...process.env, ...GIT_ATTRIBUTION_ENV }
+          env: { ...process.env, ...getGitAttributionEnv(config) }
         }, commandRunner.wslContext);
 
         // Refresh git status for this session after commit
@@ -499,7 +499,7 @@ export function registerFileHandlers(
             await commandExecutor.execAsync(retryCommitCommand, {
               cwd: session.worktreePath,
               timeout: 120_000,
-              env: { ...process.env, ...GIT_ATTRIBUTION_ENV }
+              env: { ...process.env, ...getGitAttributionEnv(config) }
             }, commandRunner.wslContext);
 
             // Refresh git status for this session after commit

--- a/main/src/ipc/project.ts
+++ b/main/src/ipc/project.ts
@@ -9,7 +9,7 @@ import { panelManager } from '../services/panelManager';
 import { parseWSLPath, validateWSLAvailable } from '../utils/wslUtils';
 import { PathResolver } from '../utils/pathResolver';
 import { CommandRunner } from '../utils/commandRunner';
-import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
+import { getGitAttributionEnv } from '../utils/attribution';
 import { detectProjectConfig } from '../services/projectConfigDetector';
 import { ensureProjectAgentContext } from '../services/agentContextManager';
 import type { ConfigManager } from '../services/configManager';
@@ -161,7 +161,7 @@ export function registerProjectHandlers(
           commandRunner.exec(`git checkout -b ${branchName}`, actualPath);
           console.log(`[Main] Created and checked out branch: ${branchName}`);
 
-          commandRunner.exec('git commit -m "Initial commit" --allow-empty', actualPath, { env: GIT_ATTRIBUTION_ENV });
+          commandRunner.exec('git commit -m "Initial commit" --allow-empty', actualPath, { env: getGitAttributionEnv(configManager.getConfig()) });
           console.log('[Main] Created initial empty commit');
         } catch (error) {
           console.error('[Main] Failed to initialize git repository:', error);

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -10,7 +10,7 @@ import type { ConfigManager } from '../../configManager';
 import type { ConversationMessage } from '../../../database/models';
 import { getShellPath, findExecutableInPath } from '../../../utils/shellPath';
 import { findNodeExecutable } from '../../../utils/nodeFinder';
-import { GIT_ATTRIBUTION_ENV } from '../../../utils/attribution';
+import { getGitAttributionEnv } from '../../../utils/attribution';
 
 const LAST_OUTPUT_TAIL_BYTES = 16 * 1024;
 
@@ -645,7 +645,7 @@ export abstract class AbstractCliManager extends EventEmitter {
 
     return {
       ...process.env,
-      ...GIT_ATTRIBUTION_ENV,
+      ...getGitAttributionEnv(this.configManager?.getConfig()),
       PATH: pathWithNode
     } as { [key: string]: string };
   }

--- a/main/src/services/runCommandManager.ts
+++ b/main/src/services/runCommandManager.ts
@@ -9,7 +9,7 @@ import { ShellDetector } from '../utils/shellDetector';
 import * as os from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
+import { getGitAttributionEnv } from '../utils/attribution';
 
 /**
  * IPty-compatible shim over a ptyHost `PtyHandle`.
@@ -155,7 +155,7 @@ export class RunCommandManager extends EventEmitter {
             const shellPath = isLinux ? (process.env.PATH || '') : getShellPath();
             const env = {
               ...process.env,
-              ...GIT_ATTRIBUTION_ENV,
+              ...getGitAttributionEnv(getRuntimeConfigManager().getConfig()),
               WORKTREE_PATH: worktreePath,
               PATH: shellPath
             } as { [key: string]: string };

--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -31,6 +31,7 @@ vi.mock('../utils/wslUtils', () => ({
 
 vi.mock('../utils/attribution', () => ({
   GIT_ATTRIBUTION_ENV: {},
+  getGitAttributionEnv: vi.fn(() => ({})),
 }));
 
 import { TerminalPanelManager } from './terminalPanelManager';

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -9,7 +9,7 @@ import { getShellPath } from '../utils/shellPath';
 import { ShellDetector } from '../utils/shellDetector';
 import type { AnalyticsManager } from './analyticsManager';
 import { getWSLShellSpawn, buildWSLENV, WSLContext } from '../utils/wslUtils';
-import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
+import { getGitAttributionEnv } from '../utils/attribution';
 import {
   type FlowControlRecord,
   createFlowControlRecord,
@@ -835,7 +835,7 @@ export class TerminalPanelManager {
     }
     const spawnEnv: Record<string, string> = {
       ...baseEnv,
-      ...GIT_ATTRIBUTION_ENV,
+      ...getGitAttributionEnv(getRuntimeConfigManager().getConfig()),
       PATH: enhancedPath,
       TERM: 'xterm-256color',
       COLORTERM: 'truecolor',

--- a/main/src/services/terminalSessionManager.ts
+++ b/main/src/services/terminalSessionManager.ts
@@ -6,7 +6,7 @@ import { ShellDetector } from '../utils/shellDetector';
 import * as os from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
+import { getGitAttributionEnv } from '../utils/attribution';
 
 /**
  * IPty-compatible shim over a ptyHost `PtyHandle`.
@@ -125,7 +125,7 @@ export class TerminalSessionManager extends EventEmitter {
     // Build spawn env once so both paths see identical values.
     const rawEnv: Record<string, string | undefined> = {
       ...process.env,
-      ...GIT_ATTRIBUTION_ENV,
+      ...getGitAttributionEnv(getRuntimeConfigManager().getConfig()),
       PATH: shellPath,
       WORKTREE_PATH: worktreePath,
       TERM: 'xterm-256color',      // Ensure TERM is set for color support

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -5,7 +5,7 @@ import type { ConfigManager } from './configManager';
 import type { AnalyticsManager } from './analyticsManager';
 import { PathResolver } from '../utils/pathResolver';
 import { CommandRunner } from '../utils/commandRunner';
-import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
+import { getGitAttributionEnv } from '../utils/attribution';
 import { worktreePoolManager } from './worktreePoolManager';
 
 export type WorktreeAuditSource = 'session-delete' | 'project-delete' | 'create-cleanup';
@@ -221,7 +221,7 @@ export class WorktreeManager {
         } catch {
           // Ignore add errors (no files to add)
         }
-        await commandRunner.execAsync('git commit -m "Initial commit" --allow-empty', projectPath, { env: GIT_ATTRIBUTION_ENV });
+        await commandRunner.execAsync('git commit -m "Initial commit" --allow-empty', projectPath, { env: getGitAttributionEnv(this.configManager?.getConfig()) });
         hasCommits = true;
       }
 
@@ -945,7 +945,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
         const escapedMessage = fullMessage.replace(/"/g, '\\"');
         command = `git commit -m "${escapedMessage}"`;
         executedCommands.push(`git commit -m "..." (in ${worktreePath})`);
-        const commitResult = await commandRunner.execAsync(command, worktreePath, { env: GIT_ATTRIBUTION_ENV });
+        const commitResult = await commandRunner.execAsync(command, worktreePath, { env: getGitAttributionEnv(config) });
         lastOutput = commitResult.stdout || commitResult.stderr || '';
 
         // Switch to main branch in the main repository
@@ -1348,7 +1348,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       // Commit with message
       const escapedMessage = message.replace(/"/g, '\\"');
-      const { stdout, stderr } = await commandRunner.execAsync(`git commit -m "${escapedMessage}"`, worktreePath, { env: GIT_ATTRIBUTION_ENV });
+      const { stdout, stderr } = await commandRunner.execAsync(`git commit -m "${escapedMessage}"`, worktreePath, { env: getGitAttributionEnv(this.configManager?.getConfig()) });
       const output = stdout || stderr || 'Committed successfully';
 
       return { output };

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -111,6 +111,10 @@ export interface AppConfig {
   };
   // Pane commit footer setting (enabled by default)
   enableCommitFooter?: boolean;
+  // Inject Pane's git committer identity (GIT_COMMITTER_NAME/EMAIL) into commits
+  // made through Pane (enabled by default). Applies to newly spawned terminals
+  // and commands only — already-running processes keep their launch-time env.
+  gitAttributionEnabled?: boolean;
   // Agent-facing Pane context in repository instructions files
   agentContext?: {
     managedAgentsMd: boolean;
@@ -182,6 +186,7 @@ export interface UpdateConfigRequest {
     baseBranch?: string;
   };
   enableCommitFooter?: boolean;
+  gitAttributionEnabled?: boolean;
   agentContext?: AppConfig['agentContext'];
   // Use interactive mode for Claude CLI (persistent process with stdin instead of spawn-per-message)
   useInteractiveMode?: boolean;

--- a/main/src/utils/attribution.test.ts
+++ b/main/src/utils/attribution.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { GIT_ATTRIBUTION_ENV, getGitAttributionEnv } from './attribution';
+import type { AppConfig } from '../types/config';
+
+describe('getGitAttributionEnv', () => {
+  it('returns the attribution env when config is undefined', () => {
+    expect(getGitAttributionEnv(undefined)).toBe(GIT_ATTRIBUTION_ENV);
+  });
+
+  it('returns the attribution env when config is null', () => {
+    expect(getGitAttributionEnv(null)).toBe(GIT_ATTRIBUTION_ENV);
+  });
+
+  it('returns the attribution env when gitAttributionEnabled is absent (default enabled)', () => {
+    expect(getGitAttributionEnv({} as AppConfig)).toBe(GIT_ATTRIBUTION_ENV);
+  });
+
+  it('returns the attribution env when gitAttributionEnabled is true', () => {
+    expect(getGitAttributionEnv({ gitAttributionEnabled: true } as AppConfig)).toBe(GIT_ATTRIBUTION_ENV);
+  });
+
+  it('returns an empty object when gitAttributionEnabled is false', () => {
+    expect(getGitAttributionEnv({ gitAttributionEnabled: false } as AppConfig)).toEqual({});
+  });
+});

--- a/main/src/utils/attribution.ts
+++ b/main/src/utils/attribution.ts
@@ -1,3 +1,5 @@
+import type { AppConfig } from '../types/config';
+
 /**
  * Git attribution environment variables.
  *
@@ -11,3 +13,12 @@ export const GIT_ATTRIBUTION_ENV = {
   GIT_COMMITTER_NAME: 'Pane',
   GIT_COMMITTER_EMAIL: 'runpane@users.noreply.github.com',
 };
+
+/**
+ * Returns GIT_ATTRIBUTION_ENV to inject into a spawned process/git command,
+ * or {} when the user has turned the `gitAttributionEnabled` setting off.
+ * Enabled by default (absent/undefined config is treated as enabled).
+ */
+export function getGitAttributionEnv(config: AppConfig | null | undefined): Record<string, string> {
+  return config?.gitAttributionEnabled === false ? {} : GIT_ATTRIBUTION_ENV;
+}


### PR DESCRIPTION
## Summary
- Adds a global `gitAttributionEnabled` setting (default `true`) that gates the `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL` injection Pane adds to every commit made through its terminals, CLI panels, and internal git operations
- The existing "Include Pane footer in commits" setting only controls the `Co-Authored-By` trailer — it never touched the committer identity, so commits always showed as "committed by runpane" on GitHub with no way to opt out
- New `getGitAttributionEnv()` helper in `attribution.ts` centralizes the default-true gating logic, wired into all 9 injection sites (terminal panels, terminal sessions, run commands, CLI panels, project init, worktree operations ×3, editor commits ×2)
- New "Attribute commits to Pane" toggle added to Settings → Worktrees & Git, right below the existing footer toggle

Fixes #343

## Test plan
- [x] `pnpm typecheck` clean across all workspaces
- [x] `pnpm lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `pnpm --filter main test` — new `attribution.test.ts` unit tests pass; updated `terminalPanelManager.test.ts` mock; full suite green aside from 3 pre-existing native-module ABI failures unrelated to this change
- [x] Manual verification in an isolated dev instance (separate `PANE_DIR`, throwaway git repo): toggled setting off → new terminal panel commit shows the user's own git identity as committer; toggled back on → new terminal panel commit shows `Pane <runpane@users.noreply.github.com>` again
- [x] Confirmed the one documented limitation: toggling only affects newly-spawned terminals/panels — an already-running panel keeps its launch-time env until reopened