### PR TITLE
Surface project Worktree Folder settings

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useMemo, useCallback, useRef, useId } from 'react';
-import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare, Settings } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
 import { SETTINGS_PREFERENCE_KEYS, normalizeSidebarPaneRowLayout, type SidebarPaneRowLayout } from '../types/settings';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { AddProjectDialog } from './AddProjectDialog';
+import ProjectSettings from './ProjectSettings';
 import { Dropdown } from './ui/Dropdown';
 import { Tooltip } from './ui/Tooltip';
 import type { DropdownItem } from './ui/Dropdown';
@@ -52,6 +53,8 @@ export function ProjectSessionList({
   const [projects, setProjects] = useState<Project[]>([]);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [createForProject, setCreateForProject] = useState<Project | null>(null);
+  const [settingsProject, setSettingsProject] = useState<Project | null>(null);
+  const [showProjectSettings, setShowProjectSettings] = useState(false);
   const [sidebarPaneRowLayout, setSidebarPaneRowLayout] = useState<SidebarPaneRowLayout>('single');
   const knownSessionIdsRef = useRef<Set<string> | null>(null);
 
@@ -193,6 +196,23 @@ export function ProjectSessionList({
   const handleNewSession = (project: Project) => {
     setCreateForProject(project);
     setShowCreateDialog(true);
+  };
+
+  const handleOpenProjectSettings = (project: Project) => {
+    setSettingsProject(project);
+    setShowProjectSettings(true);
+  };
+
+  const handleProjectUpdated = () => {
+    loadProjects();
+    window.dispatchEvent(new Event('project-changed'));
+  };
+
+  const handleProjectSettingsDeleted = () => {
+    setShowProjectSettings(false);
+    setSettingsProject(null);
+    loadProjects();
+    window.dispatchEvent(new Event('project-changed'));
   };
 
   // Session operations
@@ -417,6 +437,12 @@ export function ProjectSessionList({
               onClick: () => navigateToProject(project.id),
             },
             {
+              id: 'project-settings',
+              label: 'Project Settings',
+              icon: Settings,
+              onClick: () => handleOpenProjectSettings(project),
+            },
+            {
               id: 'delete',
               label: 'Delete Project',
               icon: Trash2,
@@ -539,6 +565,19 @@ export function ProjectSessionList({
         isOpen={showAddProjectDialog}
         onClose={() => setShowAddProjectDialog(false)}
       />
+
+      {settingsProject && (
+        <ProjectSettings
+          project={settingsProject}
+          isOpen={showProjectSettings}
+          onClose={() => {
+            setShowProjectSettings(false);
+            setSettingsProject(null);
+          }}
+          onUpdate={handleProjectUpdated}
+          onDelete={handleProjectSettingsDeleted}
+        />
+      )}
     </>
   );
 }

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -165,6 +165,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     let mockActiveProjectId = mockOptions.activeProjectId === undefined
       ? (mockProjects.find((project) => project.active === true)?.id as number | undefined) ?? null
       : mockOptions.activeProjectId;
+    let lastProjectUpdate: { projectId: string; updates: Record<string, unknown> } | null = null;
     let cloudDisconnectError: string | null = null;
     let configGetCount = 0;
     let nextConfigUpdateError: string | null = null;
@@ -372,6 +373,12 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       folders: namespace({
         getByProject: () => success([]),
       }),
+      git: namespace({
+        detectBranch: () => success('main'),
+      }),
+      dialog: namespace({
+        openDirectory: () => success('/tmp/pane-worktrees'),
+      }),
       onboarding: namespace({
         detectEnvironment: () => success({}),
         getGitHubAuthCommand: () => success({ command: '', reason: 'ready' }),
@@ -431,6 +438,16 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           { name: 'origin/main', isCurrent: false, hasWorktree: false, isRemote: true },
           { name: 'main', isCurrent: true, hasWorktree: false, isRemote: false },
         ]),
+        update: (projectId: string, updates: Record<string, unknown>) => {
+          lastProjectUpdate = { projectId, updates: clone(updates) };
+          mockProjects = mockProjects.map((project) => (
+            String(project.id) === projectId
+              ? { ...project, ...clone(updates), updated_at: new Date().toISOString() }
+              : project
+          ));
+          return success(mockProjects.find((project) => String(project.id) === projectId) ?? null);
+        },
+        detectConfig: () => success(null),
         refreshGitStatus: () => success(),
       }),
       prompts: namespace({
@@ -741,6 +758,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         getSessionFavoriteToggleCalls() {
           return clone(sessionFavoriteToggleCalls);
+        },
+        getProjectUpdates() {
+          return lastProjectUpdate ? [clone(lastProjectUpdate)] : [];
         },
       },
     });

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -2,7 +2,25 @@ import { test, expect, Page } from '@playwright/test';
 import { installElectronApiMock } from './electronApiMock';
 
 test.beforeEach(async ({ page }) => {
-  await installElectronApiMock(page);
+  await installElectronApiMock(page, {
+    initialProjects: [
+      {
+        id: 1,
+        name: 'Mock Repo',
+        path: '/tmp/mock-repo',
+        system_prompt: null,
+        run_script: null,
+        build_script: null,
+        archive_script: null,
+        active: true,
+        created_at: new Date(0).toISOString(),
+        updated_at: new Date(0).toISOString(),
+        open_ide_command: null,
+        displayOrder: 0,
+        worktree_folder: null,
+      },
+    ],
+  });
 });
 
 async function dismissStartupDialogs(page: Page) {
@@ -125,6 +143,44 @@ test.describe('Smoke Tests', () => {
     await customPathInput.pressSequentially('./venv/*');
 
     await expect(customPathInput).toHaveValue('./venv/*');
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
+  test('Repository menu opens Project Settings with editable Worktree Folder', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
+
+    await dismissStartupDialogs(page);
+
+    const repoActionsButton = page.getByRole('button', { name: 'Repository actions for Mock Repo' });
+    await expect(repoActionsButton).toBeVisible({ timeout: 5000 });
+    await clickDomNode(repoActionsButton);
+
+    await clickDomNode(page.getByRole('menuitem', { name: 'Project Settings' }));
+
+    await expect(page.getByText('Project Settings')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Worktree Folder')).toBeVisible();
+
+    const worktreeFolderInput = page.getByPlaceholder('worktrees');
+    await setInputValue(worktreeFolderInput, '/tmp/pane-worktrees');
+    await clickDomNode(page.getByRole('button', { name: 'Save Changes' }).first());
+
+    const projectUpdates = await page.evaluate(() => {
+      const mock = (window as typeof window & {
+        __paneTestElectronMock?: {
+          getProjectUpdates: () => Array<{ projectId: string; updates: Record<string, unknown> }>;
+        };
+      }).__paneTestElectronMock;
+
+      return mock?.getProjectUpdates() ?? [];
+    });
+
+    expect(projectUpdates).toHaveLength(1);
+    expect(projectUpdates[0]).toMatchObject({
+      projectId: '1',
+      updates: {
+        worktree_folder: '/tmp/pane-worktrees',
+      },
+    });
     await expect(page.getByText('Something went wrong')).toHaveCount(0);
   });
 


### PR DESCRIPTION
## Description

Closes #340.

This makes the existing per-project `Worktree Folder` setting reachable from each repository row's actions menu by adding a `Project Settings` item. It reuses the existing `ProjectSettings` modal and `projects.update` save path, including the existing `worktree_folder` behavior rather than introducing a second settings surface.

When a user saves a Worktree Folder for a project, Pane stores that project-level override and future worktrees for that project use the saved folder. Existing worktrees are not moved by this change.

## Visual Overview

![Before and after overview of the repository menu exposing Project Settings and Worktree Folder](https://github.com/dcouple/Pane/releases/download/pr-assets/worktree-folder-project-settings-issue-340-26d7934.png)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm lint` exits 0; existing repo warnings remain
- [x] Focused Playwright coverage: `pnpm exec playwright test tests/smoke.spec.ts -g "Repository menu opens Project Settings with editable Worktree Folder"`

The focused Playwright test opens the repository actions menu, enters Project Settings, edits the Worktree Folder field, saves, and asserts `projects.update` receives `worktree_folder`.

CI should execute this coverage because `.github/workflows/quality.yml` runs `xvfb-run -a pnpm test:ci:minimal`, and `playwright.ci.minimal.config.ts` includes `smoke.spec.ts`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [ ] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified

- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [ ] State management/IPC events
- [ ] Diff viewer CSS

<!-- codex-pr-test-automation-summary -->
## Codex QA Summary

Status: Pass for PR #350 first-pass QA on branch `issue-340-worktree-folder` at `26d79347` (base `main`).

- UI path exercised: repository overflow menu -> `Project Settings` -> editable `Worktree Folder`; save asserted through `projects.update` with `worktree_folder`.
- Persistence/future worktree proof: isolated temp SQLite project persisted `worktree_folder`, then `WorktreeManager.resolveWorkingDirectory` created `qa-pr-350-future-worktree` under the saved custom folder. Marker: `agent-e2e-pr350-backend`.
- Checks run: focused Playwright path, screenshot Playwright path, `pnpm typecheck`, `pnpm lint`, `pnpm run build:main`, `pnpm run build:frontend`, `pnpm --filter runpane build`, `runpane doctor --json`, and `pnpm electron:rebuild` after Node-side native-module testing.
- Environment notes: `pnpm lint` exited 0 with existing warnings; RunPane doctor reached installed Pane 2.4.29 and reported no darwin/arm64 dmg in `pr-assets`, which is unrelated to this PR. Screenshots and full QA evidence are in the marked Codex QA comment.

<!-- /codex-pr-test-automation-summary -->