### PR TITLE
Fix pinned labels, diff stats, and local review

### DIFF
--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -43,7 +43,7 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
   // Detail panel state
   const [detailVisible, setDetailVisible] = useState(() => {
     const stored = localStorage.getItem('pane-project-detail-panel-visible');
-    return stored !== null ? stored === 'true' : true;
+    return stored !== null ? stored === 'true' : false;
   });
 
   // Persist detail panel visibility

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -58,38 +58,11 @@ import { Kbd } from './ui/Kbd';
 import { useErrorStore } from '../stores/errorStore';
 import ProjectSettings from './ProjectSettings';
 
-const REVIEW_UNAVAILABLE_REASON = 'Open a PR for this branch to review changes';
-
-function canSelectPanel(panel: ToolPanel | null | undefined, hasReviewPr: boolean): panel is ToolPanel {
-  return !!panel && (panel.type !== 'diff' || hasReviewPr);
-}
-
 function pickDefaultPanel(panelList: ToolPanel[], hasReviewPr: boolean): ToolPanel | undefined {
   return (hasReviewPr ? panelList.find(p => p.type === 'diff') : undefined)
     || panelList.find(p => p.type === 'explorer')
     || panelList.find(p => p.type !== 'diff')
     || panelList[0];
-}
-
-function sanitizeReviewActivePanels(
-  node: SessionPanelLayout['root'],
-  panelById: Map<string, ToolPanel>,
-  hasReviewPr: boolean
-): SessionPanelLayout['root'] {
-  if (hasReviewPr) return node;
-
-  if (node.type === 'group') {
-    const activePanel = node.activePanelId ? panelById.get(node.activePanelId) : undefined;
-    if (activePanel?.type !== 'diff') return node;
-
-    const fallback = node.panelIds
-      .map(id => panelById.get(id))
-      .find((panel): panel is ToolPanel => !!panel && panel.type !== 'diff');
-
-    return { ...node, activePanelId: fallback?.id ?? null };
-  }
-
-  return { ...node, children: node.children.map(child => sanitizeReviewActivePanels(child, panelById, hasReviewPr)) };
 }
 
 export const SessionView = memo(() => {
@@ -250,19 +223,21 @@ export const SessionView = memo(() => {
       // Always reload panels from database when switching sessions
       panelApi.loadPanelsForSession(sid).then(async loadedPanels => {
         devLog.debug('[SessionView] Loaded panels:', loadedPanels);
-        const hasReviewPr = !!activeSession.gitStatus?.prUrl;
+        const sessionState = useSessionStore.getState();
+        const loadedSession = sessionState.activeMainRepoSession?.id === sid
+          ? sessionState.activeMainRepoSession
+          : sessionState.sessions.find(session => session.id === sid);
+        const hasReviewPr = !!loadedSession?.gitStatus?.prUrl;
         const inFlight = (usePanelStore.getState().panels[sid] || []).filter(
           p => !preLoadIds.has(p.id) && !loadedPanels.some(lp => lp.id === p.id)
         );
         setPanels(sid, inFlight.length > 0 ? [...loadedPanels, ...inFlight] : loadedPanels);
 
-        // Pick default active: Review is only selectable once a PR is known.
+        // Preserve the existing startup preference without blocking Review.
         const fallback = pickDefaultPanel(loadedPanels, hasReviewPr);
 
         const activePanelResult = await panelApi.getActivePanel(sid);
-        const effectiveActivePanel = canSelectPanel(activePanelResult, hasReviewPr)
-          ? activePanelResult
-          : fallback;
+        const effectiveActivePanel = activePanelResult ?? fallback;
         const fallbackActiveId = effectiveActivePanel?.id ?? null;
 
         if (effectiveActivePanel) {
@@ -307,22 +282,16 @@ export const SessionView = memo(() => {
             fallbackActiveId,
           );
           const { layout } = reconcileLayout(base, liveIdsNow);
-          const panelById = new Map(nowPanels.map(panel => [panel.id, panel]));
-          const safeRoot = sanitizeReviewActivePanels(layout.root, panelById, hasReviewPr);
-          const safeLayout = safeRoot === layout.root ? layout : { ...layout, root: safeRoot };
-          setLayoutInStore(sid, safeLayout);
-          setFocusedGroupInStore(sid, safeLayout.focusedGroupId ?? primaryGroup(safeLayout.root).id);
+          setLayoutInStore(sid, layout);
+          setFocusedGroupInStore(sid, layout.focusedGroupId ?? primaryGroup(layout.root).id);
         } catch (err) {
           console.warn('[SessionView] Failed to load layout, creating default:', err);
           const layout = createSingleGroupLayout(
             sortedLive.map(p => p.id),
             fallbackActiveId,
           );
-          const panelById = new Map(loadedPanels.map(panel => [panel.id, panel]));
-          const safeRoot = sanitizeReviewActivePanels(layout.root, panelById, hasReviewPr);
-          const safeLayout = safeRoot === layout.root ? layout : { ...layout, root: safeRoot };
-          setLayoutInStore(sid, safeLayout);
-          setFocusedGroupInStore(sid, safeLayout.focusedGroupId ?? primaryGroup(safeLayout.root).id);
+          setLayoutInStore(sid, layout);
+          setFocusedGroupInStore(sid, layout.focusedGroupId ?? primaryGroup(layout.root).id);
         }
       });
     }
@@ -331,7 +300,7 @@ export const SessionView = memo(() => {
     return () => {
       flushLayoutPersist();
     };
-  }, [activeSession?.id, activeSession?.gitStatus?.prUrl, setPanels, setActivePanelInStore, setLayoutInStore, setFocusedGroupInStore, flushLayoutPersist]);
+  }, [activeSession?.id, setPanels, setActivePanelInStore, setLayoutInStore, setFocusedGroupInStore, flushLayoutPersist]);
   
   // Listen for panel updates from the backend
   useEffect(() => {
@@ -495,13 +464,10 @@ export const SessionView = memo(() => {
 
   const getPanelTabPresentation = useCallback<PanelTabPresentationResolver>((panel) => {
     if (panel.type !== 'diff') return undefined;
-    const hasReviewPr = !!activeSession?.gitStatus?.prUrl;
     return {
       title: 'Review',
-      disabled: !hasReviewPr,
-      disabledReason: hasReviewPr ? undefined : REVIEW_UNAVAILABLE_REASON,
     };
-  }, [activeSession?.gitStatus?.prUrl]);
+  }, []);
 
   // --- Drag & drop state ---
   const [draggedPanelId, setDraggedPanelId] = useState<string | null>(null);
@@ -553,7 +519,6 @@ export const SessionView = memo(() => {
   const handleGroupPanelSelect = useCallback(
     (groupId: string, panel: ToolPanel) => {
       if (!activeSession) return;
-      if (panel.type === 'diff' && !activeSession.gitStatus?.prUrl) return;
       const sid = activeSession.id;
       const currentLayout = usePanelStore.getState().layouts[sid];
       if (!currentLayout) return;
@@ -584,7 +549,6 @@ export const SessionView = memo(() => {
   const handlePanelSelect = useCallback(
     async (panel: ToolPanel) => {
       if (!activeSession) return;
-      if (panel.type === 'diff' && !activeSession.gitStatus?.prUrl) return;
 
       // Add to history when panel is selected
       addToHistory(activeSession.id, panel.id);
@@ -608,7 +572,6 @@ export const SessionView = memo(() => {
   const handleCommitClick = useCallback(
     async (commitHash: string) => {
       if (!activeSession || sessionPanels.length === 0) return;
-      if (!activeSession.gitStatus?.prUrl) return;
       const diffPanel = sessionPanels.find(p => p.type === 'diff');
       if (!diffPanel) return;
       // Store pending hash before dispatching — if the diff panel is not
@@ -1033,10 +996,6 @@ export const SessionView = memo(() => {
     const currentLayout = usePanelStore.getState().layouts[sid];
     if (currentLayout) {
       const group = findGroup(currentLayout.root, groupId);
-      const panel = group?.activePanelId
-        ? usePanelStore.getState().panels[sid]?.find(candidate => candidate.id === group.activePanelId)
-        : undefined;
-      if (panel?.type === 'diff' && !activeSession.gitStatus?.prUrl) return;
       if (group?.activePanelId) {
         setActivePanelInStore(sid, group.activePanelId);
         panelApi.setActivePanel(sid, group.activePanelId).catch(() => {});

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1345,7 +1345,7 @@ export const SessionView = memo(() => {
   // Detail panel state
   const [detailVisible, setDetailVisible] = useState(() => {
     const stored = localStorage.getItem('pane-detail-panel-visible');
-    return stored !== null ? stored === 'true' : true;
+    return stored !== null ? stored === 'true' : false;
   });
 
   // Persist detail panel visibility

--- a/frontend/src/components/panels/PanelGroupView.tsx
+++ b/frontend/src/components/panels/PanelGroupView.tsx
@@ -211,12 +211,13 @@ export const PanelGroupView: React.FC<PanelGroupViewProps> = React.memo(({
         </div>
       )}
 
-      {/* Panel content stack: only the active tab is displayed; terminals
-          stay mounted behind display:none so xterm never reflows */}
+      {/* Panel content stack: only the active tab is displayed. Terminals stay
+          mounted so xterm never reflows; Review stays mounted so navigation
+          does not discard the user's local diff state. */}
       <div className="flex-1 relative min-h-0 overflow-hidden bg-bg-editor">
         {orderedPanels.map(panel => {
           const isActiveTab = panel.id === group.activePanelId;
-          const keepAlive = panel.type === 'terminal';
+          const keepAlive = panel.type === 'terminal' || panel.type === 'diff';
           const panelTabNamespace = !multiGroup || panel.metadata?.permanent === true ? 'top' : group.id;
           if (!isActiveTab && !keepAlive) return null;
           return (

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -15,6 +15,15 @@ import { ClaudeIcon, OpenAIIcon, CLI_BRAND_ICONS, getCliBrandIcon } from '../ui/
 import { PanelTabStrip } from './PanelTabStrip';
 import type { WorktreeFileSyncEntry } from '../../../../shared/types/worktreeFileSync';
 
+const ADD_TOOL_MENU_WIDTH = 280;
+const ADD_TOOL_MENU_VIEWPORT_MARGIN = 8;
+const MAX_CUSTOM_COMMAND_LABEL_LENGTH = 18;
+
+function truncateCustomCommandLabel(label: string): string {
+  if (label.length <= MAX_CUSTOM_COMMAND_LABEL_LENGTH) return label;
+  return `${label.slice(0, MAX_CUSTOM_COMMAND_LABEL_LENGTH - 3)}...`;
+}
+
 // Build prompt for setting up intelligent dev command — adapts based on Worktree File Sync config
 export function buildSetupRunScriptPrompt(fileSyncEntries?: WorktreeFileSyncEntry[]): string {
   const nodeModulesEnabled = fileSyncEntries?.some(e => e.path === 'node_modules' && e.enabled) ?? true;
@@ -151,12 +160,24 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
     const updatePosition = () => {
       if (!dropdownRef.current) return;
       const rect = dropdownRef.current.getBoundingClientRect();
+      const width = Math.min(
+        ADD_TOOL_MENU_WIDTH,
+        window.innerWidth - (ADD_TOOL_MENU_VIEWPORT_MARGIN * 2),
+      );
+      const left = Math.max(
+        ADD_TOOL_MENU_VIEWPORT_MARGIN,
+        Math.min(
+          rect.left,
+          window.innerWidth - width - ADD_TOOL_MENU_VIEWPORT_MARGIN,
+        ),
+      );
       setDropdownStyle({
         position: 'fixed',
         top: rect.bottom + 4,
-        left: rect.left,
+        left,
         zIndex: 10000,
-        minWidth: 280,
+        width,
+        maxWidth: `calc(100vw - ${ADD_TOOL_MENU_VIEWPORT_MARGIN * 2}px)`,
       });
     };
 
@@ -549,32 +570,42 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
               {availablePanelTypes.includes('terminal') && customCommands.map((cmd, index) => {
                 const currentRefIndex = refIndex++;
                 const shortcutDisplay = hotkeyDisplay(`add-tool-custom-${index}`);
+                const displayName = truncateCustomCommandLabel(cmd.name);
                 return (
-                <div key={`custom-${index}`} role="none" className="flex items-center">
-                  <button
-                    ref={(el) => { dropdownItemsRef.current[currentRefIndex] = el; }}
-                    type="button"
-                    role="menuitem"
-                    className={menuItemClass}
-                    onClick={() => handleAddPanel('terminal', {
-                      initialCommand: cmd.command,
-                      title: cmd.name
-                    })}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Delete' || e.key === 'Backspace') {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        deleteCustomCommand(index);
-                      }
-                    }}
-                    title={`${cmd.name} (Delete/Backspace to remove)`}
+                <div key={`custom-${index}`} role="none" className="flex min-w-0 items-center">
+                  <Tooltip
+                    content={(
+                      <span className="block max-w-[min(32rem,calc(100vw-1rem))] whitespace-normal break-words">
+                        <span className="block">{cmd.command}</span>
+                        <span className="mt-1 block text-xs text-text-tertiary">Delete or Backspace to remove</span>
+                      </span>
+                    )}
+                    side="bottom"
                   >
-                    {getCliBrandIcon(cmd.command, 'w-4 h-4 flex-shrink-0 mt-0.5') || <TerminalSquare className="w-4 h-4 flex-shrink-0 mt-0.5" />}
-                    <span className="ml-2 flex-1 min-w-0">
-                      <span className="block truncate">{cmd.name}</span>
-                      {shortcutDisplay && <Kbd size="xs" variant="muted" className="mt-1 origin-left scale-[0.7]">{shortcutDisplay}</Kbd>}
-                    </span>
-                  </button>
+                    <button
+                      ref={(el) => { dropdownItemsRef.current[currentRefIndex] = el; }}
+                      type="button"
+                      role="menuitem"
+                      className={cn(menuItemClass, 'min-w-0 flex-1')}
+                      onClick={() => handleAddPanel('terminal', {
+                        initialCommand: cmd.command,
+                        title: cmd.name
+                      })}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Delete' || e.key === 'Backspace') {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          deleteCustomCommand(index);
+                        }
+                      }}
+                    >
+                      {getCliBrandIcon(cmd.command, 'w-4 h-4 flex-shrink-0 mt-0.5') || <TerminalSquare className="w-4 h-4 flex-shrink-0 mt-0.5" />}
+                      <span className="ml-2 min-w-0 flex-1">
+                        <span className="block truncate">{displayName}</span>
+                        {shortcutDisplay && <Kbd size="xs" variant="muted" className="mt-1 origin-left scale-[0.7]">{shortcutDisplay}</Kbd>}
+                      </span>
+                    </button>
+                  </Tooltip>
                   <button
                     type="button"
                     className="p-1 mr-2 rounded hover:bg-surface-hover text-text-muted hover:text-text-primary transition-colors flex-shrink-0"
@@ -680,22 +711,37 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
 
           {/* Detail panel toggle */}
           {onToggleDetailPanel && (
-            <Tooltip content={detailPanelToggleDisabled ? detailPanelToggleDisabledReason : (hotkeyDisplay('toggle-detail-panel') ? <Kbd>{hotkeyDisplay('toggle-detail-panel')}</Kbd> : undefined)} side="bottom">
+            <Tooltip
+              content={detailPanelToggleDisabled
+                ? detailPanelToggleDisabledReason
+                : (
+                  <span className="flex items-center gap-2">
+                    <span>{detailPanelVisible ? 'Hide details' : 'Show details'}</span>
+                    {hotkeyDisplay('toggle-detail-panel') && (
+                      <Kbd size="xs" variant="muted">{hotkeyDisplay('toggle-detail-panel')}</Kbd>
+                    )}
+                  </span>
+                )}
+              side="bottom"
+            >
               <button
+                type="button"
                 onClick={detailPanelToggleDisabled ? undefined : onToggleDetailPanel}
                 disabled={detailPanelToggleDisabled}
                 aria-disabled={detailPanelToggleDisabled}
+                aria-label={detailPanelToggleDisabled
+                  ? detailPanelToggleDisabledReason
+                  : detailPanelVisible ? 'Hide details' : 'Show details'}
                 className={cn(
-                  "inline-flex items-center justify-center h-[var(--panel-tab-height)] px-2.5 rounded transition-colors flex-shrink-0",
+                  "inline-flex items-center justify-center h-[var(--panel-tab-height)] w-[var(--panel-tab-height)] rounded-md transition-colors flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle",
                   detailPanelToggleDisabled
                     ? "text-text-muted cursor-not-allowed opacity-50"
                     : detailPanelVisible
-                    ? "text-text-primary bg-surface-hover"
+                    ? "text-text-primary bg-surface-hover hover:text-interactive"
                     : "text-text-tertiary hover:text-text-primary hover:bg-surface-hover"
                 )}
-                title={detailPanelToggleDisabled ? detailPanelToggleDisabledReason : detailPanelVisible ? "Hide detail panel" : "Show detail panel"}
               >
-                <PanelRight className="w-4 h-4" />
+                <PanelRight aria-hidden="true" className="w-4 h-4" />
               </button>
             </Tooltip>
           )}

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -117,6 +117,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
   const showDiffSkeleton = (diffLoading || commitDiffLoading) && combinedDiff === null;
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => { mountedRef.current = false; };
   }, []);
 
@@ -690,7 +691,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
                     ? historySource === 'remote'
                       ? `No commits ahead of ${mainBranch}`
                       : 'Origin remote not found; showing recent local commits'
-                    : 'No commits found for this session'}
+                    : 'No changes to review'}
                 </p>
                 {isMainRepo && historySource === 'remote' && (
                   <p className="text-sm text-text-tertiary">

--- a/frontend/src/components/panels/diff/DiffPanel.tsx
+++ b/frontend/src/components/panels/diff/DiffPanel.tsx
@@ -74,6 +74,8 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
       Boolean(reviewUrl),
     )
   ));
+  const [hasOpenedLocal, setHasOpenedLocal] = useState(reviewMode === 'local');
+  const [hasOpenedGithub, setHasOpenedGithub] = useState(reviewMode === 'github');
   const diffState = panel.state?.customState as DiffPanelState | undefined;
   const lastRefreshRef = useRef<number>(Date.now());
   const combinedDiffRef = useRef<CombinedDiffViewHandle>(null);
@@ -87,6 +89,14 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
   useEffect(() => {
     if (!reviewUrl) setReviewModeState('local');
   }, [reviewUrl]);
+
+  useEffect(() => {
+    if (reviewMode === 'local') {
+      setHasOpenedLocal(true);
+    } else if (reviewUrl) {
+      setHasOpenedGithub(true);
+    }
+  }, [reviewMode, reviewUrl]);
 
   useEffect(() => {
     if (consumeLocalReviewModeRequest(sessionId)) {
@@ -264,24 +274,39 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
       )}
 
       {/* Main diff view */}
-      <div className="flex-1 overflow-hidden">
-        {reviewMode === 'github' && reviewUrl ? (
-          <BrowserSurface
-            panelId={panel.id}
-            sessionId={sessionId}
-            url={reviewUrl}
-            isActive={isActive}
-            compact
-          />
-        ) : (
-          <CombinedDiffView
-            ref={combinedDiffRef}
-            sessionId={sessionId}
-            selectedExecutions={[]}
-            isGitOperationRunning={false}
-            isMainRepo={isMainRepo}
-            isVisible={isActive}
-          />
+      <div className="relative flex-1 overflow-hidden">
+        {hasOpenedGithub && reviewUrl && (
+          <div
+            className="absolute inset-0"
+            aria-hidden={reviewMode !== 'github'}
+            inert={reviewMode !== 'github' ? true : undefined}
+            style={{ display: reviewMode === 'github' ? 'block' : 'none' }}
+          >
+            <BrowserSurface
+              panelId={panel.id}
+              sessionId={sessionId}
+              url={reviewUrl}
+              isActive={isActive && reviewMode === 'github'}
+              compact
+            />
+          </div>
+        )}
+        {hasOpenedLocal && (
+          <div
+            className="absolute inset-0"
+            aria-hidden={reviewMode !== 'local'}
+            inert={reviewMode !== 'local' ? true : undefined}
+            style={{ display: reviewMode === 'local' ? 'block' : 'none' }}
+          >
+            <CombinedDiffView
+              ref={combinedDiffRef}
+              sessionId={sessionId}
+              selectedExecutions={[]}
+              isGitOperationRunning={false}
+              isMainRepo={isMainRepo}
+              isVisible={isActive && reviewMode === 'local'}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/components/panels/diff/DiffPanel.tsx
+++ b/frontend/src/components/panels/diff/DiffPanel.tsx
@@ -10,6 +10,7 @@ import BrowserSurface from '../browser/BrowserSurface';
 import {
   consumeLocalReviewModeRequest,
   getReviewDefaultMode,
+  resolveReviewMode,
   setReviewDefaultMode,
   subscribeReviewDefaultMode,
   subscribeLocalReviewModeRequest,
@@ -65,9 +66,13 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
 }) => {
   const sessionContext = useSession();
   const session = sessionContext?.session;
+  const reviewUrl = useMemo(() => buildGithubReviewUrl(session?.gitStatus?.prUrl), [session?.gitStatus?.prUrl]);
   const [isStale, setIsStale] = useState(false);
   const [reviewMode, setReviewModeState] = useState<ReviewMode>(() => (
-    consumeLocalReviewModeRequest(sessionId) ? 'local' : getReviewDefaultMode()
+    resolveReviewMode(
+      consumeLocalReviewModeRequest(sessionId) ? 'local' : getReviewDefaultMode(),
+      Boolean(reviewUrl),
+    )
   ));
   const diffState = panel.state?.customState as DiffPanelState | undefined;
   const lastRefreshRef = useRef<number>(Date.now());
@@ -75,9 +80,13 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
   // Track diff-relevant git state to avoid spurious refreshes on no-op status events
   const lastGitFingerprintRef = useRef<string | null>(null);
   const wasActiveRef = useRef(isActive);
-  const reviewUrl = useMemo(() => buildGithubReviewUrl(session?.gitStatus?.prUrl), [session?.gitStatus?.prUrl]);
+  useEffect(() => subscribeReviewDefaultMode((mode) => {
+    setReviewModeState(resolveReviewMode(mode, Boolean(reviewUrl)));
+  }), [reviewUrl]);
 
-  useEffect(() => subscribeReviewDefaultMode(setReviewModeState), []);
+  useEffect(() => {
+    if (!reviewUrl) setReviewModeState('local');
+  }, [reviewUrl]);
 
   useEffect(() => {
     if (consumeLocalReviewModeRequest(sessionId)) {
@@ -190,23 +199,11 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps -- panel.state/diffState intentionally excluded: they are written inside this effect via IPC and must not re-trigger it
   }, [isActive, isStale, panel.id, sessionId, reviewMode]);
 
-  if (!reviewUrl) {
-    return (
-      <div className="diff-panel h-full flex flex-col bg-bg-primary">
-        <div className="flex-1 flex items-center justify-center p-8 text-text-secondary">
-          <div className="max-w-sm text-center space-y-2">
-            <GitBranch className="w-8 h-8 mx-auto text-text-muted" />
-            <h2 className="text-sm font-medium text-text-primary">Review unavailable</h2>
-            <p className="text-xs text-text-tertiary">
-              Open a PR for this branch to review changes.
-            </p>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  const prLabel = session?.gitStatus?.prNumber ? `#${session.gitStatus.prNumber}` : 'Pull Request';
+  const prLabel = session?.gitStatus?.prNumber
+    ? `#${session.gitStatus.prNumber}`
+    : reviewUrl
+      ? 'Pull Request'
+      : 'Local changes';
 
   return (
     <div className="diff-panel h-full flex flex-col bg-bg-primary">
@@ -224,11 +221,15 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
           <button
             type="button"
             onClick={() => handleReviewModeChange('github')}
+            disabled={!reviewUrl}
+            title={reviewUrl ? 'Review pull request on GitHub' : 'No pull request yet'}
             className={cn(
               "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs transition-colors",
               reviewMode === 'github'
                 ? "bg-interactive text-text-on-interactive"
-                : "text-text-secondary hover:bg-surface-hover"
+                : reviewUrl
+                  ? "text-text-secondary hover:bg-surface-hover"
+                  : "text-text-muted cursor-not-allowed"
             )}
             aria-pressed={reviewMode === 'github'}
           >
@@ -264,7 +265,7 @@ export const DiffPanel: React.FC<DiffPanelProps> = ({
 
       {/* Main diff view */}
       <div className="flex-1 overflow-hidden">
-        {reviewMode === 'github' ? (
+        {reviewMode === 'github' && reviewUrl ? (
           <BrowserSurface
             panelId={panel.id}
             sessionId={sessionId}

--- a/frontend/src/components/panels/diff/reviewModePreference.test.ts
+++ b/frontend/src/components/panels/diff/reviewModePreference.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { resolveReviewMode } from './reviewModePreference';
+
+describe('resolveReviewMode', () => {
+  it('uses local review when no pull request exists', () => {
+    expect(resolveReviewMode('github', false)).toBe('local');
+    expect(resolveReviewMode('local', false)).toBe('local');
+  });
+
+  it('preserves the preferred mode when a pull request exists', () => {
+    expect(resolveReviewMode('github', true)).toBe('github');
+    expect(resolveReviewMode('local', true)).toBe('local');
+  });
+});

--- a/frontend/src/components/panels/diff/reviewModePreference.ts
+++ b/frontend/src/components/panels/diff/reviewModePreference.ts
@@ -15,6 +15,10 @@ export function getReviewDefaultMode(): ReviewMode {
   return isReviewMode(stored) ? stored : 'github';
 }
 
+export function resolveReviewMode(preferredMode: ReviewMode, hasPullRequest: boolean): ReviewMode {
+  return hasPullRequest ? preferredMode : 'local';
+}
+
 export function setReviewDefaultMode(mode: ReviewMode): void {
   window.localStorage.setItem(REVIEW_MODE_STORAGE_KEY, mode);
   window.dispatchEvent(new CustomEvent(REVIEW_MODE_CHANGED_EVENT, { detail: { mode } }));

--- a/frontend/src/utils/sessionOrdering.test.ts
+++ b/frontend/src/utils/sessionOrdering.test.ts
@@ -38,6 +38,20 @@ function project(id: number, name = `Project ${id}`): Project {
 }
 
 describe('sessionOrdering', () => {
+  it('formats pinned labels with a short repository name and no owner prefix', () => {
+    const projects = new Map([
+      [1, project(1, 'bloomapi/bloom-mono')],
+      [2, project(2, 'dcouple\\doozy')],
+    ]);
+    const pinned = getPinnedSessions([
+      session({ id: 'bloom', name: 'do-tm-560', projectId: 1, isFavorite: true }),
+      session({ id: 'doozy', name: 'improve fan out', projectId: 2, isFavorite: true }),
+    ], projects);
+
+    expect(pinned.find(item => item.session.id === 'bloom')?.label).toBe('bloom-.../do-tm-560');
+    expect(pinned.find(item => item.session.id === 'doozy')?.label).toBe('doozy/improve fan out');
+  });
+
   it('orders sessions by displayOrder in the default ascending view', () => {
     const grouped = groupSessionsByProject([
       session({ id: 'newer', projectId: 1, displayOrder: 2, createdAt: '2026-01-03T00:00:00.000Z' }),

--- a/frontend/src/utils/sessionOrdering.ts
+++ b/frontend/src/utils/sessionOrdering.ts
@@ -7,6 +7,17 @@ export interface PinnedSession {
   label: string;
 }
 
+const PINNED_REPOSITORY_NAME_LENGTH = 6;
+
+function getPinnedSessionLabel(projectName: string | undefined, sessionName: string | undefined): string {
+  const repositoryName = projectName?.split(/[\\/]/).filter(Boolean).pop();
+  const shortRepositoryName = repositoryName && repositoryName.length > PINNED_REPOSITORY_NAME_LENGTH
+    ? `${repositoryName.slice(0, PINNED_REPOSITORY_NAME_LENGTH)}...`
+    : repositoryName || 'Unknown';
+
+  return `${shortRepositoryName}/${sessionName || 'Untitled'}`;
+}
+
 function hasDisplayOrder(session: Session): boolean {
   return typeof session.displayOrder === 'number' && Number.isFinite(session.displayOrder);
 }
@@ -97,7 +108,7 @@ export function getPinnedSessions(
         : session.projectId != null ? projectById.get(session.projectId)?.name : undefined;
       return {
         session,
-        label: `${projectName || 'Unknown'}/${session.name || 'Untitled'}`,
+        label: getPinnedSessionLabel(projectName, session.name),
       };
     })
     .sort((a, b) => {

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -9,6 +9,25 @@ function commandRunner(
 }
 
 describe('WorktreeManager.getSessionComparisonBranch', () => {
+  it('uses the recorded fork commit before a remote default branch for a legacy worktree', async () => {
+    const runner = commandRunner(async command => {
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const comparisonBranch = await manager.getSessionComparisonBranch(
+      {
+        baseBranch: 'HEAD',
+        baseCommit: 'pane-start-commit',
+        worktreePath: '/repo/worktrees/pane',
+      },
+      { project: { path: '/repo' }, commandRunner: runner },
+    );
+
+    expect(comparisonBranch).toBe('pane-start-commit');
+    expect(runner.execAsync).not.toHaveBeenCalled();
+  });
+
   it('uses the remote default branch for a legacy worktree session', async () => {
     const runner = commandRunner(async command => {
       if (command.includes('symbolic-ref')) {
@@ -64,5 +83,82 @@ describe('WorktreeManager.getSessionComparisonBranch', () => {
     );
 
     expect(comparisonBranch).toBe('origin/feature/local');
+  });
+});
+
+describe('WorktreeManager.getSessionLocalBaseBranch', () => {
+  it('keeps legacy write operations on the project checkout branch', async () => {
+    const runner = commandRunner(async (command, cwd) => {
+      if (command === 'git branch --show-current' && cwd === '/repo') {
+        return { stdout: 'release\n', stderr: '' };
+      }
+      if (command === 'git remote' && cwd === '/repo') {
+        return { stdout: 'origin\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const localBaseBranch = await manager.getSessionLocalBaseBranch(
+      {
+        baseBranch: 'HEAD',
+        baseCommit: 'pane-start-commit',
+        worktreePath: '/repo/worktrees/pane',
+      },
+      { project: { path: '/repo' }, commandRunner: runner },
+    );
+
+    expect(localBaseBranch).toBe('release');
+    expect(runner.execAsync).not.toHaveBeenCalledWith(
+      expect.stringContaining('symbolic-ref'),
+      expect.any(String),
+    );
+  });
+
+  it('strips the remote from an explicitly selected write target', async () => {
+    const runner = commandRunner(async (command, cwd) => {
+      if (command === 'git branch --show-current' && cwd === '/repo/worktrees/pane') {
+        return { stdout: 'pane-branch\n', stderr: '' };
+      }
+      if (command === 'git remote' && cwd === '/repo') {
+        return { stdout: 'origin\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const localBaseBranch = await manager.getSessionLocalBaseBranch(
+      { baseBranch: 'origin/release', worktreePath: '/repo/worktrees/pane' },
+      { project: { path: '/repo' }, commandRunner: runner },
+    );
+
+    expect(localBaseBranch).toBe('release');
+  });
+
+  it('uses the project branch when an existing-branch pane stored its own branch as the base', async () => {
+    const runner = commandRunner(async (command, cwd) => {
+      if (command === 'git branch --show-current' && cwd === '/repo/worktrees/pane') {
+        return { stdout: 'pane-branch\n', stderr: '' };
+      }
+      if (command === 'git branch --show-current' && cwd === '/repo') {
+        return { stdout: 'release\n', stderr: '' };
+      }
+      if (command === 'git remote' && cwd === '/repo') {
+        return { stdout: 'origin\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const localBaseBranch = await manager.getSessionLocalBaseBranch(
+      {
+        baseBranch: 'pane-branch',
+        baseCommit: 'pane-start-commit',
+        worktreePath: '/repo/worktrees/pane',
+      },
+      { project: { path: '/repo' }, commandRunner: runner },
+    );
+
+    expect(localBaseBranch).toBe('release');
   });
 });

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CommandRunner } from '../../utils/commandRunner';
+import { WorktreeManager } from '../worktreeManager';
+
+function commandRunner(
+  execAsync: (command: string, cwd: string) => Promise<{ stdout: string; stderr: string }>,
+): CommandRunner {
+  return { execAsync: vi.fn(execAsync) } as CommandRunner;
+}
+
+describe('WorktreeManager.getSessionComparisonBranch', () => {
+  it('uses the remote default branch for a legacy worktree session', async () => {
+    const runner = commandRunner(async command => {
+      if (command.includes('symbolic-ref')) {
+        return { stdout: 'origin/main\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const comparisonBranch = await manager.getSessionComparisonBranch(
+      { baseBranch: 'HEAD', worktreePath: '/repo/worktrees/pane' },
+      { project: { path: '/repo' }, commandRunner: runner },
+    );
+
+    expect(comparisonBranch).toBe('origin/main');
+  });
+
+  it('falls back to the project branch when no remote default ref exists', async () => {
+    const runner = commandRunner(async (command, cwd) => {
+      if (command.includes('symbolic-ref')) {
+        throw new Error('No remote default');
+      }
+      if (command === 'git branch --show-current' && cwd === '/repo') {
+        return { stdout: 'feature/local\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const comparisonBranch = await manager.getSessionComparisonBranch(
+      { baseBranch: 'HEAD', worktreePath: '/repo/worktrees/pane' },
+      { project: { path: '/repo' }, commandRunner: runner },
+    );
+
+    expect(comparisonBranch).toBe('feature/local');
+  });
+
+  it('preserves current-branch origin comparison for a main-repo session', async () => {
+    const runner = commandRunner(async command => {
+      if (command === 'git branch --show-current') {
+        return { stdout: 'feature/local\n', stderr: '' };
+      }
+      if (command === 'git rev-parse --verify origin/feature/local') {
+        return { stdout: 'abc123\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const comparisonBranch = await manager.getSessionComparisonBranch(
+      { baseBranch: 'HEAD', isMainRepo: true, worktreePath: '/repo' },
+      { project: { path: '/repo' }, commandRunner: runner },
+    );
+
+    expect(comparisonBranch).toBe('origin/feature/local');
+  });
+});

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -516,13 +516,14 @@ export class WorktreeManager {
    *
    * Source of truth: session.baseBranch — the ref the user picked at creation.
    * For legacy worktree sessions where baseBranch is null/empty/the literal
-   * "HEAD", prefer the remote default branch. The project root may currently
-   * be on an unrelated feature branch, which would produce incorrect diffs.
+   * "HEAD", prefer the recorded fork commit, then the remote default branch.
+   * The project root may currently be on an unrelated feature branch, which
+   * would produce incorrect diffs.
    * Main-repo sessions preserve the current-branch origin fallback.
    *
-   * The returned ref is a raw branch name (`main`, `my-feature`) or remote
-   * ref (`origin/main`, `origin/staging`) — pass it directly to git diff /
-   * git log / git rev-list. DO NOT prepend `origin/`.
+   * The returned ref is a raw branch name (`main`, `my-feature`), remote ref
+   * (`origin/main`, `origin/staging`), or recorded commit SHA. Pass it directly
+   * to git diff / git log / git rev-list. DO NOT prepend `origin/`.
    *
    * Use this for READ operations (diff, log, rev-list, status). For WRITE
    * operations that need to `git checkout` the integration target (squash/
@@ -530,7 +531,7 @@ export class WorktreeManager {
    * remote ref like `origin/main` puts the project repo in detached HEAD.
    */
   async getSessionComparisonBranch(
-    session: { baseBranch?: string; isMainRepo?: boolean; worktreePath?: string },
+    session: { baseBranch?: string; baseCommit?: string; isMainRepo?: boolean; worktreePath?: string },
     ctx: { project: { path: string }; commandRunner: CommandRunner },
   ): Promise<string> {
     // Treat the literal "HEAD" placeholder as missing — createWorktree
@@ -560,6 +561,13 @@ export class WorktreeManager {
       } else {
         return session.baseBranch;
       }
+    }
+
+    // Legacy sessions still record the commit they started from. Prefer that
+    // immutable boundary over a branch ref that may be behind local commits
+    // which existed before Pane created the worktree.
+    if (!session.isMainRepo && session.baseCommit) {
+      return session.baseCommit;
     }
 
     if (!session.isMainRepo && session.worktreePath) {
@@ -607,10 +615,31 @@ export class WorktreeManager {
    * tracking branch from origin/<name> when one exists.
    */
   async getSessionLocalBaseBranch(
-    session: { baseBranch?: string; isMainRepo?: boolean; worktreePath?: string },
+    session: { baseBranch?: string; baseCommit?: string; isMainRepo?: boolean; worktreePath?: string },
     ctx: { project: { path: string }; commandRunner: CommandRunner },
   ): Promise<string> {
-    const ref = await this.getSessionComparisonBranch(session, ctx);
+    // Do not reuse the read fallback here: it may intentionally resolve to a
+    // remote ref or immutable commit. Writes must always target a local branch.
+    let ref = session.baseBranch && session.baseBranch !== 'HEAD'
+      ? session.baseBranch
+      : await this.getProjectMainBranch(ctx.project.path, ctx.commandRunner);
+
+    // Existing-branch panes can store their own checked-out branch as the base.
+    // Merging that branch into itself is invalid, so use the project checkout's
+    // integration branch just as we do for legacy HEAD sessions.
+    if (session.worktreePath && session.baseBranch && session.baseBranch !== 'HEAD') {
+      try {
+        const { stdout } = await ctx.commandRunner.execAsync(
+          'git branch --show-current',
+          session.worktreePath,
+        );
+        if (stdout.trim() === session.baseBranch) {
+          ref = await this.getProjectMainBranch(ctx.project.path, ctx.commandRunner);
+        }
+      } catch {
+        // If the worktree cannot be inspected, trust the explicitly stored base.
+      }
+    }
 
     // Strip any known remote prefix. Cross-check against `git remote` so we
     // don't mangle a local branch that legitimately has a slash in its name.

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -515,10 +515,10 @@ export class WorktreeManager {
    * Return the ref a session's diff/status should be compared against.
    *
    * Source of truth: session.baseBranch — the ref the user picked at creation.
-   * For legacy sessions where baseBranch is null/empty/the literal "HEAD"
-   * (createWorktree stores "HEAD" as the placeholder when no base was picked),
-   * falls back to today's behavior: project root current branch, with
-   * isMainRepo origin fallback.
+   * For legacy worktree sessions where baseBranch is null/empty/the literal
+   * "HEAD", prefer the remote default branch. The project root may currently
+   * be on an unrelated feature branch, which would produce incorrect diffs.
+   * Main-repo sessions preserve the current-branch origin fallback.
    *
    * The returned ref is a raw branch name (`main`, `my-feature`) or remote
    * ref (`origin/main`, `origin/staging`) — pass it directly to git diff /
@@ -559,6 +559,21 @@ export class WorktreeManager {
         }
       } else {
         return session.baseBranch;
+      }
+    }
+
+    if (!session.isMainRepo && session.worktreePath) {
+      try {
+        const { stdout } = await ctx.commandRunner.execAsync(
+          'git symbolic-ref --quiet --short refs/remotes/origin/HEAD',
+          session.worktreePath,
+        );
+        const remoteDefaultBranch = stdout.trim();
+        if (remoteDefaultBranch) {
+          return remoteDefaultBranch;
+        }
+      } catch {
+        // Fall through for repositories without an origin/HEAD symbolic ref.
       }
     }
 

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -26,6 +26,8 @@ type ElectronApiMockOptions = {
     pinnedSectionExpanded: boolean;
     repositoriesSectionExpanded: boolean;
   }>;
+  initialExecutions?: Array<Record<string, unknown>>;
+  initialCombinedDiff?: Record<string, unknown> | null;
   activeProjectId?: number | null;
   paneChatAgentChangeDelayMs?: number;
 };
@@ -248,6 +250,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         }
         if (prop === 'onRemoteDaemonResyncRequested') {
           return (callback: () => void) => subscribe('remote-daemon:resync-required', callback);
+        }
+        if (prop === 'onGitStatusUpdated') {
+          return (callback: (data: unknown) => void) => subscribe('git-status-updated', callback);
         }
         return () => unsubscribe;
       },
@@ -479,6 +484,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         getAllWithProjects: () => success(clone(mockSessions)),
         getArchivedWithProjects: () => success([]),
         getResumable: () => success([]),
+        getExecutions: () => success(clone(mockOptions.initialExecutions ?? [])),
+        getCombinedDiff: () => success(clone(mockOptions.initialCombinedDiff ?? null)),
       }),
       remoteDaemon: namespace({
         getConfig: () => success(clone(remoteDaemonConfig)),
@@ -751,6 +758,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         setPanels(panels: Array<Record<string, unknown>>) {
           mockPanels = clone(panels);
+        },
+        emitGitStatusUpdated(sessionId: string, gitStatus: Record<string, unknown>) {
+          emit('git-status-updated', { sessionId, gitStatus: clone(gitStatus) });
         },
         getSessionsReadCount() {
           return sessionsGetCount;

--- a/tests/review-availability.spec.ts
+++ b/tests/review-availability.spec.ts
@@ -115,15 +115,20 @@ const localCombinedDiff = {
 async function openSession(
   page: Page,
   gitStatus: ReviewGitStatus = baseGitStatus,
-  options: { withLocalChanges?: boolean } = { withLocalChanges: true },
+  options: {
+    withLocalChanges?: boolean;
+    initialPanels?: Array<Record<string, unknown>>;
+    initialConfig?: Record<string, unknown>;
+  } = { withLocalChanges: true },
 ): Promise<void> {
   await installElectronApiMock(page, {
     initialProjects: [project],
     initialSessions: [createSession(gitStatus)],
-    initialPanels: panels,
+    initialPanels: options.initialPanels ?? panels,
     initialExecutions: options.withLocalChanges === false ? [] : localExecutions,
     initialCombinedDiff: options.withLocalChanges === false ? null : localCombinedDiff,
     activeProjectId: project.id,
+    initialConfig: options.initialConfig,
   });
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
   await page.getByRole('button', { name: /^Expand repository Review fixture$/ }).click();
@@ -167,6 +172,79 @@ test('Pinned panes use the short repository and pane name', async ({ page }, tes
   await capture(page, testInfo, '00-pinned-pane-short-label.png');
 });
 
+test('New panes start with details hidden and explain the toggle on hover', async ({ page }, testInfo) => {
+  await openSession(page, baseGitStatus, {
+    initialPanels: [
+      ...panels,
+      {
+        id: 'review-logs',
+        sessionId: 'review-session',
+        type: 'logs',
+        title: 'Logs',
+        state: { isActive: false, hasBeenViewed: true, customState: { isRunning: false } },
+        metadata: { createdAt: new Date(0).toISOString(), lastActiveAt: new Date(0).toISOString(), position: 3 },
+      },
+    ],
+  });
+  await page.getByRole('tab', { name: 'Logs', exact: true }).click();
+
+  const detailPanel = page.locator('.pane-detail-panel-vertical');
+  const detailToggle = page.getByRole('button', { name: 'Show details', exact: true });
+  await expect(detailToggle).toBeVisible();
+  await expect(detailPanel).toHaveCSS('width', '0px');
+
+  await detailToggle.hover();
+  await expect(page.getByRole('tooltip')).toContainText('Show details');
+  const path = testInfo.outputPath('04-detail-panel-default-collapsed.png');
+  await page.screenshot({ path });
+  await testInfo.attach('04-detail-panel-default-collapsed.png', { path, contentType: 'image/png' });
+
+  await detailToggle.click();
+  await expect(page.getByRole('button', { name: 'Hide details', exact: true })).toBeVisible();
+  await expect(detailPanel).not.toHaveCSS('width', '0px');
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: /^Expand repository Review fixture$/ }).click();
+  await page.getByRole('button', { name: 'Review changes before PR', exact: true }).click();
+  await page.getByRole('tab', { name: 'Logs', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Hide details', exact: true })).toBeVisible();
+  await expect(page.locator('.pane-detail-panel-vertical')).not.toHaveCSS('width', '0px');
+});
+
+test('Add Tool keeps long custom commands inside a narrow viewport', async ({ page }, testInfo) => {
+  const commandName = 'pnpm run extraordinarily-long-development-command';
+  const fullCommand = `${commandName} --with-options`;
+  const expectedLabel = `${commandName.slice(0, 15)}...`;
+
+  await page.setViewportSize({ width: 420, height: 720 });
+  await openSession(page, baseGitStatus, {
+    initialConfig: {
+      customCommands: [{ name: commandName, command: fullCommand }],
+    },
+  });
+
+  await page.getByRole('button', { name: 'Add Tool', exact: true }).click();
+  const menu = page.getByRole('menu');
+  const commandLabel = menu.getByText(expectedLabel, { exact: true });
+  const commandButton = menu.getByRole('menuitem', { name: expectedLabel, exact: false });
+  await expect(menu).toBeVisible();
+  await expect(commandLabel).toBeVisible();
+  await expect(commandLabel).toHaveText(expectedLabel);
+
+  const menuBounds = await menu.boundingBox();
+  expect(menuBounds).not.toBeNull();
+  expect(menuBounds!.x).toBeGreaterThanOrEqual(8);
+  expect(menuBounds!.x + menuBounds!.width).toBeLessThanOrEqual(412);
+  expect(await commandLabel.evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+
+  await commandButton.hover();
+  await expect(page.getByRole('tooltip')).toContainText(fullCommand);
+  const path = testInfo.outputPath('05-add-tool-responsive-command.png');
+  await page.screenshot({ path });
+  await testInfo.attach('05-add-tool-responsive-command.png', { path, contentType: 'image/png' });
+});
+
 test('Review stays local until a newly discovered pull request is explicitly opened', async ({ page }, testInfo) => {
   await openSession(page);
 
@@ -187,8 +265,9 @@ test('Review stays local until a newly discovered pull request is explicitly ope
   await expect(localMode).toHaveAttribute('aria-pressed', 'true');
   await expect(localMode).toHaveClass(/bg-interactive/);
   await expect(page.getByText('Local changes', { exact: true })).toBeVisible();
-  await expect(page.locator('.combined-diff-view').getByText('+8', { exact: true })).toBeVisible();
-  await expect(page.locator('.combined-diff-view').getByText('-3', { exact: true })).toBeVisible();
+  const diffSummary = page.locator('.combined-diff-view').getByText('Changes', { exact: true }).locator('..');
+  await expect(diffSummary.getByText('+8', { exact: true })).toBeVisible();
+  await expect(diffSummary.getByText('-3', { exact: true })).toBeVisible();
 
   const reviewFile = page.getByRole('button', { name: 'Expand diff for src/review.ts', exact: true });
   await expect(reviewFile).toHaveAttribute('aria-expanded', 'false');

--- a/tests/review-availability.spec.ts
+++ b/tests/review-availability.spec.ts
@@ -1,0 +1,242 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+const project = {
+  id: 374,
+  name: 'Review fixture',
+  path: '/tmp/review-fixture',
+  active: true,
+  created_at: new Date(0).toISOString(),
+  updated_at: new Date(0).toISOString(),
+};
+
+const baseGitStatus = {
+  state: 'clean',
+  ahead: 1,
+  behind: 0,
+  hasUncommittedChanges: false,
+  hasUntrackedFiles: false,
+  filesChanged: 1,
+  additions: 8,
+  deletions: 3,
+  totalCommits: 1,
+};
+
+type ReviewGitStatus = typeof baseGitStatus & {
+  prNumber?: number;
+  prTitle?: string;
+  prUrl?: string;
+};
+
+function createSession(gitStatus: ReviewGitStatus = baseGitStatus) {
+  return {
+    id: 'review-session',
+    name: 'Review changes before PR',
+    worktreePath: '/tmp/review-fixture/review-session',
+    prompt: 'Verify local and GitHub review modes',
+    status: 'stopped',
+    createdAt: new Date(0).toISOString(),
+    lastActivity: new Date(0).toISOString(),
+    output: [],
+    jsonMessages: [],
+    isRunning: false,
+    permissionMode: 'ignore',
+    projectId: project.id,
+    displayOrder: 0,
+    isFavorite: false,
+    toolType: 'none',
+    archived: false,
+    gitStatus,
+  };
+}
+
+const panels = [
+  {
+    id: 'review-terminal',
+    sessionId: 'review-session',
+    type: 'terminal',
+    title: 'Terminal',
+    state: { isActive: false, hasBeenViewed: true, customState: { isInitialized: false } },
+    metadata: { createdAt: new Date(0).toISOString(), lastActiveAt: new Date(0).toISOString(), position: 0, permanent: true },
+  },
+  {
+    id: 'review-explorer',
+    sessionId: 'review-session',
+    type: 'explorer',
+    title: 'Explorer',
+    state: { isActive: true, hasBeenViewed: true },
+    metadata: { createdAt: new Date(0).toISOString(), lastActiveAt: new Date(0).toISOString(), position: 1, permanent: true },
+  },
+  {
+    id: 'review-diff',
+    sessionId: 'review-session',
+    type: 'diff',
+    title: 'Diff',
+    state: { isActive: false, hasBeenViewed: true },
+    metadata: { createdAt: new Date(0).toISOString(), lastActiveAt: new Date(0).toISOString(), position: 2, permanent: true },
+  },
+];
+
+const localExecutions = [{
+  id: 1,
+  session_id: 'review-session',
+  execution_sequence: 1,
+  after_commit_hash: '1234567890abcdef',
+  commit_message: 'Make review available before a PR',
+  timestamp: '2026-08-06T12:00:00.000Z',
+  stats_additions: 8,
+  stats_deletions: 3,
+  stats_files_changed: 1,
+  author: 'Pane QA',
+  comparison_branch: 'origin/main',
+  history_source: 'branch',
+}];
+
+const localCombinedDiff = {
+  diff: [
+    'diff --git a/src/review.ts b/src/review.ts',
+    'index 1111111..2222222 100644',
+    '--- a/src/review.ts',
+    '+++ b/src/review.ts',
+    '@@ -1,4 +1,9 @@',
+    '-export const reviewAvailable = false;',
+    '-export const mode = "github";',
+    '-export const label = "Unavailable";',
+    '+export const reviewAvailable = true;',
+    '+export const mode = "local";',
+    '+export const label = "Local changes";',
+    '+export const githubEnabled = false;',
+    '+export const emptyState = "No changes to review";',
+  ].join('\n'),
+  stats: { additions: 8, deletions: 3, filesChanged: 1 },
+  changedFiles: ['src/review.ts'],
+};
+
+async function openSession(
+  page: Page,
+  gitStatus: ReviewGitStatus = baseGitStatus,
+  options: { withLocalChanges?: boolean } = { withLocalChanges: true },
+): Promise<void> {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [createSession(gitStatus)],
+    initialPanels: panels,
+    initialExecutions: options.withLocalChanges === false ? [] : localExecutions,
+    initialCombinedDiff: options.withLocalChanges === false ? null : localCombinedDiff,
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Review fixture$/ }).click();
+  const paneButton = page.getByRole('button', {
+    name: gitStatus.prTitle ?? 'Review changes before PR',
+    exact: true,
+  });
+  await paneButton.click();
+  await expect(page.getByRole('tab', { name: 'Review', exact: true })).toBeVisible();
+}
+
+async function capture(page: Page, testInfo: TestInfo, filename: string): Promise<void> {
+  await page.mouse.move(1_000, 650);
+  await page.waitForTimeout(300);
+  const path = testInfo.outputPath(filename);
+  await page.screenshot({ path });
+  await testInfo.attach(filename, { path, contentType: 'image/png' });
+}
+
+test('Pinned panes use the short repository and pane name', async ({ page }, testInfo) => {
+  const pinnedProject = {
+    ...project,
+    name: 'bloomapi/bloom-mono',
+  };
+  const pinnedSession = {
+    ...createSession(),
+    name: 'do-tm-560',
+    isFavorite: true,
+  };
+
+  await installElectronApiMock(page, {
+    initialProjects: [pinnedProject],
+    initialSessions: [pinnedSession],
+    initialPanels: panels,
+    activeProjectId: pinnedProject.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+
+  await expect(page.getByRole('button', { name: 'bloom-.../do-tm-560', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'bloomapi/bloom-mono/do-tm-560', exact: true })).toHaveCount(0);
+  await capture(page, testInfo, '00-pinned-pane-short-label.png');
+});
+
+test('Review stays local until a newly discovered pull request is explicitly opened', async ({ page }, testInfo) => {
+  await openSession(page);
+
+  const executionCount = await page.evaluate(async () => {
+    const response = await window.electronAPI.sessions.getExecutions('review-session');
+    return response.data?.length ?? 0;
+  });
+  expect(executionCount).toBe(1);
+
+  const reviewTab = page.getByRole('tab', { name: 'Review', exact: true });
+  await expect(reviewTab).toBeEnabled();
+  await reviewTab.click();
+
+  const githubMode = page.getByRole('button', { name: 'GitHub', exact: true });
+  const localMode = page.getByRole('button', { name: 'Local', exact: true });
+  await expect(githubMode).toBeDisabled();
+  await expect(githubMode).toHaveAttribute('title', 'No pull request yet');
+  await expect(localMode).toHaveAttribute('aria-pressed', 'true');
+  await expect(localMode).toHaveClass(/bg-interactive/);
+  await expect(page.getByText('Local changes', { exact: true })).toBeVisible();
+  await expect(page.locator('.combined-diff-view').getByText('+8', { exact: true })).toBeVisible();
+  await expect(page.locator('.combined-diff-view').getByText('-3', { exact: true })).toBeVisible();
+  await capture(page, testInfo, '01-local-review-before-pr.png');
+
+  await page.evaluate((gitStatus) => {
+    const mock = (window as typeof window & {
+      __paneTestElectronMock: {
+        emitGitStatusUpdated: (sessionId: string, status: Record<string, unknown>) => void;
+      };
+    }).__paneTestElectronMock;
+    mock.emitGitStatusUpdated('review-session', gitStatus);
+  }, {
+    ...baseGitStatus,
+    prNumber: 374,
+    prTitle: 'Review local changes before a PR',
+    prUrl: 'https://github.com/dcouple/Pane/pull/374',
+  });
+
+  await expect(githubMode).toBeEnabled();
+  await expect(localMode).toHaveAttribute('aria-pressed', 'true');
+  await expect(localMode).toHaveClass(/bg-interactive/);
+  await expect(page.locator('.diff-panel').getByText('#374', { exact: true })).toBeVisible();
+  await capture(page, testInfo, '02-pr-discovered-local-preserved.png');
+
+  await githubMode.click();
+  await expect(githubMode).toHaveAttribute('aria-pressed', 'true');
+  await expect(githubMode).toHaveClass(/bg-interactive/);
+  await expect(localMode).not.toHaveClass(/bg-interactive/);
+  await expect(page.getByText('https://github.com/dcouple/Pane/pull/374/files', { exact: true })).toBeVisible();
+  await capture(page, testInfo, '03-github-review-selected.png');
+});
+
+test('Review shows a clean local empty state before a pull request exists', async ({ page }) => {
+  await openSession(page, baseGitStatus, { withLocalChanges: false });
+
+  await page.getByRole('tab', { name: 'Review', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Local', exact: true })).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByText('No changes to review', { exact: true })).toBeVisible();
+});
+
+test('Review defaults to GitHub when the worktree already has a pull request', async ({ page }) => {
+  await openSession(page, {
+    ...baseGitStatus,
+    prNumber: 374,
+    prTitle: 'Review local changes before a PR',
+    prUrl: 'https://github.com/dcouple/Pane/pull/374',
+  });
+
+  await page.getByRole('tab', { name: 'Review', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'GitHub', exact: true })).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('button', { name: 'Local', exact: true })).toBeEnabled();
+  await expect(page.getByText('https://github.com/dcouple/Pane/pull/374/files', { exact: true })).toBeVisible();
+});

--- a/tests/review-availability.spec.ts
+++ b/tests/review-availability.spec.ts
@@ -189,6 +189,18 @@ test('Review stays local until a newly discovered pull request is explicitly ope
   await expect(page.getByText('Local changes', { exact: true })).toBeVisible();
   await expect(page.locator('.combined-diff-view').getByText('+8', { exact: true })).toBeVisible();
   await expect(page.locator('.combined-diff-view').getByText('-3', { exact: true })).toBeVisible();
+
+  const reviewFile = page.getByRole('button', { name: 'Expand diff for src/review.ts', exact: true });
+  await expect(reviewFile).toHaveAttribute('aria-expanded', 'false');
+  await reviewFile.click();
+  const expandedReviewFile = page.getByRole('button', { name: 'Collapse diff for src/review.ts', exact: true });
+  await expect(expandedReviewFile).toHaveAttribute('aria-expanded', 'true');
+  const splitMode = page.getByRole('button', { name: 'Split', exact: true });
+  await splitMode.click();
+  await page.getByRole('tab', { name: 'Explorer', exact: true }).click();
+  await reviewTab.click();
+  await expect(page.getByRole('button', { name: 'Collapse diff for src/review.ts', exact: true })).toHaveAttribute('aria-expanded', 'true');
+  await expect(splitMode).toHaveClass(/bg-interactive/);
   await capture(page, testInfo, '01-local-review-before-pr.png');
 
   await page.evaluate((gitStatus) => {
@@ -217,6 +229,10 @@ test('Review stays local until a newly discovered pull request is explicitly ope
   await expect(localMode).not.toHaveClass(/bg-interactive/);
   await expect(page.getByText('https://github.com/dcouple/Pane/pull/374/files', { exact: true })).toBeVisible();
   await capture(page, testInfo, '03-github-review-selected.png');
+
+  await localMode.click();
+  await expect(page.getByRole('button', { name: 'Collapse diff for src/review.ts', exact: true })).toHaveAttribute('aria-expanded', 'true');
+  await expect(splitMode).toHaveClass(/bg-interactive/);
 });
 
 test('Review shows a clean local empty state before a pull request exists', async ({ page }) => {


### PR DESCRIPTION
## Summary

- show pinned panes as `<short-repo>/<pane>` without the owner/folder prefix
- truncate repository names longer than six characters with `...`
- compare legacy worktree panes from their recorded fork commit, with the remote default retained only as a fallback
- keep legacy merge/rebase write operations targeted at the project checkout's local integration branch
- keep Review available before a pull request exists and show committed/uncommitted local changes there
- default Review to Local when no PR exists; keep GitHub visible but disabled with `No pull request yet`
- preserve Local mode and the active Review panel when a PR is discovered during the session
- retain GitHub as the default for worktrees that already have a PR
- preserve the Local diff's expanded files, selected history, scroll position, and display settings across tool-tab and Local/GitHub switches
- fix Local review loading under React Strict Mode
- start first-time session and project detail panels collapsed while preserving each user's saved preference
- give the detail toggle a stable square hover target and a descriptive tooltip
- keep Add Tool menus inside the viewport and cap custom-command labels at 18 characters, with the full command on hover

## Root causes

Legacy panes with an empty or `HEAD` base fell back to the project root current branch. When that checkout moved to another feature branch, every pane was diffed against that unrelated branch, producing repeated totals such as `+217322 -136285`. Using only `origin/HEAD` would still include commits that existed locally before Pane created the worktree, so legacy reads now prefer the recorded fork commit. Write operations resolve their local integration branch separately and never receive a remote ref or commit SHA.

Review availability was separately gated on `gitStatus.prUrl` in tab presentation, layout restoration, panel selection, group focus, and commit navigation. PR discovery also retriggered panel initialization, which could switch an open Local review back to Explorer. Review and Local were unmounted during ordinary navigation, discarding in-progress review state. Finally, the local diff view did not restore its mounted flag during React Strict Mode's second effect setup, leaving development builds on a loading skeleton.

The detail rail defaulted to visible whenever no preference had been saved, so every first-time pane opened with less workspace. The Add Tool portal also used a fixed width at the trigger's unbounded left edge, while custom-command rows combined a full-width command button with a separate remove button. Long entries could therefore extend the menu beyond the viewport.

## User journeys affected

1. **Pinned pane scanning:** a nested project such as `bloomapi/bloom-mono` now appears as `bloom-.../do-tm-560` in Pinned.
2. **Legacy worktree status:** panes without an explicit saved base compare from their recorded fork commit, so sidebar and Review totals exclude pre-pane local commits and no longer depend on the project root branch.
3. **Work before a PR:** clicking Review opens Local mode and shows committed or uncommitted changes; GitHub remains disabled until a PR exists.
4. **Clean worktree:** Review remains available and shows `No changes to review`.
5. **PR created while reviewing:** GitHub becomes enabled and the PR metadata appears without changing the selected Local mode or active panel.
6. **Existing PR worktree:** Review still defaults to GitHub and Local remains selectable.
7. **Commit navigation:** selecting a commit from History can open it in Local review even before a PR exists.
8. **Review continuity:** expanded files, history selection, scroll position, and Split/Unified choice survive switching to Explorer or GitHub and back to Local.
9. **Merge/rebase target:** legacy panes continue integrating into the local branch checked out in the project repository rather than being redirected to `origin/HEAD` or a detached commit.
10. **First pane open:** new users start with the detail rail collapsed; users who previously expanded it keep that choice across reloads.
11. **Adding a long custom tool:** the Add Tool menu remains on-screen at narrow widths, displays at most 18 characters, and reveals the full command on hover or keyboard focus.

## How to test

1. Pin a pane from a nested/long repository name and confirm the Pinned row uses `<six-char-repo>.../<pane>` without the owner prefix.
2. Open a legacy pane with no explicit comparison base after local commits existed on its starting branch; confirm its totals begin at the pane's recorded fork commit and exclude those pre-pane commits.
3. On a worktree with local commits or uncommitted changes but no PR, click Review; confirm Local is selected, the diff renders, and GitHub is disabled with `No pull request yet`.
4. Repeat with a clean worktree and confirm `No changes to review`.
5. While Local review is open, create/discover a PR; confirm Review stays open in Local mode and GitHub becomes enabled.
6. Select GitHub and confirm the embedded browser targets `<pr-url>/files`.
7. Open a worktree that already has a PR and confirm Review defaults to GitHub while Local remains available.
8. Expand a file and select Split in Local, switch to Explorer and back, then switch GitHub and back; confirm the file remains expanded and Split remains selected.
9. For a legacy pane while the project repository is on a non-default integration branch, run merge/rebase and confirm the write target remains that local project branch.
10. Clear the detail-panel preference and open a session or project; confirm details start hidden, the toggle tooltip says `Show details`, and expanding it persists after reload.
11. Save a custom command whose name exceeds 18 characters, open Add Tool near the right edge or at a narrow viewport, and confirm the menu stays within the screen, the visible label ends in `...`, and hover shows the full command.

## Validation

- audited the current 38 active local panes, including 37 worktrees
- confirmed all 28 active legacy worktrees have recorded fork commits that resolve in Git
- confirmed explicit bases remain unchanged for read comparisons
- confirmed legacy, explicit-remote, and existing-branch write targets resolve to local integration branches
- confirmed persisted status caches receive an authoritative startup refresh
- `pnpm --filter frontend test` (136 tests)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter main test --run` (448 tests)
- `PLAYWRIGHT_PORT=4561 pnpm exec playwright test tests/review-availability.spec.ts` (6 journeys, including state preservation and narrow-viewport bounds)
- `pnpm typecheck`
- `pnpm lint` (passes with existing repository warnings)
- `pnpm build:frontend`
- `pnpm build:main`

## Environment note

The complete main-process suite ran under the repository-required Node 22 runtime after rebuilding `better-sqlite3-multiple-ciphers` for that runtime; all 448 tests passed.

<!-- pr-test-automation-summary:start -->
## Automated QA

**Status: PASS** on head `7c2916e` using the mocked Electron IPC Playwright harness. The run covered pinned labels, local committed changes before a PR, clean local review, live PR discovery without mode/panel reset, explicit GitHub selection, an existing-PR default, expanded-file/Split-view preservation across Explorer and GitHub round trips, first-run detail defaults with preference persistence, and Add Tool bounds at a 420px viewport.

<details open>
<summary>Journey screenshots</summary>

| Step | Preview |
| --- | --- |
| Pinned label | Owner path removed and the long repo shortened to `bloom-.../do-tm-560`.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-374-7c2916e-2a9be13b8587-00-pinned-pane-short-label.png" width="420" alt="Pinned pane with shortened repository label"> |
| Local review before PR | Review is selectable, Local is active, GitHub is disabled, the local commit shows `+8 -3`, and the expanded file is shown in Split view after an Explorer round trip.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-374-7c2916e-1ac8be3aaab5-01-local-review-before-pr.png" width="420" alt="Local review with preserved expanded file and split view before a pull request"> |
| PR discovered | PR `#374` appears and GitHub enables while Review remains open in Local mode with its diff state intact.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-374-7c2916e-4c0cda15756d-02-pr-discovered-local-preserved.png" width="420" alt="Pull request discovered while Local review and diff state remain selected"> |
| GitHub selected | Explicit GitHub selection targets the pull request `/files` URL; returning to Local preserves the prior diff state.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-374-7c2916e-f74e0f7b5ea2-03-github-review-selected.png" width="420" alt="GitHub review selected with pull request files URL"> |
| Detail rail default | A new pane starts with the detail rail collapsed, while the square toggle explains `Show details` and the saved expanded state is covered after reload.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-374-7c2916e-776c2e436576-04-detail-panel-default-collapsed.png" width="420" alt="Pane with detail rail collapsed by default and descriptive toggle tooltip"> |
| Responsive Add Tool menu | At 420px wide the menu is clamped inside the viewport, the custom command is capped with `...`, and hover shows the complete command.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-374-7c2916e-74114fb8a87c-05-add-tool-responsive-command.png" width="280" alt="Narrow Add Tool menu with truncated command and full command tooltip"> |

</details>

**Still manual:** confirm authenticated GitHub content renders inside the real Electron `<webview>`; Chromium QA can prove mode selection and the generated `/files` URL but does not render Electron webview contents. Local comparison and write-target correctness is covered by focused backend tests plus the 38-pane local audit rather than the mocked UI fixture.
<!-- pr-test-automation-summary:end -->
