### PR TITLE
fix(updater): resolve buildInfo.json inside the asar archive

### DIFF
--- a/main/src/ipc/updater.ts
+++ b/main/src/ipc/updater.ts
@@ -36,8 +36,14 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
       // Try to read build info if in packaged app
       if (app.isPackaged) {
         try {
-          const buildInfoPath = path.join(process.resourcesPath, 'app', 'main', 'dist', 'buildInfo.json');
-          if (fs.existsSync(buildInfoPath)) {
+          // Packaged builds are asar-archived by default (Resources/app.asar), but
+          // asar can be disabled (Resources/app); check both so this works either way.
+          const buildInfoCandidates = [
+            path.join(process.resourcesPath, 'app.asar', 'main', 'dist', 'buildInfo.json'),
+            path.join(process.resourcesPath, 'app', 'main', 'dist', 'buildInfo.json'),
+          ];
+          const buildInfoPath = buildInfoCandidates.find((candidate) => fs.existsSync(candidate));
+          if (buildInfoPath) {
             const buildInfo = JSON.parse(fs.readFileSync(buildInfoPath, 'utf8'));
             buildDate = buildInfo.buildDate;
             gitCommit = buildInfo.gitCommit;


### PR DESCRIPTION
## Summary

Fixes #345. `version:get-info` looked for build info at `Resources/app/main/dist/buildInfo.json`, but packaged builds have `asar: true`, so everything ships inside `Resources/app.asar` instead — there's no literal `app` folder on disk. `fs.existsSync()` on the wrong path always returned `false`, so `gitCommit`/`buildDate`/`buildTimestamp` were silently `undefined` in every packaged build (official releases included), and the sidebar footer never showed a commit hash outside of dev mode. This line is unchanged since the initial release (`0f39474`), so it's affected every build to date.

- Check `Resources/app.asar/main/dist/buildInfo.json` first (the real path when `asar: true`, confirmed via `npx asar list`)
- Fall back to `Resources/app/main/dist/buildInfo.json` in case asar is ever disabled

## Test plan

- [x] `pnpm typecheck` clean
- [x] Built locally with `pnpm build:mac:arm64`, confirmed via `npx asar list ".../app.asar" | grep buildInfo` that the file lives at the path this fix now checks
- [x] Verified the extracted bundled `updater.js` inside the built `app.asar` contains the fix
- [x] Installed the built DMG and confirmed the sidebar footer now shows a commit hash (previously showed nothing)

