### PR TITLE
Fix Pane worktree push upstream setup

### DIFF
--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -65,6 +65,88 @@ describe('resolveDefaultWorktreeBase', () => {
 });
 
 describe('WorktreeManager.resolveWorkingDirectory', () => {
+  it('creates fresh worktrees from remote bases without setting upstream tracking', async () => {
+    const runner = commandRunner(async command => {
+      if (command === 'git rev-parse --is-inside-work-tree') {
+        return { stdout: 'true\n', stderr: '' };
+      }
+      if (command.startsWith('git worktree remove ')) {
+        throw new Error('No existing worktree');
+      }
+      if (command === 'git rev-parse HEAD') {
+        return { stdout: 'current-head\n', stderr: '' };
+      }
+      if (command === 'git show-ref --verify --quiet refs/heads/pane') {
+        throw new Error('Branch does not exist');
+      }
+      if (command === 'git rev-parse --verify origin/main') {
+        return { stdout: 'base-commit\n', stderr: '' };
+      }
+      if (command === 'git rev-parse origin/main') {
+        return { stdout: 'base-commit\n', stderr: '' };
+      }
+      if (command === 'git worktree add -b pane --no-track "/repo/worktrees/pane" origin/main') {
+        return { stdout: '', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const manager = new WorktreeManager();
+
+    const result = await manager.createWorktree(
+      '/repo',
+      'pane',
+      undefined,
+      'origin/main',
+      undefined,
+      { join: (...parts: string[]) => parts.join('/') } as PathResolver,
+      runner,
+    );
+
+    expect(result).toEqual({
+      worktreePath: '/repo/worktrees/pane',
+      baseCommit: 'base-commit',
+      baseBranch: 'origin/main',
+    });
+    expect(runner.execAsync).toHaveBeenCalledWith(
+      'git worktree add -b pane --no-track "/repo/worktrees/pane" origin/main',
+      '/repo',
+      { timeout: 60000 },
+    );
+    const worktreeAddCall = vi.mocked(runner.execAsync).mock.calls.find(([command]) =>
+      command.startsWith('git worktree add -b pane '),
+    );
+    expect(worktreeAddCall?.[0]).not.toContain(' --track ');
+  });
+
+  it('creates reserve worktrees without setting upstream tracking', async () => {
+    const runner = commandRunner(async command => {
+      if (command === 'git fetch') {
+        return { stdout: '', stderr: '' };
+      }
+      if (command.startsWith('git worktree add -b ')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (command === 'git rev-parse origin/main') {
+        return { stdout: 'base-commit\n', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await worktreePoolManager.createReserve(
+      '/repo',
+      'origin/main',
+      undefined,
+      { join: (...parts: string[]) => parts.join('/') } as PathResolver,
+      runner,
+    );
+
+    const worktreeAddCall = vi.mocked(runner.execAsync).mock.calls.find(([command]) =>
+      command.startsWith('git worktree add -b '),
+    );
+    expect(worktreeAddCall?.[0]).toContain('--no-track');
+    expect(worktreeAddCall?.[0]).not.toContain(' --track ');
+  });
+
   it('persists the resolved default branch when claiming a reserve worktree', async () => {
     const runner = commandRunner(async (command, cwd) => {
       if (command.includes('symbolic-ref')) {

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -309,16 +309,9 @@ export class WorktreeManager {
         baseCommit = (await commandRunner.execAsync(`git rev-parse ${baseRef}`, projectPath)).stdout.trim();
 
         if (isRemoteBranch) {
-          // Use --track flag for remote branches to set up tracking automatically
-          await commandRunner.execAsync(`git worktree add -b ${branchName} --track "${worktreePath}" ${baseBranch}`, projectPath, { timeout: 60000 });
-
-          // Verify tracking was set (for debugging)
-          try {
-            const { stdout: trackingInfo } = await commandRunner.execAsync(`git branch -vv`, worktreePath);
-            console.log(`[WorktreeManager] Branch tracking set:`, trackingInfo.trim());
-          } catch {
-            // Ignore verification errors
-          }
+          // Keep the remote base for Pane comparisons, but leave upstream unset
+          // so first push creates origin/<branchName> instead of pushing to the base.
+          await commandRunner.execAsync(`git worktree add -b ${branchName} --no-track "${worktreePath}" ${baseBranch}`, projectPath, { timeout: 60000 });
         } else {
           // Existing logic for local branches (no tracking)
           await commandRunner.execAsync(`git worktree add -b ${branchName} "${worktreePath}" ${baseRef}`, projectPath, { timeout: 60000 });

--- a/main/src/services/worktreePoolManager.ts
+++ b/main/src/services/worktreePoolManager.ts
@@ -76,7 +76,7 @@ class WorktreePoolManager {
 
     try {
       await commandRunner.execAsync(
-        `git worktree add -b ${escapeShellArg(branchName)} ${escapeShellArg(reservePath)} ${escapeShellArg(baseRef)}`,
+        `git worktree add -b ${escapeShellArg(branchName)} --no-track ${escapeShellArg(reservePath)} ${escapeShellArg(baseRef)}`,
         projectPath,
         { timeout: 60000 }
       );


### PR DESCRIPTION
## Summary
- create new Pane worktree branches from remote bases with `--no-track` so they do not track `origin/main`
- apply the same no-upstream behavior to prewarmed reserve worktrees
- add regression coverage that preserves `baseBranch = origin/main` while leaving branch upstream unset

## Testing
- `pnpm --filter main exec vitest run src/services/__tests__/worktreeManager.test.ts`
- `pnpm --filter main typecheck`
- `pnpm --filter main lint` (passes with existing warnings)
- `pnpm --filter main build`
- scripted local Git QA for right-sidebar Git semantics: create, first push, pull, fetch, stash/pop, undo commit, rebase from origin/main, merge to main

## Notes
- This intentionally does not change `session.baseBranch`; Pane still records `origin/main` for diff/status/rebase comparisons.
- The change only prevents Git branch upstream from pointing at the base branch.