### PR TITLE
Add a repository-wide commit graph

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef, useId } from 'react';
-import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare, Network } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
@@ -81,6 +81,7 @@ export function ProjectSessionList({
   const navigateToPaneChat = useNavigationStore(s => s.navigateToPaneChat);
   const paneChatStatus = useSessionAgentDisplayStatus(PANE_CHAT_SESSION_ID);
   const navigateToProject = useNavigationStore(s => s.navigateToProject);
+  const navigateToGitGraph = useNavigationStore(s => s.navigateToGitGraph);
   const setSidebarNavigationScope = useNavigationStore(s => s.setSidebarNavigationScope);
   // Expansion state lives in the navigation store so the always-mounted
   // session hotkeys (useSessionNavigationHotkeys) see the same visible ordering
@@ -412,6 +413,12 @@ export function ProjectSessionList({
               label: 'Open session on main',
               icon: GitBranch,
               onClick: () => navigateToProject(project.id),
+            },
+            {
+              id: 'commit-graph',
+              label: 'Commit graph',
+              icon: Network,
+              onClick: () => navigateToGitGraph(project.id),
             },
             {
               id: 'delete',

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -16,6 +16,7 @@ import { CommitMessageDialog } from './session/CommitMessageDialog';
 import { FolderArchiveDialog } from './session/FolderArchiveDialog';
 import { ConfirmDialog } from './ConfirmDialog';
 import { ProjectView } from './ProjectView';
+import { GitGraphView } from './gitGraph/GitGraphView';
 import { API } from '../utils/api';
 import { useResizable } from '../hooks/useResizable';
 import { useResizableHeight } from '../hooks/useResizableHeight';
@@ -1217,9 +1218,11 @@ export const SessionView = memo(() => {
     return () => { cancelled = true; };
   }, [activeSession?.id, activeSession?.isMainRepo]);
 
-  // Load project data when activeProjectId changes
+  // Load project data when activeProjectId changes. The commit graph needs it
+  // too: without a name in its header there is nothing on screen saying which
+  // repository is being graphed.
   useEffect(() => {
-    if (activeView === 'project' && activeProjectId) {
+    if ((activeView === 'project' || activeView === 'git-graph') && activeProjectId) {
       const loadProjectData = async () => {
         setIsProjectLoading(true);
         try {
@@ -1612,6 +1615,11 @@ export const SessionView = memo(() => {
   })();
   
   // Removed unused variables - now handled by panels
+
+  // Repository-wide commit graph — project-scoped, not session-scoped.
+  if (activeView === 'git-graph' && activeProjectId) {
+    return <GitGraphView projectId={activeProjectId} projectName={projectData?.name} />;
+  }
 
   // Show project view if navigation is set to project
   if (activeView === 'project' && activeProjectId) {

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1618,7 +1618,7 @@ export const SessionView = memo(() => {
 
   // Repository-wide commit graph — project-scoped, not session-scoped.
   if (activeView === 'git-graph' && activeProjectId) {
-    return <GitGraphView projectId={activeProjectId} projectName={projectData?.name} />;
+    return <GitGraphView key={activeProjectId} projectId={activeProjectId} projectName={projectData?.name} />;
   }
 
   // Show project view if navigation is set to project

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { ProjectSessionList, ArchivedSessions } from './ProjectSessionList';
 import { ArchiveProgress } from './ArchiveProgress';
-import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare, SquareTerminal } from 'lucide-react';
+import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, Network, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare, SquareTerminal } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { usePaneLogo } from '../hooks/usePaneLogo';
 import { IconButton } from './ui/Button';
@@ -388,6 +388,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
   const activeView = useNavigationStore((state) => state.activeView);
   const expandedProjects = useNavigationStore((state) => state.expandedProjects);
   const navigateToProject = useNavigationStore((state) => state.navigateToProject);
+  const navigateToGitGraph = useNavigationStore((state) => state.navigateToGitGraph);
   const navigateToSessions = useNavigationStore((state) => state.navigateToSessions);
   const navigateToPaneChat = useNavigationStore((state) => state.navigateToPaneChat);
   const paneChatStatus = useSessionAgentDisplayStatus(PANE_CHAT_SESSION_ID);
@@ -642,6 +643,19 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                         {projectAgentState === 'unknown'
                           ? <AgentActivityDot active={false} size="sm" className="absolute bottom-0 right-0" />
                           : <AgentStatusDot status={projectAgentState} size="sm" className="absolute bottom-0 right-0" />}
+                      </button>
+                    </Tooltip>
+
+                    <Tooltip content={`Commit graph for ${project.name}`} side="right">
+                      <button
+                        type="button"
+                        data-testid={`compact-repository-graph-${project.id}`}
+                        data-compact-rail-item
+                        onClick={() => navigateToGitGraph(project.id)}
+                        aria-label={`Open commit graph for ${project.name}`}
+                        className={`${COMPACT_RAIL_BUTTON} ${activeProjectId === project.id && activeView === 'git-graph' ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
+                      >
+                        <Network className="h-4 w-4" aria-hidden="true" />
                       </button>
                     </Tooltip>
 

--- a/frontend/src/components/gitGraph/GitGraphCanvas.tsx
+++ b/frontend/src/components/gitGraph/GitGraphCanvas.tsx
@@ -1,0 +1,105 @@
+import { memo } from 'react';
+import type { GitGraphRow } from '../../../../shared/types/gitGraph';
+import { LANE_WIDTH, ROW_HEIGHT, laneColor } from './graphColors';
+
+const DOT_RADIUS = 4;
+/** Length of the cap drawn above a branch tip's dot. */
+const TIP_CAP = 5;
+
+/**
+ * Path for one edge within a row's band.
+ *
+ * Every row draws its own slice, so an edge has to cover exactly the part of
+ * the band it owns: a pass-through spans the full height, a straight or merge
+ * edge leaves the dot half-way down, and a join arrives at the dot from above.
+ * Getting this wrong is what turned continuing branches into dashed lines.
+ */
+function edgePath(kind: string, x1: number, x2: number, centerY: number, rowHeight: number): string {
+  switch (kind) {
+    case 'passthrough':
+      return `M ${x1} 0 L ${x2} ${rowHeight}`;
+    case 'straight':
+      return `M ${x1} ${centerY} L ${x2} ${rowHeight}`;
+    case 'join':
+      // Mirror of the merge curve: comes down its own lane, then bends in.
+      return `M ${x1} 0 C ${x1} ${centerY * 0.5}, ${x2} ${centerY * 0.75}, ${x2} ${centerY}`;
+    default:
+      return `M ${x1} ${centerY} C ${x1} ${centerY + rowHeight * 0.35}, ${x2} ${centerY + rowHeight * 0.25}, ${x2} ${rowHeight}`;
+  }
+}
+
+interface GitGraphCanvasProps {
+  row: GitGraphRow;
+  laneCount: number;
+  /** Highlights the dot when this commit is selected in the list. */
+  isSelected: boolean;
+}
+
+/**
+ * Draws one row's slice of the commit graph: the commit dot plus every edge
+ * descending from this row into the next.
+ *
+ * Purely decorative — `aria-hidden`, zero interactivity. The clickable target
+ * is the row button in {@link GitGraphView}, which keeps the graph free of
+ * `jsx-a11y/no-static-element-interactions` violations.
+ */
+export const GitGraphCanvas = memo(function GitGraphCanvas({ row, laneCount, isSelected }: GitGraphCanvasProps) {
+  const width = Math.max(laneCount, 1) * LANE_WIDTH;
+  const centerY = ROW_HEIGHT / 2;
+  const laneX = (lane: number) => lane * LANE_WIDTH + LANE_WIDTH / 2;
+  const isMerge = row.node.parents.length > 1;
+
+  return (
+    <svg
+      width={width}
+      height={ROW_HEIGHT}
+      viewBox={`0 0 ${width} ${ROW_HEIGHT}`}
+      className="flex-shrink-0"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {row.edges.map((edge, index) => (
+        <path
+          key={`${edge.fromLane}-${edge.toLane}-${edge.kind}-${index}`}
+          d={edgePath(edge.kind, laneX(edge.fromLane), laneX(edge.toLane), centerY, ROW_HEIGHT)}
+          fill="none"
+          stroke={laneColor(edge.colorIndex)}
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          opacity={edge.danglesBelow ? 0.35 : 0.85}
+        />
+      ))}
+
+      {/*
+        Above the dot: the continuation of this lane from the row above, or —
+        when the branch starts here — a short rounded cap that reads as a
+        beginning instead of a line arriving from nowhere.
+      */}
+      <path
+        d={row.isBranchTip
+          ? `M ${laneX(row.lane)} ${centerY - TIP_CAP} L ${laneX(row.lane)} ${centerY}`
+          : `M ${laneX(row.lane)} 0 L ${laneX(row.lane)} ${centerY}`}
+        fill="none"
+        stroke={laneColor(row.colorIndex)}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        opacity={0.85}
+      />
+
+      {/*
+        A merge is drawn hollow — the standard cue, and the only thing that
+        tells two histories joining here apart from an ordinary commit.
+      */}
+      <circle
+        cx={laneX(row.lane)}
+        cy={centerY}
+        r={isSelected ? DOT_RADIUS + 1.5 : DOT_RADIUS}
+        fill={isMerge ? 'var(--color-bg-primary, #101014)' : laneColor(row.colorIndex)}
+        stroke={isMerge ? laneColor(row.colorIndex) : 'var(--color-bg-primary, #101014)'}
+        strokeWidth={isMerge ? 2 : 1.5}
+      />
+    </svg>
+  );
+});
+
+export default GitGraphCanvas;

--- a/frontend/src/components/gitGraph/GitGraphCanvas.tsx
+++ b/frontend/src/components/gitGraph/GitGraphCanvas.tsx
@@ -101,5 +101,3 @@ export const GitGraphCanvas = memo(function GitGraphCanvas({ row, laneCount, isS
     </svg>
   );
 });
-
-export default GitGraphCanvas;

--- a/frontend/src/components/gitGraph/GitGraphCommitDetail.tsx
+++ b/frontend/src/components/gitGraph/GitGraphCommitDetail.tsx
@@ -37,7 +37,7 @@ export function GitGraphCommitDetail({ projectId, node }: GitGraphCommitDetailPr
         }
         setDiff(response.data);
       })
-      .catch((err: unknown) => {
+      .catch(err => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load commit');
       })
       .finally(() => {
@@ -121,5 +121,3 @@ export function GitGraphCommitDetail({ projectId, node }: GitGraphCommitDetailPr
     </div>
   );
 }
-
-export default GitGraphCommitDetail;

--- a/frontend/src/components/gitGraph/GitGraphCommitDetail.tsx
+++ b/frontend/src/components/gitGraph/GitGraphCommitDetail.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2, User, Clock, Hash, GitFork } from 'lucide-react';
+import { API } from '../../utils/api';
+import { parseUnifiedDiffToFiles } from '../../utils/parseUnifiedDiff';
+import DiffViewer from '../panels/diff/DiffViewer';
+import { CopyableField } from '../ui/CopyableField';
+import { Badge } from '../ui/Badge';
+import type { GitGraphNode } from '../../../../shared/types/gitGraph';
+import type { GitDiffResult } from '../../types/diff';
+
+interface GitGraphCommitDetailProps {
+  projectId: number;
+  node: GitGraphNode;
+}
+
+/**
+ * Right-hand pane of the graph view: metadata for the selected commit plus its
+ * full patch, rendered with the same {@link DiffViewer} the diff panel uses so
+ * expand/collapse, split view and syntax highlighting behave identically.
+ */
+export function GitGraphCommitDetail({ projectId, node }: GitGraphCommitDetailProps) {
+  const [diff, setDiff] = useState<GitDiffResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setDiff(null);
+
+    API.projects.getCommitDetail(projectId, node.hash)
+      .then(response => {
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          throw new Error(response.error || 'Failed to load commit');
+        }
+        setDiff(response.data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load commit');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [projectId, node.hash]);
+
+  const files = useMemo(() => (diff ? parseUnifiedDiffToFiles(diff.diff) : []), [diff]);
+
+  const fullDate = useMemo(() => {
+    const date = new Date(node.authorDate);
+    return Number.isNaN(date.getTime())
+      ? node.authorDate
+      : date.toLocaleString(undefined, {
+        weekday: 'short', year: 'numeric', month: 'short', day: 'numeric',
+        hour: '2-digit', minute: '2-digit',
+      });
+  }, [node.authorDate]);
+
+  return (
+    <div className="flex h-full min-w-0 flex-col">
+      <header className="flex-shrink-0 border-b border-border-primary bg-surface-secondary px-4 py-3">
+        <h2 className="mb-2 whitespace-pre-wrap break-words text-sm font-medium leading-snug text-text-primary">
+          {node.subject}
+        </h2>
+
+        {node.refs.length > 0 && (
+          <div className="mb-2 flex flex-wrap gap-1">
+            {node.refs.map(ref => (
+              <Badge
+                key={`${ref.kind}-${ref.name}`}
+                size="sm"
+                variant={ref.kind === 'tag' ? 'warning' : ref.isCurrent ? 'primary' : 'default'}
+              >
+                {ref.name}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        <div className="space-y-0.5 text-[11px]">
+          <CopyableField icon={User} value={`${node.authorName} <${node.authorEmail}>`} />
+          <CopyableField icon={Hash} value={node.hash} mono />
+          <CopyableField icon={Clock} value={fullDate} />
+          {node.parents.length > 0 && (
+            <CopyableField icon={GitFork} value={node.parents.join(', ')} mono />
+          )}
+        </div>
+
+        {diff && (
+          <div className="mt-2 flex items-center gap-2 text-xs">
+            <span className="font-semibold text-status-success">+{diff.stats.additions}</span>
+            <span className="font-semibold text-status-error">-{diff.stats.deletions}</span>
+            <span className="text-text-muted">
+              {diff.stats.filesChanged} {diff.stats.filesChanged === 1 ? 'file' : 'files'}
+            </span>
+          </div>
+        )}
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {loading ? (
+          <div className="flex items-center justify-center gap-2 py-8 text-xs text-text-tertiary">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading commit…
+          </div>
+        ) : error ? (
+          <div className="m-4 rounded border border-status-error/30 bg-status-error/10 p-4 text-sm text-status-error">
+            {error}
+          </div>
+        ) : files.length === 0 ? (
+          <div className="p-4 text-center text-sm text-text-secondary">
+            This commit has no file changes.
+          </div>
+        ) : (
+          <DiffViewer files={files} className="h-full" />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default GitGraphCommitDetail;

--- a/frontend/src/components/gitGraph/GitGraphView.tsx
+++ b/frontend/src/components/gitGraph/GitGraphView.tsx
@@ -123,7 +123,7 @@ function RefChip({
       type="button"
       onClick={event => { event.stopPropagation(); onFocus(name); }}
       aria-pressed={isFocused}
-      className={`inline-flex max-w-[14rem] flex-shrink-0 items-center gap-1 rounded border px-1.5 py-px text-[10px] leading-tight transition-colors hover:brightness-125 ${tone}`}
+      className={`pointer-events-auto inline-flex max-w-[14rem] flex-shrink-0 items-center gap-1 rounded border px-1.5 py-px text-[10px] leading-tight transition-colors hover:brightness-125 ${tone}`}
       title={[
         worktree ? `${name} — checked out in Pane session "${worktree.sessionName ?? worktree.path}"` : name,
         divergence ? `${divergence} vs the current branch` : null,
@@ -599,9 +599,11 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
                           type="button"
                           onClick={() => setSelectedHash(row.node.hash)}
                           aria-pressed={isSelected}
+                          aria-label={`Select commit ${row.node.subject}`}
                           title={`${row.node.subject}\n${row.node.shortHash} · ${row.node.authorName} <${row.node.authorEmail}> · ${formatDate(row.node.authorDate)}`}
-                          className="flex min-w-0 flex-1 items-stretch gap-2 pr-2 text-left"
-                        >
+                          className="absolute inset-0 z-0"
+                        />
+                        <div className="pointer-events-none relative z-10 flex min-w-0 flex-1 items-stretch gap-2 pr-2 text-left">
                           {/*
                             Lanes past the gutter's width are clipped rather
                             than squeezed — the positions of the ones on screen
@@ -669,10 +671,11 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
                               {formatAge(row.node.authorDate)}
                             </span>
                           </span>
-                        </button>
+                        </div>
 
                         {/* Sibling of the row button — a button inside a button is invalid. */}
-                        <Dropdown
+                        <div className="relative z-10 flex">
+                          <Dropdown
                           position="bottom-right"
                           width="sm"
                           items={[
@@ -713,7 +716,8 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
                               <MoreHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
                             </button>
                           }
-                        />
+                          />
+                        </div>
                       </div>
                     );
                   })}

--- a/frontend/src/components/gitGraph/GitGraphView.tsx
+++ b/frontend/src/components/gitGraph/GitGraphView.tsx
@@ -1,0 +1,801 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import {
+  Copy, GitBranch, Hash, Loader2, MoreHorizontal, PanelRight, RefreshCw, Search, Tag, X,
+} from 'lucide-react';
+import { API } from '../../utils/api';
+import { Dropdown } from '../ui/Dropdown';
+import { computeGitGraphLayout } from '../../utils/gitGraphLayout';
+import { useSessionStore } from '../../stores/sessionStore';
+import { useNavigationStore } from '../../stores/navigationStore';
+import { GitGraphCanvas } from './GitGraphCanvas';
+import { LANE_WIDTH, ROW_HEIGHT, laneColor } from './graphColors';
+import { GitGraphCommitDetail } from './GitGraphCommitDetail';
+import {
+  GRAPH_REMOTE_ALL,
+  GRAPH_REMOTE_NONE,
+  type GitGraphNode,
+  type PaneWorktreeRef,
+  type RepoGitGraph,
+} from '../../../../shared/types/gitGraph';
+
+/** Rows rendered outside the viewport on each side, to hide scroll seams. */
+const VIRTUALIZE_OVERSCAN = 8;
+/** Below this many commits, virtualisation costs more than it saves. */
+const VIRTUALIZE_THRESHOLD = 200;
+/** A repo-wide `--all` log is expensive; coalesce refresh triggers. */
+const REFRESH_DEBOUNCE_MS = 2000;
+
+const LIMIT_OPTIONS = [100, 300, 1000] as const;
+/** Hard ceiling the backend enforces; "load more" stops here. */
+const MAX_LIMIT = 2000;
+/**
+ * Ref chips shown inline before a subject. Past this many the row is all
+ * chips and no commit message — the rest collapse into a "+N" pill.
+ */
+const INLINE_REFS = 2;
+/**
+ * Lanes the gutter reserves. A repository with thirty concurrent branches
+ * would otherwise push the commit text halfway across the window.
+ */
+const MAX_GUTTER_LANES = 8;
+const DETAIL_MIN_PERCENT = 25;
+const DETAIL_MAX_PERCENT = 70;
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/**
+ * "2h", "3d" — a fixed-width age, so the right-hand column lines up and the
+ * eye can scan down it. The exact timestamp lives in the row's tooltip.
+ */
+function formatAge(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const minutes = Math.max(0, Math.round((Date.now() - then) / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 365) return `${days}d`;
+  return `${Math.floor(days / 365)}y`;
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/** Stable colour per author, so the same person keeps the same badge. */
+function authorColor(seed: string): string {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) | 0;
+  return laneColor(Math.abs(hash));
+}
+
+function RefChip({
+  name,
+  kind,
+  isCurrent,
+  ahead,
+  behind,
+  worktree,
+  isFocused,
+  onFocus,
+}: {
+  name: string;
+  kind: string;
+  isCurrent: boolean;
+  ahead?: number;
+  behind?: number;
+  worktree?: PaneWorktreeRef;
+  isFocused: boolean;
+  onFocus: (ref: string) => void;
+}) {
+  const Icon = kind === 'tag' ? Tag : GitBranch;
+  const tone = isFocused
+    ? 'border-interactive bg-interactive/25 text-interactive'
+    : kind === 'tag'
+      ? 'border-status-warning/40 bg-status-warning/10 text-status-warning'
+      : worktree
+        ? 'border-interactive/50 bg-interactive/15 text-interactive'
+        : isCurrent
+          ? 'border-status-success/40 bg-status-success/10 text-status-success'
+          : 'border-border-secondary bg-surface-tertiary text-text-secondary';
+
+  // The session name is only worth appending when it says something the branch
+  // name does not — otherwise the chip reads "archive · archive".
+  const sessionLabel = worktree?.sessionName && worktree.sessionName.toLowerCase() !== name.toLowerCase()
+    ? worktree.sessionName
+    : null;
+
+  const divergence = [
+    ahead ? `${ahead} ahead` : null,
+    behind ? `${behind} behind` : null,
+  ].filter(Boolean).join(', ');
+
+  return (
+    <button
+      type="button"
+      onClick={event => { event.stopPropagation(); onFocus(name); }}
+      aria-pressed={isFocused}
+      className={`inline-flex max-w-[14rem] flex-shrink-0 items-center gap-1 rounded border px-1.5 py-px text-[10px] leading-tight transition-colors hover:brightness-125 ${tone}`}
+      title={[
+        worktree ? `${name} — checked out in Pane session "${worktree.sessionName ?? worktree.path}"` : name,
+        divergence ? `${divergence} vs the current branch` : null,
+        'Click to show only this history',
+      ].filter(Boolean).join('\n')}
+    >
+      <Icon className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
+      <span className="truncate font-mono">{name}</span>
+      {sessionLabel && <span className="truncate opacity-80">{sessionLabel}</span>}
+      {(ahead || behind) && (
+        <span className="flex-shrink-0 tabular-nums opacity-80">
+          {ahead ? `↑${ahead}` : ''}{behind ? `↓${behind}` : ''}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export interface GitGraphViewProps {
+  projectId: number;
+  projectName?: string;
+}
+
+/**
+ * Repository-wide commit graph: every branch and tag in one lane diagram,
+ * with Pane's own worktrees highlighted and a per-commit detail pane.
+ *
+ * Scoped to a project rather than a session, which is why it is a top-level
+ * view instead of a `ToolPanelType` — panels are session-keyed.
+ */
+export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
+  const [graph, setGraph] = useState<RepoGitGraph | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [limit, setLimit] = useState<number>(LIMIT_OPTIONS[1]);
+  /**
+   * Which remote's branches are graphed. Undefined until the first response
+   * says which one the repository defaulted to.
+   */
+  const [remoteScope, setRemoteScope] = useState<string | undefined>(undefined);
+  const [selectedHash, setSelectedHash] = useState<string | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  /** Free-text filter over subject, author and hash. */
+  const [query, setQuery] = useState('');
+  /** Ref the history is narrowed to, if any. */
+  const [focusRef, setFocusRef] = useState<string | undefined>(undefined);
+  const [detailPercent, setDetailPercent] = useState(46);
+  const [detailHidden, setDetailHidden] = useState(false);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const splitRef = useRef<HTMLDivElement>(null);
+  const requestIdRef = useRef(0);
+
+  const setActiveSession = useSessionStore(state => state.setActiveSession);
+  const navigateToSessions = useNavigationStore(state => state.navigateToSessions);
+  const sessions = useSessionStore(state => state.sessions);
+
+  const load = useCallback(async (mode: 'initial' | 'refresh') => {
+    const requestId = ++requestIdRef.current;
+    if (mode === 'initial') setLoading(true);
+    else setRefreshing(true);
+
+    try {
+      const response = await API.projects.getGitGraph({
+        projectId,
+        limit,
+        ...(remoteScope === undefined ? {} : { remoteScope }),
+        ...(focusRef ? { focusRef } : {}),
+      });
+      if (requestId !== requestIdRef.current) return;
+      if (!response.success || !response.data) {
+        throw new Error(response.error || 'Failed to load repository graph');
+      }
+      setGraph(response.data);
+      // Adopt whatever the repository defaulted to, so the picker agrees with
+      // what is on screen.
+      setRemoteScope(response.data.remoteScope);
+      setError(null);
+    } catch (err: unknown) {
+      if (requestId !== requestIdRef.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load repository graph');
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, [projectId, limit, remoteScope, focusRef]);
+
+  useEffect(() => {
+    void load('initial');
+  }, [load]);
+
+  // Git operations elsewhere in the app invalidate the graph. A repo-wide
+  // `--all` log per event would be far too heavy, so refreshes are debounced.
+  useEffect(() => {
+    let timer: number | undefined;
+    const schedule = () => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => { void load('refresh'); }, REFRESH_DEBOUNCE_MS);
+    };
+
+    window.addEventListener('git-status-updated', schedule);
+    window.addEventListener('panel:event', schedule);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener('git-status-updated', schedule);
+      window.removeEventListener('panel:event', schedule);
+    };
+  }, [load]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    const observer = new ResizeObserver(() => setViewportHeight(element.clientHeight));
+    observer.observe(element);
+    setViewportHeight(element.clientHeight);
+    return () => observer.disconnect();
+  }, [graph]);
+
+  const layout = useMemo(() => computeGitGraphLayout(graph?.nodes ?? []), [graph]);
+
+  const worktreeByBranch = useMemo(() => {
+    const map = new Map<string, PaneWorktreeRef>();
+    for (const worktree of graph?.paneWorktrees ?? []) {
+      if (worktree.branch) map.set(worktree.branch, worktree);
+    }
+    return map;
+  }, [graph]);
+
+  /**
+   * Rows matching the filter.
+   *
+   * Filtering hides rows, which would leave the lane edges pointing at commits
+   * that are no longer there — so a filtered list drops the lane drawing and
+   * shows a plain marker instead. Honest, and what a search result should look
+   * like anyway.
+   */
+  const isFiltering = query.trim().length > 0;
+  const rows = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return layout.rows;
+    return layout.rows.filter(row =>
+      row.node.subject.toLowerCase().includes(needle)
+      || row.node.authorName.toLowerCase().includes(needle)
+      || row.node.authorEmail.toLowerCase().includes(needle)
+      || row.node.hash.toLowerCase().startsWith(needle)
+      || row.node.refs.some(ref => ref.name.toLowerCase().includes(needle))
+    );
+  }, [layout.rows, query]);
+
+  const selectedNode: GitGraphNode | null = useMemo(
+    () => layout.rows.find(row => row.node.hash === selectedHash)?.node ?? null,
+    [layout.rows, selectedHash]
+  );
+
+  const shouldVirtualize = rows.length > VIRTUALIZE_THRESHOLD && viewportHeight > 0;
+  const firstVisible = shouldVirtualize
+    ? Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - VIRTUALIZE_OVERSCAN)
+    : 0;
+  const lastVisible = shouldVirtualize
+    ? Math.min(rows.length, Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT) + VIRTUALIZE_OVERSCAN)
+    : rows.length;
+  const visibleRows = rows.slice(firstVisible, lastVisible);
+
+  const gutterWidth = Math.min(Math.max(layout.laneCount, 1), MAX_GUTTER_LANES) * LANE_WIDTH;
+
+  const openSession = useCallback((sessionId: string) => {
+    void setActiveSession(sessionId).then(() => navigateToSessions());
+  }, [setActiveSession, navigateToSessions]);
+
+  /**
+   * Sessions of this project with uncommitted work.
+   *
+   * Git knows nothing about them — they are the rows above the newest commit
+   * that every other client calls "WIP", and the reason Pane can draw them at
+   * all is that it tracks each worktree's status itself.
+   */
+  const dirtySessions = useMemo(() => sessions.filter(session =>
+    session.projectId === projectId
+    && !session.archived
+    && session.gitStatus
+    && ['modified', 'untracked', 'conflict'].includes(session.gitStatus.state)
+  ), [sessions, projectId]);
+
+  /** Newest commit is selected on arrival: an empty detail pane says nothing. */
+  useEffect(() => {
+    if (!selectedHash && layout.rows.length > 0) setSelectedHash(layout.rows[0].node.hash);
+  }, [selectedHash, layout.rows]);
+
+  const moveSelection = useCallback((delta: number | 'first' | 'last') => {
+    if (rows.length === 0) return;
+    const current = rows.findIndex(row => row.node.hash === selectedHash);
+    const next = delta === 'first'
+      ? 0
+      : delta === 'last'
+        ? rows.length - 1
+        : Math.min(Math.max((current === -1 ? 0 : current) + delta, 0), rows.length - 1);
+
+    setSelectedHash(rows[next].node.hash);
+
+    // Keep the cursor inside the viewport; the list is virtualised, so this is
+    // arithmetic on the scroll offset rather than a DOM lookup.
+    const element = scrollRef.current;
+    if (!element) return;
+    const top = next * ROW_HEIGHT;
+    if (top < element.scrollTop) element.scrollTop = top;
+    else if (top + ROW_HEIGHT > element.scrollTop + element.clientHeight) {
+      element.scrollTop = top + ROW_HEIGHT - element.clientHeight;
+    }
+  }, [rows, selectedHash]);
+
+  /**
+   * Arrow keys walk the history, `/` jumps to the filter, Escape backs out of
+   * a filter or a focused branch. Bound on the document because the list is a
+   * stack of buttons — without this the only way through 300 commits is the
+   * mouse.
+   */
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const typing = target?.isContentEditable
+        || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName ?? '');
+
+      if (typing) {
+        if (event.key === 'Escape' && target === searchRef.current) {
+          setQuery('');
+          searchRef.current?.blur();
+        }
+        return;
+      }
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+      switch (event.key) {
+        case 'ArrowDown': case 'j': event.preventDefault(); moveSelection(1); break;
+        case 'ArrowUp': case 'k': event.preventDefault(); moveSelection(-1); break;
+        case 'PageDown': event.preventDefault(); moveSelection(10); break;
+        case 'PageUp': event.preventDefault(); moveSelection(-10); break;
+        case 'Home': event.preventDefault(); moveSelection('first'); break;
+        case 'End': event.preventDefault(); moveSelection('last'); break;
+        case '/': event.preventDefault(); searchRef.current?.focus(); break;
+        case 'Escape':
+          if (query) { event.preventDefault(); setQuery(''); }
+          else if (focusRef) { event.preventDefault(); setFocusRef(undefined); }
+          break;
+        default: break;
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [moveSelection, query, focusRef]);
+
+  /** Drag the divider between the list and the detail pane. */
+  const startDetailDrag = useCallback((event: ReactPointerEvent) => {
+    event.preventDefault();
+    const container = splitRef.current;
+    if (!container) return;
+
+    const onMove = (move: PointerEvent) => {
+      const rect = container.getBoundingClientRect();
+      if (rect.width === 0) return;
+      const percent = ((rect.right - move.clientX) / rect.width) * 100;
+      setDetailPercent(Math.min(Math.max(percent, DETAIL_MIN_PERCENT), DETAIL_MAX_PERCENT));
+    };
+    const onUp = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }, []);
+
+  const copyToClipboard = useCallback((value: string) => {
+    void navigator.clipboard?.writeText(value).catch(() => {});
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-bg-primary">
+      <header className="flex flex-shrink-0 flex-wrap items-center gap-3 border-b border-border-primary bg-surface-secondary px-4 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <GitBranch className="h-4 w-4 flex-shrink-0 text-text-tertiary" aria-hidden="true" />
+          <h1 className="truncate text-sm font-medium text-text-primary">Commit graph</h1>
+          {/* One repository at a time — say which, always. */}
+          <span className="truncate rounded bg-surface-tertiary px-1.5 py-px text-[11px] text-text-secondary">
+            {projectName ?? 'this repository'}
+          </span>
+          {graph?.currentBranch && (
+            <span className="truncate font-mono text-[11px] text-text-tertiary">on {graph.currentBranch}</span>
+          )}
+          {focusRef && (
+            <button
+              type="button"
+              onClick={() => setFocusRef(undefined)}
+              title="Show the whole repository again (Escape)"
+              className="flex flex-shrink-0 items-center gap-1 rounded-full border border-interactive/50 bg-interactive/15 px-2 py-px text-[10px] text-interactive transition-colors hover:bg-interactive/25"
+            >
+              <GitBranch className="h-2.5 w-2.5" aria-hidden="true" />
+              <span className="font-mono">{focusRef}</span>
+              <X className="h-2.5 w-2.5" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+
+        <div className="ml-auto flex flex-wrap items-center gap-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-1.5 top-1/2 h-3 w-3 -translate-y-1/2 text-text-muted" aria-hidden="true" />
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={event => setQuery(event.target.value)}
+              placeholder="Filter commits  /"
+              aria-label="Filter commits by subject, author, hash or ref"
+              className="w-44 rounded border border-border-secondary bg-surface-primary py-0.5 pl-6 pr-2 text-[11px] text-text-primary placeholder:text-text-muted focus:border-interactive focus:outline-none"
+            />
+          </div>
+
+          <fieldset className="flex items-center gap-1">
+            <legend className="sr-only">Number of commits to load</legend>
+            {LIMIT_OPTIONS.map(option => (
+              <button
+                key={option}
+                type="button"
+                aria-pressed={limit === option}
+                onClick={() => setLimit(option)}
+                className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
+                  limit === option
+                    ? 'bg-interactive text-text-on-interactive'
+                    : 'text-text-secondary hover:bg-surface-hover'
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </fieldset>
+
+          {/*
+            A fork's clone carries `origin` and `upstream`, and those are two
+            different repositories on the hosting side. Graphing every remote
+            buried this project's history under the other one's branches, so
+            the remote is an explicit choice that defaults to this repo's own.
+          */}
+          <label className="flex items-center gap-1.5 text-[11px] text-text-secondary">
+            <span className="text-[10px] uppercase tracking-wider text-text-muted">Remote</span>
+            <select
+              value={remoteScope}
+              onChange={event => setRemoteScope(event.target.value)}
+              className="rounded border border-border-secondary bg-surface-primary px-1.5 py-0.5 text-[11px] text-text-secondary focus:border-interactive focus:outline-none"
+            >
+              <option value={GRAPH_REMOTE_NONE}>Local only</option>
+              {(graph?.remotes ?? []).map(remote => (
+                <option key={remote} value={remote}>{remote}</option>
+              ))}
+              {(graph?.remotes.length ?? 0) > 1 && (
+                <option value={GRAPH_REMOTE_ALL}>All remotes</option>
+              )}
+            </select>
+          </label>
+
+          <button
+            type="button"
+            onClick={() => setDetailHidden(current => !current)}
+            aria-pressed={!detailHidden}
+            title={detailHidden ? 'Show the commit details' : 'Hide the commit details'}
+            className="rounded p-1 transition-colors hover:bg-surface-hover"
+          >
+            <PanelRight className={`h-3.5 w-3.5 ${detailHidden ? 'text-text-muted' : 'text-text-tertiary'}`} aria-hidden="true" />
+          </button>
+
+          <button
+            type="button"
+            onClick={() => { void load('refresh'); }}
+            disabled={loading || refreshing}
+            aria-label="Refresh commit graph"
+            className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 text-text-tertiary ${refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
+          </button>
+        </div>
+      </header>
+
+      {graph?.notice && (
+        <div className="flex-shrink-0 border-b border-border-primary bg-surface-tertiary px-4 py-1 text-[11px] text-text-tertiary">
+          {graph.notice}
+        </div>
+      )}
+
+      {isFiltering && !loading && !error && (
+        <div className="flex-shrink-0 border-b border-border-primary bg-surface-tertiary px-4 py-1 text-[11px] text-text-tertiary">
+          {rows.length} of {layout.rows.length} commits match “{query.trim()}” — lanes are hidden while filtering.
+        </div>
+      )}
+
+      {!isFiltering && layout.laneCount > MAX_GUTTER_LANES && (
+        <div className="flex-shrink-0 border-b border-border-primary bg-surface-tertiary px-4 py-1 text-[11px] text-text-tertiary">
+          {layout.laneCount} parallel branches in view; the gutter shows the first {MAX_GUTTER_LANES}.
+          Focus a branch or switch the remote to narrow it down.
+        </div>
+      )}
+
+      <div ref={splitRef} className="flex min-h-0 flex-1">
+        {/* Commit list */}
+        <div
+          ref={scrollRef}
+          onScroll={event => setScrollTop(event.currentTarget.scrollTop)}
+          className="min-w-0 flex-1 overflow-auto"
+        >
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-10 text-xs text-text-tertiary">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              Reading repository history…
+            </div>
+          ) : error ? (
+            <div className="m-4 rounded border border-status-error/30 bg-status-error/10 p-4 text-sm text-status-error">
+              <p className="mb-1 font-medium">Could not load the commit graph</p>
+              <p>{error}</p>
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="flex h-full items-center justify-center px-6 text-center text-sm text-text-secondary">
+              {isFiltering ? `Nothing matches “${query.trim()}”.` : 'No commits to show yet.'}
+            </div>
+          ) : (
+            <>
+              {/*
+                Work git has not been told about yet. Every other client calls
+                this the WIP row; Pane can name the session it belongs to.
+              */}
+              {!isFiltering && dirtySessions.map(session => (
+                <button
+                  key={session.id}
+                  type="button"
+                  onClick={() => openSession(session.id)}
+                  className="flex w-full items-center gap-2 border-b border-dashed border-border-secondary px-3 py-1.5 text-left transition-colors hover:bg-surface-hover"
+                >
+                  <span className="flex flex-shrink-0 justify-center" style={{ width: gutterWidth }}>
+                    <span className="h-2 w-2 rounded-full border border-dashed border-text-muted" aria-hidden="true" />
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-xs text-text-secondary">
+                    Uncommitted changes in <span className="text-text-primary">{session.name}</span>
+                  </span>
+                  <span className="flex-shrink-0 text-[10px] tabular-nums text-text-muted">
+                    {session.gitStatus?.filesChanged ? `${session.gitStatus.filesChanged} files` : 'modified'}
+                  </span>
+                </button>
+              ))}
+
+              <div style={{ height: rows.length * ROW_HEIGHT, position: 'relative' }}>
+                <div style={{ transform: `translateY(${firstVisible * ROW_HEIGHT}px)` }}>
+                  {visibleRows.map(row => {
+                    const isSelected = row.node.hash === selectedHash;
+                    const accent = laneColor(row.colorIndex);
+                    const inlineRefs = row.node.refs.slice(0, INLINE_REFS);
+                    const hiddenRefs = row.node.refs.slice(INLINE_REFS);
+
+                    return (
+                      <div
+                        key={row.node.hash}
+                        className={`group relative flex w-full items-stretch transition-colors ${
+                          isSelected ? 'bg-interactive/10' : 'hover:bg-surface-hover'
+                        }`}
+                        style={{ height: ROW_HEIGHT }}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => setSelectedHash(row.node.hash)}
+                          aria-pressed={isSelected}
+                          title={`${row.node.subject}\n${row.node.shortHash} · ${row.node.authorName} <${row.node.authorEmail}> · ${formatDate(row.node.authorDate)}`}
+                          className="flex min-w-0 flex-1 items-stretch gap-2 pr-2 text-left"
+                        >
+                          {/*
+                            Lanes past the gutter's width are clipped rather
+                            than squeezed — the positions of the ones on screen
+                            must not move because a thirty-branch repo exists.
+                          */}
+                          <span
+                            className={`flex flex-shrink-0 items-center overflow-hidden ${isFiltering ? 'justify-center' : ''}`}
+                            style={{ width: gutterWidth }}
+                          >
+                            {isFiltering ? (
+                              <span
+                                className="h-2 w-2 rounded-full"
+                                style={{ backgroundColor: accent }}
+                                aria-hidden="true"
+                              />
+                            ) : (
+                              <GitGraphCanvas row={row} laneCount={layout.laneCount} isSelected={isSelected} />
+                            )}
+                          </span>
+
+                          <span className="flex min-w-0 flex-1 flex-col justify-center py-1">
+                            <span className="flex min-w-0 items-center gap-1.5">
+                              {inlineRefs.map(ref => (
+                                <RefChip
+                                  key={`${ref.kind}-${ref.name}`}
+                                  name={ref.name}
+                                  kind={ref.kind}
+                                  isCurrent={ref.isCurrent}
+                                  ahead={ref.ahead}
+                                  behind={ref.behind}
+                                  worktree={ref.kind === 'localBranch' ? worktreeByBranch.get(ref.name) : undefined}
+                                  isFocused={focusRef === ref.name}
+                                  onFocus={setFocusRef}
+                                />
+                              ))}
+                              {hiddenRefs.length > 0 && (
+                                <span
+                                  className="flex-shrink-0 rounded border border-border-secondary bg-surface-tertiary px-1 text-[10px] text-text-tertiary"
+                                  title={hiddenRefs.map(ref => ref.name).join('\n')}
+                                >
+                                  +{hiddenRefs.length}
+                                </span>
+                              )}
+                              <span className="truncate text-xs leading-snug text-text-primary">
+                                {row.node.subject}
+                              </span>
+                            </span>
+                            <span className="flex items-center gap-1.5 text-[10px] leading-snug text-text-tertiary">
+                              <span className="font-mono" style={{ color: accent }}>{row.node.shortHash}</span>
+                              <span aria-hidden="true">·</span>
+                              <span className="truncate">{row.node.authorName}</span>
+                            </span>
+                          </span>
+
+                          {/* Fixed-width right column, so dates line up down the list. */}
+                          <span className="flex flex-shrink-0 items-center gap-2 pl-2">
+                            <span
+                              className="flex h-5 w-5 items-center justify-center rounded-full text-[9px] font-medium text-bg-primary"
+                              style={{ backgroundColor: authorColor(row.node.authorEmail || row.node.authorName) }}
+                              aria-hidden="true"
+                            >
+                              {initials(row.node.authorName)}
+                            </span>
+                            <span className="w-8 text-right text-[10px] tabular-nums text-text-muted">
+                              {formatAge(row.node.authorDate)}
+                            </span>
+                          </span>
+                        </button>
+
+                        {/* Sibling of the row button — a button inside a button is invalid. */}
+                        <Dropdown
+                          position="bottom-right"
+                          width="sm"
+                          items={[
+                            {
+                              id: 'copy-sha',
+                              label: 'Copy commit SHA',
+                              icon: Copy,
+                              onClick: () => copyToClipboard(row.node.hash),
+                            },
+                            {
+                              id: 'copy-short',
+                              label: `Copy ${row.node.shortHash}`,
+                              icon: Hash,
+                              onClick: () => copyToClipboard(row.node.shortHash),
+                            },
+                            {
+                              id: 'copy-subject',
+                              label: 'Copy subject',
+                              icon: Copy,
+                              onClick: () => copyToClipboard(row.node.subject),
+                            },
+                            ...row.node.refs
+                              .map(ref => worktreeByBranch.get(ref.name))
+                              .filter((worktree): worktree is PaneWorktreeRef => Boolean(worktree?.sessionId))
+                              .map(worktree => ({
+                                id: `open-${worktree.sessionId}`,
+                                label: `Open session “${worktree.sessionName ?? worktree.branch}”`,
+                                icon: GitBranch,
+                                onClick: () => openSession(worktree.sessionId as string),
+                              })),
+                          ]}
+                          trigger={
+                            <button
+                              type="button"
+                              aria-label={`Actions for ${row.node.shortHash}`}
+                              className="mr-1 flex-shrink-0 self-center rounded p-1 text-text-muted opacity-0 transition-opacity hover:bg-surface-hover hover:text-text-primary focus-visible:opacity-100 group-hover:opacity-100"
+                            >
+                              <MoreHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+                            </button>
+                          }
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </>
+          )}
+
+          {graph?.truncated && !loading && !error && !isFiltering && (
+            <div className="flex items-center gap-3 px-4 py-3">
+              <span className="text-[11px] text-text-muted">
+                Showing the {graph.limit} most recent commits.
+              </span>
+              {limit < MAX_LIMIT && (
+                <button
+                  type="button"
+                  onClick={() => setLimit(current => Math.min(
+                    LIMIT_OPTIONS.find(option => option > current) ?? MAX_LIMIT,
+                    MAX_LIMIT
+                  ))}
+                  disabled={refreshing}
+                  className="rounded border border-border-secondary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover disabled:opacity-50"
+                >
+                  Load more
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Detail pane */}
+        {!detailHidden && (
+          <>
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              onPointerDown={startDetailDrag}
+              className="hidden w-1 flex-shrink-0 cursor-col-resize bg-border-primary transition-colors hover:bg-interactive lg:block"
+            />
+            <aside
+              className="hidden min-w-0 flex-shrink-0 lg:flex lg:flex-col"
+              style={{ width: `${detailPercent}%` }}
+            >
+              {selectedNode ? (
+                <GitGraphCommitDetail projectId={projectId} node={selectedNode} />
+              ) : (
+                <div className="flex h-full items-center justify-center px-6 text-center text-sm text-text-secondary">
+                  Select a commit to see its changes.
+                </div>
+              )}
+            </aside>
+          </>
+        )}
+      </div>
+
+      {/* Pane worktrees legend */}
+      {(graph?.paneWorktrees.length ?? 0) > 0 && (
+        <footer className="flex flex-shrink-0 flex-wrap items-center gap-2 border-t border-border-primary bg-surface-secondary px-4 py-1.5">
+          <span className="text-[10px] uppercase tracking-wider text-text-muted">Pane worktrees</span>
+          {graph?.paneWorktrees.map(worktree => (
+            worktree.sessionId ? (
+              <button
+                key={worktree.path}
+                type="button"
+                onClick={() => openSession(worktree.sessionId as string)}
+                title={worktree.path}
+                className="inline-flex items-center gap-1 rounded border border-interactive/40 bg-interactive/10 px-1.5 py-px text-[10px] text-interactive transition-colors hover:bg-interactive/20"
+              >
+                <GitBranch className="h-2.5 w-2.5" aria-hidden="true" />
+                <span className="font-mono">{worktree.branch}</span>
+                <span className="text-text-secondary">{worktree.sessionName}</span>
+              </button>
+            ) : (
+              <span
+                key={worktree.path}
+                title={worktree.path}
+                className="inline-flex items-center gap-1 rounded border border-border-secondary px-1.5 py-px font-mono text-[10px] text-text-tertiary"
+              >
+                {worktree.branch}{worktree.isMainCheckout ? ' (main checkout)' : ''}
+              </span>
+            )
+          ))}
+        </footer>
+      )}
+    </div>
+  );
+}
+
+export default GitGraphView;

--- a/frontend/src/components/gitGraph/GitGraphView.tsx
+++ b/frontend/src/components/gitGraph/GitGraphView.tsx
@@ -13,9 +13,11 @@ import { GitGraphCommitDetail } from './GitGraphCommitDetail';
 import {
   GRAPH_REMOTE_ALL,
   GRAPH_REMOTE_NONE,
+  MAX_GRAPH_LIMIT,
   type GitGraphNode,
   type PaneWorktreeRef,
   type RepoGitGraph,
+  type RepoGitGraphRequest,
 } from '../../../../shared/types/gitGraph';
 
 /** Rows rendered outside the viewport on each side, to hide scroll seams. */
@@ -26,8 +28,6 @@ const VIRTUALIZE_THRESHOLD = 200;
 const REFRESH_DEBOUNCE_MS = 2000;
 
 const LIMIT_OPTIONS = [100, 300, 1000] as const;
-/** Hard ceiling the backend enforces; "load more" stops here. */
-const MAX_LIMIT = 2000;
 /**
  * Ref chips shown inline before a subject. Past this many the row is all
  * chips and no commit message — the rest collapse into a "+N" pill.
@@ -142,6 +142,12 @@ function RefChip({
   );
 }
 
+type SessionWorktree = PaneWorktreeRef & { sessionId: string };
+
+function hasSessionId(worktree: PaneWorktreeRef | undefined): worktree is SessionWorktree {
+  return worktree?.sessionId !== undefined;
+}
+
 export interface GitGraphViewProps {
   projectId: number;
   projectName?: string;
@@ -190,12 +196,10 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
     else setRefreshing(true);
 
     try {
-      const response = await API.projects.getGitGraph({
-        projectId,
-        limit,
-        ...(remoteScope === undefined ? {} : { remoteScope }),
-        ...(focusRef ? { focusRef } : {}),
-      });
+      const request: RepoGitGraphRequest = { projectId, limit };
+      if (remoteScope !== undefined) request.remoteScope = remoteScope;
+      if (focusRef) request.focusRef = focusRef;
+      const response = await API.projects.getGitGraph(request);
       if (requestId !== requestIdRef.current) return;
       if (!response.success || !response.data) {
         throw new Error(response.error || 'Failed to load repository graph');
@@ -347,7 +351,7 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
    */
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
+      const target = event.target instanceof HTMLElement ? event.target : null;
       const typing = target?.isContentEditable
         || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName ?? '');
 
@@ -692,12 +696,12 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
                             },
                             ...row.node.refs
                               .map(ref => worktreeByBranch.get(ref.name))
-                              .filter((worktree): worktree is PaneWorktreeRef => Boolean(worktree?.sessionId))
+                              .filter(hasSessionId)
                               .map(worktree => ({
                                 id: `open-${worktree.sessionId}`,
                                 label: `Open session “${worktree.sessionName ?? worktree.branch}”`,
                                 icon: GitBranch,
-                                onClick: () => openSession(worktree.sessionId as string),
+                                onClick: () => openSession(worktree.sessionId),
                               })),
                           ]}
                           trigger={
@@ -723,12 +727,12 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
               <span className="text-[11px] text-text-muted">
                 Showing the {graph.limit} most recent commits.
               </span>
-              {limit < MAX_LIMIT && (
+              {limit < MAX_GRAPH_LIMIT && (
                 <button
                   type="button"
                   onClick={() => setLimit(current => Math.min(
-                    LIMIT_OPTIONS.find(option => option > current) ?? MAX_LIMIT,
-                    MAX_LIMIT
+                    LIMIT_OPTIONS.find(option => option > current) ?? MAX_GRAPH_LIMIT,
+                    MAX_GRAPH_LIMIT
                   ))}
                   disabled={refreshing}
                   className="rounded border border-border-secondary px-2 py-0.5 text-[11px] text-text-secondary transition-colors hover:bg-surface-hover disabled:opacity-50"
@@ -769,12 +773,13 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
       {(graph?.paneWorktrees.length ?? 0) > 0 && (
         <footer className="flex flex-shrink-0 flex-wrap items-center gap-2 border-t border-border-primary bg-surface-secondary px-4 py-1.5">
           <span className="text-[10px] uppercase tracking-wider text-text-muted">Pane worktrees</span>
-          {graph?.paneWorktrees.map(worktree => (
-            worktree.sessionId ? (
+          {graph?.paneWorktrees.map(worktree => {
+            const sessionId = worktree.sessionId;
+            return sessionId ? (
               <button
                 key={worktree.path}
                 type="button"
-                onClick={() => openSession(worktree.sessionId as string)}
+                onClick={() => openSession(sessionId)}
                 title={worktree.path}
                 className="inline-flex items-center gap-1 rounded border border-interactive/40 bg-interactive/10 px-1.5 py-px text-[10px] text-interactive transition-colors hover:bg-interactive/20"
               >
@@ -790,12 +795,10 @@ export function GitGraphView({ projectId, projectName }: GitGraphViewProps) {
               >
                 {worktree.branch}{worktree.isMainCheckout ? ' (main checkout)' : ''}
               </span>
-            )
-          ))}
+            );
+          })}
         </footer>
       )}
     </div>
   );
 }
-
-export default GitGraphView;

--- a/frontend/src/components/gitGraph/graphColors.ts
+++ b/frontend/src/components/gitGraph/graphColors.ts
@@ -1,0 +1,24 @@
+/**
+ * Lane palette for the commit graph.
+ *
+ * Explicit hex values rather than CSS variables: these are consumed as SVG
+ * `stroke`/`fill` attributes, and the hues are chosen to stay legible on both
+ * the light and dark surfaces.
+ */
+const LANE_COLORS = [
+  '#4f8ef7',
+  '#37b877',
+  '#e0913a',
+  '#c765d6',
+  '#e05a6b',
+  '#3fb8c4',
+  '#8f8ff0',
+  '#c2a63a',
+];
+
+export function laneColor(colorIndex: number): string {
+  return LANE_COLORS[colorIndex % LANE_COLORS.length];
+}
+
+export const LANE_WIDTH = 14;
+export const ROW_HEIGHT = 44;

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -10,6 +10,7 @@ import { panelApi } from '../../../services/panelApi';
 import { usePanelStore } from '../../../stores/panelStore';
 import { clearPendingViewCommit, takePendingViewCommit } from './pendingViewCommit';
 import { useCommittedRef } from '../../../hooks/useCommittedRef';
+import { parseUnifiedDiffToFiles } from '../../../utils/parseUnifiedDiff';
 
 const HISTORY_LIMIT = 50;
 
@@ -35,33 +36,6 @@ async function loadCommitDiff(sessionId: string, commitHash: string): Promise<Co
       error: error instanceof Error ? error.message : 'Failed to load commit diff',
     };
   }
-}
-
-// --- Unified diff parser (single pass, shared between FileList and DiffViewer) ---
-
-function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
-  if (!diff?.trim()) return [];
-
-  const fileChunks = diff.match(/diff --git[\s\S]*?(?=diff --git|$)/g);
-  if (!fileChunks) return [];
-
-  return fileChunks.flatMap(chunk => {
-    const nameMatch = chunk.match(/diff --git a\/(.*?) b\/(.*?)(?:\n|$)/);
-    if (!nameMatch) return [];
-    const oldPath = nameMatch[1];
-    const newPath = nameMatch[2];
-    const isBinary = chunk.includes('Binary files') || chunk.includes('GIT binary patch');
-
-    let type: FileDiff['type'] = 'modified';
-    if (chunk.includes('new file mode')) type = 'added';
-    else if (chunk.includes('deleted file mode')) type = 'deleted';
-    else if (chunk.includes('rename from') && chunk.includes('rename to')) type = 'renamed';
-
-    const additions = (chunk.match(/^\+(?!\+\+)/gm) || []).length;
-    const deletions = (chunk.match(/^-(?!--)/gm) || []).length;
-
-    return [{ path: newPath || oldPath, oldPath, type, isBinary, additions, deletions, rawDiff: chunk }];
-  });
 }
 
 // --- CombinedDiffView ---

--- a/frontend/src/stores/navigationStore.ts
+++ b/frontend/src/stores/navigationStore.ts
@@ -10,8 +10,15 @@ let hasRegisteredInitialProjectIds = false;
 const toProjectIdArray = (projectIds: Set<number>): number[] =>
   Array.from(projectIds).sort((a, b) => a - b);
 
+/**
+ * Pane has no router — this enum is the whole navigation model. Adding a value
+ * here also requires a branch in `SessionView` and an entry in *both* sidebar
+ * components (`Sidebar` compact rail and `ProjectSessionList` expanded tree).
+ */
+export type ActiveView = 'sessions' | 'project' | 'pane-chat' | 'git-graph';
+
 interface NavigationState {
-  activeView: 'sessions' | 'project' | 'pane-chat';
+  activeView: ActiveView;
   activeProjectId: number | null;
 
   // Sidebar collapse
@@ -37,11 +44,12 @@ interface NavigationState {
   setSidebarNavigationScope: (scope: SidebarNavigationScope) => void;
 
   // Actions
-  setActiveView: (view: 'sessions' | 'project' | 'pane-chat') => void;
+  setActiveView: (view: ActiveView) => void;
   setActiveProjectId: (projectId: number | null) => void;
   navigateToProject: (projectId: number) => void;
   navigateToSessions: () => void;
   navigateToPaneChat: () => void;
+  navigateToGitGraph: (projectId: number) => void;
 }
 
 export const useNavigationStore = create<NavigationState>((set, get) => ({
@@ -117,5 +125,11 @@ export const useNavigationStore = create<NavigationState>((set, get) => ({
   navigateToPaneChat: () => set({
     activeView: 'pane-chat',
     activeProjectId: null
+  }),
+
+  // The commit graph is repo-wide, so it keeps the project it belongs to.
+  navigateToGitGraph: (projectId) => set({
+    activeView: 'git-graph',
+    activeProjectId: projectId
   }),
 }));

--- a/frontend/src/types/diff.ts
+++ b/frontend/src/types/diff.ts
@@ -19,19 +19,7 @@ export interface ExecutionDiff {
   history_limit_reached?: boolean;
 }
 
-interface GitDiffStats {
-  additions: number;
-  deletions: number;
-  filesChanged: number;
-}
-
-export interface GitDiffResult {
-  diff: string;
-  stats: GitDiffStats;
-  changedFiles: string[];
-  beforeHash?: string;
-  afterHash?: string;
-}
+export type { GitDiffResult } from '../../../shared/types/diff';
 
 export interface FileDiff {
   path: string;

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -35,6 +35,8 @@ import type { JsonValue } from '../../../shared/validation/boundaryDecoder';
 import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
+import type { RepoGitGraph, RepoGitGraphRequest } from '../../../shared/types/gitGraph';
+import type { GitDiffResult } from './diff';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
@@ -244,6 +246,10 @@ interface ElectronAPI {
     detectConfig: (projectId: string) => Promise<IPCResponse<DetectedProjectConfig | null>>;
     /** Resolve which run script to execute for a session (DB > config files > scripts/pane-run-script.js). Used by PanelTabBar Play button. */
     resolveRunScript: (sessionId: string) => Promise<IPCResponse<{ command: string; source: string } | null>>;
+    /** Repository-wide commit graph across every branch and tag. */
+    getGitGraph: (request: RepoGitGraphRequest) => Promise<IPCResponse<RepoGitGraph>>;
+    /** Full patch for one commit, resolved against the project checkout. */
+    getCommitDetail: (projectId: number, commitHash: string) => Promise<IPCResponse<GitDiffResult>>;
   };
 
   // Git operations

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -4,6 +4,7 @@ import type { Project } from '../types/project';
 import type { UpdateConfigRequest } from '../types/config';
 import type { SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
+import type { RepoGitGraphRequest } from '../../../shared/types/gitGraph';
 import type {
   RemoteDaemonClientRecord,
   RemoteDaemonClientSettings,
@@ -423,6 +424,18 @@ export class API {
     async listBranches(projectId: string) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.projects.listBranches(projectId);
+    },
+
+    /** Repository-wide commit graph across every branch and tag. */
+    async getGitGraph(request: RepoGitGraphRequest) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.projects.getGitGraph(request);
+    },
+
+    /** Full patch for one commit, resolved against the project checkout. */
+    async getCommitDetail(projectId: number, commitHash: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.projects.getCommitDetail(projectId, commitHash);
     },
   };
 

--- a/frontend/src/utils/gitGraphLayout.test.ts
+++ b/frontend/src/utils/gitGraphLayout.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { computeGitGraphLayout } from './gitGraphLayout';
+import type { GitGraphNode } from '../../../shared/types/gitGraph';
+
+function node(hash: string, parents: string[]): GitGraphNode {
+  return {
+    hash,
+    shortHash: hash.slice(0, 7),
+    parents,
+    subject: `commit ${hash}`,
+    authorName: 'Test',
+    authorEmail: 'test@example.com',
+    authorDate: '2026-01-01T00:00:00Z',
+    refs: [],
+  };
+}
+
+describe('computeGitGraphLayout', () => {
+  it('returns an empty layout for no commits', () => {
+    expect(computeGitGraphLayout([])).toEqual({ rows: [], laneCount: 0 });
+  });
+
+  it('keeps a linear history in a single lane', () => {
+    const layout = computeGitGraphLayout([
+      node('c', ['b']),
+      node('b', ['a']),
+      node('a', []),
+    ]);
+
+    expect(layout.laneCount).toBe(1);
+    expect(layout.rows.map(row => row.lane)).toEqual([0, 0, 0]);
+    expect(layout.rows.every(row => row.colorIndex === 0)).toBe(true);
+  });
+
+  it('gives a root commit no outgoing edges', () => {
+    const layout = computeGitGraphLayout([node('a', [])]);
+    expect(layout.rows[0].edges).toEqual([]);
+  });
+
+  it('opens a second lane for a merge and rejoins it', () => {
+    // m merges feature (f) into main (b); both descend from a.
+    const layout = computeGitGraphLayout([
+      node('m', ['b', 'f']),
+      node('f', ['a']),
+      node('b', ['a']),
+      node('a', []),
+    ]);
+
+    expect(layout.laneCount).toBe(2);
+    expect(layout.rows[0].lane).toBe(0);
+
+    const mergeEdge = layout.rows[0].edges.find(edge => edge.kind === 'merge');
+    expect(mergeEdge).toBeDefined();
+    expect(mergeEdge?.fromLane).toBe(0);
+    expect(mergeEdge?.toLane).toBe(1);
+
+    // Both sides converge on `a`, which must occupy a single lane — and the
+    // side that ends there is drawn joining it rather than stopping mid-air.
+    const rootRow = layout.rows[3];
+    expect(rootRow.node.hash).toBe('a');
+    expect(rootRow.edges).toEqual([
+      { fromLane: 1, toLane: 0, kind: 'join', colorIndex: 1 },
+    ]);
+  });
+
+  it('handles an octopus merge with three parents', () => {
+    const layout = computeGitGraphLayout([
+      node('m', ['p1', 'p2', 'p3']),
+      node('p1', []),
+      node('p2', []),
+      node('p3', []),
+    ]);
+
+    const mergeEdges = layout.rows[0].edges.filter(edge => edge.kind === 'merge');
+    expect(mergeEdges).toHaveLength(2);
+    expect(mergeEdges.map(edge => edge.toLane).sort()).toEqual([1, 2]);
+    expect(layout.laneCount).toBe(3);
+  });
+
+  it('places two unrelated roots in separate lanes', () => {
+    const layout = computeGitGraphLayout([
+      node('x', []),
+      node('y', []),
+    ]);
+
+    expect(layout.rows[0].lane).toBe(0);
+    // The first root frees lane 0 immediately, so the second reuses it.
+    expect(layout.rows[1].lane).toBe(0);
+    expect(layout.laneCount).toBe(1);
+  });
+
+  it('flags edges whose parent falls outside the loaded window', () => {
+    const layout = computeGitGraphLayout([node('c', ['older-than-limit'])]);
+
+    expect(layout.rows[0].edges).toHaveLength(1);
+    expect(layout.rows[0].edges[0].danglesBelow).toBe(true);
+  });
+
+  it('does not flag edges whose parent is loaded', () => {
+    const layout = computeGitGraphLayout([node('c', ['b']), node('b', [])]);
+    expect(layout.rows[0].edges[0].danglesBelow).toBeUndefined();
+  });
+
+  it('carries an unrelated in-flight branch through intervening rows', () => {
+    // `side` stays pending while the mainline advances, so rows between the
+    // branch tip and its parent must draw a pass-through edge for it.
+    const layout = computeGitGraphLayout([
+      node('side', ['old']),
+      node('c', ['b']),
+      node('b', ['old']),
+      node('old', []),
+    ]);
+
+    // The mainline leaves the dot; the unrelated branch crosses the whole row.
+    expect(layout.rows[1].edges.filter(edge => edge.kind === 'straight')).toHaveLength(1);
+    expect(layout.rows[1].edges.filter(edge => edge.kind === 'passthrough')).toHaveLength(1);
+    expect(layout.laneCount).toBeGreaterThanOrEqual(2);
+  });
+
+  /**
+   * A pass-through drawn as `straight` starts at the dot, half a row down,
+   * which is what left continuing branches looking like dashed lines.
+   */
+  it('spans crossing lanes with pass-through edges, never straight ones', () => {
+    const layout = computeGitGraphLayout([
+      node('side', ['old']),
+      node('c', ['b']),
+      node('b', ['old']),
+      node('old', []),
+    ]);
+
+    for (const row of layout.rows) {
+      for (const edge of row.edges) {
+        // A straight edge always belongs to the row's own commit.
+        if (edge.kind === 'straight') expect(edge.fromLane).toBe(row.lane);
+      }
+    }
+  });
+
+  it('marks the newest commit of a branch as its start', () => {
+    const layout = computeGitGraphLayout([
+      node('side', ['old']),
+      node('c', ['b']),
+      node('b', ['old']),
+      node('old', []),
+    ]);
+
+    // Nothing above points at `side` or at `c`; `b` and `old` are parents.
+    expect(layout.rows.map(row => row.isBranchTip)).toEqual([true, true, false, false]);
+  });
+
+  it('joins a branch that ends at a shared ancestor instead of dropping it', () => {
+    // Both `a` and `b` have `r` as parent, so one lane must visibly end at it.
+    const layout = computeGitGraphLayout([
+      node('m', ['a', 'b']),
+      node('a', ['r']),
+      node('b', ['r']),
+      node('r', []),
+    ]);
+
+    const rootRow = layout.rows[3];
+    expect(rootRow.node.hash).toBe('r');
+
+    const joins = rootRow.edges.filter(edge => edge.kind === 'join');
+    expect(joins).toHaveLength(1);
+    expect(joins[0].toLane).toBe(rootRow.lane);
+    expect(joins[0].fromLane).not.toBe(rootRow.lane);
+  });
+
+  it('never assigns a lane index at or beyond laneCount', () => {
+    const layout = computeGitGraphLayout([
+      node('m', ['a', 'b']),
+      node('a', ['r']),
+      node('b', ['r']),
+      node('r', []),
+    ]);
+
+    for (const row of layout.rows) {
+      expect(row.lane).toBeLessThan(layout.laneCount);
+      for (const edge of row.edges) {
+        expect(edge.fromLane).toBeLessThan(layout.laneCount);
+        expect(edge.toLane).toBeLessThan(layout.laneCount);
+      }
+    }
+  });
+});

--- a/frontend/src/utils/gitGraphLayout.ts
+++ b/frontend/src/utils/gitGraphLayout.ts
@@ -10,7 +10,7 @@ import type {
  * keeps the same colour for as long as it occupies the same lane, which is
  * what makes the graph readable while scrolling.
  */
-export const GRAPH_PALETTE_LENGTH = 8;
+const GRAPH_PALETTE_LENGTH = 8;
 
 /**
  * Assign a lane (column) to every commit and derive the edges to draw between
@@ -87,24 +87,26 @@ export function computeGitGraphLayout(nodes: GitGraphNode[]): GitGraphLayout {
 
     if (firstParent) {
       lanes[lane] = firstParent;
-      edges.push({
+      const edge: GitGraphEdge = {
         fromLane: lane,
         toLane: lane,
         kind: 'straight',
         colorIndex: lane % GRAPH_PALETTE_LENGTH,
-        ...(knownHashes.has(firstParent) ? {} : { danglesBelow: true }),
-      });
+      };
+      if (!knownHashes.has(firstParent)) edge.danglesBelow = true;
+      edges.push(edge);
     }
 
     for (const parent of otherParents) {
       const parentLane = claimLane(parent);
-      edges.push({
+      const edge: GitGraphEdge = {
         fromLane: lane,
         toLane: parentLane,
         kind: 'merge',
         colorIndex: parentLane % GRAPH_PALETTE_LENGTH,
-        ...(knownHashes.has(parent) ? {} : { danglesBelow: true }),
-      });
+      };
+      if (!knownHashes.has(parent)) edge.danglesBelow = true;
+      edges.push(edge);
     }
 
     // Unrelated branches still in flight keep their column through this row,
@@ -114,13 +116,14 @@ export function computeGitGraphLayout(nodes: GitGraphNode[]): GitGraphLayout {
       if (!reservedFor) continue;
       if (i === lane && firstParent) continue;
       if (edges.some(edge => edge.toLane === i)) continue;
-      edges.push({
+      const edge: GitGraphEdge = {
         fromLane: i,
         toLane: i,
         kind: 'passthrough',
         colorIndex: i % GRAPH_PALETTE_LENGTH,
-        ...(knownHashes.has(reservedFor) ? {} : { danglesBelow: true }),
-      });
+      };
+      if (!knownHashes.has(reservedFor)) edge.danglesBelow = true;
+      edges.push(edge);
     }
 
     // Trim trailing free lanes so the gutter does not stay wide after a branch

--- a/frontend/src/utils/gitGraphLayout.ts
+++ b/frontend/src/utils/gitGraphLayout.ts
@@ -1,0 +1,146 @@
+import type {
+  GitGraphEdge,
+  GitGraphLayout,
+  GitGraphNode,
+  GitGraphRow,
+} from '../../../shared/types/gitGraph';
+
+/**
+ * Number of distinct lane colours. Lanes map to colours by index so a branch
+ * keeps the same colour for as long as it occupies the same lane, which is
+ * what makes the graph readable while scrolling.
+ */
+export const GRAPH_PALETTE_LENGTH = 8;
+
+/**
+ * Assign a lane (column) to every commit and derive the edges to draw between
+ * consecutive rows — the same job `git log --graph` does with ASCII art, but
+ * as data.
+ *
+ * The algorithm is a single top-to-bottom sweep over a date-ordered commit
+ * list, maintaining `lanes[i]` = "the hash this lane is currently waiting to
+ * see". For each row:
+ *
+ *  1. The commit takes the leftmost lane reserved for its hash; if no lane is
+ *     waiting for it (a branch tip), it takes the leftmost free lane and the
+ *     row is flagged `isBranchTip` so nothing is drawn above its dot.
+ *  2. Any *other* lane also waiting for this commit ends here and emits a
+ *     `join` edge into the dot — without it those branches simply vanished
+ *     mid-air.
+ *  3. Its first parent inherits that same lane — this keeps mainline history
+ *     in a straight vertical line.
+ *  4. Every additional parent (a merge) reserves the leftmost free lane and
+ *     emits a diagonal `merge` edge.
+ *  5. Lanes still reserved after that emit `passthrough` edges spanning the
+ *     full row height. They must not be `straight`: a straight edge starts at
+ *     the dot, half a row down, which is what left the vertical lines of
+ *     unrelated branches broken into dashes.
+ *
+ * Complexity is O(commits x lanes). The input is not mutated.
+ */
+export function computeGitGraphLayout(nodes: GitGraphNode[]): GitGraphLayout {
+  if (nodes.length === 0) return { rows: [], laneCount: 0 };
+
+  const knownHashes = new Set(nodes.map(node => node.hash));
+  // lanes[i] holds the hash lane i is reserved for, or null when free.
+  const lanes: Array<string | null> = [];
+  const rows: GitGraphRow[] = [];
+  let laneCount = 0;
+
+  const claimLane = (hash: string): number => {
+    const reserved = lanes.indexOf(hash);
+    if (reserved >= 0) return reserved;
+    const free = lanes.indexOf(null);
+    if (free >= 0) {
+      lanes[free] = hash;
+      return free;
+    }
+    lanes.push(hash);
+    return lanes.length - 1;
+  };
+
+  for (const node of nodes) {
+    // Nothing above points at this commit: it is the newest on its branch.
+    const isBranchTip = lanes.indexOf(node.hash) < 0;
+    const lane = claimLane(node.hash);
+
+    const edges: GitGraphEdge[] = [];
+
+    // Any other lane also waiting for this commit (two branches converging on
+    // the same ancestor) ends here, and says so with a join edge.
+    for (let i = 0; i < lanes.length; i++) {
+      if (i === lane || lanes[i] !== node.hash) continue;
+      lanes[i] = null;
+      edges.push({
+        fromLane: i,
+        toLane: lane,
+        kind: 'join',
+        // The ending branch keeps its own colour into the dot, so the eye can
+        // follow it to where it was absorbed.
+        colorIndex: i % GRAPH_PALETTE_LENGTH,
+      });
+    }
+
+    lanes[lane] = null;
+
+    const [firstParent, ...otherParents] = node.parents;
+
+    if (firstParent) {
+      lanes[lane] = firstParent;
+      edges.push({
+        fromLane: lane,
+        toLane: lane,
+        kind: 'straight',
+        colorIndex: lane % GRAPH_PALETTE_LENGTH,
+        ...(knownHashes.has(firstParent) ? {} : { danglesBelow: true }),
+      });
+    }
+
+    for (const parent of otherParents) {
+      const parentLane = claimLane(parent);
+      edges.push({
+        fromLane: lane,
+        toLane: parentLane,
+        kind: 'merge',
+        colorIndex: parentLane % GRAPH_PALETTE_LENGTH,
+        ...(knownHashes.has(parent) ? {} : { danglesBelow: true }),
+      });
+    }
+
+    // Unrelated branches still in flight keep their column through this row,
+    // top edge to bottom edge — anything shorter leaves a gap.
+    for (let i = 0; i < lanes.length; i++) {
+      const reservedFor = lanes[i];
+      if (!reservedFor) continue;
+      if (i === lane && firstParent) continue;
+      if (edges.some(edge => edge.toLane === i)) continue;
+      edges.push({
+        fromLane: i,
+        toLane: i,
+        kind: 'passthrough',
+        colorIndex: i % GRAPH_PALETTE_LENGTH,
+        ...(knownHashes.has(reservedFor) ? {} : { danglesBelow: true }),
+      });
+    }
+
+    // Trim trailing free lanes so the gutter does not stay wide after a branch
+    // ends, while `laneCount` still reflects the widest point of the graph.
+    while (lanes.length > 0 && lanes[lanes.length - 1] === null) lanes.pop();
+
+    laneCount = Math.max(
+      laneCount,
+      lane + 1,
+      ...edges.map(edge => Math.max(edge.fromLane, edge.toLane) + 1)
+    );
+
+    rows.push({
+      node,
+      lane,
+      colorIndex: lane % GRAPH_PALETTE_LENGTH,
+      edges,
+      isBranchTip,
+    });
+  }
+
+  return { rows, laneCount };
+}

--- a/frontend/src/utils/parseUnifiedDiff.test.ts
+++ b/frontend/src/utils/parseUnifiedDiff.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseUnifiedDiffToFiles } from './parseUnifiedDiff';
+
+const SAMPLE = `diff --git a/src/a.ts b/src/a.ts
+index 111..222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,4 @@
+ context
+-removed line
++added line
++another added
+diff --git a/src/new.ts b/src/new.ts
+new file mode 100644
+index 0000000..333
+--- /dev/null
++++ b/src/new.ts
+@@ -0,0 +1,2 @@
++first
++second
+`;
+
+describe('parseUnifiedDiffToFiles', () => {
+  it('returns nothing for empty input', () => {
+    expect(parseUnifiedDiffToFiles('')).toEqual([]);
+    expect(parseUnifiedDiffToFiles('   ')).toEqual([]);
+    expect(parseUnifiedDiffToFiles('not a diff')).toEqual([]);
+  });
+
+  it('splits one entry per file and classifies the change', () => {
+    const files = parseUnifiedDiffToFiles(SAMPLE);
+    expect(files.map(f => f.path)).toEqual(['src/a.ts', 'src/new.ts']);
+    expect(files[0].type).toBe('modified');
+    expect(files[1].type).toBe('added');
+  });
+
+  it('counts changed lines without counting the +++/--- headers', () => {
+    const files = parseUnifiedDiffToFiles(SAMPLE);
+    expect(files[0].additions).toBe(2);
+    expect(files[0].deletions).toBe(1);
+    expect(files[1].additions).toBe(2);
+    expect(files[1].deletions).toBe(0);
+  });
+
+  it('detects deletions and renames', () => {
+    const deleted = parseUnifiedDiffToFiles(
+      'diff --git a/gone.ts b/gone.ts\ndeleted file mode 100644\n--- a/gone.ts\n+++ /dev/null\n@@ -1 +0,0 @@\n-bye\n'
+    );
+    expect(deleted[0].type).toBe('deleted');
+    expect(deleted[0].deletions).toBe(1);
+
+    const renamed = parseUnifiedDiffToFiles(
+      'diff --git a/old.ts b/new.ts\nsimilarity index 100%\nrename from old.ts\nrename to new.ts\n'
+    );
+    expect(renamed[0].type).toBe('renamed');
+    expect(renamed[0].oldPath).toBe('old.ts');
+    expect(renamed[0].path).toBe('new.ts');
+  });
+
+  it('flags binary files', () => {
+    const files = parseUnifiedDiffToFiles(
+      'diff --git a/logo.png b/logo.png\nindex 1..2 100644\nBinary files a/logo.png and b/logo.png differ\n'
+    );
+    expect(files[0].isBinary).toBe(true);
+  });
+
+  it('handles a large diff without pathological cost', () => {
+    // 50k added lines in one file — the shape that made Review crawl.
+    const body = Array.from({ length: 50_000 }, (_, i) => `+line ${i}`).join('\n');
+    const huge = `diff --git a/big.ts b/big.ts\nnew file mode 100644\n--- /dev/null\n+++ b/big.ts\n@@ -0,0 +1,50000 @@\n${body}\n`;
+
+    const started = performance.now();
+    const files = parseUnifiedDiffToFiles(huge);
+    const elapsed = performance.now() - started;
+
+    expect(files).toHaveLength(1);
+    expect(files[0].additions).toBe(50_000);
+    // Generous bound: the point is that it is milliseconds, not seconds.
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/frontend/src/utils/parseUnifiedDiff.ts
+++ b/frontend/src/utils/parseUnifiedDiff.ts
@@ -7,7 +7,7 @@ import type { FileDiff } from '../types/diff';
  * changed line — on a 50k-line uncommitted diff that is 50k throwaway strings
  * per file, on the UI thread. Scanning line starts directly costs nothing.
  */
-function countChangedLines(chunk: string): { additions: number; deletions: number } {
+function countChangedLines(chunk: string) {
   let additions = 0;
   let deletions = 0;
   let lineStart = 0;

--- a/frontend/src/utils/parseUnifiedDiff.ts
+++ b/frontend/src/utils/parseUnifiedDiff.ts
@@ -1,0 +1,62 @@
+import type { FileDiff } from '../types/diff';
+
+/**
+ * Count added/removed lines without allocating a match array.
+ *
+ * `chunk.match(/^\+(?!\+\+)/gm).length` builds an array with one entry per
+ * changed line — on a 50k-line uncommitted diff that is 50k throwaway strings
+ * per file, on the UI thread. Scanning line starts directly costs nothing.
+ */
+function countChangedLines(chunk: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  let lineStart = 0;
+
+  while (lineStart < chunk.length) {
+    let lineEnd = chunk.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = chunk.length;
+
+    const first = chunk[lineStart];
+    if (first === '+') {
+      // Skip the `+++ b/path` file header.
+      if (!(chunk[lineStart + 1] === '+' && chunk[lineStart + 2] === '+')) additions++;
+    } else if (first === '-') {
+      // Skip the `--- a/path` file header.
+      if (!(chunk[lineStart + 1] === '-' && chunk[lineStart + 2] === '-')) deletions++;
+    }
+
+    lineStart = lineEnd + 1;
+  }
+
+  return { additions, deletions };
+}
+
+/**
+ * Split a unified diff into one {@link FileDiff} per `diff --git` chunk.
+ *
+ * Single pass, no allocation per hunk: each chunk keeps its raw patch text so
+ * the renderer can hand it straight to `@git-diff-view/react`.
+ */
+export function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
+  if (!diff?.trim()) return [];
+
+  const fileChunks = diff.match(/diff --git[\s\S]*?(?=diff --git|$)/g);
+  if (!fileChunks) return [];
+
+  return fileChunks.flatMap(chunk => {
+    const nameMatch = chunk.match(/diff --git a\/(.*?) b\/(.*?)(?:\n|$)/);
+    if (!nameMatch) return [];
+    const oldPath = nameMatch[1];
+    const newPath = nameMatch[2];
+    const isBinary = chunk.includes('Binary files') || chunk.includes('GIT binary patch');
+
+    let type: FileDiff['type'] = 'modified';
+    if (chunk.includes('new file mode')) type = 'added';
+    else if (chunk.includes('deleted file mode')) type = 'deleted';
+    else if (chunk.includes('rename from') && chunk.includes('rename to')) type = 'renamed';
+
+    const { additions, deletions } = countChangedLines(chunk);
+
+    return [{ path: newPath || oldPath, oldPath, type, isBinary, additions, deletions, rawDiff: chunk }];
+  });
+}

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -3,7 +3,7 @@ import { PaneCommandRegistry } from '../daemon/commandRegistry';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import { registerFileHandlers } from './file';
 import { registerConfigHandlers } from './config';
-import { registerGitHandlers } from './git';
+import { decodeRepoGitGraphRequest, registerGitHandlers } from './git';
 import { registerPanelHandlers } from './panels';
 import { registerPaneChatHandlers } from './paneChat';
 import { registerPermissionHandlers } from './permissions';
@@ -255,6 +255,26 @@ function createServicesStub(overrides: Partial<AppServices> = {}): AppServices {
 }
 
 describe('daemon registry IPC bindings', () => {
+  it('decodes repository graph requests at the daemon boundary', () => {
+    expect(decodeRepoGitGraphRequest({
+      projectId: 7,
+      limit: 300,
+      remoteScope: 'origin',
+      focusRef: 'feature/graph',
+    })).toEqual({
+      projectId: 7,
+      limit: 300,
+      remoteScope: 'origin',
+      focusRef: 'feature/graph',
+    });
+  });
+
+  it('rejects malformed repository graph request numbers', () => {
+    expect(() => decodeRepoGitGraphRequest({ projectId: 1.5 })).toThrow('positive integer');
+    expect(() => decodeRepoGitGraphRequest({ projectId: 1, limit: Number.NaN })).toThrow('integer');
+    expect(() => decodeRepoGitGraphRequest({ projectId: 1, limit: 2.5 })).toThrow('integer');
+  });
+
   it('binds daemon-owned project channels through the shared registry', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -170,6 +170,8 @@ const GIT_STATUS_CHANNELS = [
   'sessions:get-executions',
   'sessions:get-execution-diff',
   'sessions:get-git-graph',
+  'projects:get-git-graph',
+  'projects:get-commit-detail',
   'git:file-status',
   'sessions:git-diff',
   'sessions:get-commit-diff-by-hash',

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -2,7 +2,7 @@ import type { IpcMain } from 'electron';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import type { AppServices } from './types';
-import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import type { PaneCommandRegistry, PaneCommandValue } from '../daemon/commandRegistry';
 import { buildGitCommitCommand } from '../utils/shellEscape';
 import { getPaneEventSink } from '../core/runtime';
 import { panelEventBus } from '../services/panelEventBus';
@@ -69,6 +69,23 @@ function normalizeWorktreePath(path: string | null | undefined): string {
 function isValidGitUrl(url: string): boolean {
   // Accept https://, ssh://, and scp-style git@host:path formats
   return /^(https?:\/\/[\w./:@-]+|ssh:\/\/[\w./:@-]+|git@[\w.-]+:[\w./-]+)(\.git)?$/.test(url);
+}
+
+export function decodeRepoGitGraphRequest(value: PaneCommandValue): RepoGitGraphRequest {
+  const request = decodeBoundary(value, boundary.object({
+    projectId: boundary.number,
+    limit: boundary.optional(boundary.number),
+    remoteScope: boundary.optional(boundary.string),
+    focusRef: boundary.optional(boundary.string),
+  }));
+
+  if (!Number.isInteger(request.projectId) || request.projectId <= 0) {
+    throw new Error('projectId must be a positive integer');
+  }
+  if (request.limit !== undefined && !Number.isInteger(request.limit)) {
+    throw new Error('limit must be an integer');
+  }
+  return request;
 }
 
 function extractRepoName(url: string): string {
@@ -460,12 +477,10 @@ export function registerGitHandlers(
    * branches of a second repository that happens to share the clone as a
    * remote (see `resolveRemoteScope`).
    */
-  commandRegistry.register('projects:get-git-graph', async (request: RepoGitGraphRequest) => {
+  commandRegistry.register('projects:get-git-graph', async (input: PaneCommandValue) => {
     try {
-      const projectId = Number(request?.projectId);
-      if (!Number.isFinite(projectId)) {
-        return { success: false, error: 'A projectId is required' };
-      }
+      const request = decodeRepoGitGraphRequest(input);
+      const { projectId } = request;
 
       const ctx = sessionManager.getProjectContextByProjectId(projectId);
       if (!ctx?.project?.path) {

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -62,7 +62,8 @@ interface RawCommitData {
  */
 function normalizeWorktreePath(path: string | null | undefined): string {
   if (!path) return '';
-  return path.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
 }
 
 function isValidGitUrl(url: string): boolean {
@@ -125,7 +126,14 @@ export function registerGitHandlers(
   services: AppServices,
   commandRegistry: PaneCommandRegistry,
 ): void {
-  const { sessionManager, gitDiffManager, worktreeManager, claudeCodeManager, gitStatusManager } = services;
+  const {
+    sessionManager,
+    gitDiffManager,
+    worktreeManager,
+    claudeCodeManager,
+    gitStatusManager,
+    databaseService,
+  } = services;
 
   // Repo-wide graph reads are self-contained; no shared state to register.
   const gitGraphManager = new GitGraphManager();

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -10,7 +10,7 @@ import { PanelEventType, PanelEvent } from '../../../shared/types/panels';
 import type { Session } from '../types/session';
 import type { GitCommit, GitGraphCommit } from '../services/gitDiffManager';
 import { GitGraphManager } from '../services/gitGraphManager';
-import type { RepoGitGraphRequest } from '../../../shared/types/gitGraph';
+import type { PaneWorktreeRef, RepoGitGraphRequest } from '../../../shared/types/gitGraph';
 import { CommandRunner } from '../utils/commandRunner';
 import { getShellPath } from '../utils/shellPath';
 import { parseWSLPath, validateWSLAvailable } from '../utils/wslUtils';
@@ -491,12 +491,16 @@ export function registerGitHandlers(
           return worktrees.map(worktree => {
             const key = normalizeWorktreePath(worktree.path);
             const session = sessionByPath.get(key);
-            return {
+            const paneWorktree: PaneWorktreeRef = {
               path: worktree.path,
               branch: worktree.branch,
               isMainCheckout: key === projectPathKey,
-              ...(session ? { sessionId: session.id, sessionName: session.name } : {}),
             };
+            if (session) {
+              paneWorktree.sessionId = session.id;
+              paneWorktree.sessionName = session.name;
+            }
+            return paneWorktree;
           });
         }
       );

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -9,6 +9,8 @@ import { panelEventBus } from '../services/panelEventBus';
 import { PanelEventType, PanelEvent } from '../../../shared/types/panels';
 import type { Session } from '../types/session';
 import type { GitCommit, GitGraphCommit } from '../services/gitDiffManager';
+import { GitGraphManager } from '../services/gitGraphManager';
+import type { RepoGitGraphRequest } from '../../../shared/types/gitGraph';
 import { CommandRunner } from '../utils/commandRunner';
 import { getShellPath } from '../utils/shellPath';
 import { parseWSLPath, validateWSLAvailable } from '../utils/wslUtils';
@@ -53,6 +55,16 @@ interface RawCommitData {
 }
 
 
+/**
+ * Worktree paths from `git worktree list` and from the sessions table can
+ * disagree on separators and trailing slashes (notably on Windows), so both
+ * sides are normalised before joining.
+ */
+function normalizeWorktreePath(path: string | null | undefined): string {
+  if (!path) return '';
+  return path.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+}
+
 function isValidGitUrl(url: string): boolean {
   // Accept https://, ssh://, and scp-style git@host:path formats
   return /^(https?:\/\/[\w./:@-]+|ssh:\/\/[\w./:@-]+|git@[\w.-]+:[\w./-]+)(\.git)?$/.test(url);
@@ -68,6 +80,8 @@ const DAEMON_GIT_STATUS_CHANNELS = [
   'sessions:get-executions',
   'sessions:get-execution-diff',
   'sessions:get-git-graph',
+  'projects:get-git-graph',
+  'projects:get-commit-detail',
   'git:file-status',
   'sessions:git-diff',
   'sessions:get-commit-diff-by-hash',
@@ -112,6 +126,9 @@ export function registerGitHandlers(
   commandRegistry: PaneCommandRegistry,
 ): void {
   const { sessionManager, gitDiffManager, worktreeManager, claudeCodeManager, gitStatusManager } = services;
+
+  // Repo-wide graph reads are self-contained; no shared state to register.
+  const gitGraphManager = new GitGraphManager();
 
   // Helper function to emit git operation events to all sessions in a project
   const emitGitOperationToProject = (sessionId: string, eventType: PanelEventType, message: string, details?: JsonObject) => {
@@ -426,6 +443,85 @@ export function registerGitHandlers(
       console.error('Failed to get git graph:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to get git graph';
       return { success: false, error: errorMessage };
+    }
+  });
+
+  /**
+   * Commit graph for one project's repository: every branch and tag of *that*
+   * repo, not just the commits unique to one session's worktree — and not the
+   * branches of a second repository that happens to share the clone as a
+   * remote (see `resolveRemoteScope`).
+   */
+  commandRegistry.register('projects:get-git-graph', async (request: RepoGitGraphRequest) => {
+    try {
+      const projectId = Number(request?.projectId);
+      if (!Number.isFinite(projectId)) {
+        return { success: false, error: 'A projectId is required' };
+      }
+
+      const ctx = sessionManager.getProjectContextByProjectId(projectId);
+      if (!ctx?.project?.path) {
+        return { success: false, error: 'Project not found' };
+      }
+
+      const { project, commandRunner } = ctx;
+
+      const data = await gitGraphManager.getRepoGraph(
+        project.path,
+        { limit: request.limit, remoteScope: request.remoteScope, focusRef: request.focusRef },
+        commandRunner,
+        async () => {
+          const worktrees = await worktreeManager.listWorktrees(project.path, commandRunner);
+          const sessions = databaseService.getAllSessions(projectId, { includeHidden: true });
+          const sessionByPath = new Map(
+            sessions
+              .filter(session => Boolean(session.worktree_path))
+              .map(session => [normalizeWorktreePath(session.worktree_path), session])
+          );
+
+          const projectPathKey = normalizeWorktreePath(project.path);
+          return worktrees.map(worktree => {
+            const key = normalizeWorktreePath(worktree.path);
+            const session = sessionByPath.get(key);
+            return {
+              path: worktree.path,
+              branch: worktree.branch,
+              isMainCheckout: key === projectPathKey,
+              ...(session ? { sessionId: session.id, sessionName: session.name } : {}),
+            };
+          });
+        }
+      );
+
+      return { success: true, data };
+    } catch (error) {
+      console.error('Failed to build repository git graph:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to build repository git graph',
+      };
+    }
+  });
+
+  /** Full patch for one commit, addressed by project rather than by session. */
+  commandRegistry.register('projects:get-commit-detail', async (projectId: number, commitHash: string) => {
+    try {
+      const ctx = sessionManager.getProjectContextByProjectId(Number(projectId));
+      if (!ctx?.project?.path) {
+        return { success: false, error: 'Project not found' };
+      }
+      if (!commitHash || !/^[0-9a-fA-F]{4,40}$/.test(commitHash)) {
+        return { success: false, error: 'A valid commit hash is required' };
+      }
+
+      const data = gitDiffManager.getCommitDiff(ctx.project.path, commitHash, ctx.commandRunner);
+      return { success: true, data };
+    } catch (error) {
+      console.error('Failed to get commit detail:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get commit detail',
+      };
     }
   });
 

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -604,6 +604,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
      * Used by `PanelTabBar` to start/stop the dev server for a session.
      */
     resolveRunScript: (sessionId: string): Promise<IPCResponse> => invokeIpc('projects:resolve-run-script', sessionId),
+    /** Repository-wide commit graph across every branch and tag. */
+    getGitGraph: (request: { projectId: number; limit?: number; remoteScope?: string; focusRef?: string }): Promise<IPCResponse> => invokeIpc('projects:get-git-graph', request),
+    /** Full patch for one commit, resolved against the project checkout. */
+    getCommitDetail: (projectId: number, commitHash: string): Promise<IPCResponse> => invokeIpc('projects:get-commit-detail', projectId, commitHash),
   },
 
   // Git operations

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -27,6 +27,7 @@ import type { AgentUsageSnapshot } from '../../shared/types/agentUsage';
 import type { CloudVmState } from '../../shared/types/cloud';
 import type { ResourceSnapshot } from '../../shared/types/resourceMonitor';
 import type { SubmitFeedbackRequest } from '../../shared/types/feedback';
+import type { RepoGitGraphRequest } from '../../shared/types/gitGraph';
 import type {
   PanePermissionRequest as PermissionRequest,
   PanePermissionResponse as PermissionResponse,
@@ -605,7 +606,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
      */
     resolveRunScript: (sessionId: string): Promise<IPCResponse> => invokeIpc('projects:resolve-run-script', sessionId),
     /** Repository-wide commit graph across every branch and tag. */
-    getGitGraph: (request: { projectId: number; limit?: number; remoteScope?: string; focusRef?: string }): Promise<IPCResponse> => invokeIpc('projects:get-git-graph', request),
+    getGitGraph: (request: RepoGitGraphRequest): Promise<IPCResponse> => invokeIpc('projects:get-git-graph', request),
     /** Full patch for one commit, resolved against the project checkout. */
     getCommitDetail: (projectId: number, commitHash: string): Promise<IPCResponse> => invokeIpc('projects:get-commit-detail', projectId, commitHash),
   },

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -1,20 +1,9 @@
 import type { Logger } from '../utils/logger';
 import type { AnalyticsManager } from './analyticsManager';
 import { CommandRunner } from '../utils/commandRunner';
+import type { GitDiffResult, GitDiffStats } from '../../../shared/types/diff';
 
-export interface GitDiffStats {
-  additions: number;
-  deletions: number;
-  filesChanged: number;
-}
-
-export interface GitDiffResult {
-  diff: string;
-  stats: GitDiffStats;
-  changedFiles: string[];
-  beforeHash?: string;
-  afterHash?: string;
-}
+export type { GitDiffResult, GitDiffStats } from '../../../shared/types/diff';
 
 export interface GitCommit {
   hash: string;

--- a/main/src/services/gitGraphManager.test.ts
+++ b/main/src/services/gitGraphManager.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   GitGraphManager,
+  type GitGraphCommandRunner,
   isPlainRefName,
   isPlainRemoteName,
   parseGraphLog,
@@ -8,7 +9,6 @@ import {
   resolveRemoteScope,
 } from './gitGraphManager';
 import { GRAPH_REMOTE_ALL, GRAPH_REMOTE_NONE } from '../../../shared/types/gitGraph';
-import type { CommandRunner } from '../utils/commandRunner';
 
 const REC = '\x01';
 const F = '\x00';
@@ -17,8 +17,14 @@ function logRecord(fields: string[]): string {
   return REC + fields.join(F);
 }
 
-function stubRunner(responses: Array<[match: string, output: string | Error]>): CommandRunner {
-  const exec = vi.fn((command: string) => {
+interface StubRunner extends GitGraphCommandRunner {
+  commands: string[];
+}
+
+function stubRunner(responses: Array<[match: string, output: string | Error]>): StubRunner {
+  const commands: string[] = [];
+  const exec = (command: string) => {
+    commands.push(command);
     for (const [match, output] of responses) {
       if (command.includes(match)) {
         if (output instanceof Error) throw output;
@@ -26,15 +32,15 @@ function stubRunner(responses: Array<[match: string, output: string | Error]>): 
       }
     }
     return '';
-  });
-  return { exec } as unknown as CommandRunner;
+  };
+  return { exec, commands };
 }
 
 const noWorktrees = async () => [];
 
 /** Every command the stub runner was asked to execute, in order. */
-function execCommands(runner: CommandRunner): string[] {
-  return (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+function execCommands(runner: StubRunner): string[] {
+  return runner.commands;
 }
 
 describe('parseGraphLog', () => {
@@ -311,7 +317,7 @@ describe('GitGraphManager focus and divergence', () => {
 
   it('falls back to the plain ref format when git has no ahead-behind', async () => {
     let attempt = 0;
-    const exec = vi.fn((command: string) => {
+    const exec = (command: string) => {
       if (command.includes('for-each-ref')) {
         attempt += 1;
         // git < 2.41 rejects the whole command rather than the one atom.
@@ -323,8 +329,8 @@ describe('GitGraphManager focus and divergence', () => {
       }
       if (command.includes('symbolic-ref')) return 'main\n';
       return '';
-    });
-    const runner = { exec } as unknown as CommandRunner;
+    };
+    const runner = { exec } satisfies GitGraphCommandRunner;
 
     const graph = await new GitGraphManager().getRepoGraph('/repo', {}, runner, noWorktrees);
 

--- a/main/src/services/gitGraphManager.test.ts
+++ b/main/src/services/gitGraphManager.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  GitGraphManager,
+  isPlainRefName,
+  isPlainRemoteName,
+  parseGraphLog,
+  parseForEachRef,
+  resolveRemoteScope,
+} from './gitGraphManager';
+import { GRAPH_REMOTE_ALL, GRAPH_REMOTE_NONE } from '../../../shared/types/gitGraph';
+import type { CommandRunner } from '../utils/commandRunner';
+
+const REC = '\x01';
+const F = '\x00';
+
+function logRecord(fields: string[]): string {
+  return REC + fields.join(F);
+}
+
+function stubRunner(responses: Array<[match: string, output: string | Error]>): CommandRunner {
+  const exec = vi.fn((command: string) => {
+    for (const [match, output] of responses) {
+      if (command.includes(match)) {
+        if (output instanceof Error) throw output;
+        return output;
+      }
+    }
+    return '';
+  });
+  return { exec } as unknown as CommandRunner;
+}
+
+const noWorktrees = async () => [];
+
+/** Every command the stub runner was asked to execute, in order. */
+function execCommands(runner: CommandRunner): string[] {
+  return (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+}
+
+describe('parseGraphLog', () => {
+  it('parses commits with parents and metadata', () => {
+    const raw =
+      logRecord(['aaa111', 'aaa111'.slice(0, 7), 'bbb222 ccc333', 'merge branches', '2026-01-02T10:00:00Z', 'Ada', 'ada@example.com']) +
+      logRecord(['bbb222', 'bbb222'.slice(0, 7), '', 'root', '2026-01-01T10:00:00Z', 'Ada', 'ada@example.com']);
+
+    const nodes = parseGraphLog(raw);
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]).toMatchObject({
+      hash: 'aaa111',
+      parents: ['bbb222', 'ccc333'],
+      subject: 'merge branches',
+      authorName: 'Ada',
+      authorEmail: 'ada@example.com',
+    });
+    expect(nodes[1].parents).toEqual([]);
+  });
+
+  it('survives a record separator appearing inside a subject', () => {
+    // A literal \x01 in the message would otherwise split one commit in two;
+    // records with no usable hash are dropped rather than corrupting the graph.
+    const raw = logRecord(['aaa111', 'aaa111', '', `weird${REC}subject`, '2026-01-01T00:00:00Z', 'Ada', 'a@b.c']);
+    const nodes = parseGraphLog(raw);
+    expect(nodes[0].hash).toBe('aaa111');
+  });
+
+  it('returns an empty array for empty output', () => {
+    expect(parseGraphLog('')).toEqual([]);
+    expect(parseGraphLog('   \n ')).toEqual([]);
+  });
+});
+
+describe('parseForEachRef', () => {
+  it('classifies heads, remotes and tags and marks the current branch', () => {
+    const raw = [
+      ['commit', 'refs/heads/main', 'aaa', ''].join(F),
+      ['commit', 'refs/heads/feature', 'bbb', ''].join(F),
+      ['commit', 'refs/remotes/origin/main', 'aaa', ''].join(F),
+      ['tag', 'refs/tags/v1.0.0', 'tagobj', 'ccc'].join(F),
+    ].join('\n');
+
+    const refs = parseForEachRef(raw, 'main');
+
+    expect(refs).toEqual([
+      { kind: 'localBranch', name: 'main', hash: 'aaa', isCurrent: true },
+      { kind: 'localBranch', name: 'feature', hash: 'bbb', isCurrent: false },
+      { kind: 'remoteBranch', name: 'origin/main', hash: 'aaa', isCurrent: false },
+      // Annotated tag peels to the commit in %(*objectname), not the tag object.
+      { kind: 'tag', name: 'v1.0.0', hash: 'ccc', isCurrent: false },
+    ]);
+  });
+
+  it('skips origin/HEAD, which is a symbolic alias', () => {
+    const raw = ['commit', 'refs/remotes/origin/HEAD', 'aaa', ''].join(F);
+    expect(parseForEachRef(raw, null)).toEqual([]);
+  });
+});
+
+describe('GitGraphManager.getRepoGraph', () => {
+  it('builds a graph and attaches refs to their commits', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ['commit', 'refs/heads/main', 'aaa', ''].join(F)],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph('/repo', {}, runner, noWorktrees);
+
+    expect(graph.currentBranch).toBe('main');
+    expect(graph.nodes).toHaveLength(1);
+    expect(graph.nodes[0].refs).toEqual([
+      { kind: 'localBranch', name: 'main', hash: 'aaa', isCurrent: true },
+    ]);
+    expect(graph.truncated).toBe(false);
+  });
+
+  it('reports a detached HEAD as its own ref', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', new Error('fatal: ref HEAD is not a symbolic ref')],
+      ['for-each-ref', ''],
+      ['rev-parse HEAD', 'aaa\n'],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph('/repo', {}, runner, noWorktrees);
+
+    expect(graph.currentBranch).toBeNull();
+    expect(graph.refs).toContainEqual({ kind: 'head', name: 'HEAD', hash: 'aaa', isCurrent: true });
+  });
+
+  it('flags truncation when more commits exist than the limit', async () => {
+    const log = Array.from({ length: 4 }, (_, i) =>
+      logRecord([`h${i}`, `h${i}`, '', `c${i}`, '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])
+    ).join('');
+    const runner = stubRunner([
+      ['git log', log],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph('/repo', { limit: 3 }, runner, noWorktrees);
+
+    expect(graph.nodes).toHaveLength(3);
+    expect(graph.truncated).toBe(true);
+    expect(graph.limit).toBe(3);
+  });
+
+  it('returns an empty graph with a notice for a repo with no commits', async () => {
+    const runner = stubRunner([
+      ['git log', new Error('fatal: your current branch does not have any commits yet')],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph('/repo', {}, runner, noWorktrees);
+
+    expect(graph.nodes).toEqual([]);
+    expect(graph.notice).toMatch(/no commits/i);
+  });
+
+  it('returns an empty graph with a notice for a non-repository path', async () => {
+    const runner = stubRunner([
+      ['git log', new Error('fatal: not a git repository (or any of the parent directories): .git')],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph('/tmp/plain-dir', {}, runner, noWorktrees);
+
+    expect(graph.nodes).toEqual([]);
+    expect(graph.notice).toMatch(/not a git repository/i);
+  });
+
+  it('still returns the graph when worktree resolution fails', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph('/repo', {}, runner, async () => {
+      throw new Error('worktree list failed');
+    });
+
+    expect(graph.nodes).toHaveLength(1);
+    expect(graph.paneWorktrees).toEqual([]);
+  });
+
+  it('omits remote refs entirely for the local-only scope', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+      ['git remote', 'origin\nupstream\n'],
+    ]);
+
+    await new GitGraphManager().getRepoGraph(
+      '/repo',
+      { remoteScope: GRAPH_REMOTE_NONE },
+      runner,
+      noWorktrees
+    );
+
+    const commands = execCommands(runner);
+    expect(commands.some(cmd => cmd.includes('git log') && cmd.includes('--branches --tags'))).toBe(true);
+    expect(commands.some(cmd => cmd.includes('for-each-ref') && cmd.includes('refs/remotes'))).toBe(false);
+  });
+
+  /**
+   * The reason this scoping exists: a fork's clone carries `origin` *and*
+   * `upstream`, and `--all` graphed the other repository's branches alongside
+   * this one's.
+   */
+  it('graphs only the chosen remote, not every remote in the clone', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+      ['git remote', 'origin\nupstream\n'],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph('/repo', {}, runner, noWorktrees);
+
+    expect(graph.remotes).toEqual(['origin', 'upstream']);
+    expect(graph.remoteScope).toBe('origin');
+
+    const commands = execCommands(runner);
+    expect(commands.some(cmd => cmd.includes('git log') && cmd.includes('--glob=refs/remotes/origin'))).toBe(true);
+    expect(commands.some(cmd => cmd.includes('git log') && cmd.includes('--all'))).toBe(false);
+    expect(commands.some(cmd => cmd.includes('for-each-ref') && cmd.includes('refs/remotes/origin'))).toBe(true);
+  });
+
+  it('takes every remote only when asked', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+      ['git remote', 'origin\nupstream\n'],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph(
+      '/repo',
+      { remoteScope: GRAPH_REMOTE_ALL },
+      runner,
+      noWorktrees
+    );
+
+    expect(graph.remoteScope).toBe(GRAPH_REMOTE_ALL);
+    expect(execCommands(runner).some(cmd => cmd.includes('git log') && cmd.includes('--all'))).toBe(true);
+  });
+});
+
+describe('GitGraphManager focus and divergence', () => {
+  it('narrows history to one ref when asked to focus it', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+      ['git remote', 'origin\n'],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph(
+      '/repo',
+      { focusRef: 'feature/x' },
+      runner,
+      noWorktrees
+    );
+
+    expect(graph.focusRef).toBe('feature/x');
+    const logCmd = execCommands(runner).find(cmd => cmd.includes('git log')) ?? '';
+    expect(logCmd).toContain('git log feature/x');
+    expect(logCmd).not.toContain('--branches');
+  });
+
+  it('ignores a focus ref that could reach the shell', async () => {
+    const runner = stubRunner([
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+      ['git remote', ''],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph(
+      '/repo',
+      { focusRef: 'main; rm -rf /' },
+      runner,
+      noWorktrees
+    );
+
+    expect(graph.focusRef).toBeUndefined();
+    expect(execCommands(runner).some(cmd => cmd.includes('rm -rf'))).toBe(false);
+  });
+
+  it('falls back to the plain ref format when git has no ahead-behind', async () => {
+    let attempt = 0;
+    const exec = vi.fn((command: string) => {
+      if (command.includes('for-each-ref')) {
+        attempt += 1;
+        // git < 2.41 rejects the whole command rather than the one atom.
+        if (command.includes('ahead-behind')) throw new Error("fatal: unknown field name: 'ahead-behind:HEAD'");
+        return ['commit', 'refs/heads/main', 'aaa', ''].join(F);
+      }
+      if (command.includes('git log')) {
+        return logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c']);
+      }
+      if (command.includes('symbolic-ref')) return 'main\n';
+      return '';
+    });
+    const runner = { exec } as unknown as CommandRunner;
+
+    const graph = await new GitGraphManager().getRepoGraph('/repo', {}, runner, noWorktrees);
+
+    expect(attempt).toBe(2);
+    expect(graph.refs).toHaveLength(1);
+    expect(graph.refs[0].ahead).toBeUndefined();
+  });
+});
+
+describe('parseForEachRef divergence', () => {
+  it('reads ahead and behind counts when git reports them', () => {
+    const raw = ['commit', 'refs/heads/feature', 'bbb', '', '3 1'].join(F);
+    expect(parseForEachRef(raw, 'main')[0]).toMatchObject({ ahead: 3, behind: 1 });
+  });
+
+  it('leaves them absent when the field is empty', () => {
+    const raw = ['commit', 'refs/heads/feature', 'bbb', '', ''].join(F);
+    const ref = parseForEachRef(raw, 'main')[0];
+    expect(ref.ahead).toBeUndefined();
+    expect(ref.behind).toBeUndefined();
+  });
+});
+
+describe('isPlainRefName', () => {
+  it('accepts branch and remote-branch names', () => {
+    expect(isPlainRefName('main')).toBe(true);
+    expect(isPlainRefName('origin/main')).toBe(true);
+    expect(isPlainRefName('feature/agent-api')).toBe(true);
+    expect(isPlainRefName('v2.4.45')).toBe(true);
+  });
+
+  it('rejects options, ranges and shell metacharacters', () => {
+    expect(isPlainRefName('--all')).toBe(false);
+    expect(isPlainRefName('main..dev')).toBe(false);
+    expect(isPlainRefName('main; echo hi')).toBe(false);
+    expect(isPlainRefName('$(whoami)')).toBe(false);
+  });
+});
+
+describe('resolveRemoteScope', () => {
+  it('prefers origin — the remote a project was cloned from', () => {
+    expect(resolveRemoteScope(undefined, ['upstream', 'origin'])).toBe('origin');
+  });
+
+  it('falls back to the first remote when there is no origin', () => {
+    expect(resolveRemoteScope(undefined, ['fork', 'upstream'])).toBe('fork');
+  });
+
+  it('is local-only for a repository with no remotes', () => {
+    expect(resolveRemoteScope(undefined, [])).toBe(GRAPH_REMOTE_NONE);
+  });
+
+  it('keeps the explicit sentinels', () => {
+    expect(resolveRemoteScope(GRAPH_REMOTE_ALL, ['origin'])).toBe(GRAPH_REMOTE_ALL);
+    expect(resolveRemoteScope(GRAPH_REMOTE_NONE, ['origin'])).toBe(GRAPH_REMOTE_NONE);
+  });
+
+  it('ignores a remote this repository does not have', () => {
+    expect(resolveRemoteScope('ghost', ['origin'])).toBe('origin');
+  });
+});
+
+describe('isPlainRemoteName', () => {
+  it('accepts ordinary remote names', () => {
+    expect(isPlainRemoteName('origin')).toBe(true);
+    expect(isPlainRemoteName('my-fork.2')).toBe(true);
+  });
+
+  it('rejects anything that could reach the shell or a glob', () => {
+    expect(isPlainRemoteName('a b')).toBe(false);
+    expect(isPlainRemoteName('origin;rm -rf /')).toBe(false);
+    expect(isPlainRemoteName('*')).toBe(false);
+  });
+});

--- a/main/src/services/gitGraphManager.test.ts
+++ b/main/src/services/gitGraphManager.test.ts
@@ -249,6 +249,7 @@ describe('GitGraphManager.getRepoGraph', () => {
 describe('GitGraphManager focus and divergence', () => {
   it('narrows history to one ref when asked to focus it', async () => {
     const runner = stubRunner([
+      ['rev-parse --verify', 'aaa\n'],
       ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
       ['symbolic-ref', 'main\n'],
       ['for-each-ref', ''],
@@ -266,6 +267,27 @@ describe('GitGraphManager focus and divergence', () => {
     const logCmd = execCommands(runner).find(cmd => cmd.includes('git log')) ?? '';
     expect(logCmd).toContain('git log feature/x');
     expect(logCmd).not.toContain('--branches');
+  });
+
+  it('ignores a well-formed focus ref that does not resolve in this repository', async () => {
+    const runner = stubRunner([
+      ['rev-parse --verify', new Error('unknown revision')],
+      ['git log', logRecord(['aaa', 'aaa', '', 'first', '2026-01-01T00:00:00Z', 'Ada', 'a@b.c'])],
+      ['symbolic-ref', 'main\n'],
+      ['for-each-ref', ''],
+    ]);
+
+    const graph = await new GitGraphManager().getRepoGraph(
+      '/repo',
+      { focusRef: 'feature/from-another-repo' },
+      runner,
+      noWorktrees
+    );
+
+    expect(graph.focusRef).toBeUndefined();
+    const logCmd = execCommands(runner).find(cmd => cmd.includes('git log')) ?? '';
+    expect(logCmd).toContain('--branches --tags');
+    expect(logCmd).not.toContain('feature/from-another-repo');
   });
 
   it('ignores a focus ref that could reach the shell', async () => {

--- a/main/src/services/gitGraphManager.ts
+++ b/main/src/services/gitGraphManager.ts
@@ -150,7 +150,9 @@ export class GitGraphManager {
     const remotes = this.getRemotes(projectPath, commandRunner);
     const remoteScope = resolveRemoteScope(options.remoteScope, remotes);
     // A focused ref replaces the ref set entirely: "just this branch's history".
-    const focusRef = options.focusRef && isPlainRefName(options.focusRef)
+    const focusRef = options.focusRef
+      && isPlainRefName(options.focusRef)
+      && this.isResolvableCommit(projectPath, options.focusRef, commandRunner)
       ? options.focusRef
       : undefined;
 
@@ -269,6 +271,21 @@ export class GitGraphManager {
       return commandRunner.exec('git rev-parse HEAD', projectPath).trim() || null;
     } catch {
       return null;
+    }
+  }
+
+  private isResolvableCommit(
+    projectPath: string,
+    refName: string,
+    commandRunner: CommandRunner
+  ): boolean {
+    try {
+      return commandRunner.exec(
+        `git rev-parse --verify --quiet "${refName}^{commit}"`,
+        projectPath
+      ).trim().length > 0;
+    } catch {
+      return false;
     }
   }
 

--- a/main/src/services/gitGraphManager.ts
+++ b/main/src/services/gitGraphManager.ts
@@ -1,0 +1,309 @@
+import type { Logger } from '../utils/logger';
+import type { CommandRunner } from '../utils/commandRunner';
+import {
+  DEFAULT_GRAPH_LIMIT,
+  GRAPH_REMOTE_ALL,
+  GRAPH_REMOTE_NONE,
+  MAX_GRAPH_LIMIT,
+  MAX_GRAPH_REFS,
+  type GitGraphNode,
+  type GitRef,
+  type PaneWorktreeRef,
+  type RepoGitGraph,
+} from '../../../shared/types/gitGraph';
+
+/**
+ * Record and field delimiters for `git log --format`.
+ *
+ * `%x01` separates commits and `%x00` separates fields, because both are
+ * impossible in a ref name and vanishingly unlikely in a commit subject. The
+ * same trick is used by `GitDiffManager.getGraphCommitHistory`.
+ */
+const RECORD_SEP = '\x01';
+const FIELD_SEP = '\x00';
+const LOG_FORMAT = '%x01%H%x00%h%x00%P%x00%s%x00%aI%x00%an%x00%ae';
+
+/** Git messages that mean "valid repo, just nothing to show". */
+function isEmptyRepoError(message: string): boolean {
+  return /does not have any commits yet|bad default revision|unknown revision/i.test(message);
+}
+
+function isNotARepoError(message: string): boolean {
+  return /not a git repository/i.test(message);
+}
+
+/**
+ * Parse `git log --format=LOG_FORMAT`. Commit subjects may contain newlines
+ * after `%s` only in pathological cases, so records are split on RECORD_SEP
+ * rather than by line.
+ */
+export function parseGraphLog(raw: string): GitGraphNode[] {
+  if (!raw.trim()) return [];
+
+  return raw
+    .split(RECORD_SEP)
+    .filter(record => record.trim().length > 0)
+    .map(record => {
+      const [hash, shortHash, parentStr, subject, authorDate, authorName, authorEmail] =
+        record.replace(/\n$/, '').split(FIELD_SEP);
+
+      return {
+        hash: (hash ?? '').trim(),
+        shortHash: shortHash ?? '',
+        parents: parentStr ? parentStr.trim().split(' ').filter(Boolean) : [],
+        subject: subject ?? '',
+        authorDate: authorDate ?? '',
+        authorName: authorName ?? '',
+        authorEmail: (authorEmail ?? '').replace(/\n[\s\S]*$/, ''),
+        refs: [],
+      } satisfies GitGraphNode;
+    })
+    .filter(node => node.hash.length > 0);
+}
+
+/**
+ * Parse `git for-each-ref --format='%(objecttype)%00%(refname)%00%(objectname)%00%(*objectname)'`.
+ *
+ * `%(*objectname)` is non-empty only for annotated tags, where it holds the
+ * commit the tag peels to — that is the hash the graph must key on.
+ */
+export function parseForEachRef(raw: string, currentBranch: string | null): GitRef[] {
+  const refs: GitRef[] = [];
+
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    const [, refName, objectName, peeled, aheadBehind] = line.split(FIELD_SEP);
+    if (!refName || !objectName) continue;
+
+    const hash = peeled && peeled.trim() ? peeled.trim() : objectName.trim();
+    // `%(ahead-behind:HEAD)` prints "3 1"; older git prints nothing at all.
+    const [ahead, behind] = (aheadBehind ?? '').trim().split(/\s+/).map(Number);
+    const divergence = Number.isFinite(ahead) && Number.isFinite(behind)
+      ? { ahead, behind }
+      : {};
+
+    if (refName.startsWith('refs/heads/')) {
+      const name = refName.slice('refs/heads/'.length);
+      refs.push({ kind: 'localBranch', name, hash, isCurrent: name === currentBranch, ...divergence });
+    } else if (refName.startsWith('refs/remotes/')) {
+      const name = refName.slice('refs/remotes/'.length);
+      // `origin/HEAD` is a symbolic alias, not a branch anyone wants to see.
+      if (name.endsWith('/HEAD')) continue;
+      refs.push({ kind: 'remoteBranch', name, hash, isCurrent: false, ...divergence });
+    } else if (refName.startsWith('refs/tags/')) {
+      refs.push({ kind: 'tag', name: refName.slice('refs/tags/'.length), hash, isCurrent: false });
+    }
+  }
+
+  return refs;
+}
+
+/** A remote name git would accept — no whitespace, no glob, no ref magic. */
+export function isPlainRemoteName(value: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(value);
+}
+
+/**
+ * A ref name safe to interpolate into a command.
+ *
+ * Slashes are legal (`origin/main`, `feature/x`), a leading dash is not — it
+ * would be read as an option — and neither is anything the shell reacts to.
+ */
+export function isPlainRefName(value: string): boolean {
+  return /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/.test(value) && !value.includes('..');
+}
+
+/**
+ * Decide which refs the graph covers.
+ *
+ * A fork's clone holds `origin` *and* `upstream`, and those are two different
+ * repositories as far as the user is concerned — graphing `--all` mixed a
+ * hundred `upstream/*` branches into what should be one project's history.
+ * The default is therefore the repo's own remote, with everything else a
+ * deliberate choice.
+ */
+export function resolveRemoteScope(requested: string | undefined, remotes: string[]): string {
+  if (requested === GRAPH_REMOTE_NONE || requested === GRAPH_REMOTE_ALL) return requested;
+  if (requested && remotes.includes(requested)) return requested;
+  // Unknown or absent: prefer origin, then whatever came first, then local only.
+  if (remotes.includes('origin')) return 'origin';
+  return remotes[0] ?? GRAPH_REMOTE_NONE;
+}
+
+export class GitGraphManager {
+  constructor(private logger?: Logger) {}
+
+  /**
+   * Build a repository-wide commit graph: every branch and tag, ordered by
+   * date, with Pane's own worktrees resolved so the UI can highlight them.
+   *
+   * Returns an empty graph (never throws) for empty repos, non-repos and
+   * detached HEADs — those are ordinary states the view renders as-is.
+   */
+  async getRepoGraph(
+    projectPath: string,
+    options: { limit?: number; remoteScope?: string; focusRef?: string },
+    commandRunner: CommandRunner,
+    resolveWorktrees: () => Promise<PaneWorktreeRef[]>
+  ): Promise<RepoGitGraph> {
+    const limit = Math.min(Math.max(options.limit ?? DEFAULT_GRAPH_LIMIT, 1), MAX_GRAPH_LIMIT);
+    const remotes = this.getRemotes(projectPath, commandRunner);
+    const remoteScope = resolveRemoteScope(options.remoteScope, remotes);
+    // A focused ref replaces the ref set entirely: "just this branch's history".
+    const focusRef = options.focusRef && isPlainRefName(options.focusRef)
+      ? options.focusRef
+      : undefined;
+
+    const empty: RepoGitGraph = {
+      nodes: [],
+      refs: [],
+      currentBranch: null,
+      paneWorktrees: [],
+      truncated: false,
+      limit,
+      remotes,
+      remoteScope,
+      ...(focusRef ? { focusRef } : {}),
+    };
+
+    let nodes: GitGraphNode[];
+    // Asking for one extra commit is how we detect that history continues past
+    // the window.
+    const refScope = focusRef
+      ? focusRef
+      : remoteScope === GRAPH_REMOTE_ALL
+        ? '--all'
+        : remoteScope === GRAPH_REMOTE_NONE
+          ? '--branches --tags'
+          : `--branches --tags --glob=refs/remotes/${remoteScope}`;
+    const logCommand = `git log ${refScope} --date-order --format="${LOG_FORMAT}" -n ${limit + 1}`;
+
+    try {
+      nodes = parseGraphLog(commandRunner.exec(logCommand, projectPath));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isNotARepoError(message)) {
+        return { ...empty, notice: 'This project directory is not a git repository.' };
+      }
+      if (isEmptyRepoError(message)) {
+        return { ...empty, notice: 'This repository has no commits yet.' };
+      }
+      this.logger?.error('Failed to read repository graph log', error instanceof Error ? error : undefined);
+      throw error;
+    }
+
+    const truncated = nodes.length > limit;
+    if (truncated) nodes = nodes.slice(0, limit);
+
+    if (nodes.length === 0) {
+      return { ...empty, notice: 'This repository has no commits yet.' };
+    }
+
+    const currentBranch = this.getCurrentBranch(projectPath, commandRunner);
+    const { refs, refsTruncated } = this.getRefs(projectPath, currentBranch, remoteScope, commandRunner);
+
+    // A detached HEAD has no branch ref, so surface it as its own marker.
+    if (!currentBranch) {
+      const headHash = this.getHeadHash(projectPath, commandRunner);
+      if (headHash) refs.push({ kind: 'head', name: 'HEAD', hash: headHash, isCurrent: true });
+    }
+
+    const refsByHash = new Map<string, GitRef[]>();
+    for (const ref of refs) {
+      const bucket = refsByHash.get(ref.hash);
+      if (bucket) bucket.push(ref);
+      else refsByHash.set(ref.hash, [ref]);
+    }
+    for (const node of nodes) {
+      node.refs = refsByHash.get(node.hash) ?? [];
+    }
+
+    let paneWorktrees: PaneWorktreeRef[] = [];
+    try {
+      paneWorktrees = await resolveWorktrees();
+    } catch (error) {
+      this.logger?.verbose(
+        `Could not resolve worktrees for ${projectPath}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    return {
+      nodes,
+      refs,
+      currentBranch,
+      paneWorktrees,
+      truncated,
+      limit,
+      remotes,
+      remoteScope,
+      ...(focusRef ? { focusRef } : {}),
+      ...(refsTruncated ? { notice: `Showing the first ${MAX_GRAPH_REFS} refs.` } : {}),
+    };
+  }
+
+  /** Remotes configured in this clone; empty for a repo with none. */
+  private getRemotes(projectPath: string, commandRunner: CommandRunner): string[] {
+    try {
+      return commandRunner.exec('git remote', projectPath)
+        .split('\n')
+        .map(line => line.trim())
+        .filter(name => name.length > 0 && isPlainRemoteName(name));
+    } catch {
+      // Not a repo, or no remotes — both are just "nothing to offer".
+      return [];
+    }
+  }
+
+  private getCurrentBranch(projectPath: string, commandRunner: CommandRunner): string | null {
+    try {
+      const output = commandRunner.exec('git symbolic-ref --short -q HEAD', projectPath).trim();
+      return output || null;
+    } catch {
+      // Non-zero exit means a detached HEAD, which is not an error here.
+      return null;
+    }
+  }
+
+  private getHeadHash(projectPath: string, commandRunner: CommandRunner): string | null {
+    try {
+      return commandRunner.exec('git rev-parse HEAD', projectPath).trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private getRefs(
+    projectPath: string,
+    currentBranch: string | null,
+    remoteScope: string,
+    commandRunner: CommandRunner
+  ): { refs: GitRef[]; refsTruncated: boolean } {
+    const scopes = remoteScope === GRAPH_REMOTE_ALL
+      ? 'refs/heads refs/remotes refs/tags'
+      : remoteScope === GRAPH_REMOTE_NONE
+        ? 'refs/heads refs/tags'
+        : `refs/heads refs/tags refs/remotes/${remoteScope}`;
+    const baseFormat = '%(objecttype)%00%(refname)%00%(objectname)%00%(*objectname)';
+    // `%(ahead-behind:)` needs git 2.41; older versions fail the whole command,
+    // so the divergence numbers are attempted first and silently dropped.
+    const formats = [`${baseFormat}%00%(ahead-behind:HEAD)`, baseFormat];
+
+    for (const format of formats) {
+      try {
+        const raw = commandRunner.exec(
+          `git for-each-ref --count=${MAX_GRAPH_REFS + 1} --format="${format}" ${scopes}`,
+          projectPath
+        );
+        const parsed = parseForEachRef(raw, currentBranch);
+        const refsTruncated = parsed.length > MAX_GRAPH_REFS;
+        return { refs: refsTruncated ? parsed.slice(0, MAX_GRAPH_REFS) : parsed, refsTruncated };
+      } catch (error) {
+        this.logger?.verbose(
+          `Could not list refs for ${projectPath}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+
+    return { refs: [], refsTruncated: false };
+  }
+}

--- a/main/src/services/gitGraphManager.ts
+++ b/main/src/services/gitGraphManager.ts
@@ -23,6 +23,8 @@ const RECORD_SEP = '\x01';
 const FIELD_SEP = '\x00';
 const LOG_FORMAT = '%x01%H%x00%h%x00%P%x00%s%x00%aI%x00%an%x00%ae';
 
+export type GitGraphCommandRunner = Pick<CommandRunner, 'exec'>;
+
 /** Git messages that mean "valid repo, just nothing to show". */
 function isEmptyRepoError(message: string): boolean {
   return /does not have any commits yet|bad default revision|unknown revision/i.test(message);
@@ -143,7 +145,7 @@ export class GitGraphManager {
   async getRepoGraph(
     projectPath: string,
     options: { limit?: number; remoteScope?: string; focusRef?: string },
-    commandRunner: CommandRunner,
+    commandRunner: GitGraphCommandRunner,
     resolveWorktrees: () => Promise<PaneWorktreeRef[]>
   ): Promise<RepoGitGraph> {
     const limit = Math.min(Math.max(options.limit ?? DEFAULT_GRAPH_LIMIT, 1), MAX_GRAPH_LIMIT);
@@ -165,8 +167,8 @@ export class GitGraphManager {
       limit,
       remotes,
       remoteScope,
-      ...(focusRef ? { focusRef } : {}),
     };
+    if (focusRef) empty.focusRef = focusRef;
 
     let nodes: GitGraphNode[];
     // Asking for one extra commit is how we detect that history continues past
@@ -229,7 +231,7 @@ export class GitGraphManager {
       );
     }
 
-    return {
+    const graph: RepoGitGraph = {
       nodes,
       refs,
       currentBranch,
@@ -238,13 +240,14 @@ export class GitGraphManager {
       limit,
       remotes,
       remoteScope,
-      ...(focusRef ? { focusRef } : {}),
-      ...(refsTruncated ? { notice: `Showing the first ${MAX_GRAPH_REFS} refs.` } : {}),
     };
+    if (focusRef) graph.focusRef = focusRef;
+    if (refsTruncated) graph.notice = `Showing the first ${MAX_GRAPH_REFS} refs.`;
+    return graph;
   }
 
   /** Remotes configured in this clone; empty for a repo with none. */
-  private getRemotes(projectPath: string, commandRunner: CommandRunner): string[] {
+  private getRemotes(projectPath: string, commandRunner: GitGraphCommandRunner): string[] {
     try {
       return commandRunner.exec('git remote', projectPath)
         .split('\n')
@@ -256,7 +259,7 @@ export class GitGraphManager {
     }
   }
 
-  private getCurrentBranch(projectPath: string, commandRunner: CommandRunner): string | null {
+  private getCurrentBranch(projectPath: string, commandRunner: GitGraphCommandRunner): string | null {
     try {
       const output = commandRunner.exec('git symbolic-ref --short -q HEAD', projectPath).trim();
       return output || null;
@@ -266,7 +269,7 @@ export class GitGraphManager {
     }
   }
 
-  private getHeadHash(projectPath: string, commandRunner: CommandRunner): string | null {
+  private getHeadHash(projectPath: string, commandRunner: GitGraphCommandRunner): string | null {
     try {
       return commandRunner.exec('git rev-parse HEAD', projectPath).trim() || null;
     } catch {
@@ -277,7 +280,7 @@ export class GitGraphManager {
   private isResolvableCommit(
     projectPath: string,
     refName: string,
-    commandRunner: CommandRunner
+    commandRunner: GitGraphCommandRunner
   ): boolean {
     try {
       return commandRunner.exec(
@@ -293,8 +296,8 @@ export class GitGraphManager {
     projectPath: string,
     currentBranch: string | null,
     remoteScope: string,
-    commandRunner: CommandRunner
-  ): { refs: GitRef[]; refsTruncated: boolean } {
+    commandRunner: GitGraphCommandRunner
+  ) {
     const scopes = remoteScope === GRAPH_REMOTE_ALL
       ? 'refs/heads refs/remotes refs/tags'
       : remoteScope === GRAPH_REMOTE_NONE

--- a/main/src/services/gitPlumbingCommands.ts
+++ b/main/src/services/gitPlumbingCommands.ts
@@ -1,6 +1,9 @@
 import { execSync } from '../utils/commandExecutor';
 import * as fs from 'fs';
 import { WSLContext, linuxToUNCPath } from '../utils/wslUtils';
+import type { GitDiffStats } from '../../../shared/types/diff';
+
+export type { GitDiffStats } from '../../../shared/types/diff';
 
 /**
  * Optimized git commands using plumbing (low-level) commands
@@ -17,12 +20,6 @@ export interface GitIndexStatus {
 export interface GitAheadBehind {
   ahead: number;
   behind: number;
-}
-
-export interface GitDiffStats {
-  additions: number;
-  deletions: number;
-  filesChanged: number;
 }
 
 /**

--- a/shared/types/diff.ts
+++ b/shared/types/diff.ts
@@ -1,0 +1,15 @@
+/** Aggregate line/file counts for a git diff payload. */
+export interface GitDiffStats {
+  additions: number;
+  deletions: number;
+  filesChanged: number;
+}
+
+/** Git patch payload shared by the main process and renderer. */
+export interface GitDiffResult {
+  diff: string;
+  stats: GitDiffStats;
+  changedFiles: string[];
+  beforeHash?: string;
+  afterHash?: string;
+}

--- a/shared/types/gitGraph.ts
+++ b/shared/types/gitGraph.ts
@@ -1,0 +1,152 @@
+/**
+ * Wire and layout types for the repository-wide commit graph.
+ *
+ * The backend returns a flat, ordered node list plus refs; lane assignment is
+ * done client-side by a pure solver so it stays unit-testable and does not
+ * depend on `git log --graph`'s version-specific ASCII art.
+ */
+
+export type GitRefKind = 'localBranch' | 'remoteBranch' | 'tag' | 'head';
+
+export interface GitRef {
+  kind: GitRefKind;
+  /** Short name: `main`, `origin/main`, `v1.2.0`. */
+  name: string;
+  /** Commit the ref resolves to (peeled, for annotated tags). */
+  hash: string;
+  /** True for the branch HEAD currently points at in the main checkout. */
+  isCurrent: boolean;
+  /**
+   * Commits this ref has that HEAD does not, and vice versa. Absent when git
+   * is too old for `%(ahead-behind:)` (< 2.41) or the ref is HEAD itself.
+   */
+  ahead?: number;
+  behind?: number;
+}
+
+export interface GitGraphNode {
+  hash: string;
+  shortHash: string;
+  parents: string[];
+  subject: string;
+  authorName: string;
+  authorEmail: string;
+  /** ISO-8601 author date. */
+  authorDate: string;
+  refs: GitRef[];
+}
+
+export interface PaneWorktreeRef {
+  /** Absolute worktree path as git reports it. */
+  path: string;
+  branch: string;
+  sessionId?: string;
+  sessionName?: string;
+  /** True for the project's own checkout rather than a session worktree. */
+  isMainCheckout: boolean;
+}
+
+export interface RepoGitGraph {
+  nodes: GitGraphNode[];
+  refs: GitRef[];
+  /** null on a detached HEAD. */
+  currentBranch: string | null;
+  paneWorktrees: PaneWorktreeRef[];
+  /** True when `limit` was hit — more history exists further back. */
+  truncated: boolean;
+  limit: number;
+  /** Remotes configured in this clone, in `git remote` order. */
+  remotes: string[];
+  /** The scope actually applied — see {@link RepoGitGraphRequest.remoteScope}. */
+  remoteScope: string;
+  /** The ref the history was narrowed to, when one was requested. */
+  focusRef?: string;
+  /** Non-fatal problems worth surfacing (no commits yet, ref cap hit, …). */
+  notice?: string;
+}
+
+/**
+ * "Local only" — heads and tags, nothing from a remote.
+ *
+ * Not a legal remote name (git rejects the empty string), so it can never
+ * collide with one.
+ */
+export const GRAPH_REMOTE_NONE = '';
+/**
+ * Every remote at once.
+ *
+ * A fork's clone usually carries both `origin` and `upstream`, and those are
+ * two different repositories on the hosting side. Graphing them together is
+ * occasionally useful and confusing by default, hence the explicit opt-in.
+ * `*` is not a legal remote name either.
+ */
+export const GRAPH_REMOTE_ALL = '*';
+
+export interface RepoGitGraphRequest {
+  projectId: number;
+  /** Commits to load. Defaults to {@link DEFAULT_GRAPH_LIMIT}. */
+  limit?: number;
+  /**
+   * Which remote's branches to include: {@link GRAPH_REMOTE_NONE},
+   * {@link GRAPH_REMOTE_ALL}, or a remote name. Defaults to `origin` when the
+   * repository has one, otherwise its first remote, otherwise local only.
+   */
+  remoteScope?: string;
+  /**
+   * Narrow the history to one ref's ancestry — "show me just this branch".
+   * Ignored when the name is not a ref this repository has.
+   */
+  focusRef?: string;
+}
+
+export const DEFAULT_GRAPH_LIMIT = 300;
+export const MAX_GRAPH_LIMIT = 2000;
+export const MAX_GRAPH_REFS = 2000;
+
+// --- Client-side layout ---
+
+/**
+ * Which part of a row's band an edge occupies. Rows are drawn independently,
+ * so each edge has to say where it starts and ends vertically or the lines
+ * come out as dashes.
+ *
+ * - `straight` — this commit to its first parent: dot → bottom edge.
+ * - `merge` — this commit to a further parent in another lane: dot → bottom.
+ * - `passthrough` — a branch that neither starts nor ends here, crossing the
+ *   whole row: top edge → bottom edge.
+ * - `join` — a lane above that ends at this commit: top edge → dot.
+ */
+export type GitGraphEdgeKind = 'straight' | 'merge' | 'passthrough' | 'join';
+
+export interface GitGraphEdge {
+  fromLane: number;
+  toLane: number;
+  kind: GitGraphEdgeKind;
+  /** Stable palette index derived from the lane the edge belongs to. */
+  colorIndex: number;
+  /**
+   * True when the edge leaves the loaded window (its parent is older than
+   * `limit`), so the renderer can fade it out instead of drawing a dead end.
+   */
+  danglesBelow?: boolean;
+}
+
+export interface GitGraphRow {
+  node: GitGraphNode;
+  /** 0-based lane (column) holding this commit's dot. */
+  lane: number;
+  colorIndex: number;
+  /** Edges drawn in this row's band, including pass-throughs. */
+  edges: GitGraphEdge[];
+  /**
+   * True when no lane above was waiting for this commit — the newest commit on
+   * its branch. Nothing connects to it from above, and the renderer marks the
+   * start rather than drawing a line out of nowhere.
+   */
+  isBranchTip: boolean;
+}
+
+export interface GitGraphLayout {
+  rows: GitGraphRow[];
+  laneCount: number;
+}

--- a/tests/commit-graph.spec.ts
+++ b/tests/commit-graph.spec.ts
@@ -1,0 +1,128 @@
+import path from 'path';
+import { expect, test } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+const project = {
+  id: 1,
+  name: 'Pane',
+  path: '/tmp/pane',
+  active: true,
+  created_at: '2026-08-01T00:00:00.000Z',
+  updated_at: '2026-08-01T00:00:00.000Z',
+};
+
+const mainRef = {
+  kind: 'localBranch',
+  name: 'main',
+  hash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  isCurrent: true,
+  ahead: 0,
+  behind: 0,
+};
+
+const featureRef = {
+  kind: 'localBranch',
+  name: 'feature/commit-graph',
+  hash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  isCurrent: false,
+  ahead: 3,
+  behind: 1,
+};
+
+const graph = {
+  nodes: [
+    {
+      hash: featureRef.hash,
+      shortHash: 'bbbbbbb',
+      parents: [mainRef.hash],
+      subject: 'Add a repository-wide commit graph',
+      authorName: 'Ada Lovelace',
+      authorEmail: 'ada@example.com',
+      authorDate: '2026-08-23T18:00:00.000Z',
+      refs: [featureRef],
+    },
+    {
+      hash: mainRef.hash,
+      shortHash: 'aaaaaaa',
+      parents: [],
+      subject: 'Release v2.4.70',
+      authorName: 'Grace Hopper',
+      authorEmail: 'grace@example.com',
+      authorDate: '2026-08-22T18:00:00.000Z',
+      refs: [mainRef],
+    },
+  ],
+  refs: [featureRef, mainRef],
+  currentBranch: 'main',
+  paneWorktrees: [{
+    path: '/tmp/pane/worktrees/commit-graph',
+    branch: 'feature/commit-graph',
+    sessionId: 'graph-session',
+    sessionName: 'Commit graph work',
+    isMainCheckout: false,
+  }],
+  truncated: false,
+  limit: 300,
+  remotes: ['origin', 'upstream'],
+  remoteScope: 'origin',
+};
+
+const commitDetail = {
+  diff: 'diff --git a/src/graph.ts b/src/graph.ts\nnew file mode 100644\n--- /dev/null\n+++ b/src/graph.ts\n@@ -0,0 +1 @@\n+export const graph = true;\n',
+  stats: { additions: 1, deletions: 0, filesChanged: 1 },
+  changedFiles: ['src/graph.ts'],
+  afterHash: featureRef.hash,
+};
+
+test('repository commit graph supports navigation, detail, filtering, and keyboard selection', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await installElectronApiMock(page, {
+    initialConfig: { theme: 'night-owl' },
+    initialProjects: [project],
+    activeProjectId: 1,
+    initialUiState: {
+      expandedProjects: [1],
+      pinnedSectionExpanded: true,
+      repositoriesSectionExpanded: true,
+    },
+    initialGitGraph: graph,
+    initialCommitDetail: commitDetail,
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: 'Repository actions for Pane' }).click();
+  await page.getByRole('menuitem', { name: 'Commit graph' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Commit graph', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Select commit Add a repository-wide commit graph' })).toBeVisible();
+  await expect(page.getByText('src/graph.ts', { exact: true })).toBeVisible();
+  await expect(page.getByRole('complementary').getByText('+1', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('feature/commit-graph', { exact: true }).first()).toBeVisible();
+
+  await page.waitForTimeout(750);
+  await page.screenshot({
+    path: path.resolve('tmp/pr-384-qa/01-commit-graph-default.png'),
+    fullPage: true,
+  });
+
+  const filter = page.getByRole('searchbox', { name: 'Filter commits by subject, author, hash or ref' });
+  await filter.fill('Grace');
+  await expect(page.getByText('1 of 2 commits match')).toBeVisible();
+  await expect(page.getByText('Release v2.4.70', { exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Select commit Add a repository-wide commit graph' })).toHaveCount(0);
+
+  await page.screenshot({
+    path: path.resolve('tmp/pr-384-qa/02-commit-graph-filtered.png'),
+    fullPage: true,
+  });
+
+  await filter.fill('');
+  await filter.blur();
+  await page.keyboard.press('ArrowDown');
+  await expect(page.getByRole('button', { name: 'Select commit Release v2.4.70' })).toHaveAttribute('aria-pressed', 'true');
+
+  await page.getByRole('button', { name: 'Collapse sidebar' }).click();
+  await expect(page.getByRole('navigation', { name: 'Compact sidebar' })).toBeVisible();
+  await page.getByTestId('compact-repository-graph-1').click();
+  await expect(page.getByRole('heading', { name: 'Commit graph', exact: true })).toBeVisible();
+});

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -45,6 +45,8 @@ type ElectronApiMockOptions = {
   }>;
   initialExecutions?: JsonObject[];
   initialCombinedDiff?: JsonObject | null;
+  initialGitGraph?: JsonObject;
+  initialCommitDetail?: JsonObject;
   initialTerminalStates?: Record<string, JsonObject>;
   initialAgentUsage?: JsonObject;
   forcedAgentUsageError?: string;
@@ -546,6 +548,12 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           { name: 'main', isCurrent: true, hasWorktree: false, isRemote: false },
         ]),
         refreshGitStatus: () => success(),
+        getGitGraph: (request: { focusRef?: string }) => {
+          const data = clone(mockOptions.initialGitGraph ?? {});
+          if (request.focusRef) data.focusRef = request.focusRef;
+          return success(data);
+        },
+        getCommitDetail: () => success(clone(mockOptions.initialCommitDetail ?? null)),
       }),
       prompts: namespace({
         getAll: () => success([]),


### PR DESCRIPTION
## Description

Pane could show a session's own commits, but never the repository as a whole —
which branch a session came from, what is on main, where a tag sits. This adds a
project-scoped graph of every branch and tag, with Pane's own worktrees marked.

- Lane diagram solved client-side from a flat commit list, so the layout is
  unit-testable and independent of `git log --graph` ASCII art
- Branch starts, joins and crossing lanes are distinct edge kinds; merges are
  drawn hollow
- Filter by subject, author, hash or ref; focus one branch's history; arrow keys,
  `/` and Escape to navigate
- Pane worktrees, uncommitted work and ahead/behind counts tie the graph back to
  the sessions
- Selecting a commit loads its full patch into the same `DiffViewer` the diff
  panel uses

The remote scope defaults to the repository's own remote rather than `--all`: a
fork's clone carries `origin` *and* `upstream`, and those are two different
repositories on the hosting side.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`
- [x] I have added tests that prove my fix is effective or that my feature works

## Critical Areas Modified
- [x] State management/IPC events (`projects:get-git-graph`,
      `projects:get-commit-detail`, both through the shared registry)

## Screenshots (if applicable)
<img width="3828" height="2070" alt="image" src="https://github.com/user-attachments/assets/7b449d31-ee15-4079-b388-6fca8ebe8cfd" />

## Additional Notes

Tests: layout solver (13), graph manager and ref parsing (28), including
remote-scope resolution and rejection of ref names that could reach a shell.

`frontend/src/utils/parseUnifiedDiff.ts` also appears in the "commit file
details" PR — same file, same content, needed by both. Whichever merges first,
the other should merge cleanly.

These four feature PRs are independent but all add an entry to the same
navigation plumbing (`navigationStore`'s `ActiveView`, the two sidebar
components, `preload.ts`, `api.ts`, `electron.d.ts`). Whichever lands first,
the others need a small rebase there — no logic overlaps.

Not done: the packaged-build check from CONTRIBUTING. I develop on Windows,
so `pnpm build:mac` was not run.


<!-- pr-test-automation-summary:start -->
## Automated UI QA

Status: passed on `b0adf343` with synthetic repository/commit fixtures.

- Expanded and compact sidebar navigation open the repository commit graph.
- Graph lanes, refs, worktree marker, selected commit detail, unified diff, free-text filtering, and ArrowDown selection were verified.
- `tests/commit-graph.spec.ts`: 1/1 passed.
- Root `pnpm typecheck` and `pnpm lint`: passed.

| Default graph and commit detail | Filtered history |
| --- | --- |
| <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-384-b0adf343-4327b4e635f0-01-commit-graph-default.png" width="420" alt="Repository commit graph with selected commit detail"> | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-384-b0adf343-8aba6840e8ac-02-commit-graph-filtered.png" width="420" alt="Repository commit graph filtered to one commit"> |

Remaining human check: visual judgment with a large real repository and many concurrent lanes.
<!-- pr-test-automation-summary:end -->
