### PR TITLE
Add global keyboard shortcut preference

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -108,6 +108,7 @@ function App() {
   const [resumableSessions, setResumableSessions] = useState<ResumableSession[]>([]);
   const [isResumeDialogOpen, setIsResumeDialogOpen] = useState(false);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [isKeyboardShortcutsOpen, setIsKeyboardShortcutsOpen] = useState(false);
   const [isDocsOpen, setIsDocsOpen] = useState(false);
   const [showCreateSessionDialog, setShowCreateSessionDialog] = useState(false);
   const [showAddProjectDialog, setShowAddProjectDialog] = useState(false);
@@ -825,6 +826,10 @@ function App() {
           onCategoryChange={setSettingsCategory}
           openRequest={settingsOpenRequest}
           onOpenRequestHandled={() => setSettingsOpenRequest(undefined)}
+          onShowKeyboardShortcuts={() => {
+            closeSettings();
+            setIsKeyboardShortcutsOpen(true);
+          }}
         />
         <AnalyticsConsentDialog
           isOpen={isAnalyticsConsentOpen}
@@ -891,6 +896,11 @@ function App() {
           onClose={() => setShowAddProjectDialog(false)}
         />
         <Help isOpen={isHelpOpen} onClose={() => setIsHelpOpen(false)} />
+        <Help
+          isOpen={isKeyboardShortcutsOpen}
+          onClose={() => setIsKeyboardShortcutsOpen(false)}
+          shortcutsOnly
+        />
         <DocsDialog isOpen={isDocsOpen} onClose={() => setIsDocsOpen(false)} />
         <ShortcutHintsOverlay isVisible={shortcutHintsVisible} shortcuts={terminalShortcuts} />
         </div>

--- a/frontend/src/components/CommitDialog.tsx
+++ b/frontend/src/components/CommitDialog.tsx
@@ -4,6 +4,7 @@ import { formatKeyDisplay } from '../utils/hotkeyUtils';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import { Textarea } from './ui/Textarea';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../stores/configStore';
 
 interface CommitDialogProps {
   isOpen: boolean;
@@ -22,6 +23,7 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
   const [isCommitting, setIsCommitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
 
   // Set default message
   useEffect(() => {
@@ -59,13 +61,13 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
   }, [commitMessage, onCommit, onClose]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    if (keyboardShortcutsEnabled && e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       handleCommit();
     } else if (e.key === 'Escape') {
       onClose();
     }
-  }, [handleCommit, onClose]);
+  }, [handleCommit, keyboardShortcutsEnabled, onClose]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="md">

--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -10,6 +10,7 @@ import { Button } from './ui/Button';
 import { Input } from './ui/Input';
 import { useSessionPreferencesStore, type SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import { useSessionStore } from '../stores/sessionStore';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../stores/configStore';
 import { generatePaneName, sanitizePaneName } from '../utils/paneName';
 
 // Interface for branch information
@@ -72,6 +73,7 @@ export function CreateSessionDialog({
   const { showError } = useErrorStore();
   const { preferences, loadPreferences, updatePreferences } = useSessionPreferencesStore();
   const existingSessions = useSessionStore(state => state.sessions);
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
 
   // Load session creation preferences when dialog opens
   useEffect(() => {
@@ -267,7 +269,7 @@ export function CreateSessionDialog({
       if (!isOpen) return;
 
       // Cmd/Ctrl + Enter to submit
-      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      if (keyboardShortcutsEnabled && (e.metaKey || e.ctrlKey) && e.key === 'Enter') {
         e.preventDefault();
         const form = document.getElementById('create-session-form') as HTMLFormElement;
         if (form) {
@@ -279,7 +281,7 @@ export function CreateSessionDialog({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen]);
+  }, [isOpen, keyboardShortcutsEnabled]);
 
   // Auto-focus name input on dialog open (always available immediately)
   useEffect(() => {

--- a/frontend/src/components/Help.tsx
+++ b/frontend/src/components/Help.tsx
@@ -65,13 +65,17 @@ function KeyboardShortcutsSection() {
 interface HelpProps {
   isOpen: boolean;
   onClose: () => void;
+  shortcutsOnly?: boolean;
 }
 
-export default function Help({ isOpen, onClose }: HelpProps) {
+export default function Help({ isOpen, onClose, shortcutsOnly = false }: HelpProps) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl" showCloseButton={false}>
-      <ModalHeader title="Pane Help" />
+      <ModalHeader title={shortcutsOnly ? 'Keyboard Shortcuts' : 'Pane Help'} />
       <ModalBody>
+        {shortcutsOnly ? (
+          <KeyboardShortcutsSection />
+        ) : (
         <div className="space-y-8">
             {/* Quick Start */}
             <section>
@@ -286,7 +290,8 @@ export default function Help({ isOpen, onClose }: HelpProps) {
                 <li>Enable notifications to know when Claude needs your input</li>
               </ul>
             </section>
-          </div>
+        </div>
+        )}
       </ModalBody>
       
       <div className="p-4 border-t border-border-primary text-center text-sm text-text-muted">

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -42,9 +42,10 @@ interface SettingsProps {
   onCategoryChange: (category: SettingsCategoryId) => void;
   openRequest?: SettingsOpenRequest;
   onOpenRequestHandled: () => void;
+  onShowKeyboardShortcuts: () => void;
 }
 
-export function Settings({ isOpen, onClose, category, onCategoryChange, openRequest, onOpenRequestHandled }: SettingsProps) {
+export function Settings({ isOpen, onClose, category, onCategoryChange, openRequest, onOpenRequestHandled, onShowKeyboardShortcuts }: SettingsProps) {
   const persistence = useSettingsPersistence(isOpen);
   const dirtyForms = useDirtySettingsForms();
   const {
@@ -114,6 +115,10 @@ export function Settings({ isOpen, onClose, category, onCategoryChange, openRequ
     });
   }, [onClose, requestTransition]);
 
+  const showKeyboardShortcuts = useCallback(() => {
+    requestTransition(onShowKeyboardShortcuts);
+  }, [onShowKeyboardShortcuts, requestTransition]);
+
   const openRemoteSubview = useCallback((subview: RemoteAccessSubviewId) => {
     requestTransition(() => setRemoteSubview(subview));
   }, [requestTransition]);
@@ -141,7 +146,7 @@ export function Settings({ isOpen, onClose, category, onCategoryChange, openRequ
       case 'integrations':
         return <IntegrationsSettings persistence={persistence} {...sharedDirtyProps} />;
       case 'shortcuts':
-        return <ShortcutsSettings persistence={persistence} {...sharedDirtyProps} />;
+        return <ShortcutsSettings persistence={persistence} onShowKeyboardShortcuts={showKeyboardShortcuts} {...sharedDirtyProps} />;
       case 'privacy':
         return <PrivacySettings persistence={persistence} />;
       case 'advanced':

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -41,7 +41,7 @@ const SKELETON_TRANSCRIPT_WIDTHS = ['w-2/3', 'w-1/2', 'w-5/6', 'w-1/3', 'w-3/4',
 // lines, and a prompt box, swept by a single shimmer so it reads as one
 // cohesive loading surface. Shown while initializing, refreshing, and CLI startup.
 const TerminalLoadingSkeleton: React.FC = () => (
-  <div className="relative w-full h-full overflow-hidden px-4 py-4 font-mono select-none" aria-label="Loading terminal">
+  <div className="relative w-full h-full overflow-hidden px-4 py-4 font-mono select-none" role="status" aria-label="Loading terminal">
     <div className="flex h-full flex-col gap-4">
       <div className="rounded-md border border-border-primary p-3 space-y-2 max-w-md">
         <div className="h-3.5 w-40 rounded bg-surface-tertiary" />

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -11,7 +11,7 @@ import { TerminalPanelProps } from '../../types/panelComponents';
 import { isHotkeyEnabledForEvent, useHotkeyStore } from '../../stores/hotkeyStore';
 import { renderLog, devLog } from '../../utils/console';
 import { getTerminalTheme } from '../../utils/terminalTheme';
-import { resolveTerminalKeyHandling } from '../../utils/terminalKeyHandling';
+import { resolveTerminalKeyHandling, shouldOpenTerminalSearch } from '../../utils/terminalKeyHandling';
 import { isMac } from '../../utils/platformUtils';
 import { FileEdit, FolderOpen } from 'lucide-react';
 import { useTerminalLinks } from '../terminal/hooks/useTerminalLinks';
@@ -27,7 +27,7 @@ import { createAtTerminalHandler } from '../../services/terminalInterceptor/hand
 import { InterceptorDropdown } from '../terminal/InterceptorDropdown';
 import { InterceptorToast } from '../terminal/InterceptorToast';
 import { usePanelStore } from '../../stores/panelStore';
-import { useConfigStore } from '../../stores/configStore';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../../stores/configStore';
 import type { InterceptorState, AtTerminalHandlerState, TerminalSuggestion } from '../../services/terminalInterceptor/types';
 import '@xterm/xterm/css/xterm.css';
 
@@ -233,6 +233,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   const interceptorRef = useRef<TerminalInterceptor | null>(null);
   const skipNextInterceptRef = useRef(false); // set by AltGr @ detection
   const terminalPowerMode = useConfigStore((state) => state.config?.terminalPowerMode ?? 'performance');
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
+  const keyboardShortcutsEnabledRef = useRef(keyboardShortcutsEnabled);
   const useBatterySaverTerminalVisibility = terminalPowerMode === 'batterySaver';
   const panelVisible = isActive;
   const effectiveVisible = useBatterySaverTerminalVisibility ? panelVisible && windowFocused : true;
@@ -294,6 +296,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   useEffect(() => {
     isCliPanelRef.current = isCliPanel;
   }, [isCliPanel]);
+
+  useEffect(() => {
+    keyboardShortcutsEnabledRef.current = keyboardShortcutsEnabled;
+  }, [keyboardShortcutsEnabled]);
 
   useEffect(() => {
     if (terminalState?.isCliReady && !isCliReady) {
@@ -767,12 +773,11 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
   // Open search on Ctrl/Cmd+F from the container div
   const handleTerminalKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const ctrlOrMeta = e.ctrlKey || e.metaKey;
-    if (ctrlOrMeta && e.key.toLowerCase() === 'f') {
+    if (shouldOpenTerminalSearch(e, keyboardShortcutsEnabled)) {
       e.preventDefault();
       openSearch();
     }
-  }, [openSearch]);
+  }, [keyboardShortcutsEnabled, openSearch]);
 
   const getDropdownPosition = useCallback((): { x: number; y: number } => {
     const container = terminalRef.current;
@@ -906,6 +911,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
         // Intercept app-level shortcuts before xterm consumes them
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+          if (!keyboardShortcutsEnabledRef.current) return !isHotkeyEnabledForEvent(e);
+
           const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
           // Ctrl/Cmd+K: clear xterm scrollback without writing ^K to the PTY.
@@ -925,6 +932,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             isTuiActive: tuiActiveRef.current,
             isCliPanel: isCliPanelRef.current,
             isMac: isMac(),
+            keyboardShortcutsEnabled: keyboardShortcutsEnabledRef.current,
           });
 
           // Shift+Enter sends the same ESC+CR sequence as Alt+Enter for CLI

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -15,7 +15,7 @@ import { ExplorerPanelState } from '../../../../../shared/types/panels';
 import { isMac, isWindows } from '../../../utils/platformUtils';
 import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
 import { TerminalPopover, PopoverButton } from '../../terminal/TerminalPopover';
-import { useConfigStore } from '../../../stores/configStore';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../../../stores/configStore';
 import { LiveRegion } from '../../ui/LiveRegion';
 
 interface FileItem {
@@ -89,6 +89,7 @@ function HeadlessFileTree({
   // Platform-adaptive label
   const revealLabel = isMac() ? 'Reveal in Finder' : isWindows() ? 'Show in Explorer' : 'Show in File Manager';
   const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
 
   // Initialize expanded state from persisted state or default to root expanded.
   // Normalize legacy '' root to ROOT_ID so saved state from the old FileTree still works.
@@ -703,7 +704,7 @@ function HeadlessFileTree({
       const isEditingText = target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || !!target?.isContentEditable;
       if (isEditingText && e.key !== 'Escape') return;
 
-      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+      if (keyboardShortcutsEnabled && (e.metaKey || e.ctrlKey) && e.key === 'f') {
         e.preventDefault();
         setShowSearch(prev => !prev);
       }
@@ -722,6 +723,7 @@ function HeadlessFileTree({
           searchInputRef.current?.focus();
         }
       }
+      if (!keyboardShortcutsEnabled) return;
       if (e.key === 'F2' && selectedItems.length === 1) {
         const item = tree.getItemInstance(selectedItems[0])?.getItemData();
         if (item) {
@@ -752,7 +754,7 @@ function HeadlessFileTree({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [searchQuery, showNewItemDialog, contextMenu, selectedItems, tree, startRename, handleDelete, clipboard, handlePaste]);
+  }, [searchQuery, showNewItemDialog, contextMenu, keyboardShortcutsEnabled, selectedItems, tree, startRename, handleDelete, clipboard, handlePaste]);
 
   return (
     <div

--- a/frontend/src/components/panels/logPanel/LogsView.tsx
+++ b/frontend/src/components/panels/logPanel/LogsView.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../../utils/cn';
 import AnsiToHtml from 'ansi-to-html';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { LiveRegion } from '../../ui/LiveRegion';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../../../stores/configStore';
 
 interface LogEntry {
   timestamp: string;
@@ -30,6 +31,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const lastLogCount = useRef(0);
   const { theme } = useTheme();
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
 
   // Create ANSI to HTML converter with theme-aware colors
   const ansiConverter = useMemo(() => {
@@ -174,7 +176,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
 
     const handleKeyDown = (e: KeyboardEvent) => {
       // Cmd+F or Ctrl+F for search
-      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+      if (keyboardShortcutsEnabled && (e.metaKey || e.ctrlKey) && e.key === 'f') {
         e.preventDefault();
         setSearchVisible(true);
         setTimeout(() => searchInputRef.current?.focus(), 100);
@@ -197,7 +199,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isVisible, searchVisible, searchMatches, goToNextMatch, goToPreviousMatch]);
+  }, [isVisible, keyboardShortcutsEnabled, searchVisible, searchMatches, goToNextMatch, goToPreviousMatch]);
 
   const handleClearLogs = async () => {
     try {

--- a/frontend/src/components/settings/catalog.tsx
+++ b/frontend/src/components/settings/catalog.tsx
@@ -92,9 +92,9 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategoryDefinition[] = [
   {
     id: 'shortcuts',
     label: 'Shortcuts',
-    description: 'Terminal snippet hotkeys.',
+    description: 'Application and terminal snippet hotkeys.',
     icon: Keyboard,
-    settingIds: ['terminal-shortcuts'],
+    settingIds: ['keyboard-shortcuts', 'command-palette-shortcut', 'terminal-shortcuts'],
     aliases: ['hotkeys', 'keyboard', 'snippets'],
   },
   {

--- a/frontend/src/components/settings/categories/ShortcutsSettings.tsx
+++ b/frontend/src/components/settings/categories/ShortcutsSettings.tsx
@@ -4,6 +4,7 @@ import { Button, IconButton } from '../../ui/Button';
 import { Input, Textarea } from '../../ui/Input';
 import { SettingsSection } from '../../ui/SettingsSection';
 import { SettingRow, SettingsPage } from '../SettingRow';
+import { ImmediateToggle } from '../SettingsControls';
 import type { SettingsPersistence } from '../useSettingsPersistence';
 import type { TerminalShortcut } from '../../../types/config';
 import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
@@ -11,9 +12,10 @@ import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
 interface ShortcutsSettingsProps {
   persistence: SettingsPersistence;
   onDirtyChange: (dirty: boolean) => void;
+  onShowKeyboardShortcuts: () => void;
 }
 
-export function ShortcutsSettings({ persistence, onDirtyChange }: ShortcutsSettingsProps) {
+export function ShortcutsSettings({ persistence, onDirtyChange, onShowKeyboardShortcuts }: ShortcutsSettingsProps) {
   const config = persistence.config!;
   const persistedShortcuts = config.terminalShortcuts ?? [];
   const persistedKey = JSON.stringify(persistedShortcuts);
@@ -46,7 +48,40 @@ export function ShortcutsSettings({ persistence, onDirtyChange }: ShortcutsSetti
   };
 
   return (
-    <SettingsPage title="Shortcuts" description="Bind application-wide Ctrl/Cmd+Alt+letter shortcuts to terminal snippets.">
+    <SettingsPage title="Shortcuts" description="Control Pane keyboard shortcuts and terminal snippet hotkeys.">
+      <SettingsSection title="Application shortcuts">
+        <SettingRow
+          settingId="keyboard-shortcuts"
+          label="Enable Pane keyboard shortcuts"
+          description="When disabled, Pane won't intercept keyboard shortcuts, allowing them to pass through to terminals and embedded apps, except for the Command Palette option below."
+          saveState={persistence.saveStates['keyboard-shortcuts']}
+        >
+          <ImmediateToggle
+            label="Enable Pane keyboard shortcuts"
+            value={config.keyboardShortcutsEnabled !== false}
+            onSave={(value) => persistence.saveConfig('keyboard-shortcuts', { keyboardShortcutsEnabled: value })}
+          />
+        </SettingRow>
+        <SettingRow
+          settingId="command-palette-shortcut"
+          label="Keep Command Palette shortcut enabled"
+          description="Keep Ctrl/Cmd+Shift+P available when other Pane keyboard shortcuts are disabled."
+          saveState={persistence.saveStates['command-palette-shortcut']}
+        >
+          <ImmediateToggle
+            label="Keep Command Palette shortcut enabled"
+            value={config.commandPaletteShortcutEnabled !== false}
+            onSave={(value) => persistence.saveConfig('command-palette-shortcut', { commandPaletteShortcutEnabled: value })}
+          />
+        </SettingRow>
+        <button
+          type="button"
+          className="text-sm font-medium text-interactive underline underline-offset-4 hover:text-interactive-hover"
+          onClick={onShowKeyboardShortcuts}
+        >
+          View all Pane keyboard shortcuts
+        </button>
+      </SettingsSection>
       <SettingsSection title="Terminal snippets">
         <SettingRow
           settingId="terminal-shortcuts"

--- a/frontend/src/components/settings/categories/ShortcutsSettings.tsx
+++ b/frontend/src/components/settings/categories/ShortcutsSettings.tsx
@@ -53,7 +53,7 @@ export function ShortcutsSettings({ persistence, onDirtyChange, onShowKeyboardSh
         <SettingRow
           settingId="keyboard-shortcuts"
           label="Enable Pane keyboard shortcuts"
-          description="When disabled, Pane won't intercept keyboard shortcuts, allowing them to pass through to terminals and embedded apps, except for the Command Palette option below."
+          description="When disabled, Pane shortcuts won't work, but native terminal and embedded app shortcuts will. The Command Palette shortcut can remain enabled below."
           saveState={persistence.saveStates['keyboard-shortcuts']}
         >
           <ImmediateToggle

--- a/frontend/src/hooks/useAIInputPanel.ts
+++ b/frontend/src/hooks/useAIInputPanel.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect, KeyboardEvent } from 'react';
 import type { CodexInputOptions } from '../../../shared/types/models';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../stores/configStore';
 
 export interface AttachedImage {
   id: string;
@@ -91,6 +92,7 @@ export const buildMessageWithAttachments = (
 
 export const useAIInputPanel = (options: UseAIInputPanelOptions) => {
   const { onSendMessage, onCancel, disabled } = options;
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
   
   const [input, setInput] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -249,11 +251,11 @@ export const useAIInputPanel = (options: UseAIInputPanelOptions) => {
     }
     
     // Handle submit on Enter with modifier (Cmd/Ctrl+Enter)
-    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    if (keyboardShortcutsEnabled && e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       await handleSubmit();
     }
-  }, [onCancel, handleSubmit]);
+  }, [keyboardShortcutsEnabled, onCancel, handleSubmit]);
 
   const adjustTextareaHeight = useCallback(() => {
     const textarea = textareaRef.current;

--- a/frontend/src/hooks/useShortcutHintsOverlay.ts
+++ b/frontend/src/hooks/useShortcutHintsOverlay.ts
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../stores/configStore';
 
 const HOLD_DELAY_MS = 300;
 
 export function useShortcutHintsOverlay(): { isVisible: boolean } {
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
   const [isVisible, setIsVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isShowingRef = useRef(false);
@@ -19,6 +21,11 @@ export function useShortcutHintsOverlay(): { isVisible: boolean } {
   }, []);
 
   useEffect(() => {
+    if (!keyboardShortcutsEnabled) {
+      cancel();
+      return;
+    }
+
     const isModifierKey = (key: string) =>
       key === 'Meta' || key === 'Control' || key === 'Alt';
 
@@ -63,7 +70,7 @@ export function useShortcutHintsOverlay(): { isVisible: boolean } {
       window.removeEventListener('blur', handleBlur);
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [cancel]);
+  }, [cancel, keyboardShortcutsEnabled]);
 
   return { isVisible };
 }

--- a/frontend/src/stores/configStore.ts
+++ b/frontend/src/stores/configStore.ts
@@ -10,6 +10,17 @@ interface ConfigStore {
   updateConfig: (updates: UpdateConfigRequest) => Promise<AppConfig>;
 }
 
+export function areKeyboardShortcutsEnabled(config: AppConfig | null): boolean {
+  return config !== null && config.keyboardShortcutsEnabled !== false;
+}
+
+export function isCommandPaletteShortcutEnabled(config: AppConfig | null): boolean {
+  return config !== null && (
+    config.keyboardShortcutsEnabled !== false
+    || config.commandPaletteShortcutEnabled !== false
+  );
+}
+
 export const useConfigStore = create<ConfigStore>((set, get) => ({
   config: null,
   isLoading: false,

--- a/frontend/src/stores/hotkeyStore.test.ts
+++ b/frontend/src/stores/hotkeyStore.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { areKeyboardShortcutsEnabled, isCommandPaletteShortcutEnabled, useConfigStore } from './configStore';
+import { useHotkeyStore } from './hotkeyStore';
+
+describe('hotkeyStore keyboard shortcut preference', () => {
+  let keydownListener: ((event: KeyboardEvent) => void) | undefined;
+
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      addEventListener: (type: string, listener: (event: KeyboardEvent) => void) => {
+        if (type === 'keydown') keydownListener = listener;
+      },
+      removeEventListener: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    useHotkeyStore.getState().unregister('test-shortcut');
+    useHotkeyStore.getState().unregister('open-command-palette');
+    useConfigStore.setState({ config: null });
+    vi.unstubAllGlobals();
+  });
+
+  it('does not execute or prevent disabled Pane shortcuts', () => {
+    const action = vi.fn();
+    const preventDefault = vi.fn();
+    useConfigStore.setState({ config: { keyboardShortcutsEnabled: false } });
+    useHotkeyStore.getState().register({
+      id: 'test-shortcut',
+      label: 'Test shortcut',
+      keys: 'mod+w',
+      category: 'tabs',
+      action,
+    });
+
+    keydownListener?.({
+      key: 'w',
+      code: 'KeyW',
+      ctrlKey: true,
+      metaKey: false,
+      altKey: false,
+      shiftKey: false,
+      target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
+      getModifierState: () => false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(action).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('waits for config while preserving legacy enabled behavior', () => {
+    expect(areKeyboardShortcutsEnabled(null)).toBe(false);
+    expect(areKeyboardShortcutsEnabled({})).toBe(true);
+    expect(isCommandPaletteShortcutEnabled(null)).toBe(false);
+    expect(isCommandPaletteShortcutEnabled({ keyboardShortcutsEnabled: false })).toBe(true);
+  });
+
+  it('allows only the Command Palette shortcut when configured as an exception', () => {
+    const paletteAction = vi.fn();
+    const preventDefault = vi.fn();
+    useConfigStore.setState({ config: { keyboardShortcutsEnabled: false } });
+    useHotkeyStore.getState().register({
+      id: 'open-command-palette',
+      label: 'Open Command Palette',
+      keys: 'mod+shift+p',
+      category: 'navigation',
+      action: paletteAction,
+    });
+
+    keydownListener?.({
+      key: 'P',
+      code: 'KeyP',
+      ctrlKey: true,
+      metaKey: false,
+      altKey: false,
+      shiftKey: true,
+      target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
+      getModifierState: () => false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(paletteAction).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+
+    useConfigStore.setState({
+      config: {
+        keyboardShortcutsEnabled: false,
+        commandPaletteShortcutEnabled: false,
+      },
+    });
+    keydownListener?.({
+      key: 'P',
+      code: 'KeyP',
+      ctrlKey: true,
+      metaKey: false,
+      altKey: false,
+      shiftKey: true,
+      target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
+      getModifierState: () => false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(paletteAction).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -29,6 +29,7 @@
  * @module hotkeyStore
  */
 import { create } from 'zustand';
+import { areKeyboardShortcutsEnabled, isCommandPaletteShortcutEnabled, useConfigStore } from './configStore';
 
 export interface HotkeyDefinition {
   /** Unique identifier, e.g. 'open-prompt-history' */
@@ -154,6 +155,11 @@ let lookupIndex: Map<string, string> = new Map(); // normalized keys → hotkey 
 export function isHotkeyEnabledForEvent(e: KeyboardEvent): boolean {
   const hotkeyId = lookupIndex.get(normalizeKeyEvent(e));
   if (!hotkeyId) return false;
+
+  const config = useConfigStore.getState().config;
+  if (!areKeyboardShortcutsEnabled(config)) {
+    if (hotkeyId !== 'open-command-palette' || !isCommandPaletteShortcutEnabled(config)) return false;
+  }
 
   const def = useHotkeyStore.getState().hotkeys.get(hotkeyId);
   if (!def) return false;

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -134,6 +134,10 @@ export interface AppConfig {
   customCommands?: CustomCommand[];
   // Terminal shortcuts — hotkey-triggered clipboard paste snippets
   terminalShortcuts?: TerminalShortcut[];
+  // Whether Pane intercepts application keyboard shortcuts
+  keyboardShortcutsEnabled?: boolean;
+  // Whether the Command Palette shortcut remains active when other shortcuts are disabled
+  commandPaletteShortcutEnabled?: boolean;
   // Worktree file sync — files/dirs to copy from main repo into new worktrees
   worktreeFileSync?: WorktreeFileSyncEntry[];
   // Preferred shell for Windows terminals
@@ -184,6 +188,8 @@ export interface UpdateConfigRequest {
   analytics?: AnalyticsConfig;
   customCommands?: CustomCommand[];
   terminalShortcuts?: TerminalShortcut[];
+  keyboardShortcutsEnabled?: boolean;
+  commandPaletteShortcutEnabled?: boolean;
   worktreeFileSync?: WorktreeFileSyncEntry[];
   preferredShell?: PreferredShell;
   terminalPowerMode?: PreferredTerminalPowerMode;

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -48,6 +48,8 @@ export type SettingsSettingId =
   | 'remote-existing-profile'
   | 'cloud-workspace'
   | 'voice-transcription'
+  | 'keyboard-shortcuts'
+  | 'command-palette-shortcut'
   | 'terminal-shortcuts'
   | 'analytics'
   | 'verbose-logging'

--- a/frontend/src/utils/terminalKeyHandling.test.ts
+++ b/frontend/src/utils/terminalKeyHandling.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   resolveTerminalKeyHandling,
+  shouldOpenTerminalSearch,
   TERMINAL_MULTILINE_NEWLINE_SEQUENCE,
   type TerminalKeyLike,
 } from './terminalKeyHandling';
@@ -16,14 +17,27 @@ const key = (overrides: Partial<TerminalKeyLike>): TerminalKeyLike => ({
   ...overrides,
 });
 
-const tui = (overrides: Partial<{ isTuiActive: boolean; isCliPanel: boolean; isMac: boolean }> = {}) => ({
+const tui = (overrides: Partial<{
+  isTuiActive: boolean;
+  isCliPanel: boolean;
+  isMac: boolean;
+  keyboardShortcutsEnabled: boolean;
+}> = {}) => ({
   isTuiActive: true,
   isCliPanel: true,
   isMac: false,
+  keyboardShortcutsEnabled: true,
   ...overrides,
 });
 
 describe('resolveTerminalKeyHandling', () => {
+  it('passes keys through when Pane keyboard shortcuts are disabled', () => {
+    expect(resolveTerminalKeyHandling(
+      key({ key: 'w', code: 'KeyW', ctrlKey: true }),
+      tui({ keyboardShortcutsEnabled: false }),
+    )).toEqual({ action: 'pass-through' });
+  });
+
   it('sends the multiline sequence for Shift+Enter outside TUI mode', () => {
     expect(resolveTerminalKeyHandling(
       key({ key: 'Enter', shiftKey: true }),
@@ -152,5 +166,13 @@ describe('resolveTerminalKeyHandling', () => {
       }),
       tui(),
     )).toEqual({ action: 'pass-through' });
+  });
+});
+
+describe('shouldOpenTerminalSearch', () => {
+  it('only opens search when Pane keyboard shortcuts are enabled', () => {
+    const event = key({ key: 'f', code: 'KeyF', ctrlKey: true });
+    expect(shouldOpenTerminalSearch(event, true)).toBe(true);
+    expect(shouldOpenTerminalSearch(event, false)).toBe(false);
   });
 });

--- a/frontend/src/utils/terminalKeyHandling.ts
+++ b/frontend/src/utils/terminalKeyHandling.ts
@@ -11,6 +11,7 @@ export interface TerminalKeyHandlingState {
   isTuiActive: boolean;
   isCliPanel: boolean;
   isMac: boolean;
+  keyboardShortcutsEnabled: boolean;
 }
 
 export interface TerminalKeyLike {
@@ -21,6 +22,15 @@ export interface TerminalKeyLike {
   metaKey: boolean;
   altKey: boolean;
   getModifierState: (key: string) => boolean;
+}
+
+export function shouldOpenTerminalSearch(
+  event: Pick<TerminalKeyLike, 'ctrlKey' | 'metaKey' | 'key'>,
+  keyboardShortcutsEnabled: boolean,
+): boolean {
+  return keyboardShortcutsEnabled
+    && (event.ctrlKey || event.metaKey)
+    && event.key.toLowerCase() === 'f';
 }
 
 function isPaneNavigationShortcut(
@@ -62,6 +72,8 @@ export function resolveTerminalKeyHandling(
   event: TerminalKeyLike,
   state: TerminalKeyHandlingState,
 ): TerminalKeyHandlingDecision {
+  if (!state.keyboardShortcutsEnabled) return { action: 'pass-through' };
+
   const ctrlOrMeta = event.ctrlKey || event.metaKey;
   const shiftEnter = event.shiftKey && !ctrlOrMeta && event.key === 'Enter';
 

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -63,6 +63,7 @@ import * as path from 'path';
 import * as os from 'os';
 import type { SessionManager } from './services/sessionManager';
 import type { ConfigManager } from './services/configManager';
+import { areKeyboardShortcutsEnabled, shouldForwardCommandPaletteShortcut } from './utils/keyboardShortcuts';
 import type { WorktreeManager } from './services/worktreeManager';
 import type { GitStatusManager } from './services/gitStatusManager';
 import type { DatabaseService } from './database/database';
@@ -407,6 +408,11 @@ async function createWindow() {
 
       const key = input.key.toLowerCase();
       const code = input.code;
+      const config = configManager.getConfig();
+      if (
+        !areKeyboardShortcutsEnabled(config)
+        && !shouldForwardCommandPaletteShortcut(config, input)
+      ) return;
 
       // Skip AltGr: on Windows/Linux international layouts, AltGr reports
       // control+alt simultaneously. We detect this as control+alt without
@@ -530,6 +536,7 @@ async function createWindow() {
   // can use it to close tabs. We intercept at before-input-event and re-emit
   // the key as a DOM keydown via IPC so the renderer's hotkey system sees it.
   mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (!areKeyboardShortcutsEnabled(configManager.getConfig())) return;
     if ((input.control || input.meta) && input.key.toLowerCase() === 'w' && input.type === 'keyDown') {
       event.preventDefault();
       mainWindow?.webContents.send('synthetic-keydown', {

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -81,6 +81,8 @@ export class ConfigManager extends EventEmitter {
         managedAgentsMd: true
       },
       remoteDaemon: createDefaultRemoteDaemonConfig(),
+      keyboardShortcutsEnabled: true,
+      commandPaletteShortcutEnabled: true,
       terminalShortcuts: [
         {
           id: 'default-root-cause',

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -133,6 +133,10 @@ export interface AppConfig {
   customCommands?: CustomCommand[];
   // Terminal shortcuts — hotkey-triggered clipboard paste snippets
   terminalShortcuts?: TerminalShortcut[];
+  // Whether Pane intercepts application keyboard shortcuts
+  keyboardShortcutsEnabled?: boolean;
+  // Whether the Command Palette shortcut remains active when other shortcuts are disabled
+  commandPaletteShortcutEnabled?: boolean;
   // Worktree file sync — files/dirs to copy from main repo into new worktrees
   worktreeFileSync?: WorktreeFileSyncEntry[];
   // Preferred shell for Windows terminals
@@ -203,6 +207,10 @@ export interface UpdateConfigRequest {
   customCommands?: CustomCommand[];
   // Terminal shortcuts — hotkey-triggered clipboard paste snippets
   terminalShortcuts?: TerminalShortcut[];
+  // Whether Pane intercepts application keyboard shortcuts
+  keyboardShortcutsEnabled?: boolean;
+  // Whether the Command Palette shortcut remains active when other shortcuts are disabled
+  commandPaletteShortcutEnabled?: boolean;
   // Worktree file sync — files/dirs to copy from main repo into new worktrees
   worktreeFileSync?: WorktreeFileSyncEntry[];
   // Preferred shell for Windows terminals

--- a/main/src/utils/keyboardShortcuts.test.ts
+++ b/main/src/utils/keyboardShortcuts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areKeyboardShortcutsEnabled,
+  isCommandPaletteShortcutEnabled,
+  shouldForwardCommandPaletteShortcut,
+} from './keyboardShortcuts';
+
+describe('areKeyboardShortcutsEnabled', () => {
+  it('defaults to enabled for existing configurations', () => {
+    expect(areKeyboardShortcutsEnabled({})).toBe(true);
+  });
+
+  it('honors explicit enabled and disabled values', () => {
+    expect(areKeyboardShortcutsEnabled({ keyboardShortcutsEnabled: true })).toBe(true);
+    expect(areKeyboardShortcutsEnabled({ keyboardShortcutsEnabled: false })).toBe(false);
+  });
+
+  it('keeps the Command Palette shortcut as an optional exception', () => {
+    expect(isCommandPaletteShortcutEnabled({ keyboardShortcutsEnabled: false })).toBe(true);
+    expect(isCommandPaletteShortcutEnabled({
+      keyboardShortcutsEnabled: false,
+      commandPaletteShortcutEnabled: false,
+    })).toBe(false);
+    expect(isCommandPaletteShortcutEnabled({
+      keyboardShortcutsEnabled: true,
+      commandPaletteShortcutEnabled: false,
+    })).toBe(true);
+  });
+
+  it('forwards only the exact Command Palette chord from embedded panels', () => {
+    const config = { keyboardShortcutsEnabled: false, commandPaletteShortcutEnabled: true };
+    expect(shouldForwardCommandPaletteShortcut(config, { shift: true, alt: false, code: 'KeyP' })).toBe(true);
+    expect(shouldForwardCommandPaletteShortcut(config, { shift: false, alt: false, code: 'KeyP' })).toBe(false);
+    expect(shouldForwardCommandPaletteShortcut(config, { shift: true, alt: true, code: 'KeyP' })).toBe(false);
+    expect(shouldForwardCommandPaletteShortcut(config, { shift: true, alt: false, code: 'KeyW' })).toBe(false);
+    expect(shouldForwardCommandPaletteShortcut(
+      { keyboardShortcutsEnabled: false, commandPaletteShortcutEnabled: false },
+      { shift: true, alt: false, code: 'KeyP' },
+    )).toBe(false);
+  });
+});

--- a/main/src/utils/keyboardShortcuts.ts
+++ b/main/src/utils/keyboardShortcuts.ts
@@ -1,0 +1,23 @@
+import type { AppConfig } from '../types/config';
+
+export function areKeyboardShortcutsEnabled(
+  config: Pick<AppConfig, 'keyboardShortcutsEnabled'>,
+): boolean {
+  return config.keyboardShortcutsEnabled !== false;
+}
+
+export function isCommandPaletteShortcutEnabled(
+  config: Pick<AppConfig, 'keyboardShortcutsEnabled' | 'commandPaletteShortcutEnabled'>,
+): boolean {
+  return areKeyboardShortcutsEnabled(config) || config.commandPaletteShortcutEnabled !== false;
+}
+
+export function shouldForwardCommandPaletteShortcut(
+  config: Pick<AppConfig, 'keyboardShortcutsEnabled' | 'commandPaletteShortcutEnabled'>,
+  input: { shift: boolean; alt: boolean; code: string },
+): boolean {
+  return isCommandPaletteShortcutEnabled(config)
+    && input.shift
+    && !input.alt
+    && input.code === 'KeyP';
+}

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -89,7 +89,7 @@ test.describe('Settings', () => {
     await page.keyboard.press('Control+Alt+/');
 
     await expect(page.getByRole('dialog', { name: 'Pane Settings' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Shortcuts' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Shortcuts', exact: true })).toBeVisible();
     await expect(page.locator('[data-setting-id="terminal-shortcuts"]')).toBeFocused();
   });
 
@@ -114,7 +114,7 @@ test.describe('Settings', () => {
     });
     await page.getByRole('button', { name: 'Shortcuts', exact: true }).click();
 
-    await expect(page.getByText("When disabled, Pane won't intercept keyboard shortcuts, allowing them to pass through to terminals and embedded apps, except for the Command Palette option below.")).toBeVisible();
+    await expect(page.getByText("When disabled, Pane shortcuts won't work, but native terminal and embedded app shortcuts will. The Command Palette shortcut can remain enabled below.")).toBeVisible();
     const paletteToggle = page.getByRole('switch', { name: 'Keep Command Palette shortcut enabled' });
     await expect(paletteToggle).toHaveAttribute('aria-checked', 'true');
     await paletteToggle.click();

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -93,6 +93,58 @@ test.describe('Settings', () => {
     await expect(page.locator('[data-setting-id="terminal-shortcuts"]')).toBeFocused();
   });
 
+  test('disables Pane keyboard shortcut interception from shortcut settings', async ({ page }) => {
+    await bootSettings(page);
+    await page.getByRole('button', { name: 'Shortcuts', exact: true }).click();
+
+    const toggle = page.getByRole('switch', { name: 'Enable Pane keyboard shortcuts' });
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await toggle.click();
+    await expect(page.getByText('Saved', { exact: true })).toBeVisible();
+
+    const updates = await page.evaluate(() => (
+      window as typeof window & { __paneTestElectronMock: SettingsMock }
+    ).__paneTestElectronMock.getConfigUpdates());
+    expect(updates).toContainEqual({ keyboardShortcutsEnabled: false });
+  });
+
+  test('configures the Command Palette exception and opens the shortcut reference', async ({ page }) => {
+    await bootSettings(page, {
+      initialConfig: { keyboardShortcutsEnabled: false, commandPaletteShortcutEnabled: true },
+    });
+    await page.getByRole('button', { name: 'Shortcuts', exact: true }).click();
+
+    await expect(page.getByText("When disabled, Pane won't intercept keyboard shortcuts, allowing them to pass through to terminals and embedded apps, except for the Command Palette option below.")).toBeVisible();
+    const paletteToggle = page.getByRole('switch', { name: 'Keep Command Palette shortcut enabled' });
+    await expect(paletteToggle).toHaveAttribute('aria-checked', 'true');
+    await paletteToggle.click();
+
+    const updates = await page.evaluate(() => (
+      window as typeof window & { __paneTestElectronMock: SettingsMock }
+    ).__paneTestElectronMock.getConfigUpdates());
+    expect(updates).toContainEqual({ commandPaletteShortcutEnabled: false });
+
+    await page.getByRole('button', { name: 'View all Pane keyboard shortcuts' }).click();
+    await expect(page.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toBeVisible();
+    await expect(page.getByText('Open Command Palette')).toBeVisible();
+  });
+
+  test('guards the shortcut reference when snippet edits are dirty', async ({ page }) => {
+    await bootSettings(page);
+    await page.getByRole('button', { name: 'Shortcuts', exact: true }).click();
+    await page.getByRole('button', { name: 'Add Shortcut' }).click();
+    await page.getByRole('button', { name: 'View all Pane keyboard shortcuts' }).click();
+
+    const confirm = page.getByRole('dialog', { name: 'Discard unsaved changes?' });
+    await expect(confirm).toBeVisible();
+    await confirm.getByRole('button', { name: 'Stay' }).click();
+    await expect(page.getByRole('dialog', { name: 'Pane Settings' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'View all Pane keyboard shortcuts' }).click();
+    await confirm.getByRole('button', { name: 'Discard Changes' }).click();
+    await expect(page.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toBeVisible();
+  });
+
   test('persists immediate config and database preferences through their owners', async ({ page }) => {
     await bootSettings(page, { initialConfig: { autoCheckUpdates: true } });
 


### PR DESCRIPTION
## Summary

- add a Settings > Shortcuts toggle for all Pane keyboard shortcut interception with clear terminal and embedded-app pass-through copy
- add an independent option to keep only the Command Palette shortcut active when other Pane shortcuts are disabled
- link Settings to the live in-app Pane keyboard shortcut reference, preserving the unsaved-edit confirmation flow
- gate renderer, terminal, editor, dialog, and embedded-browser shortcut paths on the live preferences
- preserve existing behavior by default and avoid interception while renderer config is loading

Closes #368

## Testing

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter frontend test` (116 tests)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter main exec vitest run` (397 tests)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm test -- tests/settings.spec.ts` (19 tests)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm lint`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm typecheck`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm build`