### PR TITLE
Fix compact sidebar state parity and responsive UX

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -34,6 +34,9 @@ const SIDEBAR_SECTION_ROW = 'mt-2 flex w-full items-center justify-between gap-2
 const SIDEBAR_SECTION_LABEL = 'truncate text-[13px] font-semibold uppercase leading-4 text-text-tertiary';
 
 interface ProjectSessionListProps {
+  projects: Project[];
+  onProjectsChange: (update: (projects: Project[]) => Project[]) => void;
+  onProjectsRefresh: () => void;
   sessionSortAscending: boolean;
   pinnedSectionExpanded: boolean;
   repositoriesSectionExpanded: boolean;
@@ -45,6 +48,9 @@ interface ProjectSessionListProps {
 }
 
 export function ProjectSessionList({
+  projects,
+  onProjectsChange,
+  onProjectsRefresh,
   sessionSortAscending,
   pinnedSectionExpanded,
   repositoriesSectionExpanded,
@@ -54,7 +60,6 @@ export function ProjectSessionList({
   onRemoteDesktopClick,
   remoteDesktopTooltip,
 }: ProjectSessionListProps) {
-  const [projects, setProjects] = useState<Project[]>([]);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [createForProject, setCreateForProject] = useState<Project | null>(null);
   const [sidebarPaneRowLayout, setSidebarPaneRowLayout] = useState<SidebarPaneRowLayout>('single');
@@ -85,29 +90,6 @@ export function ProjectSessionList({
   const agentStatusByPanel = usePanelStore(s => s.agentStatus);
   const agentPanelSessions = usePanelStore(s => s.agentStatusSession);
   const unviewedBySession = usePanelStore(s => s.unviewedCompletedActivity);
-
-  // Load projects
-  const loadProjects = useCallback(async () => {
-    try {
-      const res = await API.projects.getAll();
-      if (res.success && res.data) {
-        setProjects(res.data);
-      }
-    } catch (e) {
-      console.error('Failed to load projects:', e);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadProjects();
-    const handle = () => loadProjects();
-    window.addEventListener('project-changed', handle);
-    window.addEventListener('project-sessions-refresh', handle);
-    return () => {
-      window.removeEventListener('project-changed', handle);
-      window.removeEventListener('project-sessions-refresh', handle);
-    };
-  }, [loadProjects]);
 
   useEffect(() => {
     let cancelled = false;
@@ -223,7 +205,7 @@ export function ProjectSessionList({
   const handleDeleteProject = async (projectId: number) => {
     try {
       await API.projects.delete(String(projectId));
-      loadProjects();
+      onProjectsRefresh();
       window.dispatchEvent(new Event('project-changed'));
     } catch (e) {
       console.error('Failed to delete project:', e);
@@ -253,7 +235,7 @@ export function ProjectSessionList({
     }
 
     let payload: Array<{ id: number; displayOrder: number }> = [];
-    setProjects(current => {
+    onProjectsChange(current => {
       const newProjects = [...current];
       const fromIndex = newProjects.findIndex(p => p.id === dragProjectId);
       const toIndex = newProjects.findIndex(p => p.id === targetProjectId);
@@ -275,7 +257,7 @@ export function ProjectSessionList({
         window.dispatchEvent(new Event('project-changed'));
       } catch (err) {
         console.error('Failed to reorder projects:', err);
-        loadProjects();
+        onProjectsRefresh();
       }
     }
   };

--- a/frontend/src/components/SessionStatusBadge.tsx
+++ b/frontend/src/components/SessionStatusBadge.tsx
@@ -5,6 +5,7 @@ import { AgentActivityDot, AgentStatusDot } from './ui/AgentStatusDot';
 interface SessionStatusBadgeProps {
   sessionId: string;
   size?: 'sm' | 'md';
+  unknownClassName?: string;
 }
 
 /**
@@ -13,11 +14,11 @@ interface SessionStatusBadgeProps {
  * panels. `unknown` means no terminal panel has reported yet (or the session
  * has none); an inert placeholder holds the dot's footprint.
  */
-export const SessionStatusBadge: React.FC<SessionStatusBadgeProps> = ({ sessionId, size = 'md' }) => {
+export const SessionStatusBadge: React.FC<SessionStatusBadgeProps> = ({ sessionId, size = 'md', unknownClassName }) => {
   const displayStatus = useSessionAgentDisplayStatus(sessionId);
 
   if (displayStatus === 'unknown') {
-    return <AgentActivityDot active={false} size={size} />;
+    return <AgentActivityDot active={false} size={size} inactiveClassName={unknownClassName} />;
   }
 
   return <AgentStatusDot status={displayStatus} size={size} />;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { ProjectSessionList, ArchivedSessions } from './ProjectSessionList';
 import { ArchiveProgress } from './ArchiveProgress';
-import { ArrowUpDown, ChevronDown, ChevronRight, Cpu, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare } from 'lucide-react';
+import { ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { usePaneLogo } from '../hooks/usePaneLogo';
 import { isMac } from '../utils/platformUtils';
@@ -17,11 +17,12 @@ import type { DropdownItem } from './ui/Dropdown';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
 import { SessionStatusBadge } from './SessionStatusBadge';
-import { AgentStatusDot } from './ui/AgentStatusDot';
+import { AgentActivityDot, AgentStatusDot } from './ui/AgentStatusDot';
 import { useSessionAgentDisplayStatus } from '../hooks/useAgentStatus';
 import { PANE_CHAT_SESSION_ID } from '../../../shared/types/paneChat';
 import { API } from '../utils/api';
 import type { Project } from '../types/project';
+import type { Session } from '../types/session';
 import { useSessionNavigationHotkeys } from '../hooks/useSessionNavigationHotkeys';
 import { useResourceMonitor } from '../hooks/useResourceMonitor';
 import {
@@ -31,6 +32,9 @@ import {
   type RemotePaneConnectionState,
 } from '../../../shared/types/remoteDaemon';
 import { getRemoteFooterStatus } from '../utils/remoteRuntimePresentation';
+import { usePanelStore } from '../stores/panelStore';
+import { rollupAgentDisplayStatus, rollupSessionAgentState, toAgentDisplayStatus } from '../utils/agentStatus';
+import { createProjectById, getPinnedSessions, groupSessionsByProject } from '../utils/sessionOrdering';
 
 // --- Collapsed sidebar tooltip content ---
 
@@ -42,6 +46,24 @@ function CollapsedProjectTooltip({ project, sessionCount }: { project: Project; 
       <p className="text-[10px] text-text-tertiary">
         {sessionCount} {sessionCount === 1 ? 'workspace' : 'workspaces'}
       </p>
+    </div>
+  );
+}
+
+function CompactSessionTooltip({
+  session,
+  label,
+}: {
+  session: Session;
+  label: string;
+}) {
+  return (
+    <div className="max-w-xs space-y-1.5">
+      <p className="text-[11px] font-medium leading-snug text-text-primary whitespace-pre-wrap break-words">
+        {label}
+      </p>
+      <div className="border-t border-border-primary" />
+      <SessionDetailTooltip session={session} showName={false} />
     </div>
   );
 }
@@ -64,6 +86,9 @@ const RESOURCE_POPOVER_WIDTH = 320;
 const RESOURCE_POPOVER_GAP = 8;
 const RESOURCE_POPOVER_VIEWPORT_MARGIN = 8;
 type SidebarSection = 'pinned' | 'repositories';
+const COMPACT_RAIL_BUTTON = 'relative flex h-9 min-h-9 w-9 min-w-9 shrink-0 items-center justify-center rounded transition-colors focus:outline-none focus:ring-2 focus:ring-interactive';
+const COMPACT_RAIL_IDLE = 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary';
+const COMPACT_RAIL_ACTIVE = 'bg-interactive/20 text-interactive ring-1 ring-interactive/50';
 
 function formatMemory(mb: number): string {
   if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
@@ -351,10 +376,15 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const activeProjectId = useNavigationStore((state) => state.activeProjectId);
   const activeView = useNavigationStore((state) => state.activeView);
+  const expandedProjects = useNavigationStore((state) => state.expandedProjects);
   const navigateToProject = useNavigationStore((state) => state.navigateToProject);
+  const navigateToSessions = useNavigationStore((state) => state.navigateToSessions);
   const navigateToPaneChat = useNavigationStore((state) => state.navigateToPaneChat);
   const paneChatStatus = useSessionAgentDisplayStatus(PANE_CHAT_SESSION_ID);
   const setSidebarNavigationScope = useNavigationStore((state) => state.setSidebarNavigationScope);
+  const agentStatusByPanel = usePanelStore((state) => state.agentStatus);
+  const agentPanelSessions = usePanelStore((state) => state.agentStatusSession);
+  const unviewedBySession = usePanelStore((state) => state.unviewedCompletedActivity);
   useSessionNavigationHotkeys({ projects, sessionSortAscending });
 
   const handleRefreshGitStatus = async () => {
@@ -394,6 +424,22 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
     return projects.find(p => p.active) || projects[0];
   }, [projects, activeProjectId]);
 
+  const sessionsByProject = useMemo(
+    () => groupSessionsByProject(sessions, sessionSortAscending),
+    [sessions, sessionSortAscending],
+  );
+  const projectById = useMemo(() => createProjectById(projects), [projects]);
+  const pinnedSessions = useMemo(
+    () => getPinnedSessions(sessions, projectById),
+    [sessions, projectById],
+  );
+
+  const openCompactSession = useCallback((sessionId: string, scope: 'pinned' | 'repositories') => {
+    setSidebarNavigationScope(scope);
+    void setActiveSession(sessionId);
+    navigateToSessions();
+  }, [navigateToSessions, setActiveSession, setSidebarNavigationScope]);
+
   // Collapsed sidebar view
   if (collapsed) {
     return (
@@ -408,125 +454,229 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
             <div className="h-3 flex-shrink-0" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
           )}
           {/* Logo */}
-          <div className="flex items-center justify-center px-1 py-2 border-b border-border-primary">
+          <div className="flex shrink-0 items-center justify-center border-b border-border-primary px-1 py-2">
             <img src={paneLogo} alt="Pane" className="h-6 w-6" />
           </div>
 
-          {/* Projects with their sessions */}
-          <div className="flex-1 overflow-y-auto overflow-x-hidden py-2 flex flex-col items-center gap-1.5">
+          <div className="flex shrink-0 flex-col items-center gap-1 border-b border-border-primary py-2">
+            <Tooltip content="Home" side="right">
+              <button
+                type="button"
+                data-compact-rail-item
+                onClick={() => {
+                  setSidebarNavigationScope('repositories');
+                  void setActiveSession(null);
+                  navigateToSessions();
+                }}
+                aria-label="Home"
+                className={`${COMPACT_RAIL_BUTTON} ${activeView === 'sessions' && !activeSessionId ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
+              >
+                <Home className="h-4 w-4" />
+              </button>
+            </Tooltip>
+
             <Tooltip content="Pane Chat" side="right">
               <button
                 type="button"
+                data-testid="compact-pane-chat"
+                data-compact-rail-item
                 onClick={() => {
                   setSidebarNavigationScope('repositories');
-                  setActiveSession(null);
+                  void setActiveSession(null);
                   navigateToPaneChat();
                 }}
                 aria-label="Pane Chat"
-                className={`relative w-8 h-8 rounded flex items-center justify-center transition-colors ${
-                  activeView === 'pane-chat'
-                    ? 'bg-interactive/20 text-interactive ring-1 ring-interactive/50'
-                    : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary'
-                }`}
+                className={`${COMPACT_RAIL_BUTTON} ${activeView === 'pane-chat' ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
               >
-                <MessageSquare className="w-4 h-4" />
-                <AgentStatusDot status={paneChatStatus} size="sm" className="absolute -top-0.5 -right-0.5" />
+                <MessageSquare className="h-4 w-4" />
+                <AgentStatusDot status={paneChatStatus} size="sm" className="absolute right-0 top-0" />
               </button>
             </Tooltip>
+
             {showRemoteDesktopLink && (
               <Tooltip content={REMOTE_DESKTOP_TOOLTIP} side="right">
                 <button
                   type="button"
+                  data-compact-rail-item
                   onClick={handleOpenRemoteDesktop}
                   aria-label="Open Remote Desktop"
-                  className="w-8 h-8 rounded flex items-center justify-center text-text-tertiary hover:bg-surface-hover hover:text-text-primary transition-colors"
+                  className={`${COMPACT_RAIL_BUTTON} ${COMPACT_RAIL_IDLE}`}
                 >
-                  <Monitor className="w-4 h-4" />
+                  <Monitor className="h-4 w-4" />
                 </button>
               </Tooltip>
             )}
-            {projects.map((project) => {
-              const isActiveProject = project.id === activeProject?.id;
-              const initial = project.name.charAt(0).toUpperCase();
-              const projectSessions = sessions.filter(s => s.projectId === project.id && !s.archived);
-              return (
-                <div key={project.id} className="flex flex-col items-center gap-0.5 w-full">
-                  {/* Project initial */}
-                  <Tooltip content={<CollapsedProjectTooltip project={project} sessionCount={projectSessions.length} />} side="right">
-                    <button
-                      onClick={() => navigateToProject(project.id)}
-                      className={`w-8 h-8 rounded flex items-center justify-center text-xs font-semibold transition-colors ${
-                        isActiveProject
-                          ? 'bg-interactive/20 text-interactive ring-1 ring-interactive/50'
-                          : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary'
-                      }`}
-                    >
-                      {initial}
-                    </button>
-                  </Tooltip>
-                  {/* Session status badges — grouped under this project */}
-                  {projectSessions.map((session) => {
-                    const isActive = session.id === activeSessionId;
-                    return (
-                      <Tooltip key={session.id} content={<SessionDetailTooltip session={session} />} side="right">
-                        <button
-                          onClick={() => {
-                            setSidebarNavigationScope('repositories');
-                            setActiveSession(session.id);
-                          }}
-                          className={`w-8 h-8 rounded flex items-center justify-center transition-colors ${
-                            isActive ? 'bg-interactive/20 ring-1 ring-interactive/50' : 'hover:bg-surface-hover'
-                          }`}
-                        >
-                          {/* At-a-glance agent status (blocked / working / done), with a
-                              binary activity fallback for non-agent sessions. */}
-                          <SessionStatusBadge sessionId={session.id} />
-                        </button>
-                      </Tooltip>
-                    );
-                  })}
-                </div>
-              );
-            })}
-            {/* New session button */}
-            {activeProject && (
-              <button
-                onClick={() => setShowCreateDialog(true)}
-                className="w-8 h-8 rounded flex items-center justify-center text-text-tertiary hover:bg-surface-hover hover:text-interactive transition-colors"
-                title="New Pane"
-              >
-                <Plus className="w-4 h-4" />
-              </button>
-            )}
           </div>
 
+          <nav
+            aria-label="Compact sidebar"
+            className="flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto overflow-x-hidden py-2"
+          >
+            {pinnedSessions.length > 0 && (
+              <div role="group" aria-label="Pinned panes" className="flex w-full shrink-0 flex-col items-center gap-0.5">
+                <Tooltip content={`${sidebarSectionExpansion.pinned ? 'Collapse' : 'Expand'} pinned panes`} side="right">
+                  <button
+                    type="button"
+                    data-testid="compact-pinned-toggle"
+                    data-compact-rail-item
+                    onClick={() => handlePinnedSectionExpandedChange(!sidebarSectionExpansion.pinned)}
+                    aria-label={`${sidebarSectionExpansion.pinned ? 'Collapse' : 'Expand'} pinned panes`}
+                    aria-expanded={sidebarSectionExpansion.pinned}
+                    className={`${COMPACT_RAIL_BUTTON} ${COMPACT_RAIL_IDLE}`}
+                  >
+                    <Pin className="h-4 w-4" />
+                    {sidebarSectionExpansion.pinned
+                      ? <ChevronDown className="absolute bottom-0.5 right-0.5 h-2.5 w-2.5" />
+                      : <ChevronRight className="absolute bottom-0.5 right-0.5 h-2.5 w-2.5" />}
+                  </button>
+                </Tooltip>
+
+                {sidebarSectionExpansion.pinned && pinnedSessions.map(({ session, label }) => (
+                  <Tooltip
+                    key={`compact-pinned-${session.id}`}
+                    content={<CompactSessionTooltip session={session} label={label} />}
+                    side="right"
+                  >
+                    <button
+                      type="button"
+                      data-testid={`compact-pinned-pane-${session.id}`}
+                      data-compact-rail-item
+                      onClick={() => openCompactSession(session.id, 'pinned')}
+                      aria-label={`Open pinned pane ${label}`}
+                      className={`${COMPACT_RAIL_BUTTON} ${session.id === activeSessionId && activeView === 'sessions' ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
+                    >
+                      <SessionStatusBadge
+                        sessionId={session.id}
+                        unknownClassName="bg-text-tertiary/60 opacity-100 duration-150"
+                      />
+                    </button>
+                  </Tooltip>
+                ))}
+              </div>
+            )}
+
+            <div role="group" aria-label="Repositories" className="flex w-full shrink-0 flex-col items-center gap-0.5">
+              <Tooltip content={`${sidebarSectionExpansion.repositories ? 'Collapse' : 'Expand'} repositories`} side="right">
+                <button
+                  type="button"
+                  data-testid="compact-repositories-toggle"
+                  data-compact-rail-item
+                  onClick={() => handleRepositoriesSectionExpandedChange(!sidebarSectionExpansion.repositories)}
+                  aria-label={`${sidebarSectionExpansion.repositories ? 'Collapse' : 'Expand'} repositories`}
+                  aria-expanded={sidebarSectionExpansion.repositories}
+                  className={`${COMPACT_RAIL_BUTTON} ${COMPACT_RAIL_IDLE}`}
+                >
+                  <FolderGit2 className="h-4 w-4" />
+                  {sidebarSectionExpansion.repositories
+                    ? <ChevronDown className="absolute bottom-0.5 right-0.5 h-2.5 w-2.5" />
+                    : <ChevronRight className="absolute bottom-0.5 right-0.5 h-2.5 w-2.5" />}
+                </button>
+              </Tooltip>
+
+              {sidebarSectionExpansion.repositories && projects.map((project) => {
+                const isActiveProject = project.id === activeProject?.id && activeView === 'project';
+                const initial = project.name.charAt(0).toUpperCase();
+                const projectSessions = sessionsByProject.get(project.id) ?? [];
+                const projectAgentState = rollupAgentDisplayStatus(
+                  projectSessions.map(session => toAgentDisplayStatus(
+                    rollupSessionAgentState(agentStatusByPanel, agentPanelSessions, session.id),
+                    Boolean(unviewedBySession[session.id]),
+                  )),
+                );
+
+                return (
+                  <div key={project.id} className="flex w-full shrink-0 flex-col items-center gap-0.5">
+                    <Tooltip content={<CollapsedProjectTooltip project={project} sessionCount={projectSessions.length} />} side="right">
+                      <button
+                        type="button"
+                        data-testid={`compact-repository-${project.id}`}
+                        data-compact-rail-item
+                        onClick={() => navigateToProject(project.id)}
+                        aria-label={`Open main workspace for ${project.name}`}
+                        className={`${COMPACT_RAIL_BUTTON} text-xs font-semibold ${isActiveProject ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
+                      >
+                        {initial}
+                        {projectAgentState === 'unknown'
+                          ? <AgentActivityDot active={false} size="sm" className="absolute bottom-0 right-0" />
+                          : <AgentStatusDot status={projectAgentState} size="sm" className="absolute bottom-0 right-0" />}
+                      </button>
+                    </Tooltip>
+
+                    {expandedProjects.has(project.id) && projectSessions.map((session) => (
+                      <Tooltip
+                        key={session.id}
+                        content={<CompactSessionTooltip session={session} label={session.name || 'Untitled'} />}
+                        side="right"
+                      >
+                        <button
+                          type="button"
+                          data-testid={`compact-repository-pane-${session.id}`}
+                          data-compact-rail-item
+                          onClick={() => openCompactSession(session.id, 'repositories')}
+                          aria-label={`Open pane ${project.name}/${session.name || 'Untitled'}`}
+                          className={`${COMPACT_RAIL_BUTTON} ${session.id === activeSessionId && activeView === 'sessions' ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
+                        >
+                          <SessionStatusBadge
+                            sessionId={session.id}
+                            unknownClassName="bg-text-tertiary/60 opacity-100 duration-150"
+                          />
+                        </button>
+                      </Tooltip>
+                    ))}
+                  </div>
+                );
+              })}
+
+              {sidebarSectionExpansion.repositories && activeProject && (
+                <Tooltip content={`New pane in ${activeProject.name}`} side="right">
+                  <button
+                    type="button"
+                    data-compact-rail-item
+                    onClick={() => setShowCreateDialog(true)}
+                    aria-label={`New pane in ${activeProject.name}`}
+                    className={`${COMPACT_RAIL_BUTTON} ${COMPACT_RAIL_IDLE} hover:text-interactive`}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </button>
+                </Tooltip>
+              )}
+            </div>
+          </nav>
+
           {/* Bottom actions */}
-          <div className="flex-shrink-0 flex flex-col items-center gap-1 py-2 border-t border-border-primary">
+          <div className="flex shrink-0 flex-col items-center gap-1 border-t border-border-primary py-2">
             <Tooltip content={remoteFooterTooltip} side="right" interactive delay={250}>
               <button
                 type="button"
+                data-compact-rail-item
                 onClick={onRemoteSettingsClick}
                 aria-label={remoteFooterStatus.ariaLabel}
-                className="w-8 h-8 rounded flex items-center justify-center text-text-tertiary hover:bg-surface-hover transition-colors"
+                className={`${COMPACT_RAIL_BUTTON} ${COMPACT_RAIL_IDLE}`}
               >
                 <span className={`h-2.5 w-2.5 rounded-full ${remoteFooterStatus.dotClassName}`} />
               </button>
             </Tooltip>
             <Tooltip content={hotkeyDisplay('open-settings') ? <Kbd>{hotkeyDisplay('open-settings')}</Kbd> : undefined} side="right">
-              <IconButton
+              <button
+                type="button"
+                data-compact-rail-item
                 onClick={onSettingsClick}
                 aria-label="Settings"
-                size="sm"
-                icon={<SettingsIcon className="w-4 h-4" />}
-              />
+                className={`${COMPACT_RAIL_BUTTON} ${COMPACT_RAIL_IDLE}`}
+              >
+                <SettingsIcon className="h-4 w-4" />
+              </button>
             </Tooltip>
             <Tooltip content={hotkeyDisplay('toggle-sidebar') ? <Kbd>{hotkeyDisplay('toggle-sidebar')}</Kbd> : undefined} side="right">
-              <IconButton
+              <button
+                type="button"
+                data-compact-rail-item
                 onClick={onToggleCollapse}
                 aria-label="Expand sidebar"
-                size="sm"
-                icon={<PanelLeftOpen className="w-4 h-4" />}
-              />
+                className={`${COMPACT_RAIL_BUTTON} ${COMPACT_RAIL_IDLE}`}
+              >
+                <PanelLeftOpen className="h-4 w-4" />
+              </button>
             </Tooltip>
           </div>
         </div>
@@ -638,6 +788,9 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
 
         <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
           <ProjectSessionList
+            projects={projects}
+            onProjectsChange={setProjects}
+            onProjectsRefresh={loadProjects}
             sessionSortAscending={sessionSortAscending}
             pinnedSectionExpanded={sidebarSectionExpansion.pinned}
             repositoriesSectionExpanded={sidebarSectionExpansion.repositories}

--- a/frontend/src/components/ui/AgentStatusDot.tsx
+++ b/frontend/src/components/ui/AgentStatusDot.tsx
@@ -39,6 +39,7 @@ interface AgentActivityDotProps {
   /** Pulse while active. */
   pulse?: boolean;
   className?: string;
+  inactiveClassName?: string;
 }
 
 /**
@@ -52,6 +53,7 @@ export const AgentActivityDot: React.FC<AgentActivityDotProps> = ({
   activeColorClass = 'bg-status-info',
   pulse = false,
   className,
+  inactiveClassName = 'bg-text-muted/20 opacity-40 duration-[3s]',
 }) => (
   <span className={cn('inline-flex items-center justify-center', containerSizeClasses[size], className)}>
     <span
@@ -60,7 +62,7 @@ export const AgentActivityDot: React.FC<AgentActivityDotProps> = ({
         sizeClasses[size],
         active
           ? `${activeColorClass} opacity-100 duration-150`
-          : 'bg-text-muted/20 opacity-40 duration-[3s]',
+          : inactiveClassName,
         active && pulse && 'animate-pulse',
       )}
     />

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -19,6 +19,13 @@ type ElectronApiMockOptions = {
   initialProjects?: Array<Record<string, unknown>>;
   initialSessions?: Array<Record<string, unknown>>;
   initialPanels?: Array<Record<string, unknown>>;
+  initialUiState?: Partial<{
+    expandedProjects: number[];
+    expandedFolders: string[];
+    sessionSortAscending: boolean;
+    pinnedSectionExpanded: boolean;
+    repositoriesSectionExpanded: boolean;
+  }>;
   activeProjectId?: number | null;
   paneChatAgentChangeDelayMs?: number;
 };
@@ -162,6 +169,14 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     let mockProjects = clone(mockOptions.initialProjects ?? []);
     let mockSessions = clone(mockOptions.initialSessions ?? []);
     let mockPanels = clone(mockOptions.initialPanels ?? []);
+    const uiState = {
+      expandedProjects: [] as number[],
+      expandedFolders: [] as string[],
+      sessionSortAscending: true,
+      pinnedSectionExpanded: true,
+      repositoriesSectionExpanded: true,
+      ...clone(mockOptions.initialUiState ?? {}),
+    };
     let mockActiveProjectId = mockOptions.activeProjectId === undefined
       ? (mockProjects.find((project) => project.active === true)?.id as number | undefined) ?? null
       : mockOptions.activeProjectId;
@@ -651,18 +666,22 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           subscribe('remote-daemon:host-state-changed', callback),
       }),
       uiState: namespace({
-        getExpanded: () => success({
-          expandedProjects: [],
-          expandedFolders: [],
-          sessionSortAscending: true,
-          pinnedSectionExpanded: true,
-          repositoriesSectionExpanded: true,
-        }),
+        getExpanded: () => success(clone(uiState)),
         saveExpanded: () => success(),
-        saveExpandedProjects: () => success(),
+        saveExpandedProjects: (projectIds: number[]) => {
+          uiState.expandedProjects = clone(projectIds);
+          return success();
+        },
         saveExpandedFolders: () => success(),
-        saveSessionSortAscending: () => success(),
-        saveSidebarSectionExpanded: () => success(),
+        saveSessionSortAscending: (ascending: boolean) => {
+          uiState.sessionSortAscending = ascending;
+          return success();
+        },
+        saveSidebarSectionExpanded: (section: 'pinned' | 'repositories', expanded: boolean) => {
+          if (section === 'pinned') uiState.pinnedSectionExpanded = expanded;
+          else uiState.repositoriesSectionExpanded = expanded;
+          return success();
+        },
       }),
     };
 

--- a/tests/sidebar-compact.spec.ts
+++ b/tests/sidebar-compact.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+const projects = [
+  {
+    id: 1,
+    name: 'Alpha',
+    path: '/tmp/alpha',
+    active: true,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 2,
+    name: 'Beta',
+    path: '/tmp/beta',
+    active: false,
+    created_at: '2026-01-02T00:00:00.000Z',
+    updated_at: '2026-01-02T00:00:00.000Z',
+  },
+];
+
+function session(
+  id: string,
+  name: string,
+  projectId: number,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    name,
+    projectId,
+    worktreePath: `/tmp/${id}`,
+    prompt: '',
+    status: 'stopped',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    lastActivity: '2026-01-01T00:00:00.000Z',
+    output: [],
+    jsonMessages: [],
+    permissionMode: 'ignore',
+    toolType: 'none',
+    archived: false,
+    isHidden: false,
+    isFavorite: false,
+    ...overrides,
+  };
+}
+
+async function collapseSidebar(page: Page) {
+  const collapse = page.getByRole('button', { name: 'Collapse sidebar' });
+  await expect(collapse).toBeVisible({ timeout: 10_000 });
+  await collapse.click();
+  await expect(page.getByRole('navigation', { name: 'Compact sidebar' })).toBeVisible();
+}
+
+test.describe('compact sidebar', () => {
+  test('mirrors an expanded pinned section and collapsed repositories section', async ({ page }) => {
+    await installElectronApiMock(page, {
+      initialConfig: { theme: 'night-owl' },
+      initialProjects: projects,
+      initialSessions: [
+        session('pinned', 'Pinned work', 1, {
+          isFavorite: true,
+          favoritePinnedAt: '2026-01-03T00:00:00.000Z',
+        }),
+        session('regular', 'Regular work', 1),
+      ],
+      initialUiState: {
+        expandedProjects: [1],
+        pinnedSectionExpanded: true,
+        repositoriesSectionExpanded: false,
+      },
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await collapseSidebar(page);
+
+    await expect(page.getByTestId('compact-pinned-toggle')).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('compact-pinned-pane-pinned')).toBeVisible();
+    await expect(page.getByTestId('compact-repositories-toggle')).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByTestId('compact-repository-1')).toHaveCount(0);
+    await expect(page.getByTestId('compact-repository-pane-regular')).toHaveCount(0);
+    await page.mouse.move(320, 180);
+    await page.screenshot({
+      path: 'test-results/compact-sidebar-pinned-only.png',
+      clip: { x: 0, y: 0, width: 260, height: 720 },
+    });
+
+    const paneChat = page.getByTestId('compact-pane-chat');
+    await paneChat.click();
+    await expect(page.getByRole('heading', { name: 'Pane Chat' })).toBeVisible();
+    const activePaneChatSize = await paneChat.boundingBox();
+    expect(activePaneChatSize?.width).toBe(36);
+    expect(activePaneChatSize?.height).toBe(36);
+    await page.mouse.move(320, 180);
+    await page.screenshot({
+      path: 'test-results/compact-sidebar-pane-chat-active.png',
+      clip: { x: 0, y: 0, width: 360, height: 720 },
+    });
+  });
+
+  test('uses repository expansion, shared filtering, and stable control sizing', async ({ page }) => {
+    await page.setViewportSize({ width: 640, height: 360 });
+    const extraSessions = Array.from({ length: 8 }, (_, index) =>
+      session(`extra-${index}`, `Extra ${index}`, 1, {
+        createdAt: `2026-01-${String(index + 10).padStart(2, '0')}T00:00:00.000Z`,
+      }));
+
+    await installElectronApiMock(page, {
+      initialConfig: { theme: 'night-owl' },
+      initialProjects: projects,
+      initialSessions: [
+        session('pinned', 'Pinned work', 1, {
+          isFavorite: true,
+          favoritePinnedAt: '2026-01-03T00:00:00.000Z',
+        }),
+        session('regular', 'Regular work', 1),
+        session('beta', 'Beta work', 2),
+        session('hidden', 'Hidden work', 1, { isHidden: true }),
+        ...extraSessions,
+      ],
+      initialUiState: {
+        expandedProjects: [1],
+        pinnedSectionExpanded: false,
+        repositoriesSectionExpanded: true,
+      },
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await collapseSidebar(page);
+
+    await expect(page.getByTestId('compact-pinned-toggle')).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByTestId('compact-pinned-pane-pinned')).toHaveCount(0);
+    await expect(page.getByTestId('compact-repository-1')).toBeVisible();
+    await expect(page.getByTestId('compact-repository-pane-pinned')).toBeVisible();
+    await expect(page.getByTestId('compact-repository-pane-regular')).toBeVisible();
+    await expect(page.getByTestId('compact-repository-pane-beta')).toHaveCount(0);
+    await expect(page.getByTestId('compact-repository-pane-hidden')).toHaveCount(0);
+
+    await page.getByTestId('compact-repositories-toggle').click();
+    await expect(page.getByTestId('compact-repositories-toggle')).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByTestId('compact-repository-1')).toHaveCount(0);
+
+    await page.getByTestId('compact-repositories-toggle').click();
+    await page.getByTestId('compact-pinned-toggle').click();
+    await expect(page.getByTestId('compact-pinned-pane-pinned')).toBeVisible();
+
+    const itemSizes = await page.locator('[data-compact-rail-item]').evaluateAll(elements =>
+      elements.map(element => {
+        const rect = element.getBoundingClientRect();
+        return { width: rect.width, height: rect.height };
+      }));
+    expect(itemSizes.length).toBeGreaterThan(10);
+    expect(itemSizes.every(({ width, height }) => width === 36 && height === 36)).toBe(true);
+
+    const paneChatSize = await page.getByTestId('compact-pane-chat').boundingBox();
+    expect(paneChatSize?.width).toBe(36);
+    expect(paneChatSize?.height).toBe(36);
+    await expect(page.getByRole('button', { name: 'Expand sidebar' })).toBeVisible();
+    await page.getByTestId('compact-repository-1').scrollIntoViewIfNeeded();
+    await page.mouse.move(320, 180);
+    await page.screenshot({
+      path: 'test-results/compact-sidebar-short-repositories.png',
+      clip: { x: 0, y: 0, width: 180, height: 360 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- rebuild the compact sidebar around the persisted Pinned, Repositories, and repository expansion state
- share repository data plus pane ordering/filtering with the expanded sidebar and preserve pinned/repository navigation scopes
- standardize compact controls at 36px with fixed global/footer regions, visible neutral pane indicators, and explicit accessible labels
- add Playwright coverage for state parity, filtering, short viewport scrolling, and Pane Chat sizing

## Testing
- `pnpm typecheck`
- `pnpm lint` (passes with existing repository warnings)
- `pnpm --filter frontend test`
- `pnpm run build:frontend`
- `pnpm test -- tests/sidebar-compact.spec.ts`

<!-- pr-test-automation-summary:start -->
## Automated QA

**Status:** Passed on commit `77f218b` using Playwright with deterministic mocked Electron API data.

**CI:** All reported GitHub checks passed, including quality/smoke, main-process tests on macOS/Linux/Windows, the Runpane wrapper matrix, and security checks.

- Verified Pinned and Repositories independently honor their saved expanded/collapsed state.
- Verified repository pane visibility follows the saved repository expansion state, hidden panes stay filtered, and navigation scopes remain correct.
- Verified every compact control, including Pane Chat in its active state, remains exactly 36x36px.
- Verified the repository list scrolls at 360px viewport height while global and footer controls remain reachable.

<details open>
<summary>Compact sidebar screenshots</summary>

| State | Preview |
| --- | --- |
| Pinned open, repositories collapsed. The pinned pane remains available while repository content stays hidden. | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-375-77f218b-e0c9bc9598cf-pinned-only.png" width="260" alt="Compact sidebar with Pinned open and Repositories collapsed"> |
| Pane Chat active. The selected control stays within the fixed compact rail instead of growing into the content area. | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-375-77f218b-8e06c97d74c1-pane-chat-active.png" width="360" alt="Pane Chat active in the compact sidebar"> |
| Repositories open at a short viewport height. Repository content scrolls while the footer controls remain fixed and visible. | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-375-77f218b-834743d25ac0-short-repositories.png" width="180" alt="Compact repository sidebar at a short viewport height"> |

</details>

**Remaining manual review:** Spot-check the compact rail in a packaged macOS build with real saved repositories and pane activity. The automated pass intentionally mocked Electron API data and did not mutate the developer's Pane profile.
<!-- pr-test-automation-summary:end -->
