### PR TITLE
fix: restore Linux builds and headless remote setup after Electron 41 upgrade

### DIFF
--- a/docs/SELF_HOSTED_REMOTE_DAEMON.md
+++ b/docs/SELF_HOSTED_REMOTE_DAEMON.md
@@ -62,12 +62,16 @@ pane --remote-setup --label "VM"
 ```
 
 On displayless Linux hosts, prefer `runpane install daemon`; the npm and PyPI
-wrappers set Electron's required headless environment automatically. For a
-direct packaged launch, set it explicitly:
+wrappers pass Electron's required headless flags automatically. For a direct
+packaged launch, pass them explicitly:
 
 ```bash
-ELECTRON_OZONE_PLATFORM_HINT=headless pane --remote-setup --label "VM"
+pane --ozone-platform=headless --disable-gpu --remote-setup --label "VM"
 ```
+
+These must be command-line arguments: Electron picks its Ozone platform before
+the app starts, so the environment variable `ELECTRON_OZONE_PLATFORM_HINT` no
+longer works (removed in Electron 38, ignored from 39 on).
 
 The wrappers are lightweight installers and configurators. They currently
 download the packaged Pane runtime because the daemon is not distributed as a
@@ -247,9 +251,11 @@ the security tradeoff.
 
 ### Remote setup exits because X11 or `$DISPLAY` is missing
 
-Use `runpane install daemon`, or prefix a direct packaged launch with
-`ELECTRON_OZONE_PLATFORM_HINT=headless`. This failure occurs before Tailscale
-setup and does not mean the daemon requires a graphical session.
+Use `runpane install daemon`, or add `--ozone-platform=headless --disable-gpu`
+to a direct packaged launch. This failure occurs before Tailscale setup and does
+not mean the daemon requires a graphical session. If you previously relied on
+`ELECTRON_OZONE_PLATFORM_HINT=headless`, switch to the flags: Electron removed
+that variable in 38 and ignores it from 39 on.
 
 ### The headless daemon starts but remote connect fails
 

--- a/main/src/daemon/setupRemoteHost.ts
+++ b/main/src/daemon/setupRemoteHost.ts
@@ -573,21 +573,25 @@ function buildHeadlessDaemonCommand(paneDir: string): string {
     if (process.platform === 'win32') {
       return `cd /d ${quoteForWindows(sourceRoot)} && set "PANE_DIR=${paneDir}" && pnpm daemon:headless -- --pane-dir ${quoteForWindows(paneDir)}`;
     }
-    return `cd ${quoteForPosix(sourceRoot)} && ${buildPosixHeadlessEnvironment(paneDir)} pnpm daemon:headless -- --pane-dir ${quoteForPosix(paneDir)}`;
+    return `cd ${quoteForPosix(sourceRoot)} && ${buildPosixHeadlessEnvironment(paneDir)} pnpm daemon:headless --${buildLinuxHeadlessFlags()} --pane-dir ${quoteForPosix(paneDir)}`;
   }
 
   if (process.platform === 'win32') {
     return `${quoteForWindows(process.execPath)} --daemon-headless --pane-dir ${quoteForWindows(paneDir)}`;
   }
 
-  return `${buildPosixHeadlessEnvironment(paneDir)} ${quoteForPosix(process.execPath)} --daemon-headless --pane-dir ${quoteForPosix(paneDir)}`;
+  return `${buildPosixHeadlessEnvironment(paneDir)} ${quoteForPosix(process.execPath)}${buildLinuxHeadlessFlags()} --daemon-headless --pane-dir ${quoteForPosix(paneDir)}`;
+}
+
+// Ozone selects its platform before the app's main script runs, so this must be
+// passed as argv — app.commandLine.appendSwitch() is too late, and
+// ELECTRON_OZONE_PLATFORM_HINT was removed in Electron 38 (no-op since 39).
+function buildLinuxHeadlessFlags(): string {
+  return process.platform === 'linux' ? ' --ozone-platform=headless --disable-gpu' : '';
 }
 
 function buildPosixHeadlessEnvironment(paneDir: string): string {
   const entries = [`PANE_DIR=${quoteForPosix(paneDir)}`];
-  if (process.platform === 'linux') {
-    entries.push('ELECTRON_OZONE_PLATFORM_HINT=headless');
-  }
   return entries.join(' ');
 }
 

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -37,9 +37,12 @@ if (process.platform === 'linux') {
   app.commandLine.appendSwitch('gtk-version', '3');
 
   if (launchHeadlessDaemon || launchRemoteSetup) {
-    // Best-effort fallback. Packaged no-display Linux launches need
-    // ELECTRON_OZONE_PLATFORM_HINT=headless in the parent environment.
-    app.commandLine.appendSwitch('ozone-platform', 'headless');
+    // Ozone has already picked its platform by the time this script runs, so
+    // appending --ozone-platform here cannot select headless: no-display Linux
+    // launches must pass `--ozone-platform=headless` as argv. (Before Electron
+    // 38, ELECTRON_OZONE_PLATFORM_HINT=headless did that for us; the variable
+    // was removed in 38 and is a no-op from 39 on.) --disable-gpu is still read
+    // late enough to take effect here.
     app.commandLine.appendSwitch('disable-gpu');
   }
 }

--- a/packages/runpane-py/src/runpane/installers.py
+++ b/packages/runpane-py/src/runpane/installers.py
@@ -75,10 +75,23 @@ def install_pane_artifact(
 
 def spawn_pane(executable_path: str, args: List[str]) -> int:
     try:
-        return subprocess.call([executable_path, *args], env=build_pane_daemon_environment())
+        return subprocess.call(
+            [executable_path, *build_pane_daemon_args(args)],
+            env=build_pane_daemon_environment(),
+        )
     except OSError as error:
         print(f"Failed to launch Pane: {error}")
         return 1
+
+
+def build_pane_daemon_args(args: List[str], system_name: Optional[str] = None) -> List[str]:
+    """Ozone resolves its platform before the app's main script runs, so headless
+    selection must arrive as argv. ELECTRON_OZONE_PLATFORM_HINT (below) was removed
+    in Electron 38 and is a no-op from 39 on; it is kept only so older Pane builds
+    keep working."""
+    if (system_name or platform.system()).lower() != "linux":
+        return list(args)
+    return ["--ozone-platform=headless", "--disable-gpu", *args]
 
 
 def build_pane_daemon_environment(

--- a/packages/runpane/src/installers.ts
+++ b/packages/runpane/src/installers.ts
@@ -59,7 +59,7 @@ export async function installPaneArtifact(
 
 export function spawnPane(executablePath: string, args: string[]): Promise<number> {
   return new Promise((resolve) => {
-    const child = childProcess.spawn(executablePath, args, {
+    const child = childProcess.spawn(executablePath, buildPaneDaemonArgs(args), {
       stdio: 'inherit',
       shell: false,
       env: buildPaneDaemonEnvironment()
@@ -70,6 +70,18 @@ export function spawnPane(executablePath: string, args: string[]): Promise<numbe
       resolve(1);
     });
   });
+}
+
+// Ozone resolves its platform before the app's main script runs, so headless
+// selection must arrive as argv. ELECTRON_OZONE_PLATFORM_HINT (below) was
+// removed in Electron 38 and is a no-op from 39 on; it is kept only so older
+// Pane builds keep working.
+export function buildPaneDaemonArgs(args: string[], platform = process.platform): string[] {
+  if (platform !== 'linux') {
+    return [...args];
+  }
+
+  return ['--ozone-platform=headless', '--disable-gpu', ...args];
 }
 
 export function buildPaneDaemonEnvironment(

--- a/scripts/test-packaged-headless-remote-setup.sh
+++ b/scripts/test-packaged-headless-remote-setup.sh
@@ -13,10 +13,10 @@ trap 'rm -rf "$pane_dir" "$output_file"' EXIT
 
 set +e
 env -u DISPLAY \
-  ELECTRON_OZONE_PLATFORM_HINT=headless \
   "$appimage" \
   --appimage-extract-and-run \
   --no-sandbox \
+  --ozone-platform=headless \
   --remote-setup \
   --label "Headless CI" \
   --pane-dir "$pane_dir" \

--- a/scripts/test-runpane-contract.js
+++ b/scripts/test-runpane-contract.js
@@ -604,6 +604,34 @@ print(json.dumps({
   assert.deepStrictEqual(pythonJson.darwin, baseEnvironment);
 }
 
+function compareDaemonLaunchArgsParity() {
+  const { buildPaneDaemonArgs } = require(path.join(rootDir, 'packages', 'runpane', 'dist', 'installers.js'));
+  const baseArgs = ['--remote-setup', '--label', 'VM'];
+
+  // Ozone reads its platform from argv before the app boots, so the headless
+  // flags must lead the argument list on Linux and be absent elsewhere.
+  assert.deepStrictEqual(buildPaneDaemonArgs(baseArgs, 'linux'), [
+    '--ozone-platform=headless',
+    '--disable-gpu',
+    ...baseArgs
+  ]);
+  assert.deepStrictEqual(buildPaneDaemonArgs(baseArgs, 'darwin'), baseArgs);
+
+  const pythonOutput = runPythonSnippet(`
+import json
+from runpane.installers import build_pane_daemon_args
+
+base = ["--remote-setup", "--label", "VM"]
+print(json.dumps({
+    "linux": build_pane_daemon_args(base, "Linux"),
+    "darwin": build_pane_daemon_args(base, "Darwin"),
+}))
+`);
+  const pythonJson = JSON.parse(pythonOutput.split(/\r?\n/).filter(Boolean).pop());
+  assert.deepStrictEqual(pythonJson.linux, buildPaneDaemonArgs(baseArgs, 'linux'));
+  assert.deepStrictEqual(pythonJson.darwin, buildPaneDaemonArgs(baseArgs, 'darwin'));
+}
+
 function compareRemoteSetupDiagnosticParity() {
   const { collectRemoteSetupCheck } = require(path.join(rootDir, 'packages', 'runpane', 'dist', 'doctor.js'));
   const probes = {
@@ -1255,6 +1283,7 @@ async function runChecks() {
   compareWrapperTelemetrySanitizers();
   compareExistingReusePolicy();
   compareDaemonLaunchEnvironmentParity();
+  compareDaemonLaunchArgsParity();
   compareRemoteSetupDiagnosticParity();
   checkPlatformMatchingEdgeCases();
   await checkExistingDaemonShortCircuit();


### PR DESCRIPTION
## Problem

Two failures, one cause.

**Linux release builds have failed since v2.4.31.** The `build (ubuntu-latest)` job fails at *Verify packaged headless remote setup*, which skips `publish-windows`, `publish-release`, and `checksums`. As a result **v2.4.31, v2.4.32 and v2.4.33 are all stuck as draft releases with no Windows installers, no `latest.yml` (Windows auto-update manifest), and no `SHA256SUMS.txt`.**

**Headless remote daemon setup is broken for users on those same versions** — this is not only a CI problem.

## Root cause

The Electron 37 → 41.10.3 upgrade (#352) landed immediately after v2.4.30, the last green build.

Every headless launch path relied on `ELECTRON_OZONE_PLATFORM_HINT=headless`. That variable was [removed in Electron 38](https://github.com/electron/electron/issues/48001) and is ignored from 39 on. On Electron 37 it worked only as an implementation side-effect: the hint was never validated against an allow-list, so `headless` passed straight through onto `--ozone-platform`.

The intended fallback could not cover it either. Electron resolves the Ozone platform in `PreEarlyInitialization()`, **before** the main script executes, so `app.commandLine.appendSwitch('ozone-platform', 'headless')` in `index.ts` was always too late to select a platform.

With neither mechanism live, Chromium's `auto` default (the default since Chromium 140 / Electron 38) resolves to Wayland if present, else X11 — and with `$DISPLAY` unset it exits with `Missing X server or $DISPLAY` / `The platform failed to initialize`.

## Fix

Pass `--ozone-platform=headless --disable-gpu` as **argv** from every headless launch site. An explicit `--ozone-platform` always wins: the hint path is skipped entirely when the switch is already present.

| Site | Change |
|---|---|
| `scripts/test-packaged-headless-remote-setup.sh` | flags on the AppImage invocation (unblocks the build) |
| `main/src/daemon/setupRemoteHost.ts` | flags in the generated systemd unit / launch command |
| `packages/runpane/src/installers.ts` | new `buildPaneDaemonArgs()` prepends flags on Linux |
| `packages/runpane-py/src/runpane/installers.py` | matching `build_pane_daemon_args()` |
| `main/src/index.ts` | drop the no-op `ozone-platform` switch, keep `--disable-gpu` (still read late enough), correct the comment |
| `docs/SELF_HOSTED_REMOTE_DAEMON.md` | document the flags; note the env var is dead |

`spawnPane` / `spawn_pane` are only used for `--remote-setup`, never the GUI (which uses `launchPaneClient`), so prepending headless flags there is safe.

The env var is left in the wrapper environments so older Pane builds keep working.

## Verification

- `pnpm typecheck` — clean
- `node scripts/test-runpane-contract.js` — passes, now including a new npm↔Python parity assertion on the argument builder so the two launch paths cannot drift
- Main-process tests: 389 passed. The 4 failures are pre-existing local `better-sqlite3` native-binding errors, identical on an untouched worktree, and unrelated to this change
- **Proven against the real job.** `Build & Release` does not run on PRs (only on `release` pushes, `v*` tags, and `workflow_dispatch`), so this PR's checks cannot exercise it. I dispatched it against this branch: [run 29958580933](https://github.com/dcouple/Pane/actions/runs/29958580933) — **`Verify packaged headless remote setup`: success**, the step that has failed on every release since v2.4.31. All builds completed on macOS, Linux, and both Windows arches.

  All four build jobs in that run then failed at the *same* later step, `upload-artifact`, with `The artifact name is not valid: ... Contains the following character: Forward slash /` — because the artifact name embeds `github.ref_name` and this branch is `fix/headless-ozone-platform`. Tags (`v2.4.34`) contain no slash, so this cannot affect a release. See follow-up below.

## Follow-up (not in this PR)

1. **Artifact names break on slash branches.** `name: pane-${{ matrix.os }}-${{ github.ref_name }}` cannot be uploaded from any branch containing `/`, which makes `workflow_dispatch` unusable for validating the release pipeline before cutting a tag — exactly what was needed here. Worth sanitizing the slug (or using `github.run_id`), but it touches the upload/download pairing across four jobs, so it is kept out of this fix.
2. **v2.4.31–v2.4.33 are incomplete drafts** with no Windows installers, no `latest.yml`, and no `SHA256SUMS.txt`. Their tags point at commits without this fix, so re-running the workflow on them will not help; completing distribution needs a fresh tag once this merges.
