### PR TITLE
Fix first-open dropdown menu rendering off-screen

### DIFF
--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -198,10 +198,25 @@ export function Dropdown({
   // Fixed position for portal rendering
   const [fixedStyle, setFixedStyle] = useState<CSSProperties>({});
 
-  // Smart positioning for auto mode
-  useEffect(() => {
-    if (isOpen && dropdownRef.current) {
-      const rect = dropdownRef.current.getBoundingClientRect();
+  // Smart positioning for auto mode. Must run BEFORE paint: fixedStyle
+  // persists across closes, so the first open after mount used to paint the
+  // portal unpositioned (static flow at the end of the portal container —
+  // off-screen) until a post-paint effect corrected it, and the correction
+  // only became visible on the SECOND open. While open, a rAF loop re-anchors
+  // the menu whenever the trigger actually moves (drawer expand animation,
+  // layout shifts, window resizes).
+  useLayoutEffect(() => {
+    if (!isOpen || !dropdownRef.current) return;
+
+    let lastRectKey = '';
+    const computePosition = () => {
+      const el = dropdownRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const rectKey = `${rect.top},${rect.left},${rect.width},${rect.height}`;
+      if (rectKey === lastRectKey) return;
+      lastRectKey = rectKey;
+
       const viewportHeight = window.innerHeight;
       const viewportWidth = window.innerWidth;
 
@@ -242,8 +257,15 @@ export function Dropdown({
         delete pos.right;
       }
       setFixedStyle(pos);
-    }
-  }, [isOpen, position]);
+    };
+
+    computePosition();
+    let raf = requestAnimationFrame(function track() {
+      computePosition();
+      raf = requestAnimationFrame(track);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [isOpen, position, width]);
 
   // Handle click outside
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes the sidebar "..." menu (and any shared Dropdown) opening off-screen on its first click, then working on the second click.

**Root cause**: `Dropdown` computed its fixed portal position in a post-paint `useEffect`, while `fixedStyle` state persisted across closes. The first open after mount painted the menu unpositioned — static flow at the end of the portal container, i.e. off-screen — and the corrected style only became visible on the next open. The expanded sidebar is a separate render branch from the collapsed rail, so every drawer toggle remounts the Dropdown and resets the cached style — which is why the detour happened on every visit, not once per app run.

**Fix**: position is computed in a pre-paint `useLayoutEffect` so the menu never paints unpositioned, plus a rAF loop that re-anchors the open menu whenever the trigger rect actually moves (drawer expand animation, layout shifts, window resizes). The loop recomputes only on rect change and cancels on close.

## Testing
- Typecheck, lint (0 errors), and frontend build clean.
- Applies to all `Dropdown` consumers (sidebar menu, session menus, selects unaffected — `Select.tsx` has its own positioning).