### PR TITLE
Fix omitted pane bases and active sidebar state

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -720,7 +720,7 @@ function SessionRow({
       className={cn(
         'group/session relative w-full text-left pl-3 pr-2 transition-colors flex items-center gap-1',
         rowLayout === 'single' ? 'py-1.5' : 'py-2',
-        isActive ? 'bg-interactive/30' : 'hover:bg-surface-hover'
+        isActive ? 'bg-surface-hover' : 'hover:bg-surface-hover'
       )}
     >
       {/* Always-present left accent bar reflecting the agent status. */}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -88,7 +88,7 @@ const RESOURCE_POPOVER_VIEWPORT_MARGIN = 8;
 type SidebarSection = 'pinned' | 'repositories';
 const COMPACT_RAIL_BUTTON = 'relative flex h-9 min-h-9 w-9 min-w-9 shrink-0 items-center justify-center rounded transition-colors focus:outline-none focus:ring-2 focus:ring-interactive';
 const COMPACT_RAIL_IDLE = 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary';
-const COMPACT_RAIL_ACTIVE = 'bg-interactive/20 text-interactive ring-1 ring-interactive/50';
+const COMPACT_RAIL_ACTIVE = 'bg-surface-hover text-text-primary';
 
 function formatMemory(mb: number): string {
   if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -20,7 +20,24 @@ describe('resolveDefaultWorktreeBase', () => {
       if (command.includes('symbolic-ref')) {
         return { stdout: 'origin/main\n', stderr: '' };
       }
+      if (command.includes('origin/main^{commit}')) {
+        return { stdout: 'abc123\n', stderr: '' };
+      }
       throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(resolveDefaultWorktreeBase('/repo', runner)).resolves.toBe('origin/main');
+  });
+
+  it('falls back when the remote default branch is dangling', async () => {
+    const runner = commandRunner(async command => {
+      if (command.includes('symbolic-ref')) {
+        return { stdout: 'origin/deleted\n', stderr: '' };
+      }
+      if (command.includes('origin/main^{commit}')) {
+        return { stdout: 'abc123\n', stderr: '' };
+      }
+      throw new Error(`Unknown ref: ${command}`);
     });
 
     await expect(resolveDefaultWorktreeBase('/repo', runner)).resolves.toBe('origin/main');
@@ -52,6 +69,9 @@ describe('WorktreeManager.resolveWorkingDirectory', () => {
     const runner = commandRunner(async (command, cwd) => {
       if (command.includes('symbolic-ref')) {
         return { stdout: 'origin/main\n', stderr: '' };
+      }
+      if (command.includes('origin/main^{commit}')) {
+        return { stdout: 'abc123\n', stderr: '' };
       }
       if (command === 'git branch --show-current' && cwd === '/repo/worktrees/pane') {
         return { stdout: 'pane\n', stderr: '' };
@@ -97,6 +117,9 @@ describe('WorktreeManager.resolveWorkingDirectory', () => {
     const runner = commandRunner(async command => {
       if (command.includes('symbolic-ref')) {
         return { stdout: 'origin/main\n', stderr: '' };
+      }
+      if (command.includes('origin/main^{commit}')) {
+        return { stdout: 'abc123\n', stderr: '' };
       }
       throw new Error(`Unexpected command: ${command}`);
     });

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -29,7 +29,7 @@ describe('resolveDefaultWorktreeBase', () => {
   it('falls back to a conventional remote main ref when origin HEAD is unavailable', async () => {
     const runner = commandRunner(async command => {
       if (command.includes('symbolic-ref')) throw new Error('No remote HEAD');
-      if (command.includes("'origin/main^{commit}'")) {
+      if (command.startsWith('git rev-parse --verify ') && command.includes('origin/main^{commit}')) {
         return { stdout: 'abc123\n', stderr: '' };
       }
       throw new Error(`Unknown ref: ${command}`);
@@ -59,7 +59,7 @@ describe('WorktreeManager.resolveWorkingDirectory', () => {
       if (command === 'git rev-parse --verify origin/pane') {
         throw new Error('No remote pane branch');
       }
-      if (command === "git rev-parse 'HEAD'") {
+      if (command.startsWith('git rev-parse ') && command.includes('HEAD')) {
         return { stdout: 'base-commit\n', stderr: '' };
       }
       throw new Error(`Unexpected command: ${command}`);

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -1,12 +1,136 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CommandRunner } from '../../utils/commandRunner';
-import { WorktreeManager } from '../worktreeManager';
+import type { PathResolver } from '../../utils/pathResolver';
+import { resolveDefaultWorktreeBase, WorktreeManager } from '../worktreeManager';
+import { worktreePoolManager } from '../worktreePoolManager';
 
 function commandRunner(
   execAsync: (command: string, cwd: string) => Promise<{ stdout: string; stderr: string }>,
 ): CommandRunner {
   return { execAsync: vi.fn(execAsync) } as CommandRunner;
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveDefaultWorktreeBase', () => {
+  it('uses the remote default branch instead of the project checkout HEAD', async () => {
+    const runner = commandRunner(async command => {
+      if (command.includes('symbolic-ref')) {
+        return { stdout: 'origin/main\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(resolveDefaultWorktreeBase('/repo', runner)).resolves.toBe('origin/main');
+  });
+
+  it('falls back to a conventional remote main ref when origin HEAD is unavailable', async () => {
+    const runner = commandRunner(async command => {
+      if (command.includes('symbolic-ref')) throw new Error('No remote HEAD');
+      if (command.includes("'origin/main^{commit}'")) {
+        return { stdout: 'abc123\n', stderr: '' };
+      }
+      throw new Error(`Unknown ref: ${command}`);
+    });
+
+    await expect(resolveDefaultWorktreeBase('/repo', runner)).resolves.toBe('origin/main');
+  });
+
+  it('uses HEAD only when no conventional integration ref exists', async () => {
+    const runner = commandRunner(async () => {
+      throw new Error('Unknown ref');
+    });
+
+    await expect(resolveDefaultWorktreeBase('/repo', runner)).resolves.toBe('HEAD');
+  });
+});
+
+describe('WorktreeManager.resolveWorkingDirectory', () => {
+  it('persists the resolved default branch when claiming a reserve worktree', async () => {
+    const runner = commandRunner(async (command, cwd) => {
+      if (command.includes('symbolic-ref')) {
+        return { stdout: 'origin/main\n', stderr: '' };
+      }
+      if (command === 'git branch --show-current' && cwd === '/repo/worktrees/pane') {
+        return { stdout: 'pane\n', stderr: '' };
+      }
+      if (command === 'git rev-parse --verify origin/pane') {
+        throw new Error('No remote pane branch');
+      }
+      if (command === "git rev-parse 'HEAD'") {
+        return { stdout: 'base-commit\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    vi.spyOn(worktreePoolManager, 'claimReserve').mockResolvedValue({ worktreePath: '/repo/worktrees/pane' });
+    const manager = new WorktreeManager();
+
+    const result = await manager.resolveWorkingDirectory(
+      '/repo',
+      'pane',
+      undefined,
+      true,
+      undefined,
+      {} as PathResolver,
+      runner,
+    );
+
+    expect(worktreePoolManager.claimReserve).toHaveBeenCalledWith(
+      '/repo',
+      'origin/main',
+      'pane',
+      'pane',
+      undefined,
+      expect.anything(),
+      runner,
+    );
+    expect(result).toEqual({
+      worktreePath: '/repo/worktrees/pane',
+      baseCommit: 'base-commit',
+      baseBranch: 'origin/main',
+    });
+  });
+
+  it('passes the resolved default branch to fresh worktree creation', async () => {
+    const runner = commandRunner(async command => {
+      if (command.includes('symbolic-ref')) {
+        return { stdout: 'origin/main\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    vi.spyOn(worktreePoolManager, 'claimReserve').mockResolvedValue(null);
+    vi.spyOn(worktreePoolManager, 'createReserve').mockResolvedValue();
+    const manager = new WorktreeManager();
+    const createWorktree = vi.spyOn(manager, 'createWorktree').mockResolvedValue({
+      worktreePath: '/repo/worktrees/pane',
+      baseCommit: 'base-commit',
+      baseBranch: 'origin/main',
+    });
+
+    const result = await manager.resolveWorkingDirectory(
+      '/repo',
+      'pane',
+      undefined,
+      true,
+      undefined,
+      {} as PathResolver,
+      runner,
+    );
+
+    expect(createWorktree).toHaveBeenCalledWith(
+      '/repo',
+      'pane',
+      undefined,
+      'origin/main',
+      undefined,
+      expect.anything(),
+      runner,
+    );
+    expect(result.baseBranch).toBe('origin/main');
+  });
+});
 
 describe('WorktreeManager.getSessionComparisonBranch', () => {
   it('uses the recorded fork commit before a remote default branch for a legacy worktree', async () => {

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -114,6 +114,41 @@ export async function detectGitBase(
   return { baseBranch: actualBaseBranch, baseCommit };
 }
 
+/**
+ * Resolve a stable integration ref when callers do not choose a base branch.
+ * The project checkout may be on an unrelated feature branch, so HEAD is only
+ * safe as a final fallback for repositories without a conventional base ref.
+ */
+export async function resolveDefaultWorktreeBase(
+  projectPath: string,
+  commandRunner: CommandRunner,
+): Promise<string> {
+  try {
+    const { stdout } = await commandRunner.execAsync(
+      'git symbolic-ref --quiet --short refs/remotes/origin/HEAD',
+      projectPath,
+    );
+    const remoteDefault = stdout.trim();
+    if (remoteDefault) return remoteDefault;
+  } catch {
+    // Fall through to common remote and local integration branches.
+  }
+
+  for (const candidate of ['origin/main', 'origin/master', 'main', 'master']) {
+    try {
+      await commandRunner.execAsync(
+        `git rev-parse --verify ${escapeShellArg(`${candidate}^{commit}`)}`,
+        projectPath,
+      );
+      return candidate;
+    } catch {
+      // Try the next conventional integration ref.
+    }
+  }
+
+  return 'HEAD';
+}
+
 export class WorktreeManager {
   private projectsCache: Map<string, { baseDir: string }> = new Map();
 
@@ -316,10 +351,11 @@ export class WorktreeManager {
     commandRunner: CommandRunner
   ): Promise<{ worktreePath: string; baseCommit: string | undefined; baseBranch: string | undefined }> {
     if (useWorktree) {
+      const effectiveBase = baseBranch || await resolveDefaultWorktreeBase(projectPath, commandRunner);
+
       // Try claiming a pre-created reserve worktree for instant creation
       try {
         const branchName = worktreeName; // worktreeName is used as both dir name and branch name
-        const effectiveBase = baseBranch || 'HEAD';
         const claimed = await worktreePoolManager.claimReserve(
           projectPath,
           effectiveBase,
@@ -331,18 +367,17 @@ export class WorktreeManager {
         );
         if (claimed) {
           // Detect base commit from the claimed worktree
-          const { baseBranch: detectedBranch, baseCommit } = await detectGitBase(claimed.worktreePath, commandRunner);
-          return { worktreePath: claimed.worktreePath, baseCommit, baseBranch: detectedBranch || baseBranch };
+          const { baseCommit } = await detectGitBase(claimed.worktreePath, commandRunner);
+          return { worktreePath: claimed.worktreePath, baseCommit, baseBranch: effectiveBase };
         }
       } catch (error) {
         console.warn('[WorktreeManager] Pool claim failed, falling back to fresh worktree:', error);
       }
 
       // Fall back to standard worktree creation
-      const result = await this.createWorktree(projectPath, worktreeName, undefined, baseBranch, worktreeFolder, pathResolver, commandRunner);
+      const result = await this.createWorktree(projectPath, worktreeName, undefined, effectiveBase, worktreeFolder, pathResolver, commandRunner);
 
       // Trigger background replenishment after successful creation
-      const effectiveBase = baseBranch || 'HEAD';
       worktreePoolManager.createReserve(projectPath, effectiveBase, worktreeFolder, pathResolver, commandRunner).catch(err => {
         console.warn('[WorktreeManager] Background reserve creation failed:', err);
       });

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -129,7 +129,13 @@ export async function resolveDefaultWorktreeBase(
       projectPath,
     );
     const remoteDefault = stdout.trim();
-    if (remoteDefault) return remoteDefault;
+    if (remoteDefault) {
+      await commandRunner.execAsync(
+        `git rev-parse --verify ${escapeShellArg(`${remoteDefault}^{commit}`)}`,
+        projectPath,
+      );
+      return remoteDefault;
+    }
   } catch {
     // Fall through to common remote and local integration branches.
   }

--- a/tests/sidebar-compact.spec.ts
+++ b/tests/sidebar-compact.spec.ts
@@ -54,6 +54,47 @@ async function collapseSidebar(page: Page) {
 }
 
 test.describe('compact sidebar', () => {
+  test('keeps the hover background on the active pane in both sidebar modes', async ({ page }) => {
+    await installElectronApiMock(page, {
+      initialConfig: { theme: 'night-owl' },
+      initialProjects: projects,
+      initialSessions: [
+        session('pinned', 'Pinned work', 1, {
+          isFavorite: true,
+          favoritePinnedAt: '2026-01-03T00:00:00.000Z',
+        }),
+        session('regular', 'Regular work', 1),
+      ],
+      initialUiState: {
+        expandedProjects: [1],
+        pinnedSectionExpanded: true,
+        repositoriesSectionExpanded: true,
+      },
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const fullSidebarPane = page.getByRole('button', { name: 'Regular work', exact: true });
+    await fullSidebarPane.click();
+    await expect(fullSidebarPane).toHaveAttribute('aria-current', 'page');
+    await expect(fullSidebarPane.locator('..')).toHaveClass(/bg-surface-hover/);
+    await fullSidebarPane.evaluate(element => element.blur());
+    await page.mouse.move(640, 360);
+    await page.screenshot({
+      path: 'test-results/sidebar-active-pane-full.png',
+      clip: { x: 0, y: 0, width: 340, height: 720 },
+    });
+
+    await collapseSidebar(page);
+    const compactSidebarPane = page.getByTestId('compact-repository-pane-regular');
+    await expect(compactSidebarPane).toHaveClass(/bg-surface-hover/);
+    await page.mouse.move(320, 180);
+    await page.screenshot({
+      path: 'test-results/sidebar-active-pane-compact.png',
+      clip: { x: 0, y: 0, width: 180, height: 720 },
+    });
+  });
+
   test('mirrors an expanded pinned section and collapsed repositories section', async ({ page }) => {
     await installElectronApiMock(page, {
       initialConfig: { theme: 'night-owl' },


### PR DESCRIPTION
## Summary

- resolve omitted pane/worktree bases from the remote default branch instead of the project checkout's current `HEAD`
- preserve the resolved comparison ref when a pre-warmed reserve worktree is claimed
- keep the existing hover surface visible on the selected pane in both full and compact sidebars
- add focused unit and Playwright regression coverage

## Root cause

Desktop pane creation explicitly submits the selected base branch, but CLI, automation, and legacy callers may omit `baseBranch`. Both fresh and reserve worktree creation previously substituted the root checkout's `HEAD`. If that checkout was on an unrelated or deleted feature branch, Pane persisted that commit and later calculated very large, misleading diffs after the worktree was reset or rebased onto `main`. The reserve path also dropped the effective base ref after claiming the worktree, producing `NULL` bases where the fresh path produced `HEAD`.

Omitted bases now resolve in this order: remote default (`origin/HEAD`), conventional remote refs (`origin/main`, `origin/master`), conventional local refs (`main`, `master`), then `HEAD` only for repositories without any conventional integration ref. Explicit user-selected bases are unchanged.

## User journeys

1. Create a pane in the desktop dialog with `origin/main` selected: the explicit base remains `origin/main`.
2. Create a pane through RunPane/automation without `baseBranch` while the root checkout is on a feature branch: the pane starts from and records the remote default branch.
3. Repeat omitted-base creation with and without a pre-warmed reserve: both paths record the same base ref and fork commit.
4. Select a pane in the full sidebar: its hover background remains visible after the pointer leaves.
5. Collapse the sidebar: the same selected pane retains the hover background in compact mode.

## Testing

- `pnpm lint` (passes; existing warnings only)
- `pnpm typecheck`
- `pnpm --filter main exec vitest run src/services/__tests__/worktreeManager.test.ts` (12 passed)
- `PLAYWRIGHT_PORT=4538 pnpm test -- tests/sidebar-compact.spec.ts` (3 passed)
- `pnpm build` (universal macOS app, DMG, ZIP, and block maps)
- `pnpm build:frontend` after the compact-sidebar adjustment

## Local verification

The affected Bloom checkout was repaired after backing up `~/.pane/sessions.db`. A live project refresh replaced the repeated `+217322 -136285` values with direct `origin/main` comparisons: inactive TM branches now show zero line changes, while active branches show their plausible local diffs (for example `do-tm-302` at `+1973 -14`).

<!-- pr-test-automation-summary:start -->
### Automated QA

Status: passed.

- Verified full and compact selected-pane states with Playwright at desktop and 48px rail widths.
- Verified fresh and reserve omitted-base paths persist `origin/main` through focused Vitest cases.
- Verified the production frontend and universal macOS package build.

| Full sidebar | Compact sidebar |
| --- | --- |
| The selected `Regular work` row retains the same subtle surface shown on hover after focus and pointer leave.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-377-9b3e243-fcefedfc14fd-active-pane-full.png" width="340" alt="Full sidebar with persistent active pane background"> | The corresponding compact rail item retains the same active surface at the 48px sidebar width.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-377-9b3e243-835c15e4b317-active-pane-compact.png" width="180" alt="Compact sidebar with persistent active pane background"> |
<!-- pr-test-automation-summary:end -->
