### PR TITLE
Fix archive test Git identity setup

### DIFF
--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -159,6 +159,8 @@ function createTempGitRepo(name = 'repo'): string {
   const repoPath = path.join(parent, name);
   fs.mkdirSync(repoPath);
   execFileSync('git', ['init'], { cwd: repoPath, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'Pane Test'], { cwd: repoPath, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'pane-test@example.invalid'], { cwd: repoPath, stdio: 'ignore' });
   return repoPath;
 }
 


### PR DESCRIPTION
## Summary

Fixes the cross-platform CI failure in the new `runpane:panes:archive` tests by making the temp Git repository helper hermetic. The helper now configures repository-local `user.name` and `user.email` immediately after `git init`, so test-owned commits do not depend on runner/global Git identity.

This unblocks the v2.4.30 release train failure from Code Quality run https://github.com/dcouple/Pane/actions/runs/29871312593, where Ubuntu and Windows failed at `git commit --allow-empty -m init` before the archive behavior was exercised.

## Scope

- Changed only `main/src/ipc/runpane.test.ts`
- No archive handler changes
- No generated contract or wrapper changes
- No version bump, publish, deploy, or merge

## Verification

Run under Node 22.23.1:

- `pnpm install --frozen-lockfile` PASS
- Strict identity reproduction: `env -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.useConfigOnly GIT_CONFIG_VALUE_0=true pnpm --filter main exec vitest run src/ipc/runpane.test.ts -t 'runpane:panes:archive'` PASS, `11 passed | 30 skipped`
- `pnpm --filter main exec vitest run src/ipc/runpane.test.ts -t 'runpane:panes:archive'` PASS, `11 passed | 30 skipped`
- `pnpm --filter main exec vitest run src/ipc/runpane.test.ts` PASS, `41 passed`
- `pnpm --filter main exec vitest run` PASS, `356 passed`
- `CI=1 pnpm --filter main test` PASS, `356 passed`
- `pnpm run typecheck` PASS
- `pnpm run lint` PASS with existing warnings only
