### PR TITLE
Fix Pane navigation shortcuts in active TUIs

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -8,7 +8,7 @@ import type { Unicode11Addon } from '@xterm/addon-unicode11';
 import { useSession } from '../../contexts/SessionContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { TerminalPanelProps } from '../../types/panelComponents';
-import { useHotkeyStore } from '../../stores/hotkeyStore';
+import { isHotkeyEnabledForEvent, useHotkeyStore } from '../../stores/hotkeyStore';
 import { renderLog, devLog } from '../../utils/console';
 import { getTerminalTheme } from '../../utils/terminalTheme';
 import { resolveTerminalKeyHandling } from '../../utils/terminalKeyHandling';
@@ -891,7 +891,9 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             return false;
           }
           if (terminalKeyDecision.action === 'block') return false;
-          if (terminalKeyDecision.action === 'release-to-app') return false;
+          if (terminalKeyDecision.action === 'release-to-app') {
+            return !isHotkeyEnabledForEvent(e);
+          }
           if (terminalKeyDecision.action === 'pass-through') return true;
 
           // Ctrl/Cmd+1-9: switch sessions

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -878,6 +878,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           const terminalKeyDecision = resolveTerminalKeyHandling(e, {
             isTuiActive: tuiActiveRef.current,
             isCliPanel: isCliPanelRef.current,
+            isMac: isMac(),
           });
 
           // Shift+Enter sends the same ESC+CR sequence as Alt+Enter for CLI
@@ -890,6 +891,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             return false;
           }
           if (terminalKeyDecision.action === 'block') return false;
+          if (terminalKeyDecision.action === 'release-to-app') return false;
           if (terminalKeyDecision.action === 'pass-through') return true;
 
           // Ctrl/Cmd+1-9: switch sessions

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -151,6 +151,16 @@ function normalizeHotkeyString(keys: string): string {
 let listenerAttached = false;
 let lookupIndex: Map<string, string> = new Map(); // normalized keys → hotkey id
 
+export function isHotkeyEnabledForEvent(e: KeyboardEvent): boolean {
+  const hotkeyId = lookupIndex.get(normalizeKeyEvent(e));
+  if (!hotkeyId) return false;
+
+  const def = useHotkeyStore.getState().hotkeys.get(hotkeyId);
+  if (!def) return false;
+  if (def.devOnly && process.env.NODE_ENV !== 'development') return false;
+  return !def.enabled || def.enabled();
+}
+
 function isXtermHelperTarget(target: HTMLElement): boolean {
   return target.classList.contains('xterm-helper-textarea') || target.closest('.xterm') !== null;
 }
@@ -182,11 +192,7 @@ function handleKeyDown(e: KeyboardEvent) {
   // Skip if typing in input and shortcut doesn't use mod key
   if (isInput && !pressed.includes('mod')) return;
 
-  // Check devOnly
-  if (def.devOnly && process.env.NODE_ENV !== 'development') return;
-
-  // Check enabled
-  if (def.enabled && !def.enabled()) return;
+  if (!isHotkeyEnabledForEvent(e)) return;
 
   e.preventDefault();
   def.action();

--- a/frontend/src/utils/terminalKeyHandling.test.ts
+++ b/frontend/src/utils/terminalKeyHandling.test.ts
@@ -95,6 +95,17 @@ describe('resolveTerminalKeyHandling', () => {
     )).toEqual({ action: 'pass-through' });
   });
 
+  it('requires Cmd instead of Ctrl for Pane shortcuts on macOS', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'ArrowRight', code: 'ArrowRight', ctrlKey: true, altKey: true }),
+      tui({ isMac: true }),
+    )).toEqual({ action: 'pass-through' });
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'ArrowRight', code: 'ArrowRight', metaKey: true, altKey: true }),
+      tui({ isMac: true }),
+    )).toEqual({ action: 'release-to-app' });
+  });
+
   it.each(['a', 'd', 'w', 'p', 'n', 'b', 'f'])(
     'preserves Ctrl+%s for the active TUI',
     (letter) => {
@@ -113,6 +124,18 @@ describe('resolveTerminalKeyHandling', () => {
         ctrlKey: true,
         altKey: true,
         getModifierState: (modifier) => modifier === 'AltGraph',
+      }),
+      tui(),
+    )).toEqual({ action: 'pass-through' });
+  });
+
+  it('does not treat modified AltGr digit output as a Pane shortcut when AltGraph is unavailable', () => {
+    expect(resolveTerminalKeyHandling(
+      key({
+        key: '@',
+        code: 'Digit2',
+        ctrlKey: true,
+        altKey: true,
       }),
       tui(),
     )).toEqual({ action: 'pass-through' });

--- a/frontend/src/utils/terminalKeyHandling.test.ts
+++ b/frontend/src/utils/terminalKeyHandling.test.ts
@@ -7,9 +7,19 @@ import {
 
 const key = (overrides: Partial<TerminalKeyLike>): TerminalKeyLike => ({
   key: 'a',
+  code: 'KeyA',
   shiftKey: false,
   ctrlKey: false,
   metaKey: false,
+  altKey: false,
+  getModifierState: () => false,
+  ...overrides,
+});
+
+const tui = (overrides: Partial<{ isTuiActive: boolean; isCliPanel: boolean; isMac: boolean }> = {}) => ({
+  isTuiActive: true,
+  isCliPanel: true,
+  isMac: false,
   ...overrides,
 });
 
@@ -17,49 +27,107 @@ describe('resolveTerminalKeyHandling', () => {
   it('sends the multiline sequence for Shift+Enter outside TUI mode', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: 'Enter', shiftKey: true }),
-      { isTuiActive: false, isCliPanel: false },
+      tui({ isTuiActive: false, isCliPanel: false }),
     )).toEqual({ action: 'send-input', input: TERMINAL_MULTILINE_NEWLINE_SEQUENCE });
   });
 
   it('sends the multiline sequence for CLI agent panels in TUI mode', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: 'Enter', shiftKey: true }),
-      { isTuiActive: true, isCliPanel: true },
+      tui(),
     )).toEqual({ action: 'send-input', input: TERMINAL_MULTILINE_NEWLINE_SEQUENCE });
   });
 
   it('passes Shift+Enter through for ordinary TUI apps', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: 'Enter', shiftKey: true }),
-      { isTuiActive: true, isCliPanel: false },
+      tui({ isCliPanel: false }),
     )).toEqual({ action: 'pass-through' });
   });
 
   it('does not swallow Ctrl+Shift+Enter chords', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: 'Enter', shiftKey: true, ctrlKey: true }),
-      { isTuiActive: true, isCliPanel: true },
+      tui(),
     )).toEqual({ action: 'pass-through' });
   });
 
   it('blocks Cmd/Ctrl+V in TUI mode so native paste can run', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: 'v', metaKey: true }),
-      { isTuiActive: true, isCliPanel: true },
+      tui(),
     )).toEqual({ action: 'block' });
   });
 
   it('passes Ctrl+C through in TUI mode so fullscreen apps can handle interrupts', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: 'c', ctrlKey: true }),
-      { isTuiActive: true, isCliPanel: true },
+      tui(),
     )).toEqual({ action: 'pass-through' });
   });
 
   it('continues to later terminal shortcut handling outside TUI mode', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: '1', metaKey: true }),
-      { isTuiActive: false, isCliPanel: true },
+      tui({ isTuiActive: false }),
     )).toEqual({ action: 'continue' });
+  });
+
+  it.each([
+    ['focus groups', key({ key: 'ArrowRight', code: 'ArrowRight', ctrlKey: true, altKey: true })],
+    ['switch sessions', key({ key: 'Tab', code: 'Tab', ctrlKey: true })],
+    ['switch group tabs', key({ key: '!', code: 'Digit1', ctrlKey: true, shiftKey: true })],
+    ['add tools', key({ key: '1', code: 'Digit1', ctrlKey: true, altKey: true })],
+    ['zoom groups', key({ key: 'Z', code: 'KeyZ', ctrlKey: true, shiftKey: true })],
+    ['split groups', key({ key: '\\', code: 'Backslash', ctrlKey: true })],
+  ])('releases Pane %s shortcuts while a TUI is active', (_label, event) => {
+    expect(resolveTerminalKeyHandling(event, tui())).toEqual({ action: 'release-to-app' });
+  });
+
+  it('releases Cmd+Backslash but preserves Ctrl+Backslash on macOS', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: '\\', code: 'Backslash', metaKey: true }),
+      tui({ isMac: true }),
+    )).toEqual({ action: 'release-to-app' });
+    expect(resolveTerminalKeyHandling(
+      key({ key: '\\', code: 'Backslash', ctrlKey: true }),
+      tui({ isMac: true }),
+    )).toEqual({ action: 'pass-through' });
+  });
+
+  it.each(['a', 'd', 'w', 'p', 'n', 'b', 'f'])(
+    'preserves Ctrl+%s for the active TUI',
+    (letter) => {
+      expect(resolveTerminalKeyHandling(
+        key({ key: letter, code: `Key${letter.toUpperCase()}`, ctrlKey: true }),
+        tui(),
+      )).toEqual({ action: 'pass-through' });
+    },
+  );
+
+  it('does not treat AltGr digits as Pane shortcuts', () => {
+    expect(resolveTerminalKeyHandling(
+      key({
+        key: '1',
+        code: 'Digit1',
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: (modifier) => modifier === 'AltGraph',
+      }),
+      tui(),
+    )).toEqual({ action: 'pass-through' });
+  });
+
+  it('does not swallow navigation-like chords with unsupported extra modifiers', () => {
+    expect(resolveTerminalKeyHandling(
+      key({
+        key: 'ArrowRight',
+        code: 'ArrowRight',
+        ctrlKey: true,
+        altKey: true,
+        shiftKey: true,
+      }),
+      tui(),
+    )).toEqual({ action: 'pass-through' });
   });
 });

--- a/frontend/src/utils/terminalKeyHandling.ts
+++ b/frontend/src/utils/terminalKeyHandling.ts
@@ -2,6 +2,7 @@ export const TERMINAL_MULTILINE_NEWLINE_SEQUENCE = '\x1b\r';
 
 export type TerminalKeyHandlingDecision =
   | { action: 'continue' }
+  | { action: 'release-to-app' }
   | { action: 'pass-through' }
   | { action: 'block' }
   | { action: 'send-input'; input: string };
@@ -9,13 +10,45 @@ export type TerminalKeyHandlingDecision =
 export interface TerminalKeyHandlingState {
   isTuiActive: boolean;
   isCliPanel: boolean;
+  isMac: boolean;
 }
 
 export interface TerminalKeyLike {
   key: string;
+  code: string;
   shiftKey: boolean;
   ctrlKey: boolean;
   metaKey: boolean;
+  altKey: boolean;
+  getModifierState: (key: string) => boolean;
+}
+
+function isPaneNavigationShortcut(
+  event: TerminalKeyLike,
+  state: TerminalKeyHandlingState,
+): boolean {
+  const ctrlOrMeta = event.ctrlKey || event.metaKey;
+  if (!ctrlOrMeta) return false;
+
+  const isAltGr = event.getModifierState('AltGraph');
+  if (
+    event.altKey
+    && !isAltGr
+    && !event.shiftKey
+    && (
+      ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)
+      || /^Digit[1-9]$/.test(event.code)
+    )
+  ) {
+    return true;
+  }
+
+  if (!event.altKey && event.key === 'Tab') return true;
+  if (!event.altKey && event.shiftKey && /^Digit[1-9]$/.test(event.code)) return true;
+  if (!event.altKey && event.shiftKey && event.key.toLowerCase() === 'z') return true;
+
+  const isBackslash = event.code === 'Backslash' || event.code === 'IntlBackslash';
+  return !event.altKey && isBackslash && (state.isMac ? event.metaKey : event.ctrlKey);
 }
 
 export function resolveTerminalKeyHandling(
@@ -27,6 +60,10 @@ export function resolveTerminalKeyHandling(
 
   if (shiftEnter && (!state.isTuiActive || state.isCliPanel)) {
     return { action: 'send-input', input: TERMINAL_MULTILINE_NEWLINE_SEQUENCE };
+  }
+
+  if (state.isTuiActive && isPaneNavigationShortcut(event, state)) {
+    return { action: 'release-to-app' };
   }
 
   if (state.isTuiActive) {

--- a/frontend/src/utils/terminalKeyHandling.ts
+++ b/frontend/src/utils/terminalKeyHandling.ts
@@ -27,17 +27,24 @@ function isPaneNavigationShortcut(
   event: TerminalKeyLike,
   state: TerminalKeyHandlingState,
 ): boolean {
-  const ctrlOrMeta = event.ctrlKey || event.metaKey;
-  if (!ctrlOrMeta) return false;
+  const primaryModifier = state.isMac ? event.metaKey : event.ctrlKey;
+  if (!primaryModifier) return false;
 
   const isAltGr = event.getModifierState('AltGraph');
+  const digitMatch = event.code.match(/^Digit([1-9])$/);
+  const isUnreportedAltGrDigit = !state.isMac
+    && event.ctrlKey
+    && event.altKey
+    && digitMatch
+    && event.key !== digitMatch[1];
   if (
     event.altKey
     && !isAltGr
+    && !isUnreportedAltGrDigit
     && !event.shiftKey
     && (
       ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)
-      || /^Digit[1-9]$/.test(event.code)
+      || digitMatch
     )
   ) {
     return true;
@@ -48,7 +55,7 @@ function isPaneNavigationShortcut(
   if (!event.altKey && event.shiftKey && event.key.toLowerCase() === 'z') return true;
 
   const isBackslash = event.code === 'Backslash' || event.code === 'IntlBackslash';
-  return !event.altKey && isBackslash && (state.isMac ? event.metaKey : event.ctrlKey);
+  return !event.altKey && isBackslash;
 }
 
 export function resolveTerminalKeyHandling(


### PR DESCRIPTION
## Summary
- allow Pane layout and navigation shortcuts to bypass active terminal TUIs
- preserve terminal-native Ctrl chords, AltGr input, and macOS Ctrl+\ SIGQUIT
- add focused regression coverage for shortcut routing

## Testing
- `pnpm --filter frontend exec vitest run src/utils/terminalKeyHandling.test.ts`
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend lint` (passes with existing warnings)
- `pnpm --filter frontend build`