### PR TITLE
Fix terminal scrollback duplication via rendered-state replay; loading skeleton

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -31,20 +31,42 @@ import { useConfigStore } from '../../stores/configStore';
 import type { InterceptorState, AtTerminalHandlerState, TerminalSuggestion } from '../../services/terminalInterceptor/types';
 import '@xterm/xterm/css/xterm.css';
 
-const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+// Hold the loading overlay at least this long past ready so the terminal
+// underneath finishes painting before it is revealed.
+const TERMINAL_OVERLAY_LINGER_MS = 150;
 
-const TerminalSpinner: React.FC = () => {
-  const [frame, setFrame] = useState(0);
+const SKELETON_TRANSCRIPT_WIDTHS = ['w-2/3', 'w-1/2', 'w-5/6', 'w-1/3', 'w-3/4', 'w-2/5'];
 
-  useEffect(() => {
-    const interval = setInterval(() => setFrame(f => (f + 1) % SPINNER_FRAMES.length), 80);
-    return () => clearInterval(interval);
-  }, []);
-
-  return (
-    <span className="text-accent-primary text-2xl font-mono">{SPINNER_FRAMES[frame]}</span>
-  );
-};
+// Opaque stand-in shaped like a CLI agent session: greeting banner, transcript
+// lines, and a prompt box, swept by a single shimmer so it reads as one
+// cohesive loading surface. Shown while initializing, refreshing, and CLI startup.
+const TerminalLoadingSkeleton: React.FC = () => (
+  <div className="relative w-full h-full overflow-hidden px-4 py-4 font-mono select-none" aria-label="Loading terminal">
+    <div className="flex h-full flex-col gap-4">
+      <div className="rounded-md border border-border-primary p-3 space-y-2 max-w-md">
+        <div className="h-3.5 w-40 rounded bg-surface-tertiary" />
+        <div className="h-3 w-56 rounded bg-surface-tertiary" />
+        <div className="h-3 w-32 rounded bg-surface-tertiary" />
+      </div>
+      <div className="space-y-2.5 max-w-2xl">
+        {SKELETON_TRANSCRIPT_WIDTHS.map((w, i) => (
+          <div key={i} className={`h-3 rounded bg-surface-tertiary ${w}`} />
+        ))}
+      </div>
+      <div className="flex-1" />
+      <div className="space-y-2">
+        <div className="rounded-md border border-border-primary px-3 py-2.5">
+          <div className="h-3 w-24 rounded bg-surface-tertiary" />
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="h-2.5 w-20 rounded bg-surface-tertiary" />
+          <div className="h-2.5 w-28 rounded bg-surface-tertiary" />
+        </div>
+      </div>
+    </div>
+    <div className="pointer-events-none absolute inset-0 animate-shimmer bg-gradient-to-r from-transparent via-[color-mix(in_srgb,var(--color-text-primary)_4%,transparent)] to-transparent" />
+  </div>
+);
 
 // Type for terminal state restoration
 interface TerminalRestoreState {
@@ -161,10 +183,12 @@ function waitForNextPaint(): Promise<void> {
  * xterm falls back to the DOM renderer. Never call `clearTextureAtlas()`
  * here: the atlas is shared across terminals.
  *
- * PERSISTENCE: main owns the raw scrollback (authoritative, ANSI-safe
- * trimmed); the renderer serializes a formatting-preserving snapshot on
- * hide (throttled to SNAPSHOT_MIN_INTERVAL_MS) and on unmount, used only for
- * app-restart restore. Live restores always prefer main's raw scrollback.
+ * PERSISTENCE: main owns the raw scrollback log plus a headless emulator that
+ * renders every PTY byte; the renderer serializes a formatting-preserving
+ * snapshot on hide (throttled to SNAPSHOT_MIN_INTERVAL_MS) and on unmount,
+ * used only for app-restart restore. Live normal-buffer restores replay main's
+ * rendered emulator serialization (duplicate-free by construction); the raw
+ * append log remains for snapshot/scrollback readers.
  *
  * UNMOUNT (session switch / panel close): serialize a final snapshot, then
  * dispose WebGL, addons, and the xterm instance. Remounts restore from
@@ -178,8 +202,12 @@ function waitForNextPaint(): Promise<void> {
  * without a renderer per session. The tradeoff is that remounting exposes
  * foreground-TUI redraw assumptions hidden by retained-DOM designs. Restoring
  * cells recreates terminal state but cannot make the application recompute its
- * layout, which is why activation finishes with a timed real PTY size
- * transition and return.
+ * layout, which is why the alternate-screen activation path finishes with a
+ * timed real PTY size transition. The normal-buffer path deliberately does
+ * NOT force one: the emulator serialization is already the exact current
+ * screen, and forced width transitions made normal-buffer TUIs (Claude Code)
+ * re-render their transcript tail — duplicating scrollback on every
+ * activation once content overflowed the viewport.
  */
 export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActive, autoFocus = true }) => {
   renderLog('[TerminalPanel] Component rendering, panel:', panel.id, 'isActive:', isActive);
@@ -272,6 +300,20 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
       setIsCliReady(true);
     }
   }, [terminalState?.isCliReady, isCliReady]);
+
+  // Loading-skeleton visibility: show immediately when any loading state is
+  // active, hide only after a short linger so the terminal underneath has
+  // finished painting before the mask lifts.
+  const overlayActive = !isInitialized || isRefreshing || (isCliPanel && !isCliReady);
+  const [overlayVisible, setOverlayVisible] = useState(true);
+  useEffect(() => {
+    if (overlayActive) {
+      setOverlayVisible(true);
+      return;
+    }
+    const lingerTimer = setTimeout(() => setOverlayVisible(false), TERMINAL_OVERLAY_LINGER_MS);
+    return () => clearTimeout(lingerTimer);
+  }, [overlayActive]);
 
   // Listen for cliReady event (only for CLI panels that aren't already ready)
   useEffect(() => {
@@ -592,13 +634,18 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     }
   }, [panel.id]);
 
-  // Full-depth refresh: normal buffers reset+replay main's raw scrollback at the
-  // settled width; alternate buffers preserve their live model. Both paths end
-  // with a forced PTY resize so foreground applications redraw even when the
-  // dimensions did not change. Runs on initial construction, remount/session
-  // switch, battery-saver activation, sustained-blur recovery, and manual
-  // Refresh. Eligible same-session hot activations use reconcileMountedTerminal
-  // instead and never enter this function.
+  // Full-depth refresh: normal buffers reset+replay main's rendered emulator
+  // serialization at the settled width; alternate buffers preserve their live
+  // model and end with a forced PTY resize so the fullscreen app redraws. The
+  // normal-buffer path must NOT force a PTY resize: the serialized snapshot is
+  // already the exact current screen, and a forced width transition makes
+  // normal-buffer TUIs (Claude Code) re-render their transcript tail — when
+  // that content overflows the viewport the re-render scrolls, appending a
+  // duplicate copy to scrollback on every activation. Runs on initial
+  // construction, remount/session switch, battery-saver activation,
+  // sustained-blur recovery, and manual Refresh. Eligible same-session hot
+  // activations use reconcileMountedTerminal instead and never enter this
+  // function.
   const handleRefreshTerminal = useCallback(async () => {
     const terminal = xtermRef.current;
     if (!terminal) return;
@@ -629,6 +676,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         setShowScrollDown(true);
       };
 
+      // Fit BEFORE requesting state so the emulator serializes at the settled
+      // width — resizing after getState would replay a stale-width snapshot,
+      // and the normal-buffer path has no forced app redraw left to repair it.
+      await resizePtyToFit();
       const state = await window.electronAPI.invoke('terminal:getState', panel.id);
       if (state?.isAlternateScreen) {
         // Renderer refresh alone cannot repair an application frame that was
@@ -643,17 +694,12 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         return;
       }
 
-      // Fit first so reset+replay lands at the settled width, not a stale/tiny grid
-      await resizePtyToFit();
       terminal.reset();
       const finishRefresh = async () => {
         restoreScrollPosition();
         // The old post-replay fit() invalidated WebGL via a dims change; after reordering
         // that fit is a same-size no-op, so an explicit refresh is needed for WebGL redraw
         if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
-        // Claude's default renderer can remain in the normal buffer while still
-        // needing the same application redraw as a fullscreen alternate-buffer TUI.
-        await resizePtyToFit(true);
       };
 
       if (state?.scrollbackBuffer) {
@@ -1923,14 +1969,9 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         </button>
       )}
 
-      {(!isInitialized || isRefreshing || (isCliPanel && !isCliReady)) && (
-        <div className="absolute inset-0 flex items-center justify-center bg-surface-primary z-10">
-          <div className="flex flex-col items-center gap-3">
-            <TerminalSpinner />
-            <div className="text-text-secondary text-sm">
-              {!isInitialized ? 'Initializing terminal...' : isRefreshing ? 'Refreshing terminal...' : 'Starting CLI...'}
-            </div>
-          </div>
+      {overlayVisible && (
+        <div className="absolute inset-0 bg-surface-primary z-10">
+          <TerminalLoadingSkeleton />
         </div>
       )}
 

--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -416,6 +416,34 @@ describe('TerminalPanelManager hidden output delivery', () => {
     disposeFlowControlRecord(terminal.flowControl);
   });
 
+  it('serves normal-buffer restore content from the rendered emulator, not the raw append log', async () => {
+    const manager = new TerminalPanelManager() as unknown as SnapshotAccess;
+    const screenEmulator = new TerminalStateEmulator(40, 5);
+    const frame = 'PR #363 state unchanged';
+    // Live stream: the frame prints once, then forced-redraw repaints re-emit it
+    // after cursor-home — the traffic that duplicated rows when the raw log was
+    // replayed. The emulator overwrites in place, like a live terminal.
+    const initial = `${frame}\r\n`;
+    const repaint = `\x1b[H${frame}\x1b[K\r\n`;
+    screenEmulator.write(initial);
+    screenEmulator.write(repaint);
+    screenEmulator.write(repaint);
+    await screenEmulator.waitForIdle();
+    const terminal = createTerminal({
+      scrollbackBuffer: initial + repaint + repaint,
+      screenEmulator,
+      isAlternateScreen: false,
+    });
+    manager.terminals.set(terminal.panelId, terminal);
+
+    const restoreState = await manager.getTerminalState(terminal.panelId);
+    const restored = restoreState?.scrollbackBuffer as string;
+    expect(restored.split(frame).length - 1).toBe(1);
+    expect(terminal.scrollbackBuffer.split(frame).length - 1).toBe(3);
+    screenEmulator.dispose();
+    disposeFlowControlRecord(terminal.flowControl);
+  });
+
   it('submits Codex initial input through the composer sequence', async () => {
     vi.useFakeTimers();
     const manager = new TerminalPanelManager() as unknown as InitialInputAccess;

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -31,10 +31,11 @@ const MIN_PTY_COLS = 20;
 const MIN_PTY_ROWS = 5;
 const FORCED_REDRAW_TRANSITION_MS = 50;
 const FORCED_REDRAW_SETTLE_MS = 80;
-// Formal ceiling for the raw-ANSI scrollback shipped on restore/getState replay. Peer consensus:
+// Formal ceiling for the restore/getState replay payload (now the emulator
+// serialization for normal buffers, raw ANSI log otherwise). Peer consensus:
 // Orca (TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT) and Superset (MAX_HISTORY_SCROLLBACK_BYTES) both use
-// 512 * 1024. Above the 500KB live trim, so it does not reduce today's payload — the measurable win
-// is omitting the up-to-8MB serialized snapshot from getState when raw scrollback exists.
+// 512 * 1024. The 2500-line emulator serialization sits well under this in
+// practice; the cap is a backstop against pathological payloads.
 const MAX_RESTORE_PAYLOAD_SIZE = 512 * 1024;
 
 type CliAgentType = NonNullable<TerminalPanelState['agentType']>;
@@ -1413,13 +1414,22 @@ export class TerminalPanelManager {
     
     // Save state to panel
     const state = panel.state;
+    const savedIsAlternateScreen =
+      terminal.screenEmulator?.isAlternateScreen ?? terminal.isAlternateScreen;
+    // Same source as getTerminalState: persist the rendered emulator model for
+    // normal buffers so restarts replay a duplicate-free snapshot, not the raw
+    // append log with its accumulated repaint traffic.
+    const savedScrollback =
+      !savedIsAlternateScreen && terminal.screenEmulator
+        ? this.trimAnsiSafe(terminal.screenEmulator.serializeForRestore(true), MAX_RESTORE_PAYLOAD_SIZE)
+        : terminal.scrollbackBuffer;
     state.customState = {
       ...state.customState,
       isInitialized: true,
       cwd: cwd,
-      scrollbackBuffer: terminal.scrollbackBuffer,
+      scrollbackBuffer: savedScrollback,
       alternateScreenBuffer: terminal.alternateScreenBuffer,
-      isAlternateScreen: terminal.screenEmulator?.isAlternateScreen ?? terminal.isAlternateScreen,
+      isAlternateScreen: savedIsAlternateScreen,
       commandHistory: terminal.commandHistory.slice(-100), // Keep last 100 commands
       lastActivityTime: terminal.lastActivity.toISOString(),
       lastActiveCommand: terminal.currentCommand,
@@ -1503,8 +1513,16 @@ export class TerminalPanelManager {
 
     await terminal.screenEmulator?.waitForIdle();
 
-    const cappedScrollback = this.trimAnsiSafe(terminal.scrollbackBuffer, MAX_RESTORE_PAYLOAD_SIZE);
     const isAlternateScreen = terminal.screenEmulator?.isAlternateScreen ?? terminal.isAlternateScreen;
+    // Normal-buffer restore content comes from the rendered emulator model, not
+    // the raw append log: the log accumulates repaint traffic (forced activation
+    // redraws re-emit the current frame), which a reset+replay renders as
+    // duplicated rows. The emulator consumed those bytes like a live terminal —
+    // repaints overwrite in place — so its serialization is duplicate-free.
+    const cappedScrollback =
+      !isAlternateScreen && terminal.screenEmulator
+        ? this.trimAnsiSafe(terminal.screenEmulator.serializeForRestore(true), MAX_RESTORE_PAYLOAD_SIZE)
+        : this.trimAnsiSafe(terminal.scrollbackBuffer, MAX_RESTORE_PAYLOAD_SIZE);
     return {
       isInitialized: true,
       cwd: process.cwd(), // Simplified - would need platform-specific implementation

--- a/main/src/services/terminalStateEmulator.test.ts
+++ b/main/src/services/terminalStateEmulator.test.ts
@@ -48,6 +48,24 @@ describe('TerminalStateEmulator', () => {
     emulator.dispose();
   });
 
+  it('retains scrollback history in the post-dispose serialization snapshot', async () => {
+    const emulator = new TerminalStateEmulator(40, 3);
+    // 10 lines through a 3-row viewport: the early lines live only in scrollback
+    for (let i = 1; i <= 10; i++) {
+      emulator.write(`history-line-${String(i).padStart(2, '0')}\r\n`);
+    }
+    await emulator.waitForIdle();
+
+    emulator.dispose();
+
+    // destroyTerminal fires saveTerminalState without awaiting it, so the save
+    // reads this snapshot after disposal — it must still include scrollback,
+    // or closing a terminal silently truncates its persisted history.
+    const serialized = emulator.serializeForRestore(true);
+    expect(serialized).toContain('history-line-01');
+    expect(serialized).toContain('history-line-10');
+  });
+
   it('includes active input modes in restore serialization', async () => {
     const emulator = new TerminalStateEmulator(20, 5);
     emulator.write('\x1b[?1h\x1b[?1004h\x1b[?2004h');

--- a/main/src/services/terminalStateEmulator.ts
+++ b/main/src/services/terminalStateEmulator.ts
@@ -59,11 +59,18 @@ export class TerminalStateEmulator {
       : this.terminal.buffer.active.type === 'alternate';
   }
 
-  /** Serialize the visible normal buffer and, when active, the alternate buffer. */
-  serializeForRestore(): string {
+  /**
+   * Serialize the visible normal buffer and, when active, the alternate buffer.
+   * Pass includeScrollback to also serialize normal-buffer scrollback history —
+   * the restore source for normal buffers, since this model rendered every PTY
+   * byte and therefore contains no repaint duplication.
+   */
+  serializeForRestore(includeScrollback = false): string {
     return this.disposed
       ? this.finalSerializedBuffer
-      : this.serializeAddon.serialize({ scrollback: 0 });
+      : this.serializeAddon.serialize({
+          scrollback: includeScrollback ? HEADLESS_SCROLLBACK_LINES : 0,
+        });
   }
 
   /** Return plain text for the currently visible viewport. */
@@ -91,7 +98,10 @@ export class TerminalStateEmulator {
   dispose(): void {
     if (this.disposed) return;
     this.finalIsAlternateScreen = this.isAlternateScreen;
-    this.finalSerializedBuffer = this.serializeForRestore();
+    // Capture WITH scrollback: destroyTerminal fires saveTerminalState without
+    // awaiting it, so the save usually reads this snapshot after disposal — a
+    // viewport-only capture would silently drop the session's history.
+    this.finalSerializedBuffer = this.serializeForRestore(true);
     this.finalScreenText = this.getScreenText();
     this.disposed = true;
     this.terminal.dispose();


### PR DESCRIPTION
## Summary
- **Root cause**: every panel activation forced a one-column-and-back PTY width transition after replaying the raw scrollback log. Claude Code re-renders its transcript tail on width changes; once content overflows the viewport that re-render scrolls, appending one duplicate copy of the current frame per activation (reproducible after 3-5 pane switches on long threads). Native terminals never resize on focus, which is why they don't show it.
- **Fix 1**: normal-buffer restore/replay content (activation refresh, remount, and restart persistence) now comes from the main-process headless xterm emulator's serialization — the exact rendered screen plus 2500 lines of scrollback, duplicate-free and garble-free by construction. The raw append log is unchanged and still serves snapshot/scrollback readers.
- **Fix 2**: the forced PTY resize after normal-buffer replay (introduced in #336 to repair stale raw-log replays) is removed — it was the duplication engine and is obsolete now that the replay source is the exact current screen. Alternate-screen TUIs keep their forced redraw; the masked full-refresh choreography is otherwise untouched.
- **Hardening** (from dual code review): `dispose()` snapshots the emulator WITH scrollback so close/quit-time saves keep session history; activation fits before serializing so snapshots are captured at the settled width.
- **QoL**: the initializing/refreshing/starting-CLI overlay is now one cohesive shimmering CLI-agent-shaped skeleton (banner, transcript lines, prompt box) that lingers 150ms past ready so the terminal underneath finishes painting before the mask lifts.

## Testing
- Driven end-to-end in the real Electron app (isolated PANE_DIR): a live Claude Code pane printed 70 viewport-overflowing lines, then 5 genuine pane switches + manual Refresh — content appeared exactly once with intact formatting; frontend logs confirmed all five full activation refreshes executed.
- Manually verified by the reporter against the original long-thread repro.
- Unit: 25/25 terminal manager + emulator tests, including new regressions for rendered-vs-raw restore content and post-dispose scrollback retention. Typecheck, lint (0 errors), and main+frontend builds clean.

## Scope notes
- Persisted history depth for closed panels is now bounded by the emulator's 2500 scrollback lines (previously ~500KB of raw log).
- `terminal:getScrollbackClean` / save-scrollback-to-file still read the raw log for live panels; migrating those to the emulator is a possible follow-up.