### PR TITLE
Show per-file details for commits, and stop review from freezing the app

### DIFF
--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -23,6 +23,7 @@ interface DetailPanelProps {
   onSwapLayout?: () => void;
   terminalShortcuts?: React.ReactNode;
   onCommitClick?: (hash: string) => void;
+  onCommitFileClick?: (hash: string, path: string) => void;
 }
 
 const sidebarButtonClass = 'w-full justify-start text-sm !px-2';
@@ -53,6 +54,7 @@ export function DetailPanel({
   onSwapLayout,
   terminalShortcuts,
   onCommitClick,
+  onCommitFileClick,
 }: DetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(state => state.immersiveMode);
@@ -90,6 +92,7 @@ export function DetailPanel({
         onSwapLayout={onSwapLayout}
         terminalShortcuts={terminalShortcuts}
         onCommitClick={onCommitClick}
+        onCommitFileClick={onCommitFileClick}
       />
     );
   }
@@ -251,6 +254,8 @@ export function DetailPanel({
                 sessionId={session.id}
                 baseBranch={session.baseBranch || 'main'}
                 onCommitClick={onCommitClick}
+                expandable
+                onFileClick={onCommitFileClick}
               />
             </div>
           </div>

--- a/frontend/src/components/ExecutionList.tsx
+++ b/frontend/src/components/ExecutionList.tsx
@@ -3,9 +3,7 @@ import { RotateCcw, GitCommitHorizontal, ChevronRight, ChevronDown } from 'lucid
 import type { ExecutionListProps, ExecutionDiff } from '../types/diff';
 import { useScrollSurface } from '../hooks/useScrollSurface';
 import { CommitFileList } from './git/CommitFileList';
-
-/** Pseudo-ref the backend understands for uncommitted working-tree changes. */
-const WORKING_TREE_REF = 'index';
+import { WORKING_TREE_REF } from '../../../shared/types/git';
 
 function executionRef(execution: ExecutionDiff): string | null {
   if (execution.id === 0) return WORKING_TREE_REF;

--- a/frontend/src/components/ExecutionList.tsx
+++ b/frontend/src/components/ExecutionList.tsx
@@ -1,7 +1,18 @@
-import React, { useState, memo } from 'react';
-import { RotateCcw, GitCommitHorizontal } from 'lucide-react';
-import type { ExecutionListProps } from '../types/diff';
+import React, { useState, memo, useCallback } from 'react';
+import { RotateCcw, GitCommitHorizontal, ChevronRight, ChevronDown } from 'lucide-react';
+import type { ExecutionListProps, ExecutionDiff } from '../types/diff';
 import { useScrollSurface } from '../hooks/useScrollSurface';
+import { CommitFileList } from './git/CommitFileList';
+
+/** Pseudo-ref the backend understands for uncommitted working-tree changes. */
+const WORKING_TREE_REF = 'index';
+
+function executionRef(execution: ExecutionDiff): string | null {
+  if (execution.id === 0) return WORKING_TREE_REF;
+  const hash = execution.after_commit_hash;
+  if (!hash || hash === 'UNCOMMITTED') return null;
+  return hash;
+}
 
 const ExecutionList: React.FC<ExecutionListProps> = memo(({
   sessionId,
@@ -12,9 +23,11 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
   onRevert,
   onRestore,
   historyLimitReached = false,
-  historyLimit
+  historyLimit,
+  onFileClick
 }) => {
   const [rangeStart, setRangeStart] = useState<number | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const limitDisplay = historyLimit ?? 50;
   const executionListRef = React.useRef<HTMLDivElement>(null);
   const scrollSurfaceRef = useScrollSurface<HTMLDivElement>({
@@ -23,6 +36,15 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
     priority: 80,
     ownerElement: () => executionListRef.current,
   });
+
+  const toggleExpanded = useCallback((executionId: number) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(executionId)) next.delete(executionId);
+      else next.add(executionId);
+      return next;
+    });
+  }, []);
 
   const handleCommitClick = (executionId: number, event: React.MouseEvent) => {
     if (event.shiftKey && rangeStart !== null) {
@@ -89,10 +111,14 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
           const isUncommitted = execution.id === 0;
           const isFirst = idx === 0;
           const isLast = idx === executions.length - 1;
+          const commitRef = executionRef(execution);
+          const isExpanded = expandedIds.has(execution.id);
+          const canExpand = commitRef !== null && execution.stats_files_changed > 0;
+          const filesPanelId = `execution-files-${execution.id}`;
 
           return (
+            <div key={execution.id}>
             <div
-              key={execution.id}
               className={`
                 group relative flex items-stretch gap-2 px-3 transition-colors
                 ${isSelected ? 'bg-interactive/10 border-l-2 border-l-interactive' : 'border-l-2 border-l-transparent hover:bg-surface-hover'}
@@ -138,17 +164,35 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
 
                 {/* Stats + actions */}
                 <div className="flex items-start justify-between mt-0.5">
-                  <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
-                    {execution.stats_files_changed > 0 ? (
-                      <>
-                        <span className="text-status-success">+{execution.stats_additions}</span>
-                        <span className="text-status-error">-{execution.stats_deletions}</span>
-                        <span>{execution.stats_files_changed} {execution.stats_files_changed === 1 ? 'file' : 'files'}</span>
-                      </>
-                    ) : (
-                      <span>No changes</span>
-                    )}
-                  </div>
+                  {canExpand ? (
+                    <button
+                      type="button"
+                      aria-expanded={isExpanded}
+                      aria-controls={filesPanelId}
+                      aria-label={`${isExpanded ? 'Hide' : 'Show'} changed files`}
+                      onClick={(e) => { e.stopPropagation(); toggleExpanded(execution.id); }}
+                      className="pointer-events-auto -ml-0.5 flex items-center gap-1 rounded px-0.5 text-[10px] text-text-muted transition-colors hover:text-text-secondary focus:outline-none focus:ring-1 focus:ring-interactive"
+                    >
+                      {isExpanded
+                        ? <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                        : <ChevronRight className="h-3 w-3 flex-shrink-0" aria-hidden="true" />}
+                      <span className="text-status-success">+{execution.stats_additions}</span>
+                      <span className="text-status-error">-{execution.stats_deletions}</span>
+                      <span>{execution.stats_files_changed} {execution.stats_files_changed === 1 ? 'file' : 'files'}</span>
+                    </button>
+                  ) : (
+                    <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
+                      {execution.stats_files_changed > 0 ? (
+                        <>
+                          <span className="text-status-success">+{execution.stats_additions}</span>
+                          <span className="text-status-error">-{execution.stats_deletions}</span>
+                          <span>{execution.stats_files_changed} {execution.stats_files_changed === 1 ? 'file' : 'files'}</span>
+                        </>
+                      ) : (
+                        <span>No changes</span>
+                      )}
+                    </div>
+                  )}
                   <div className="pointer-events-auto flex flex-col items-end gap-0.5 flex-shrink-0">
                     {isUncommitted && onCommit && execution.stats_files_changed > 0 && (
                       <button
@@ -182,6 +226,19 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
                   </div>
                 </div>
               </div>
+            </div>
+            {isExpanded && commitRef && (
+              <div
+                id={filesPanelId}
+                className={`border-l-2 ${isSelected ? 'border-l-interactive bg-interactive/5' : 'border-l-transparent'} pl-3`}
+              >
+                <CommitFileList
+                  sessionId={sessionId}
+                  commitRef={commitRef}
+                  onFileClick={onFileClick}
+                />
+              </div>
+            )}
             </div>
           );
         })}

--- a/frontend/src/components/GitHistoryGraph.tsx
+++ b/frontend/src/components/GitHistoryGraph.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, memo } from 'react';
 import { API } from '../utils/api';
-import { Loader2, GitCommitHorizontal, FileText, Plus, Minus, User, Clock, Hash, GitFork } from 'lucide-react';
+import { Loader2, GitCommitHorizontal, FileText, Plus, Minus, User, Clock, Hash, GitFork, ChevronRight, ChevronDown } from 'lucide-react';
 import { Tooltip } from './ui/Tooltip';
 import { CopyableField } from './ui/CopyableField';
+import { CommitFileList } from './git/CommitFileList';
 
 interface GitGraphCommitData {
   hash: string;
@@ -27,6 +28,13 @@ interface GitHistoryGraphProps {
   baseBranch: string;
   layout?: 'compact' | 'wide';
   onCommitClick?: (hash: string) => void;
+  /**
+   * Show a per-commit toggle that lists the files the commit touched.
+   * Only meaningful in the `wide` layout — the compact sidebar has no room.
+   */
+  expandable?: boolean;
+  /** Called when a file inside an expanded commit is activated. */
+  onFileClick?: (hash: string, path: string) => void;
 }
 
 function CommitTooltipContent({ entry }: { entry: GitGraphCommitData }) {
@@ -92,11 +100,21 @@ const CommitRow = memo(function CommitRow({
   isLast,
   layout = 'compact',
   onClick,
+  sessionId,
+  expandable = false,
+  isExpanded = false,
+  onToggleExpand,
+  onFileClick,
 }: {
   entry: GitGraphCommitData;
   isLast: boolean;
   layout?: 'compact' | 'wide';
   onClick?: (hash: string) => void;
+  sessionId: string;
+  expandable?: boolean;
+  isExpanded?: boolean;
+  onToggleExpand?: (hash: string) => void;
+  onFileClick?: (hash: string, path: string) => void;
 }) {
   const isIndex = entry.hash === 'index';
   const date = new Date(entry.committerDate);
@@ -183,7 +201,39 @@ const CommitRow = memo(function CommitRow({
       </Row>
   );
 
-  if (layout === 'wide') return row;
+  if (layout === 'wide') {
+    if (!expandable) return row;
+
+    const filesPanelId = `git-history-files-${entry.hash}`;
+    return (
+      <div>
+        <div className="flex items-stretch">
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            aria-controls={filesPanelId}
+            aria-label={`${isExpanded ? 'Hide' : 'Show'} files changed in ${entry.hash === 'index' ? 'uncommitted changes' : entry.hash.slice(0, 7)}`}
+            onClick={() => onToggleExpand?.(entry.hash)}
+            className="flex flex-shrink-0 items-center rounded-sm px-0.5 text-text-muted transition-colors hover:text-text-secondary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-interactive"
+          >
+            {isExpanded
+              ? <ChevronDown className="h-3 w-3" aria-hidden="true" />
+              : <ChevronRight className="h-3 w-3" aria-hidden="true" />}
+          </button>
+          <div className="min-w-0 flex-1">{row}</div>
+        </div>
+        {isExpanded && (
+          <div id={filesPanelId} className="ml-4 border-l border-border-secondary">
+            <CommitFileList
+              sessionId={sessionId}
+              commitRef={entry.hash}
+              onFileClick={onFileClick}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <Tooltip content={<CommitTooltipContent entry={entry} />} side="left" interactive>
@@ -192,11 +242,28 @@ const CommitRow = memo(function CommitRow({
   );
 });
 
-export function GitHistoryGraph({ sessionId, baseBranch, layout = 'compact', onCommitClick }: GitHistoryGraphProps) {
+export function GitHistoryGraph({
+  sessionId,
+  baseBranch,
+  layout = 'compact',
+  onCommitClick,
+  expandable = false,
+  onFileClick,
+}: GitHistoryGraphProps) {
   const [rawEntries, setRawEntries] = useState<GitGraphCommitData[]>([]);
   const [currentBranch, setCurrentBranch] = useState(baseBranch);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expandedHashes, setExpandedHashes] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = useCallback((hash: string) => {
+    setExpandedHashes(prev => {
+      const next = new Set(prev);
+      if (next.has(hash)) next.delete(hash);
+      else next.add(hash);
+      return next;
+    });
+  }, []);
 
   const fetchGraph = useCallback(async () => {
     try {
@@ -288,6 +355,11 @@ export function GitHistoryGraph({ sessionId, baseBranch, layout = 'compact', onC
             isLast={i === rawEntries.length - 1}
             layout={layout}
             onClick={onCommitClick}
+            sessionId={sessionId}
+            expandable={expandable}
+            isExpanded={expandedHashes.has(entry.hash)}
+            onToggleExpand={toggleExpanded}
+            onFileClick={onFileClick}
           />
         ))}
       </div>

--- a/frontend/src/components/HorizontalDetailPanel.tsx
+++ b/frontend/src/components/HorizontalDetailPanel.tsx
@@ -17,6 +17,7 @@ interface HorizontalDetailPanelProps {
   onSwapLayout?: () => void;
   terminalShortcuts?: React.ReactNode;
   onCommitClick?: (hash: string) => void;
+  onCommitFileClick?: (hash: string, path: string) => void;
 }
 
 export function HorizontalDetailPanel({
@@ -28,6 +29,7 @@ export function HorizontalDetailPanel({
   onSwapLayout,
   terminalShortcuts,
   onCommitClick,
+  onCommitFileClick,
 }: HorizontalDetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(state => state.immersiveMode);
@@ -191,6 +193,8 @@ export function HorizontalDetailPanel({
               baseBranch={session.baseBranch || 'main'}
               layout="wide"
               onCommitClick={onCommitClick}
+              expandable
+              onFileClick={onCommitFileClick}
             />
           </div>
         )}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -578,23 +578,31 @@ export const SessionView = memo(() => {
   );
 
   const handleCommitClick = useCallback(
-    async (commitHash: string) => {
+    async (commitHash: string, filePath?: string) => {
       if (!activeSession || sessionPanels.length === 0) return;
       const diffPanel = sessionPanels.find(p => p.type === 'diff');
       if (!diffPanel) return;
       // Store pending hash before dispatching — if the diff panel is not
       // currently active, CombinedDiffView is unmounted and will read this
       // module-level variable when it mounts after the panel switch.
-      setPendingViewCommit(activeSession.id, commitHash);
+      setPendingViewCommit(activeSession.id, commitHash, filePath);
       requestLocalReviewMode(activeSession.id);
       await handlePanelSelect(diffPanel);
       window.setTimeout(() => {
         window.dispatchEvent(new CustomEvent('diff:view-commit', {
-          detail: { sessionId: activeSession.id, commitHash },
+          detail: { sessionId: activeSession.id, commitHash, filePath },
         }));
       }, 0);
     },
     [activeSession, sessionPanels, handlePanelSelect]
+  );
+
+  // A file inside an expanded commit in the history graph was clicked.
+  const handleCommitFileClick = useCallback(
+    (commitHash: string, filePath: string) => {
+      void handleCommitClick(commitHash, filePath);
+    },
+    [handleCommitClick]
   );
 
   // Tab cycling: navigates between panels in the focused group using
@@ -1727,6 +1735,7 @@ export const SessionView = memo(() => {
                   onToggleCollapse={toggleDetailCollapse}
                   onSwapLayout={toggleLayoutSwap}
                   onCommitClick={handleCommitClick}
+                  onCommitFileClick={handleCommitFileClick}
                   terminalShortcuts={
                     <>
                       {agentPresets.map(preset => (
@@ -1936,6 +1945,7 @@ export const SessionView = memo(() => {
                 mergeError={hook.mergeError}
                 onSwapLayout={toggleLayoutSwap}
                 onCommitClick={handleCommitClick}
+                onCommitFileClick={handleCommitFileClick}
               />
             </>
           )}

--- a/frontend/src/components/git/CommitFileList.tsx
+++ b/frontend/src/components/git/CommitFileList.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { API } from '../../utils/api';
+import type { GitCommitFileChange, GitCommitFilesResult, GitFileChangeStatus } from '../../../../shared/types/git';
+import { readCommitFileCache, writeCommitFileCache } from './commitFileCache';
+
+const STATUS_LABEL: Record<GitFileChangeStatus, string> = {
+  added: 'A',
+  modified: 'M',
+  deleted: 'D',
+  renamed: 'R',
+  copied: 'C',
+  typechange: 'T',
+  unmerged: 'U',
+  unknown: '?',
+};
+
+const STATUS_CLASS: Record<GitFileChangeStatus, string> = {
+  added: 'text-status-success',
+  modified: 'text-interactive',
+  deleted: 'text-status-error',
+  renamed: 'text-interactive',
+  copied: 'text-interactive',
+  typechange: 'text-status-warning',
+  unmerged: 'text-status-warning',
+  unknown: 'text-text-muted',
+};
+
+const STATUS_TITLE: Record<GitFileChangeStatus, string> = {
+  added: 'Added',
+  modified: 'Modified',
+  deleted: 'Deleted',
+  renamed: 'Renamed',
+  copied: 'Copied',
+  typechange: 'Type changed',
+  unmerged: 'Unmerged',
+  unknown: 'Unknown change',
+};
+
+function splitPath(path: string): { dir: string; name: string } {
+  const idx = path.lastIndexOf('/');
+  if (idx < 0) return { dir: '', name: path };
+  return { dir: path.slice(0, idx + 1), name: path.slice(idx + 1) };
+}
+
+function FileRow({
+  file,
+  onClick,
+}: {
+  file: GitCommitFileChange;
+  onClick?: () => void;
+}) {
+  const { dir, name } = splitPath(file.path);
+  const statusTitle = STATUS_TITLE[file.status];
+  const title = file.status === 'renamed' || file.status === 'copied'
+    ? `${statusTitle} from ${file.oldPath} to ${file.path}`
+    : `${statusTitle}: ${file.path}`;
+
+  const body = (
+    <>
+      <span
+        className={`w-3 flex-shrink-0 font-mono text-[10px] leading-none ${STATUS_CLASS[file.status]}`}
+        aria-hidden="true"
+      >
+        {STATUS_LABEL[file.status]}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-left text-[11px] leading-snug">
+        {dir && <span className="text-text-muted">{dir}</span>}
+        <span className="text-text-secondary">{name}</span>
+      </span>
+      <span className="flex flex-shrink-0 items-center gap-1 font-mono text-[10px] leading-none">
+        {file.isBinary ? (
+          <span className="text-text-muted">bin</span>
+        ) : (
+          <>
+            {(file.additions ?? 0) > 0 && <span className="text-status-success">+{file.additions}</span>}
+            {(file.deletions ?? 0) > 0 && <span className="text-status-error">-{file.deletions}</span>}
+            {file.additions === null && file.deletions === null && (
+              <span className="text-text-muted">new</span>
+            )}
+          </>
+        )}
+      </span>
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div className="flex items-center gap-1.5 py-0.5 pl-6 pr-2" title={title}>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={`${statusTitle}: ${file.path}. Show diff.`}
+      className="flex w-full items-center gap-1.5 rounded-sm py-0.5 pl-6 pr-2 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-inset focus:ring-interactive"
+    >
+      {body}
+    </button>
+  );
+}
+
+export interface CommitFileListProps {
+  sessionId: string;
+  /** Commit hash, or `index` for uncommitted working-tree changes. */
+  commitRef: string;
+  /** Called when a file row is activated; wire this to reveal the file's diff. */
+  onFileClick?: (commitRef: string, path: string) => void;
+  className?: string;
+}
+
+/**
+ * Lazily loads and renders the files a single commit touched, with per-file
+ * change kind and +/- counts. Mounted only when a commit row is expanded, so
+ * a 50-commit history costs nothing until the user asks for detail.
+ */
+export function CommitFileList({ sessionId, commitRef, onFileClick, className = '' }: CommitFileListProps) {
+  const [result, setResult] = useState<GitCommitFilesResult | null>(
+    () => readCommitFileCache(sessionId, commitRef) ?? null
+  );
+  const [loading, setLoading] = useState(!result);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const cached = readCommitFileCache(sessionId, commitRef);
+    if (cached) {
+      setResult(cached);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    API.sessions.getCommitFiles(sessionId, commitRef)
+      .then(response => {
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          throw new Error(response.error || 'Failed to load changed files');
+        }
+        writeCommitFileCache(sessionId, commitRef, response.data);
+        setResult(response.data);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load changed files');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [commitRef, sessionId]);
+
+  if (loading) {
+    return (
+      <div className={`flex items-center gap-1.5 py-1 pl-6 text-[10px] text-text-muted ${className}`}>
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        Loading files…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={`py-1 pl-6 pr-2 text-[10px] text-status-error ${className}`}>{error}</div>
+    );
+  }
+
+  if (!result || result.files.length === 0) {
+    return (
+      <div className={`py-1 pl-6 pr-2 text-[10px] text-text-muted ${className}`}>No files changed</div>
+    );
+  }
+
+  return (
+    <div className={`pb-1 ${className}`}>
+      {result.isMergeAgainstFirstParent && (
+        <div className="py-0.5 pl-6 pr-2 text-[10px] italic text-text-muted">
+          Merge commit — showing changes against the first parent
+        </div>
+      )}
+      {result.files.map(file => (
+        <FileRow
+          key={`${file.status}-${file.oldPath}-${file.path}`}
+          file={file}
+          onClick={onFileClick ? () => onFileClick(commitRef, file.path) : undefined}
+        />
+      ))}
+      {result.truncated && (
+        <div className="py-0.5 pl-6 pr-2 text-[10px] text-text-muted">
+          Showing {result.files.length} of {result.totalFiles} files
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CommitFileList;

--- a/frontend/src/components/git/CommitFileList.tsx
+++ b/frontend/src/components/git/CommitFileList.tsx
@@ -4,40 +4,18 @@ import { API } from '../../utils/api';
 import type { GitCommitFileChange, GitCommitFilesResult, GitFileChangeStatus } from '../../../../shared/types/git';
 import { readCommitFileCache, writeCommitFileCache } from './commitFileCache';
 
-const STATUS_LABEL: Record<GitFileChangeStatus, string> = {
-  added: 'A',
-  modified: 'M',
-  deleted: 'D',
-  renamed: 'R',
-  copied: 'C',
-  typechange: 'T',
-  unmerged: 'U',
-  unknown: '?',
-};
+const STATUS_META = {
+  added: { label: 'A', className: 'text-status-success', title: 'Added' },
+  modified: { label: 'M', className: 'text-interactive', title: 'Modified' },
+  deleted: { label: 'D', className: 'text-status-error', title: 'Deleted' },
+  renamed: { label: 'R', className: 'text-interactive', title: 'Renamed' },
+  copied: { label: 'C', className: 'text-interactive', title: 'Copied' },
+  typechange: { label: 'T', className: 'text-status-warning', title: 'Type changed' },
+  unmerged: { label: 'U', className: 'text-status-warning', title: 'Unmerged' },
+  unknown: { label: '?', className: 'text-text-muted', title: 'Unknown change' },
+} satisfies Record<GitFileChangeStatus, { label: string; className: string; title: string }>;
 
-const STATUS_CLASS: Record<GitFileChangeStatus, string> = {
-  added: 'text-status-success',
-  modified: 'text-interactive',
-  deleted: 'text-status-error',
-  renamed: 'text-interactive',
-  copied: 'text-interactive',
-  typechange: 'text-status-warning',
-  unmerged: 'text-status-warning',
-  unknown: 'text-text-muted',
-};
-
-const STATUS_TITLE: Record<GitFileChangeStatus, string> = {
-  added: 'Added',
-  modified: 'Modified',
-  deleted: 'Deleted',
-  renamed: 'Renamed',
-  copied: 'Copied',
-  typechange: 'Type changed',
-  unmerged: 'Unmerged',
-  unknown: 'Unknown change',
-};
-
-function splitPath(path: string): { dir: string; name: string } {
+function splitPath(path: string) {
   const idx = path.lastIndexOf('/');
   if (idx < 0) return { dir: '', name: path };
   return { dir: path.slice(0, idx + 1), name: path.slice(idx + 1) };
@@ -51,18 +29,18 @@ function FileRow({
   onClick?: () => void;
 }) {
   const { dir, name } = splitPath(file.path);
-  const statusTitle = STATUS_TITLE[file.status];
+  const status = STATUS_META[file.status];
   const title = file.status === 'renamed' || file.status === 'copied'
-    ? `${statusTitle} from ${file.oldPath} to ${file.path}`
-    : `${statusTitle}: ${file.path}`;
+    ? `${status.title} from ${file.oldPath} to ${file.path}`
+    : `${status.title}: ${file.path}`;
 
   const body = (
     <>
       <span
-        className={`w-3 flex-shrink-0 font-mono text-[10px] leading-none ${STATUS_CLASS[file.status]}`}
+        className={`w-3 flex-shrink-0 font-mono text-[10px] leading-none ${status.className}`}
         aria-hidden="true"
       >
-        {STATUS_LABEL[file.status]}
+        {status.label}
       </span>
       <span className="min-w-0 flex-1 truncate text-left text-[11px] leading-snug">
         {dir && <span className="text-text-muted">{dir}</span>}
@@ -97,7 +75,7 @@ function FileRow({
       type="button"
       onClick={onClick}
       title={title}
-      aria-label={`${statusTitle}: ${file.path}. Show diff.`}
+      aria-label={`${status.title}: ${file.path}. Show diff.`}
       className="flex w-full items-center gap-1.5 rounded-sm py-0.5 pl-6 pr-2 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-inset focus:ring-interactive"
     >
       {body}
@@ -148,7 +126,7 @@ export function CommitFileList({ sessionId, commitRef, onFileClick, className = 
         writeCommitFileCache(sessionId, commitRef, response.data);
         setResult(response.data);
       })
-      .catch((err: unknown) => {
+      .catch(err => {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : 'Failed to load changed files');
       })
@@ -202,5 +180,3 @@ export function CommitFileList({ sessionId, commitRef, onFileClick, className = 
     </div>
   );
 }
-
-export default CommitFileList;

--- a/frontend/src/components/git/commitFileCache.ts
+++ b/frontend/src/components/git/commitFileCache.ts
@@ -1,0 +1,36 @@
+import type { GitCommitFilesResult } from '../../../../shared/types/git';
+
+/**
+ * Per-commit file listings are immutable, so they are cached for the lifetime
+ * of the renderer. The working tree (`index`) is deliberately never cached —
+ * it changes constantly and must always be re-read.
+ */
+const cache = new Map<string, GitCommitFilesResult>();
+
+export const WORKING_TREE_REF = 'index';
+
+export function commitFileCacheKey(sessionId: string, commitRef: string): string {
+  return `${sessionId}:${commitRef}`;
+}
+
+export function readCommitFileCache(sessionId: string, commitRef: string): GitCommitFilesResult | undefined {
+  if (commitRef === WORKING_TREE_REF) return undefined;
+  return cache.get(commitFileCacheKey(sessionId, commitRef));
+}
+
+export function writeCommitFileCache(sessionId: string, commitRef: string, value: GitCommitFilesResult): void {
+  if (commitRef === WORKING_TREE_REF) return;
+  cache.set(commitFileCacheKey(sessionId, commitRef), value);
+}
+
+/** Drop cached listings after a git operation rewrites history. */
+export function invalidateCommitFileCache(sessionId?: string): void {
+  if (!sessionId) {
+    cache.clear();
+    return;
+  }
+  const prefix = `${sessionId}:`;
+  for (const key of Array.from(cache.keys())) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}

--- a/frontend/src/components/git/commitFileCache.ts
+++ b/frontend/src/components/git/commitFileCache.ts
@@ -1,4 +1,4 @@
-import type { GitCommitFilesResult } from '../../../../shared/types/git';
+import { WORKING_TREE_REF, type GitCommitFilesResult } from '../../../../shared/types/git';
 
 /**
  * Per-commit file listings are immutable, so they are cached for the lifetime
@@ -7,9 +7,7 @@ import type { GitCommitFilesResult } from '../../../../shared/types/git';
  */
 const cache = new Map<string, GitCommitFilesResult>();
 
-export const WORKING_TREE_REF = 'index';
-
-export function commitFileCacheKey(sessionId: string, commitRef: string): string {
+function commitFileCacheKey(sessionId: string, commitRef: string): string {
   return `${sessionId}:${commitRef}`;
 }
 
@@ -30,7 +28,7 @@ export function invalidateCommitFileCache(sessionId?: string): void {
     return;
   }
   const prefix = `${sessionId}:`;
-  for (const key of Array.from(cache.keys())) {
+  for (const key of cache.keys()) {
     if (key.startsWith(prefix)) cache.delete(key);
   }
 }

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, memo, useCallback, useRef, useMemo, forwardRef, useImperativeHandle } from 'react';
 import DiffViewer, { DiffViewerHandle } from './DiffViewer';
 import ExecutionList from '../../ExecutionList';
+import { invalidateCommitFileCache } from '../../git/commitFileCache';
 import { CommitDialog } from '../../CommitDialog';
 import { API } from '../../../utils/api';
+import { parseUnifiedDiffToFiles } from '../../../utils/parseUnifiedDiff';
 import type { CombinedDiffViewProps, FileDiff } from '../../../types/diff';
 import type { ExecutionDiff, GitDiffResult } from '../../../types/diff';
 import { RefreshCw } from 'lucide-react';
@@ -35,33 +37,6 @@ async function loadCommitDiff(sessionId: string, commitHash: string): Promise<Co
       error: error instanceof Error ? error.message : 'Failed to load commit diff',
     };
   }
-}
-
-// --- Unified diff parser (single pass, shared between FileList and DiffViewer) ---
-
-function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
-  if (!diff?.trim()) return [];
-
-  const fileChunks = diff.match(/diff --git[\s\S]*?(?=diff --git|$)/g);
-  if (!fileChunks) return [];
-
-  return fileChunks.flatMap(chunk => {
-    const nameMatch = chunk.match(/diff --git a\/(.*?) b\/(.*?)(?:\n|$)/);
-    if (!nameMatch) return [];
-    const oldPath = nameMatch[1];
-    const newPath = nameMatch[2];
-    const isBinary = chunk.includes('Binary files') || chunk.includes('GIT binary patch');
-
-    let type: FileDiff['type'] = 'modified';
-    if (chunk.includes('new file mode')) type = 'added';
-    else if (chunk.includes('deleted file mode')) type = 'deleted';
-    else if (chunk.includes('rename from') && chunk.includes('rename to')) type = 'renamed';
-
-    const additions = (chunk.match(/^\+(?!\+\+)/gm) || []).length;
-    const deletions = (chunk.match(/^-(?!--)/gm) || []).length;
-
-    return [{ path: newPath || oldPath, oldPath, type, isBinary, additions, deletions, rawDiff: chunk }];
-  });
 }
 
 // --- CombinedDiffView ---
@@ -118,6 +93,8 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
   const [isResizing, setIsResizing] = useState(false);
 
   const diffViewerRef = useRef<DiffViewerHandle>(null);
+  // Path a file-row click asked us to reveal once the matching diff has loaded.
+  const pendingRevealPathRef = useRef<string | null>(null);
 
   const isAnyLoading = executionsLoading || diffLoading || commitDiffLoading;
   const showInitialSkeleton = executionsLoading && executions.length === 0;
@@ -319,11 +296,12 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
 
   const triggerSoftRefresh = useCallback(() => {
     diffCacheRef.current.clear();
+    invalidateCommitFileCache(sessionId);
     commitDiffRequestIdRef.current += 1;
     combinedDiffRequestIdRef.current += 1;
     setViewingCommitHash(null);
     setExecutionRefreshNonce(prev => prev + 1);
-  }, []);
+  }, [sessionId]);
 
   // Expose refresh() to parent (DiffPanel) via ref.
   // Same-session refresh keeps current diff visible while refreshed data loads.
@@ -336,18 +314,21 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
   // fired while this component was unmounted (non-active panels are not rendered).
   useEffect(() => {
     // Consume any pending hash written before this component mounted
-    const pendingCommitHash = takePendingViewCommit(sessionId);
-    if (pendingCommitHash !== null) {
+    const pendingCommit = takePendingViewCommit(sessionId);
+    if (pendingCommit !== null) {
       combinedDiffRequestIdRef.current += 1;
-      setViewingCommitHash(pendingCommitHash);
+      pendingRevealPathRef.current = pendingCommit.filePath ?? null;
+      setViewingCommitHash(pendingCommit.commitHash);
       setSelectedExecutions([]);
     }
 
     const handler = (event: Event) => {
       // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
-      const { sessionId: eventSessionId, commitHash } = (event as CustomEvent<{ sessionId: string; commitHash: string }>).detail;
+      const { sessionId: eventSessionId, commitHash, filePath } =
+        (event as CustomEvent<{ sessionId: string; commitHash: string; filePath?: string }>).detail;
       if (eventSessionId !== sessionId) return;
       combinedDiffRequestIdRef.current += 1;
+      pendingRevealPathRef.current = filePath ?? null;
       setViewingCommitHash(commitHash);
       setSelectedExecutions([]);
       clearPendingViewCommit();
@@ -471,9 +452,29 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
 
   const handleSelectionChange = (newSelection: number[]) => {
     commitDiffRequestIdRef.current += 1;
+    pendingRevealPathRef.current = null;
     setViewingCommitHash(null); // exit hash mode
     setSelectedExecutions(newSelection);
   };
+
+  // A file row inside an expanded commit was clicked: switch the diff pane to
+  // that commit (if it is not already showing it) and remember which file to
+  // scroll to once the patch has been parsed.
+  const handleFileClick = useCallback((commitRef: string, path: string) => {
+    pendingRevealPathRef.current = path;
+    if (viewingCommitHashRef.current === commitRef) {
+      // Already showing this commit — reveal immediately.
+      const index = parsedFilesRef.current.findIndex(file => file.path === path);
+      if (index >= 0) {
+        pendingRevealPathRef.current = null;
+        diffViewerRef.current?.scrollToFile(index);
+      }
+      return;
+    }
+    commitDiffRequestIdRef.current += 1;
+    setViewingCommitHash(commitRef);
+    setSelectedExecutions([]);
+  }, []);
 
   const handleManualRefresh = () => {
     triggerSoftRefresh();
@@ -525,6 +526,26 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     if (!combinedDiff?.diff) return [];
     return parseUnifiedDiffToFiles(combinedDiff.diff);
   }, [combinedDiff]);
+
+  const parsedFilesRef = useRef(parsedFiles);
+  parsedFilesRef.current = parsedFiles;
+
+  // Consume a pending file reveal once the newly requested diff has parsed.
+  // DiffViewer resets its expanded set on a file-list change, so the reveal is
+  // deferred by a frame to land after that reset.
+  useEffect(() => {
+    const path = pendingRevealPathRef.current;
+    if (!path || parsedFiles.length === 0) return;
+
+    const index = parsedFiles.findIndex(file => file.path === path);
+    pendingRevealPathRef.current = null;
+    if (index < 0) return;
+
+    const frame = requestAnimationFrame(() => {
+      diffViewerRef.current?.scrollToFile(index);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [parsedFiles]);
 
   const handleRestore = useCallback(async () => {
     if (!window.confirm('Are you sure you want to restore all uncommitted changes? This will discard all your local modifications.')) {
@@ -653,6 +674,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
                   onRestore={handleRestore}
                   historyLimitReached={limitReached}
                   historyLimit={HISTORY_LIMIT}
+                  onFileClick={handleFileClick}
                 />
               </div>
             </div>

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -474,7 +474,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     commitDiffRequestIdRef.current += 1;
     setViewingCommitHash(commitRef);
     setSelectedExecutions([]);
-  }, []);
+  }, [viewingCommitHashRef]);
 
   const handleManualRefresh = () => {
     triggerSoftRefresh();

--- a/frontend/src/components/panels/diff/pendingViewCommit.test.ts
+++ b/frontend/src/components/panels/diff/pendingViewCommit.test.ts
@@ -12,15 +12,15 @@ describe('pendingViewCommit', () => {
     setPendingViewCommit('session-a', 'abc123');
 
     expect(takePendingViewCommit('session-b')).toBeNull();
-    expect(takePendingViewCommit('session-a')).toBe('abc123');
+    expect(takePendingViewCommit('session-a')).toEqual({ commitHash: 'abc123', filePath: undefined });
     expect(takePendingViewCommit('session-a')).toBeNull();
   });
 
   it('replaces an older pending commit', () => {
     setPendingViewCommit('session-a', 'abc123');
-    setPendingViewCommit('session-b', 'def456');
+    setPendingViewCommit('session-b', 'def456', 'src/file.ts');
 
     expect(takePendingViewCommit('session-a')).toBeNull();
-    expect(takePendingViewCommit('session-b')).toBe('def456');
+    expect(takePendingViewCommit('session-b')).toEqual({ commitHash: 'def456', filePath: 'src/file.ts' });
   });
 });

--- a/frontend/src/components/panels/diff/pendingViewCommit.ts
+++ b/frontend/src/components/panels/diff/pendingViewCommit.ts
@@ -1,20 +1,21 @@
 interface PendingViewCommit {
   sessionId: string;
   commitHash: string;
+  filePath?: string;
 }
 
 let pendingViewCommit: PendingViewCommit | null = null;
 
 /** Called by SessionView before dispatching 'diff:view-commit'. */
-export function setPendingViewCommit(sessionId: string, commitHash: string): void {
-  pendingViewCommit = { sessionId, commitHash };
+export function setPendingViewCommit(sessionId: string, commitHash: string, filePath?: string): void {
+  pendingViewCommit = { sessionId, commitHash, filePath };
 }
 
-export function takePendingViewCommit(sessionId: string): string | null {
+export function takePendingViewCommit(sessionId: string): Omit<PendingViewCommit, 'sessionId'> | null {
   if (pendingViewCommit?.sessionId !== sessionId) return null;
-  const { commitHash } = pendingViewCommit;
+  const { commitHash, filePath } = pendingViewCommit;
   pendingViewCommit = null;
-  return commitHash;
+  return { commitHash, filePath };
 }
 
 export function clearPendingViewCommit(): void {

--- a/frontend/src/types/diff.ts
+++ b/frontend/src/types/diff.ts
@@ -60,6 +60,11 @@ export interface ExecutionListProps {
   onRestore?: () => void;
   historyLimitReached?: boolean;
   historyLimit?: number;
+  /**
+   * Called when a file inside an expanded commit is activated.
+   * `commitRef` is a commit hash, or `index` for uncommitted changes.
+   */
+  onFileClick?: (commitRef: string, path: string) => void;
 }
 
 export interface CombinedDiffViewProps {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -35,6 +35,7 @@ import type { JsonValue } from '../../../shared/validation/boundaryDecoder';
 import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
+import type { GitCommitFilesResult } from '../../../shared/types/git';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
@@ -154,6 +155,7 @@ interface ElectronAPI {
     gitDiff: (sessionId: string) => Promise<IPCResponse>;
     getCombinedDiff: (sessionId: string, executionIds?: number[]) => Promise<IPCResponse>;
     getCommitDiffByHash: (sessionId: string, commitHash: string) => Promise<IPCResponse>;
+    getCommitFiles: (sessionId: string, ref: string) => Promise<IPCResponse<GitCommitFilesResult>>;
 
     // Script operations
     hasRunScript: (sessionId: string) => Promise<IPCResponse>;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -190,6 +190,12 @@ export class API {
       return window.electronAPI.sessions.getCommitDiffByHash(sessionId, commitHash);
     },
 
+    /** Per-file change details for one commit, or `index` for the working tree. */
+    async getCommitFiles(sessionId: string, ref: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.sessions.getCommitFiles(sessionId, ref);
+    },
+
     // Main repo session
     async getOrCreateMainRepoSession(projectId: number) {
       if (!isElectron()) throw new Error('Electron API not available');

--- a/frontend/src/utils/parseUnifiedDiff.test.ts
+++ b/frontend/src/utils/parseUnifiedDiff.test.ts
@@ -64,6 +64,16 @@ describe('parseUnifiedDiffToFiles', () => {
     expect(files[0].isBinary).toBe(true);
   });
 
+  it('decodes Git-quoted non-ASCII paths for file reveal matching', () => {
+    const files = parseUnifiedDiffToFiles(
+      'diff --git "a/t\\303\\244st.txt" "b/t\\303\\244st.txt"\n--- "a/t\\303\\244st.txt"\n+++ "b/t\\303\\244st.txt"\n@@ -1 +1,2 @@\n old\n+new\n'
+    );
+
+    expect(files).toHaveLength(1);
+    expect(files[0].oldPath).toBe('täst.txt');
+    expect(files[0].path).toBe('täst.txt');
+  });
+
   it('handles a large diff without pathological cost', () => {
     // 50k added lines in one file — the shape that made Review crawl.
     const body = Array.from({ length: 50_000 }, (_, i) => `+line ${i}`).join('\n');

--- a/frontend/src/utils/parseUnifiedDiff.test.ts
+++ b/frontend/src/utils/parseUnifiedDiff.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseUnifiedDiffToFiles } from './parseUnifiedDiff';
+
+const SAMPLE = `diff --git a/src/a.ts b/src/a.ts
+index 111..222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,4 @@
+ context
+-removed line
++added line
++another added
+diff --git a/src/new.ts b/src/new.ts
+new file mode 100644
+index 0000000..333
+--- /dev/null
++++ b/src/new.ts
+@@ -0,0 +1,2 @@
++first
++second
+`;
+
+describe('parseUnifiedDiffToFiles', () => {
+  it('returns nothing for empty input', () => {
+    expect(parseUnifiedDiffToFiles('')).toEqual([]);
+    expect(parseUnifiedDiffToFiles('   ')).toEqual([]);
+    expect(parseUnifiedDiffToFiles('not a diff')).toEqual([]);
+  });
+
+  it('splits one entry per file and classifies the change', () => {
+    const files = parseUnifiedDiffToFiles(SAMPLE);
+    expect(files.map(f => f.path)).toEqual(['src/a.ts', 'src/new.ts']);
+    expect(files[0].type).toBe('modified');
+    expect(files[1].type).toBe('added');
+  });
+
+  it('counts changed lines without counting the +++/--- headers', () => {
+    const files = parseUnifiedDiffToFiles(SAMPLE);
+    expect(files[0].additions).toBe(2);
+    expect(files[0].deletions).toBe(1);
+    expect(files[1].additions).toBe(2);
+    expect(files[1].deletions).toBe(0);
+  });
+
+  it('detects deletions and renames', () => {
+    const deleted = parseUnifiedDiffToFiles(
+      'diff --git a/gone.ts b/gone.ts\ndeleted file mode 100644\n--- a/gone.ts\n+++ /dev/null\n@@ -1 +0,0 @@\n-bye\n'
+    );
+    expect(deleted[0].type).toBe('deleted');
+    expect(deleted[0].deletions).toBe(1);
+
+    const renamed = parseUnifiedDiffToFiles(
+      'diff --git a/old.ts b/new.ts\nsimilarity index 100%\nrename from old.ts\nrename to new.ts\n'
+    );
+    expect(renamed[0].type).toBe('renamed');
+    expect(renamed[0].oldPath).toBe('old.ts');
+    expect(renamed[0].path).toBe('new.ts');
+  });
+
+  it('flags binary files', () => {
+    const files = parseUnifiedDiffToFiles(
+      'diff --git a/logo.png b/logo.png\nindex 1..2 100644\nBinary files a/logo.png and b/logo.png differ\n'
+    );
+    expect(files[0].isBinary).toBe(true);
+  });
+
+  it('handles a large diff without pathological cost', () => {
+    // 50k added lines in one file — the shape that made Review crawl.
+    const body = Array.from({ length: 50_000 }, (_, i) => `+line ${i}`).join('\n');
+    const huge = `diff --git a/big.ts b/big.ts\nnew file mode 100644\n--- /dev/null\n+++ b/big.ts\n@@ -0,0 +1,50000 @@\n${body}\n`;
+
+    const started = performance.now();
+    const files = parseUnifiedDiffToFiles(huge);
+    const elapsed = performance.now() - started;
+
+    expect(files).toHaveLength(1);
+    expect(files[0].additions).toBe(50_000);
+    // Generous bound: the point is that it is milliseconds, not seconds.
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/frontend/src/utils/parseUnifiedDiff.ts
+++ b/frontend/src/utils/parseUnifiedDiff.ts
@@ -31,6 +31,66 @@ function countChangedLines(chunk: string): { additions: number; deletions: numbe
   return { additions, deletions };
 }
 
+const GIT_ESCAPE_BYTES: Record<string, number> = {
+  a: 0x07,
+  b: 0x08,
+  t: 0x09,
+  n: 0x0a,
+  v: 0x0b,
+  f: 0x0c,
+  r: 0x0d,
+  '"': 0x22,
+  '\\': 0x5c,
+};
+
+function decodeGitQuotedPath(token: string): string {
+  const bytes: number[] = [];
+  const encoder = new TextEncoder();
+  const content = token.slice(1, -1);
+
+  for (let index = 0; index < content.length; index++) {
+    const character = content[index];
+    if (character !== '\\') {
+      bytes.push(...encoder.encode(character));
+      continue;
+    }
+
+    const escaped = content[++index];
+    if (escaped === undefined) break;
+    if (/[0-7]/.test(escaped)) {
+      let octal = escaped;
+      while (octal.length < 3 && /[0-7]/.test(content[index + 1] ?? '')) {
+        octal += content[++index];
+      }
+      bytes.push(Number.parseInt(octal, 8));
+      continue;
+    }
+    bytes.push(GIT_ESCAPE_BYTES[escaped] ?? escaped.charCodeAt(0));
+  }
+
+  return new TextDecoder().decode(Uint8Array.from(bytes));
+}
+
+function parseDiffHeaderPaths(chunk: string): { oldPath: string; newPath: string } | null {
+  const lineEnd = chunk.indexOf('\n');
+  const header = chunk.slice('diff --git '.length, lineEnd < 0 ? chunk.length : lineEnd);
+
+  if (header.startsWith('"')) {
+    const separator = header.indexOf('" "', 1);
+    if (separator < 0 || !header.endsWith('"')) return null;
+    const oldToken = header.slice(0, separator + 1);
+    const newToken = header.slice(separator + 2);
+    const oldPath = decodeGitQuotedPath(oldToken);
+    const newPath = decodeGitQuotedPath(newToken);
+    if (!oldPath.startsWith('a/') || !newPath.startsWith('b/')) return null;
+    return { oldPath: oldPath.slice(2), newPath: newPath.slice(2) };
+  }
+
+  const match = header.match(/^a\/(.*?) b\/(.*)$/);
+  if (!match) return null;
+  return { oldPath: match[1], newPath: match[2] };
+}
+
 /**
  * Split a unified diff into one {@link FileDiff} per `diff --git` chunk.
  *
@@ -44,10 +104,9 @@ export function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
   if (!fileChunks) return [];
 
   return fileChunks.flatMap(chunk => {
-    const nameMatch = chunk.match(/diff --git a\/(.*?) b\/(.*?)(?:\n|$)/);
-    if (!nameMatch) return [];
-    const oldPath = nameMatch[1];
-    const newPath = nameMatch[2];
+    const paths = parseDiffHeaderPaths(chunk);
+    if (!paths) return [];
+    const { oldPath, newPath } = paths;
     const isBinary = chunk.includes('Binary files') || chunk.includes('GIT binary patch');
 
     let type: FileDiff['type'] = 'modified';

--- a/frontend/src/utils/parseUnifiedDiff.ts
+++ b/frontend/src/utils/parseUnifiedDiff.ts
@@ -1,0 +1,62 @@
+import type { FileDiff } from '../types/diff';
+
+/**
+ * Count added/removed lines without allocating a match array.
+ *
+ * `chunk.match(/^\+(?!\+\+)/gm).length` builds an array with one entry per
+ * changed line — on a 50k-line uncommitted diff that is 50k throwaway strings
+ * per file, on the UI thread. Scanning line starts directly costs nothing.
+ */
+function countChangedLines(chunk: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  let lineStart = 0;
+
+  while (lineStart < chunk.length) {
+    let lineEnd = chunk.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = chunk.length;
+
+    const first = chunk[lineStart];
+    if (first === '+') {
+      // Skip the `+++ b/path` file header.
+      if (!(chunk[lineStart + 1] === '+' && chunk[lineStart + 2] === '+')) additions++;
+    } else if (first === '-') {
+      // Skip the `--- a/path` file header.
+      if (!(chunk[lineStart + 1] === '-' && chunk[lineStart + 2] === '-')) deletions++;
+    }
+
+    lineStart = lineEnd + 1;
+  }
+
+  return { additions, deletions };
+}
+
+/**
+ * Split a unified diff into one {@link FileDiff} per `diff --git` chunk.
+ *
+ * Single pass, no allocation per hunk: each chunk keeps its raw patch text so
+ * the renderer can hand it straight to `@git-diff-view/react`.
+ */
+export function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
+  if (!diff?.trim()) return [];
+
+  const fileChunks = diff.match(/diff --git[\s\S]*?(?=diff --git|$)/g);
+  if (!fileChunks) return [];
+
+  return fileChunks.flatMap(chunk => {
+    const nameMatch = chunk.match(/diff --git a\/(.*?) b\/(.*?)(?:\n|$)/);
+    if (!nameMatch) return [];
+    const oldPath = nameMatch[1];
+    const newPath = nameMatch[2];
+    const isBinary = chunk.includes('Binary files') || chunk.includes('GIT binary patch');
+
+    let type: FileDiff['type'] = 'modified';
+    if (chunk.includes('new file mode')) type = 'added';
+    else if (chunk.includes('deleted file mode')) type = 'deleted';
+    else if (chunk.includes('rename from') && chunk.includes('rename to')) type = 'renamed';
+
+    const { additions, deletions } = countChangedLines(chunk);
+
+    return [{ path: newPath || oldPath, oldPath, type, isBinary, additions, deletions, rawDiff: chunk }];
+  });
+}

--- a/frontend/src/utils/parseUnifiedDiff.ts
+++ b/frontend/src/utils/parseUnifiedDiff.ts
@@ -7,7 +7,7 @@ import type { FileDiff } from '../types/diff';
  * changed line — on a 50k-line uncommitted diff that is 50k throwaway strings
  * per file, on the UI thread. Scanning line starts directly costs nothing.
  */
-function countChangedLines(chunk: string): { additions: number; deletions: number } {
+function countChangedLines(chunk: string) {
   let additions = 0;
   let deletions = 0;
   let lineStart = 0;
@@ -31,17 +31,17 @@ function countChangedLines(chunk: string): { additions: number; deletions: numbe
   return { additions, deletions };
 }
 
-const GIT_ESCAPE_BYTES: Record<string, number> = {
-  a: 0x07,
-  b: 0x08,
-  t: 0x09,
-  n: 0x0a,
-  v: 0x0b,
-  f: 0x0c,
-  r: 0x0d,
-  '"': 0x22,
-  '\\': 0x5c,
-};
+const GIT_ESCAPE_BYTES = new Map([
+  ['a', 0x07],
+  ['b', 0x08],
+  ['t', 0x09],
+  ['n', 0x0a],
+  ['v', 0x0b],
+  ['f', 0x0c],
+  ['r', 0x0d],
+  ['"', 0x22],
+  ['\\', 0x5c],
+]);
 
 function decodeGitQuotedPath(token: string): string {
   const bytes: number[] = [];
@@ -65,7 +65,7 @@ function decodeGitQuotedPath(token: string): string {
       bytes.push(Number.parseInt(octal, 8));
       continue;
     }
-    bytes.push(GIT_ESCAPE_BYTES[escaped] ?? escaped.charCodeAt(0));
+    bytes.push(GIT_ESCAPE_BYTES.get(escaped) ?? escaped.charCodeAt(0));
   }
 
   return new TextDecoder().decode(Uint8Array.from(bytes));

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -173,6 +173,7 @@ const GIT_STATUS_CHANNELS = [
   'git:file-status',
   'sessions:git-diff',
   'sessions:get-commit-diff-by-hash',
+  'sessions:get-commit-files',
   'sessions:get-combined-diff',
   'sessions:check-rebase-conflicts',
   'sessions:has-stash',

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -71,6 +71,7 @@ const DAEMON_GIT_STATUS_CHANNELS = [
   'git:file-status',
   'sessions:git-diff',
   'sessions:get-commit-diff-by-hash',
+  'sessions:get-commit-files',
   'sessions:get-combined-diff',
   'sessions:check-rebase-conflicts',
   'sessions:has-stash',
@@ -563,6 +564,33 @@ export function registerGitHandlers(
       console.error('Failed to get commit diff by hash:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to get commit diff';
       return { success: false, error: errorMessage };
+    }
+  });
+
+  commandRegistry.register('sessions:get-commit-files', async (sessionId: string, ref: string) => {
+    try {
+      const session = await sessionManager.getSession(sessionId);
+      if (!session || !session.worktreePath) {
+        return { success: false, error: 'Session or worktree path not found' };
+      }
+
+      if (session.archived) {
+        return { success: false, error: 'Cannot list changed files for an archived session' };
+      }
+
+      const ctx = sessionManager.getProjectContext(sessionId);
+      if (!ctx) {
+        return { success: false, error: 'Project context not found for session' };
+      }
+
+      const data = gitDiffManager.getCommitFileChanges(session.worktreePath, ref, ctx.commandRunner);
+      return { success: true, data };
+    } catch (error) {
+      console.error('Failed to list commit files:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to list commit files',
+      };
     }
   });
 

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -503,6 +503,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     gitDiff: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-diff', sessionId),
     getCombinedDiff: (sessionId: string, executionIds?: number[]): Promise<IPCResponse> => invokeIpc('sessions:get-combined-diff', sessionId, executionIds),
     getCommitDiffByHash: (sessionId: string, commitHash: string): Promise<IPCResponse> => invokeIpc('sessions:get-commit-diff-by-hash', sessionId, commitHash),
+    getCommitFiles: (sessionId: string, ref: string): Promise<IPCResponse> => invokeIpc('sessions:get-commit-files', sessionId, ref),
 
     // Main repo session
     getOrCreateMainRepoSession: (projectId: number): Promise<IPCResponse> => invokeIpc('sessions:get-or-create-main-repo', projectId),

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -5,9 +5,9 @@ import {
   parseNameStatusZ,
   parseUntrackedPathsZ,
   mergeFileChanges,
-  WORKING_TREE_REF,
 } from './gitDiffManager';
-import type { CommandRunner } from '../utils/commandRunner';
+import { WORKING_TREE_REF } from '../../../shared/types/git';
+import { CommandRunner } from '../utils/commandRunner';
 
 const COMMIT_HASH = 'a'.repeat(40);
 const MERGE_HASH = 'b'.repeat(40);
@@ -18,13 +18,14 @@ const LARGE_COMMIT_HASH = 'c'.repeat(40);
  * command, so each test only has to describe the outputs it cares about.
  */
 function stubRunner(responses: Array<[match: string, output: string]>): CommandRunner {
-  const exec = vi.fn((command: string) => {
+  const runner = new CommandRunner({ path: '/repo' });
+  vi.spyOn(runner, 'exec').mockImplementation((command: string) => {
     for (const [match, output] of responses) {
       if (command.includes(match)) return output;
     }
     return '';
   });
-  return { exec } as unknown as CommandRunner;
+  return runner;
 }
 
 describe('parseNumstatZ', () => {
@@ -150,7 +151,7 @@ describe('GitDiffManager.getCommitFileChanges', () => {
     const result = new GitDiffManager().getCommitFileChanges('/repo', MERGE_HASH, runner);
 
     expect(result.isMergeAgainstFirstParent).toBe(true);
-    const commands = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+    const commands = vi.mocked(runner.exec).mock.calls.map(call => call[0]);
     expect(commands.some(cmd => cmd.includes('--numstat') && cmd.includes('--first-parent'))).toBe(true);
   });
 
@@ -189,33 +190,16 @@ describe('GitDiffManager.getCommitFileChanges', () => {
   });
 
   it('returns an empty result instead of throwing on git failure', () => {
-    const runner = {
-      exec: vi.fn(() => {
-        throw new Error('fatal: bad revision');
-      }),
-    } as unknown as CommandRunner;
+    const runner = stubRunner([]);
+    vi.mocked(runner.exec).mockImplementation(() => {
+      throw new Error('fatal: bad revision');
+    });
 
     const result = new GitDiffManager().getCommitFileChanges('/repo', COMMIT_HASH, runner);
 
     expect(result.files).toEqual([]);
     expect(result.totalFiles).toBe(0);
   });
-});
-
-describe('GitDiffManager.getCommitFileChanges error handling', () => {
-  it('returns an empty result instead of throwing on git failure', () => {
-    const runner = {
-      exec: vi.fn(() => {
-        throw new Error('fatal: bad revision');
-      }),
-    } as unknown as CommandRunner;
-
-    const result = new GitDiffManager().getCommitFileChanges('/repo', COMMIT_HASH, runner);
-
-    expect(result.files).toEqual([]);
-    expect(result.totalFiles).toBe(0);
-  });
-
   it('rejects a shell-like ref before running a command', () => {
     const runner = stubRunner([]);
 

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  GitDiffManager,
+  parseNumstatZ,
+  parseNameStatusZ,
+  parseUntrackedPathsZ,
+  mergeFileChanges,
+  WORKING_TREE_REF,
+  MAX_UNTRACKED_INLINE_FILES,
+  chunkByCommandLength,
+} from './gitDiffManager';
+import type { CommandRunner } from '../utils/commandRunner';
+
+/**
+ * Builds a CommandRunner stub whose `exec` dispatches on a substring of the
+ * command, so each test only has to describe the outputs it cares about.
+ */
+function stubRunner(responses: Array<[match: string, output: string]>): CommandRunner {
+  const exec = vi.fn((command: string) => {
+    for (const [match, output] of responses) {
+      if (command.includes(match)) return output;
+    }
+    return '';
+  });
+  return { exec } as unknown as CommandRunner;
+}
+
+describe('parseNumstatZ', () => {
+  it('parses plain add/modify/delete records', () => {
+    const raw = '10\t2\tsrc/a.ts\0' + '0\t7\tsrc/b.ts\0' + '3\t0\tREADME.md\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'src/a.ts', path: 'src/a.ts', additions: 10, deletions: 2, isBinary: false },
+      { oldPath: 'src/b.ts', path: 'src/b.ts', additions: 0, deletions: 7, isBinary: false },
+      { oldPath: 'README.md', path: 'README.md', additions: 3, deletions: 0, isBinary: false },
+    ]);
+  });
+
+  it('parses a rename record with its two trailing path tokens', () => {
+    const raw = '1\t1\t\0old/name.ts\0new/name.ts\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'old/name.ts', path: 'new/name.ts', additions: 1, deletions: 1, isBinary: false },
+    ]);
+  });
+
+  it('marks binary files with null counts', () => {
+    const raw = '-\t-\tassets/logo.png\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'assets/logo.png', path: 'assets/logo.png', additions: null, deletions: null, isBinary: true },
+    ]);
+  });
+
+  it('keeps paths containing spaces, quotes and tabs intact', () => {
+    const raw = '2\t0\tsrc/my "odd"\tname.ts\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'src/my "odd"\tname.ts', path: 'src/my "odd"\tname.ts', additions: 2, deletions: 0, isBinary: false },
+    ]);
+  });
+
+  it('returns an empty list for empty output', () => {
+    expect(parseNumstatZ('')).toEqual([]);
+  });
+});
+
+describe('parseNameStatusZ', () => {
+  it('parses single-path statuses', () => {
+    const raw = 'M\0src/a.ts\0' + 'A\0src/new.ts\0' + 'D\0src/gone.ts\0';
+    expect(parseNameStatusZ(raw)).toEqual([
+      { oldPath: 'src/a.ts', path: 'src/a.ts', status: 'modified' },
+      { oldPath: 'src/new.ts', path: 'src/new.ts', status: 'added' },
+      { oldPath: 'src/gone.ts', path: 'src/gone.ts', status: 'deleted' },
+    ]);
+  });
+
+  it('parses renames with a similarity score and two paths', () => {
+    const raw = 'R100\0old/name.ts\0new/name.ts\0';
+    expect(parseNameStatusZ(raw)).toEqual([
+      { oldPath: 'old/name.ts', path: 'new/name.ts', status: 'renamed', similarity: 100 },
+    ]);
+  });
+
+  it('maps unknown status letters to "unknown"', () => {
+    expect(parseNameStatusZ('X\0weird.ts\0')).toEqual([
+      { oldPath: 'weird.ts', path: 'weird.ts', status: 'unknown' },
+    ]);
+  });
+});
+
+describe('parseUntrackedPathsZ', () => {
+  it('returns only untracked entries and skips rename originals', () => {
+    // Porcelain v1 with -z packs `XY path` into one token; renames add a
+    // second token holding the original path.
+    const raw = ' M tracked.ts\0' + 'R  renamed-new.ts\0renamed-old.ts\0' + '?? brand-new.ts\0';
+    expect(parseUntrackedPathsZ(raw)).toEqual(['brand-new.ts']);
+  });
+
+  it('handles empty output', () => {
+    expect(parseUntrackedPathsZ('')).toEqual([]);
+  });
+});
+
+describe('mergeFileChanges', () => {
+  it('takes counts from numstat and the change kind from name-status', () => {
+    const numstat = parseNumstatZ('1\t1\t\0old.ts\0new.ts\0');
+    const nameStatus = parseNameStatusZ('R95\0old.ts\0new.ts\0');
+    expect(mergeFileChanges(numstat, nameStatus)).toEqual([
+      {
+        path: 'new.ts',
+        oldPath: 'old.ts',
+        status: 'renamed',
+        additions: 1,
+        deletions: 1,
+        isBinary: false,
+        similarity: 95,
+      },
+    ]);
+  });
+
+  it('falls back to "modified" when name-status has no matching path', () => {
+    const merged = mergeFileChanges(parseNumstatZ('4\t1\tsrc/a.ts\0'), []);
+    expect(merged[0].status).toBe('modified');
+  });
+});
+
+describe('GitDiffManager.getCommitFileChanges', () => {
+  it('lists files for a normal commit', () => {
+    const runner = stubRunner([
+      ['rev-list', 'abc123 parent1\n'],
+      ['--numstat', '10\t2\tsrc/a.ts\0'],
+      ['--name-status', 'M\0src/a.ts\0'],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'abc123', runner);
+
+    expect(result.ref).toBe('abc123');
+    expect(result.isMergeAgainstFirstParent).toBe(false);
+    expect(result.truncated).toBe(false);
+    expect(result.totalFiles).toBe(1);
+    expect(result.files[0]).toMatchObject({ path: 'src/a.ts', status: 'modified', additions: 10, deletions: 2 });
+  });
+
+  it('flags merge commits and diffs them against the first parent', () => {
+    const runner = stubRunner([
+      ['rev-list', 'merge1 parent1 parent2\n'],
+      ['--numstat', '1\t0\tsrc/a.ts\0'],
+      ['--name-status', 'M\0src/a.ts\0'],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'merge1', runner);
+
+    expect(result.isMergeAgainstFirstParent).toBe(true);
+    const commands = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+    expect(commands.some(cmd => cmd.includes('--numstat') && cmd.includes('--first-parent'))).toBe(true);
+  });
+
+  it('truncates commits above the per-commit cap', () => {
+    const numstat = Array.from({ length: 600 }, (_, i) => `1\t0\tfile${i}.ts\0`).join('');
+    const runner = stubRunner([
+      ['rev-list', 'big1 parent1\n'],
+      ['--numstat', numstat],
+      ['--name-status', ''],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'big1', runner);
+
+    expect(result.totalFiles).toBe(600);
+    expect(result.files).toHaveLength(500);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('includes untracked files without counts for the working tree', () => {
+    const runner = stubRunner([
+      ['git diff --numstat', '3\t1\ttracked.ts\0'],
+      ['git diff --name-status', 'M\0tracked.ts\0'],
+      ['status --porcelain', '?? untracked.ts\0'],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', WORKING_TREE_REF, runner);
+
+    expect(result.ref).toBe(WORKING_TREE_REF);
+    expect(result.files).toHaveLength(2);
+    expect(result.files[1]).toMatchObject({
+      path: 'untracked.ts',
+      status: 'added',
+      additions: null,
+      deletions: null,
+    });
+  });
+
+  it('returns an empty result instead of throwing on git failure', () => {
+    const runner = {
+      exec: vi.fn(() => {
+        throw new Error('fatal: bad revision');
+      }),
+    } as unknown as CommandRunner;
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
+
+    expect(result.files).toEqual([]);
+    expect(result.totalFiles).toBe(0);
+  });
+});
+
+describe('chunkByCommandLength', () => {
+  it('keeps every file and preserves order', () => {
+    const files = Array.from({ length: 500 }, (_, i) => `src/some/nested/path/file-${i}.ts`);
+    const batches = chunkByCommandLength(files);
+    expect(batches.flat()).toEqual(files);
+  });
+
+  it('keeps each batch within the command-line budget', () => {
+    const files = Array.from({ length: 500 }, (_, i) => `src/file-${i}.ts`);
+    for (const batch of chunkByCommandLength(files, 200)) {
+      const rendered = batch.map(f => `"${f}"`).join(' ');
+      // One over-long path may exceed the budget on its own; more may not.
+      if (batch.length > 1) expect(rendered.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it('never drops a path longer than the whole budget', () => {
+    const long = 'a'.repeat(500);
+    expect(chunkByCommandLength([long], 100).flat()).toEqual([long]);
+  });
+
+  it('returns nothing for no files', () => {
+    expect(chunkByCommandLength([])).toEqual([]);
+  });
+});
+
+/**
+ * These guard the freeze: a worktree carrying an unignored build tree used to
+ * cost one child process per untracked file — twice over — on the main process.
+ */
+describe('working-directory capture is bounded and off the main thread', () => {
+  function asyncRunner(untracked: string[], counters: { cat: number; wc: number; lsFiles: number }) {
+    return {
+      exec: vi.fn(() => ''),
+      execAsync: vi.fn(async (command: string) => {
+        if (command.startsWith('cat ')) {
+          counters.cat++;
+          return { stdout: 'hello\nworld', stderr: '' };
+        }
+        if (command.startsWith('wc -l ')) {
+          counters.wc++;
+          const paths = command.match(/"/g)?.length ?? 0;
+          const fileCount = paths / 2;
+          const lines = Array.from({ length: fileCount }, (_, i) => `  2 file${i}`).join('\n');
+          return { stdout: `${lines}\n  ${fileCount * 2} total`, stderr: '' };
+        }
+        if (command.includes('ls-files --others')) {
+          counters.lsFiles++;
+          return { stdout: untracked.join('\n'), stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      }),
+    } as unknown as CommandRunner;
+  }
+
+  it('caps content reads and batches line counts for a huge untracked set', async () => {
+    const untracked = Array.from({ length: 5000 }, (_, i) => `app/build/res/values-${i}.arsc.flat`);
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(untracked, counters));
+
+    // Content inlining is capped...
+    expect(counters.cat).toBeLessThanOrEqual(MAX_UNTRACKED_INLINE_FILES);
+    // ...and 5000 line counts collapse into a handful of batched spawns,
+    // where the old code spawned one process per file.
+    expect(counters.wc).toBeGreaterThan(0);
+    expect(counters.wc).toBeLessThan(100);
+    // Every untracked file is still reported, even when its content is not.
+    expect(result.changedFiles).toHaveLength(5000);
+    expect(result.stats.filesChanged).toBe(5000);
+  });
+
+  it('lists untracked files exactly once per capture', async () => {
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(['a.ts', 'b.ts'], counters));
+    expect(counters.lsFiles).toBe(1);
+  });
+
+  it('still inlines content for an ordinary number of untracked files', async () => {
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(
+      '/repo',
+      asyncRunner(['README.md', 'src/new.ts', 'notes.txt'], counters)
+    );
+
+    expect(counters.cat).toBe(3);
+    expect(result.diff).toContain('README.md');
+    expect(result.diff).toContain('+hello');
+  });
+
+  it('never blocks on the synchronous exec path', async () => {
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+    const runner = asyncRunner(['a.ts'], counters);
+
+    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', runner);
+
+    // Only getCurrentCommitHash stays sync; nothing that scales with file count.
+    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
+    expect(syncCalls.every(call => call[0].includes('rev-parse'))).toBe(true);
+  });
+});
+
+describe('GitDiffManager.getCommitFileChanges error handling', () => {
+  it('returns an empty result instead of throwing on git failure', () => {
+    const runner = {
+      exec: vi.fn(() => {
+        throw new Error('fatal: bad revision');
+      }),
+    } as unknown as CommandRunner;
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
+
+    expect(result.files).toEqual([]);
+    expect(result.totalFiles).toBe(0);
+  });
+});

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -6,8 +6,6 @@ import {
   parseUntrackedPathsZ,
   mergeFileChanges,
   WORKING_TREE_REF,
-  MAX_UNTRACKED_INLINE_FILES,
-  chunkByCommandLength,
 } from './gitDiffManager';
 import type { CommandRunner } from '../utils/commandRunner';
 
@@ -197,108 +195,6 @@ describe('GitDiffManager.getCommitFileChanges', () => {
 
     expect(result.files).toEqual([]);
     expect(result.totalFiles).toBe(0);
-  });
-});
-
-describe('chunkByCommandLength', () => {
-  it('keeps every file and preserves order', () => {
-    const files = Array.from({ length: 500 }, (_, i) => `src/some/nested/path/file-${i}.ts`);
-    const batches = chunkByCommandLength(files);
-    expect(batches.flat()).toEqual(files);
-  });
-
-  it('keeps each batch within the command-line budget', () => {
-    const files = Array.from({ length: 500 }, (_, i) => `src/file-${i}.ts`);
-    for (const batch of chunkByCommandLength(files, 200)) {
-      const rendered = batch.map(f => `"${f}"`).join(' ');
-      // One over-long path may exceed the budget on its own; more may not.
-      if (batch.length > 1) expect(rendered.length).toBeLessThanOrEqual(200);
-    }
-  });
-
-  it('never drops a path longer than the whole budget', () => {
-    const long = 'a'.repeat(500);
-    expect(chunkByCommandLength([long], 100).flat()).toEqual([long]);
-  });
-
-  it('returns nothing for no files', () => {
-    expect(chunkByCommandLength([])).toEqual([]);
-  });
-});
-
-/**
- * These guard the freeze: a worktree carrying an unignored build tree used to
- * cost one child process per untracked file — twice over — on the main process.
- */
-describe('working-directory capture is bounded and off the main thread', () => {
-  function asyncRunner(untracked: string[], counters: { cat: number; wc: number; lsFiles: number }) {
-    return {
-      exec: vi.fn(() => ''),
-      execAsync: vi.fn(async (command: string) => {
-        if (command.startsWith('cat ')) {
-          counters.cat++;
-          return { stdout: 'hello\nworld', stderr: '' };
-        }
-        if (command.startsWith('wc -l ')) {
-          counters.wc++;
-          const paths = command.match(/"/g)?.length ?? 0;
-          const fileCount = paths / 2;
-          const lines = Array.from({ length: fileCount }, (_, i) => `  2 file${i}`).join('\n');
-          return { stdout: `${lines}\n  ${fileCount * 2} total`, stderr: '' };
-        }
-        if (command.includes('ls-files --others')) {
-          counters.lsFiles++;
-          return { stdout: untracked.join('\n'), stderr: '' };
-        }
-        return { stdout: '', stderr: '' };
-      }),
-    } as unknown as CommandRunner;
-  }
-
-  it('caps content reads and batches line counts for a huge untracked set', async () => {
-    const untracked = Array.from({ length: 5000 }, (_, i) => `app/build/res/values-${i}.arsc.flat`);
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-
-    const result = await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(untracked, counters));
-
-    // Content inlining is capped...
-    expect(counters.cat).toBeLessThanOrEqual(MAX_UNTRACKED_INLINE_FILES);
-    // ...and 5000 line counts collapse into a handful of batched spawns,
-    // where the old code spawned one process per file.
-    expect(counters.wc).toBeGreaterThan(0);
-    expect(counters.wc).toBeLessThan(100);
-    // Every untracked file is still reported, even when its content is not.
-    expect(result.changedFiles).toHaveLength(5000);
-    expect(result.stats.filesChanged).toBe(5000);
-  });
-
-  it('lists untracked files exactly once per capture', async () => {
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(['a.ts', 'b.ts'], counters));
-    expect(counters.lsFiles).toBe(1);
-  });
-
-  it('still inlines content for an ordinary number of untracked files', async () => {
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-    const result = await new GitDiffManager().captureWorkingDirectoryDiff(
-      '/repo',
-      asyncRunner(['README.md', 'src/new.ts', 'notes.txt'], counters)
-    );
-
-    expect(counters.cat).toBe(3);
-    expect(result.diff).toContain('README.md');
-    expect(result.diff).toContain('+hello');
-  });
-
-  it('never blocks on the synchronous exec path', async () => {
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-    const runner = asyncRunner(['a.ts'], counters);
-
-    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', runner);
-
-    // Only getCurrentCommitHash stays sync; nothing that scales with file count.
-    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
-    expect(syncCalls.every(call => call[0].includes('rev-parse'))).toBe(true);
   });
 });
 

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -9,6 +9,10 @@ import {
 } from './gitDiffManager';
 import type { CommandRunner } from '../utils/commandRunner';
 
+const COMMIT_HASH = 'a'.repeat(40);
+const MERGE_HASH = 'b'.repeat(40);
+const LARGE_COMMIT_HASH = 'c'.repeat(40);
+
 /**
  * Builds a CommandRunner stub whose `exec` dispatches on a substring of the
  * command, so each test only has to describe the outputs it cares about.
@@ -122,14 +126,14 @@ describe('mergeFileChanges', () => {
 describe('GitDiffManager.getCommitFileChanges', () => {
   it('lists files for a normal commit', () => {
     const runner = stubRunner([
-      ['rev-list', 'abc123 parent1\n'],
+      ['rev-list', `${COMMIT_HASH} parent1\n`],
       ['--numstat', '10\t2\tsrc/a.ts\0'],
       ['--name-status', 'M\0src/a.ts\0'],
     ]);
 
-    const result = new GitDiffManager().getCommitFileChanges('/repo', 'abc123', runner);
+    const result = new GitDiffManager().getCommitFileChanges('/repo', COMMIT_HASH, runner);
 
-    expect(result.ref).toBe('abc123');
+    expect(result.ref).toBe(COMMIT_HASH);
     expect(result.isMergeAgainstFirstParent).toBe(false);
     expect(result.truncated).toBe(false);
     expect(result.totalFiles).toBe(1);
@@ -138,12 +142,12 @@ describe('GitDiffManager.getCommitFileChanges', () => {
 
   it('flags merge commits and diffs them against the first parent', () => {
     const runner = stubRunner([
-      ['rev-list', 'merge1 parent1 parent2\n'],
+      ['rev-list', `${MERGE_HASH} parent1 parent2\n`],
       ['--numstat', '1\t0\tsrc/a.ts\0'],
       ['--name-status', 'M\0src/a.ts\0'],
     ]);
 
-    const result = new GitDiffManager().getCommitFileChanges('/repo', 'merge1', runner);
+    const result = new GitDiffManager().getCommitFileChanges('/repo', MERGE_HASH, runner);
 
     expect(result.isMergeAgainstFirstParent).toBe(true);
     const commands = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
@@ -153,12 +157,12 @@ describe('GitDiffManager.getCommitFileChanges', () => {
   it('truncates commits above the per-commit cap', () => {
     const numstat = Array.from({ length: 600 }, (_, i) => `1\t0\tfile${i}.ts\0`).join('');
     const runner = stubRunner([
-      ['rev-list', 'big1 parent1\n'],
+      ['rev-list', `${LARGE_COMMIT_HASH} parent1\n`],
       ['--numstat', numstat],
       ['--name-status', ''],
     ]);
 
-    const result = new GitDiffManager().getCommitFileChanges('/repo', 'big1', runner);
+    const result = new GitDiffManager().getCommitFileChanges('/repo', LARGE_COMMIT_HASH, runner);
 
     expect(result.totalFiles).toBe(600);
     expect(result.files).toHaveLength(500);
@@ -191,7 +195,7 @@ describe('GitDiffManager.getCommitFileChanges', () => {
       }),
     } as unknown as CommandRunner;
 
-    const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
+    const result = new GitDiffManager().getCommitFileChanges('/repo', COMMIT_HASH, runner);
 
     expect(result.files).toEqual([]);
     expect(result.totalFiles).toBe(0);
@@ -206,9 +210,18 @@ describe('GitDiffManager.getCommitFileChanges error handling', () => {
       }),
     } as unknown as CommandRunner;
 
-    const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
+    const result = new GitDiffManager().getCommitFileChanges('/repo', COMMIT_HASH, runner);
 
     expect(result.files).toEqual([]);
     expect(result.totalFiles).toBe(0);
+  });
+
+  it('rejects a shell-like ref before running a command', () => {
+    const runner = stubRunner([]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'HEAD; touch /tmp/pwned', runner);
+
+    expect(result.files).toEqual([]);
+    expect(runner.exec).not.toHaveBeenCalled();
   });
 });

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -74,10 +74,10 @@ describe('parseNameStatusZ', () => {
     ]);
   });
 
-  it('parses renames with a similarity score and two paths', () => {
+  it('parses renames with two paths', () => {
     const raw = 'R100\0old/name.ts\0new/name.ts\0';
     expect(parseNameStatusZ(raw)).toEqual([
-      { oldPath: 'old/name.ts', path: 'new/name.ts', status: 'renamed', similarity: 100 },
+      { oldPath: 'old/name.ts', path: 'new/name.ts', status: 'renamed' },
     ]);
   });
 
@@ -113,7 +113,6 @@ describe('mergeFileChanges', () => {
         additions: 1,
         deletions: 1,
         isBinary: false,
-        similarity: 95,
       },
     ]);
   });

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -50,6 +50,8 @@ export interface GitGraphCommit {
 /** Uncommitted working-tree changes are addressed by this pseudo-ref. */
 export const WORKING_TREE_REF = 'index';
 
+const COMMIT_OBJECT_ID_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
 /**
  * Caps on inlining untracked file content into a synthesized diff.
  *
@@ -558,6 +560,10 @@ export class GitDiffManager {
     try {
       if (ref === WORKING_TREE_REF || ref === 'UNCOMMITTED') {
         return this.getWorkingTreeFileChanges(worktreePath, commandRunner);
+      }
+      if (!COMMIT_OBJECT_ID_PATTERN.test(ref)) {
+        this.logger?.warn(`Rejected invalid commit object ID: ${ref}`);
+        return empty;
       }
 
       // `git show` prints nothing for a merge commit unless we ask for a

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -1,6 +1,12 @@
 import type { Logger } from '../utils/logger';
 import type { AnalyticsManager } from './analyticsManager';
 import { CommandRunner } from '../utils/commandRunner';
+import {
+  MAX_FILES_PER_COMMIT,
+  type GitCommitFileChange,
+  type GitCommitFilesResult,
+  type GitFileChangeStatus,
+} from '../../../shared/types/git';
 
 export interface GitDiffStats {
   additions: number;
@@ -37,6 +43,225 @@ export interface GitGraphCommit {
   deletions?: number;
 }
 
+/** Uncommitted working-tree changes are addressed by this pseudo-ref. */
+export const WORKING_TREE_REF = 'index';
+
+/**
+ * Caps on inlining untracked file content into a synthesized diff.
+ *
+ * Reading an untracked file costs one synchronous child process on the main
+ * process, so an unignored build directory would otherwise stall the whole app.
+ */
+export const MAX_UNTRACKED_INLINE_FILES = 200;
+export const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
+
+/** A working-tree diff can be large; don't truncate it at Node's 1MB default. */
+const MAX_DIFF_BUFFER_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Windows caps a command line at ~32k characters. Batches stay well under it so
+ * a single oversized path can never push a command over the edge.
+ */
+const MAX_COMMAND_LENGTH = 6000;
+
+/** Split paths into batches that fit in one command line. */
+export function chunkByCommandLength(files: string[], maxLength = MAX_COMMAND_LENGTH): string[][] {
+  const batches: string[][] = [];
+  let current: string[] = [];
+  let length = 0;
+
+  for (const file of files) {
+    // +3 covers the two quotes and the separating space.
+    const cost = file.length + 3;
+    if (current.length > 0 && length + cost > maxLength) {
+      batches.push(current);
+      current = [];
+      length = 0;
+    }
+    current.push(file);
+    length += cost;
+  }
+
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+interface NumstatEntry {
+  oldPath: string;
+  path: string;
+  additions: number | null;
+  deletions: number | null;
+  isBinary: boolean;
+}
+
+/**
+ * Parse `--numstat -z` output.
+ *
+ * With `-z` each record is `<add>\t<del>\t<path>\0`, except renames/copies
+ * which emit an empty path field followed by two NUL-separated paths:
+ * `<add>\t<del>\t\0<oldPath>\0<newPath>\0`. Binary files report `-` for both
+ * counts. Paths are never quoted under `-z`, so a tab or quote inside a
+ * filename is safe as long as we only split on the first two tabs.
+ */
+export function parseNumstatZ(raw: string): NumstatEntry[] {
+  const tokens = raw.split('\0');
+  const entries: NumstatEntry[] = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+    i++;
+    if (!token) continue;
+
+    const firstTab = token.indexOf('\t');
+    if (firstTab < 0) continue;
+    const secondTab = token.indexOf('\t', firstTab + 1);
+    if (secondTab < 0) continue;
+
+    const addRaw = token.slice(0, firstTab);
+    const delRaw = token.slice(firstTab + 1, secondTab);
+    const pathField = token.slice(secondTab + 1);
+
+    let oldPath: string;
+    let path: string;
+    if (pathField === '') {
+      // Rename/copy: the two paths follow as separate NUL-delimited tokens.
+      oldPath = tokens[i] ?? '';
+      i++;
+      path = tokens[i] ?? '';
+      i++;
+      if (!path) path = oldPath;
+    } else {
+      oldPath = pathField;
+      path = pathField;
+    }
+
+    const isBinary = addRaw === '-' || delRaw === '-';
+    entries.push({
+      oldPath,
+      path,
+      additions: isBinary ? null : Number.parseInt(addRaw, 10) || 0,
+      deletions: isBinary ? null : Number.parseInt(delRaw, 10) || 0,
+      isBinary,
+    });
+  }
+
+  return entries;
+}
+
+function toFileChangeStatus(code: string): GitFileChangeStatus {
+  switch (code) {
+    case 'A': return 'added';
+    case 'M': return 'modified';
+    case 'D': return 'deleted';
+    case 'R': return 'renamed';
+    case 'C': return 'copied';
+    case 'T': return 'typechange';
+    case 'U': return 'unmerged';
+    default: return 'unknown';
+  }
+}
+
+interface NameStatusEntry {
+  oldPath: string;
+  path: string;
+  status: GitFileChangeStatus;
+  similarity?: number;
+}
+
+/**
+ * Parse `--name-status -z` output: `M\0path\0`, `A\0path\0`,
+ * `R100\0oldPath\0newPath\0`. Only `R` and `C` carry two paths.
+ */
+export function parseNameStatusZ(raw: string): NameStatusEntry[] {
+  const tokens = raw.split('\0');
+  const entries: NameStatusEntry[] = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    const statusToken = tokens[i];
+    i++;
+    if (!statusToken) continue;
+
+    const code = statusToken[0];
+    const status = toFileChangeStatus(code);
+    const similarityRaw = statusToken.slice(1);
+    const similarity = similarityRaw ? Number.parseInt(similarityRaw, 10) : undefined;
+
+    if (code === 'R' || code === 'C') {
+      const oldPath = tokens[i] ?? '';
+      i++;
+      const path = tokens[i] ?? '';
+      i++;
+      if (!oldPath && !path) continue;
+      entries.push({
+        oldPath,
+        path: path || oldPath,
+        status,
+        similarity: Number.isNaN(similarity as number) ? undefined : similarity,
+      });
+    } else {
+      const path = tokens[i] ?? '';
+      i++;
+      if (!path) continue;
+      entries.push({ oldPath: path, path, status });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Zip numstat counts with name-status change kinds, keyed by post-change path.
+ * numstat is the source of truth for the file set; a path missing from
+ * name-status falls back to `modified`.
+ */
+export function mergeFileChanges(
+  numstat: NumstatEntry[],
+  nameStatus: NameStatusEntry[]
+): GitCommitFileChange[] {
+  const statusByPath = new Map(nameStatus.map(entry => [entry.path, entry]));
+
+  return numstat.map(entry => {
+    const match = statusByPath.get(entry.path);
+    return {
+      path: entry.path,
+      oldPath: match?.oldPath || entry.oldPath || entry.path,
+      status: match?.status ?? 'modified',
+      additions: entry.additions,
+      deletions: entry.deletions,
+      isBinary: entry.isBinary,
+      ...(match?.similarity !== undefined ? { similarity: match.similarity } : {}),
+    };
+  });
+}
+
+/**
+ * Parse untracked paths out of `git status --porcelain -z`.
+ *
+ * Porcelain v1 with `-z` emits `XY <path>\0`; rename entries emit a second
+ * path token which we skip. Only `??` records are returned.
+ */
+export function parseUntrackedPathsZ(raw: string): string[] {
+  const tokens = raw.split('\0');
+  const paths: string[] = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+    i++;
+    if (!token || token.length < 4) continue;
+
+    const code = token.slice(0, 2);
+    const path = token.slice(3);
+    // Rename/copy records carry the original path as an extra token.
+    if (code[0] === 'R' || code[0] === 'C') i++;
+    if (code === '??') paths.push(path);
+  }
+
+  return paths;
+}
+
 export class GitDiffManager {
   constructor(
     private logger?: Logger,
@@ -54,15 +279,19 @@ export class GitDiffManager {
       // Get current commit hash
       const beforeHash = this.getCurrentCommitHash(worktreePath, commandRunner);
 
+      // Listed once and threaded through: each `git ls-files` is a process
+      // spawn, and the three consumers below used to ask for it separately.
+      const untrackedFiles = await this.getUntrackedFilesAsync(worktreePath, commandRunner);
+
       // Get diff of working directory vs HEAD
-      const diff = this.getGitDiffString(worktreePath, commandRunner);
+      const diff = await this.getGitDiffStringAsync(worktreePath, untrackedFiles, commandRunner);
       console.log(`Captured diff length: ${diff.length}`);
 
       // Get changed files
-      const changedFiles = this.getChangedFiles(worktreePath, commandRunner);
+      const changedFiles = await this.getChangedFilesAsync(worktreePath, untrackedFiles, commandRunner);
 
       // Get diff stats
-      const stats = this.getDiffStats(worktreePath, commandRunner);
+      const stats = await this.getDiffStatsAsync(worktreePath, untrackedFiles, commandRunner);
 
       this.logger?.verbose(`Captured diff: ${stats.filesChanged} files, +${stats.additions} -${stats.deletions}`);
       console.log(`Diff stats:`, stats);
@@ -270,6 +499,113 @@ export class GitDiffManager {
   }
 
   /**
+   * List the files touched by a single commit — or by the working tree when
+   * `ref` is {@link WORKING_TREE_REF} — with per-file +/- counts and change kind.
+   *
+   * Deliberately patch-free: the diff panel calls this lazily when one commit
+   * row is expanded, so listing 50 commits never costs 50 `git show`s.
+   */
+  getCommitFileChanges(
+    worktreePath: string,
+    ref: string,
+    commandRunner: CommandRunner
+  ): GitCommitFilesResult {
+    const empty: GitCommitFilesResult = {
+      ref,
+      files: [],
+      totalFiles: 0,
+      truncated: false,
+      isMergeAgainstFirstParent: false,
+    };
+
+    try {
+      if (ref === WORKING_TREE_REF || ref === 'UNCOMMITTED') {
+        return this.getWorkingTreeFileChanges(worktreePath, commandRunner);
+      }
+
+      // `git show` prints nothing for a merge commit unless we ask for a
+      // specific parent. Detect the merge first so the UI can say so.
+      const parents = this.getCommitParents(worktreePath, ref, commandRunner);
+      const isMerge = parents.length > 1;
+      const mergeFlags = isMerge ? ' -m --first-parent' : '';
+
+      const numstatRaw = commandRunner.exec(
+        `git show --format= --numstat -M -z${mergeFlags} ${ref}`,
+        worktreePath
+      );
+      const nameStatusRaw = commandRunner.exec(
+        `git show --format= --name-status -M -z${mergeFlags} ${ref}`,
+        worktreePath
+      );
+
+      const files = mergeFileChanges(parseNumstatZ(numstatRaw), parseNameStatusZ(nameStatusRaw));
+      return this.clampFileChanges(ref, files, isMerge);
+    } catch (error) {
+      this.logger?.error(
+        `Failed to list changed files for ${ref} in ${worktreePath}`,
+        error instanceof Error ? error : undefined
+      );
+      return empty;
+    }
+  }
+
+  private getWorkingTreeFileChanges(
+    worktreePath: string,
+    commandRunner: CommandRunner
+  ): GitCommitFilesResult {
+    const numstatRaw = commandRunner.exec('git diff --numstat -M -z HEAD', worktreePath);
+    const nameStatusRaw = commandRunner.exec('git diff --name-status -M -z HEAD', worktreePath);
+    const files = mergeFileChanges(parseNumstatZ(numstatRaw), parseNameStatusZ(nameStatusRaw));
+
+    // Untracked files are invisible to `git diff`. Counting their lines would
+    // mean reading every file, so they are listed without counts instead.
+    try {
+      const statusRaw = commandRunner.exec('git status --porcelain -z', worktreePath);
+      const known = new Set(files.map(file => file.path));
+      for (const path of parseUntrackedPathsZ(statusRaw)) {
+        if (known.has(path)) continue;
+        files.push({
+          path,
+          oldPath: path,
+          status: 'added',
+          additions: null,
+          deletions: null,
+          isBinary: false,
+        });
+      }
+    } catch {
+      // An unreadable status is not worth failing the whole listing over.
+    }
+
+    return this.clampFileChanges(WORKING_TREE_REF, files, false);
+  }
+
+  private getCommitParents(worktreePath: string, ref: string, commandRunner: CommandRunner): string[] {
+    try {
+      const output = commandRunner.exec(`git rev-list --parents -n 1 ${ref} --`, worktreePath);
+      // Output is "<commit> <parent1> <parent2> ...".
+      return output.trim().split(/\s+/).filter(Boolean).slice(1);
+    } catch {
+      return [];
+    }
+  }
+
+  private clampFileChanges(
+    ref: string,
+    files: GitCommitFileChange[],
+    isMergeAgainstFirstParent: boolean
+  ): GitCommitFilesResult {
+    const truncated = files.length > MAX_FILES_PER_COMMIT;
+    return {
+      ref,
+      files: truncated ? files.slice(0, MAX_FILES_PER_COMMIT) : files,
+      totalFiles: files.length,
+      truncated,
+      isMergeAgainstFirstParent,
+    };
+  }
+
+  /**
    * Parse numstat output to get diff statistics
    */
   private parseNumstatOutput(lines: string[]): GitDiffStats {
@@ -402,42 +738,6 @@ export class GitDiffManager {
     return result;
   }
 
-  private getGitDiffString(worktreePath: string, commandRunner: CommandRunner): string {
-    try {
-      // First check if we're in a valid git repository
-      try {
-        commandRunner.exec('git rev-parse --git-dir', worktreePath);
-      } catch {
-        console.error(`Not a git repository: ${worktreePath}`);
-        return '';
-      }
-
-      // Check git status to see what files have changes
-      const status = commandRunner.exec('git status --porcelain', worktreePath);
-      console.log(`Git status in ${worktreePath}:`, status || '(no changes)');
-
-      // Get diff of both staged and unstaged changes against HEAD
-      // Using 'git diff HEAD' to include both staged and unstaged changes
-      let diff = commandRunner.exec('git diff HEAD', worktreePath);
-      console.log(`Git diff in ${worktreePath}: ${diff.length} characters`);
-
-      // Get untracked files and create diff-like output for them
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
-      if (untrackedFiles.length > 0) {
-        console.log(`Found ${untrackedFiles.length} untracked files`);
-        const untrackedDiff = this.createDiffForUntrackedFiles(worktreePath, untrackedFiles, commandRunner);
-        if (untrackedDiff) {
-          diff = diff ? diff + '\n' + untrackedDiff : untrackedDiff;
-        }
-      }
-      
-      return diff;
-    } catch (error) {
-      this.logger?.warn(`Could not get git diff in ${worktreePath}`, error instanceof Error ? error : undefined);
-      console.error(`Error getting git diff:`, error);
-      return '';
-    }
-  }
 
   private getGitCommitDiff(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): string {
     try {
@@ -445,23 +745,6 @@ export class GitDiffManager {
     } catch {
       this.logger?.warn(`Could not get git commit diff in ${worktreePath}`);
       return '';
-    }
-  }
-
-  private getChangedFiles(worktreePath: string, commandRunner: CommandRunner): string[] {
-    try {
-      // Get tracked changed files
-      const trackedOutput = commandRunner.exec('git diff --name-only HEAD', worktreePath);
-      const trackedFiles = trackedOutput.trim().split('\n').filter((f: string) => f.length > 0);
-
-      // Get untracked files
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
-      
-      // Combine both lists
-      return [...trackedFiles, ...untrackedFiles];
-    } catch {
-      this.logger?.warn(`Could not get changed files in ${worktreePath}`);
-      return [];
     }
   }
 
@@ -475,44 +758,141 @@ export class GitDiffManager {
     }
   }
 
-  private getDiffStats(worktreePath: string, commandRunner: CommandRunner): GitDiffStats {
+  // --- Working-directory capture (async) -----------------------------------
+
+  /** Untracked paths, honouring .gitignore. */
+  private async getUntrackedFilesAsync(worktreePath: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
-      const output = commandRunner.exec('git diff --stat HEAD', worktreePath);
+      const { stdout } = await commandRunner.execAsync('git ls-files --others --exclude-standard', worktreePath);
+      if (!stdout?.trim()) return [];
+      return stdout.trim().split('\n').map(file => file.trim()).filter(Boolean);
+    } catch {
+      this.logger?.warn(`Could not get untracked files in ${worktreePath}`);
+      return [];
+    }
+  }
 
-      const trackedStats = this.parseDiffStats(output);
+  private async getGitDiffStringAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<string> {
+    let diff = '';
+    try {
+      const { stdout } = await commandRunner.execAsync('git diff HEAD', worktreePath, { maxBuffer: MAX_DIFF_BUFFER_BYTES });
+      diff = stdout ?? '';
+    } catch (error) {
+      this.logger?.warn(`Could not get tracked diff in ${worktreePath}: ${error instanceof Error ? error.message : error}`);
+    }
 
-      // Add stats for untracked files
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
-      if (untrackedFiles.length > 0) {
-        let untrackedAdditions = 0;
-        for (const file of untrackedFiles) {
-          // Skip invalid filenames
-          if (!file || file.trim().length === 0) {
-            continue;
-          }
+    if (untrackedFiles.length === 0) return diff;
+    return diff + await this.createDiffForUntrackedFilesAsync(worktreePath, untrackedFiles, commandRunner);
+  }
 
-          try {
-            const cleanFile = file.trim();
-            const filePath = `${worktreePath}/${cleanFile}`;
-            const lines = commandRunner.exec(`wc -l < "${filePath}"`, worktreePath);
-            untrackedAdditions += parseInt(lines.trim()) || 0;
-          } catch {
-            // Skip files that can't be counted
-          }
-        }
-        
-        return {
-          additions: trackedStats.additions + untrackedAdditions,
-          deletions: trackedStats.deletions,
-          filesChanged: trackedStats.filesChanged + untrackedFiles.length
-        };
-      }
-      
-      return trackedStats;
+  private async getChangedFilesAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<string[]> {
+    try {
+      const { stdout } = await commandRunner.execAsync('git diff --name-only HEAD', worktreePath);
+      const tracked = (stdout ?? '').trim().split('\n').map(file => file.trim()).filter(Boolean);
+      return [...tracked, ...untrackedFiles];
+    } catch {
+      this.logger?.warn(`Could not get changed files in ${worktreePath}`);
+      return [...untrackedFiles];
+    }
+  }
+
+  private async getDiffStatsAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<GitDiffStats> {
+    let trackedStats: GitDiffStats = { additions: 0, deletions: 0, filesChanged: 0 };
+    try {
+      const { stdout } = await commandRunner.execAsync('git diff --shortstat HEAD', worktreePath);
+      trackedStats = this.parseDiffStats((stdout ?? '').trim());
     } catch {
       this.logger?.warn(`Could not get diff stats in ${worktreePath}`);
-      return { additions: 0, deletions: 0, filesChanged: 0 };
     }
+
+    if (untrackedFiles.length === 0) return trackedStats;
+
+    const untrackedAdditions = await this.countLinesBatched(worktreePath, untrackedFiles, commandRunner);
+    return {
+      additions: trackedStats.additions + untrackedAdditions,
+      deletions: trackedStats.deletions,
+      filesChanged: trackedStats.filesChanged + untrackedFiles.length,
+    };
+  }
+
+  private async countLinesBatched(
+    worktreePath: string,
+    files: string[],
+    commandRunner: CommandRunner
+  ): Promise<number> {
+    let total = 0;
+    for (const batch of chunkByCommandLength(files)) {
+      const args = batch.map(file => `"${worktreePath}/${file}"`).join(' ');
+      try {
+        const { stdout } = await commandRunner.execAsync(`wc -l ${args}`, worktreePath);
+        for (const line of (stdout ?? '').trim().split('\n')) {
+          const match = line.trim().match(/^(\d+)\s+(.*)$/);
+          if (!match) continue;
+          if (batch.length > 1 && match[2].trim() === 'total') continue;
+          total += Number.parseInt(match[1], 10) || 0;
+        }
+      } catch {
+        // Unreadable files do not contribute to the line count.
+      }
+    }
+    return total;
+  }
+
+  private async createDiffForUntrackedFilesAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<string> {
+    const parts: string[] = [];
+    let bytes = 0;
+    let inlined = 0;
+
+    for (const file of untrackedFiles) {
+      if (inlined >= MAX_UNTRACKED_INLINE_FILES || bytes >= MAX_UNTRACKED_INLINE_BYTES) {
+        this.logger?.warn(
+          `Untracked diff truncated in ${worktreePath}: ${untrackedFiles.length} untracked files exceed the inline budget`
+        );
+        break;
+      }
+
+      try {
+        const { stdout } = await commandRunner.execAsync(
+          `cat "${worktreePath}/${file}"`,
+          worktreePath,
+          { maxBuffer: 1024 * 1024 }
+        );
+        inlined++;
+
+        const lines = (stdout ?? '').split('\n');
+        const header =
+          `diff --git a/${file} b/${file}\n`
+          + 'new file mode 100644\n'
+          + 'index 0000000..0000000\n'
+          + '--- /dev/null\n'
+          + `+++ b/${file}\n`
+          + `@@ -0,0 +1,${lines.length} @@\n`;
+        const body = lines.map(line => `+${line}`).join('\n') + '\n';
+
+        parts.push(header, body);
+        bytes += header.length + body.length;
+      } catch {
+        // Binary or unreadable files are omitted from the synthesized patch.
+      }
+    }
+
+    return parts.join('');
   }
 
   private getCommitDiffStats(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): GitDiffStats {
@@ -555,64 +935,4 @@ export class GitDiffManager {
     }
   }
 
-  /**
-   * Get list of untracked files
-   */
-  private getUntrackedFiles(worktreePath: string, commandRunner: CommandRunner): string[] {
-    try {
-      const output = commandRunner.exec('git ls-files --others --exclude-standard', worktreePath);
-      
-      // Handle empty output case
-      if (!output || output.trim().length === 0) {
-        return [];
-      }
-      
-      return output.trim().split('\n').filter((f: string) => f && f.trim().length > 0);
-    } catch {
-      this.logger?.warn(`Could not get untracked files in ${worktreePath}`);
-      return [];
-    }
-  }
-
-  /**
-   * Create diff-like output for untracked files
-   */
-  private createDiffForUntrackedFiles(worktreePath: string, untrackedFiles: string[], commandRunner: CommandRunner): string {
-    let diffOutput = '';
-    
-    for (const file of untrackedFiles) {
-      // Skip invalid filenames
-      if (!file || file.trim().length === 0) {
-        continue;
-      }
-      
-      try {
-        const cleanFile = file.trim();
-        const filePath = `${worktreePath}/${cleanFile}`;
-        const fileContent = commandRunner.exec(`cat "${filePath}"`, worktreePath, { maxBuffer: 1024 * 1024 });
-        
-        // Create a diff-like format for the new file
-        diffOutput += `diff --git a/${cleanFile} b/${cleanFile}\n`;
-        diffOutput += `new file mode 100644\n`;
-        diffOutput += `index 0000000..0000000\n`;
-        diffOutput += `--- /dev/null\n`;
-        diffOutput += `+++ b/${cleanFile}\n`;
-        
-        // Add the file content with '+' prefix for each line
-        const lines = fileContent.split('\n');
-        if (lines.length > 0) {
-          diffOutput += `@@ -0,0 +1,${lines.length} @@\n`;
-          for (const line of lines) {
-            diffOutput += `+${line}\n`;
-          }
-        }
-      } catch (error) {
-        // Skip files that can't be read (binary files, etc.)
-        const cleanFile = file.trim();
-        this.logger?.verbose(`Could not read untracked file ${cleanFile}: ${error}`);
-      }
-    }
-    
-    return diffOutput;
-  }
 }

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -1,6 +1,10 @@
+import { createReadStream } from 'fs';
+import { readFile, stat } from 'fs/promises';
+import { join } from 'path';
 import type { Logger } from '../utils/logger';
 import type { AnalyticsManager } from './analyticsManager';
 import { CommandRunner } from '../utils/commandRunner';
+import { linuxToUNCPath, posixJoin, type WSLContext } from '../utils/wslUtils';
 import {
   MAX_FILES_PER_COMMIT,
   type GitCommitFileChange,
@@ -49,41 +53,74 @@ export const WORKING_TREE_REF = 'index';
 /**
  * Caps on inlining untracked file content into a synthesized diff.
  *
- * Reading an untracked file costs one synchronous child process on the main
- * process, so an unignored build directory would otherwise stall the whole app.
+ * The resulting patch is parsed with a regex in the renderer, so an unignored
+ * build directory would otherwise hand it megabytes to chew through.
  */
 export const MAX_UNTRACKED_INLINE_FILES = 200;
 export const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Per-file ceiling for inlining. Matches the buffer the previous `cat` had, so
+ * the same oversized files are left out of the patch as before.
+ */
+const MAX_UNTRACKED_INLINE_FILE_BYTES = 1024 * 1024;
 
 /** A working-tree diff can be large; don't truncate it at Node's 1MB default. */
 const MAX_DIFF_BUFFER_BYTES = 64 * 1024 * 1024;
 
 /**
- * Windows caps a command line at ~32k characters. Batches stay well under it so
- * a single oversized path can never push a command over the edge.
+ * Split NUL-separated git output.
+ *
+ * Git only quotes and escapes a path when it has to delimit it with a newline;
+ * under `-z` the bytes come through exactly as they are on disk. Nothing is
+ * trimmed here for the same reason — a leading or trailing space is part of the
+ * name, not padding.
  */
-const MAX_COMMAND_LENGTH = 6000;
+export function splitNulSeparated(raw: string): string[] {
+  return raw.split('\0').filter(entry => entry.length > 0);
+}
 
-/** Split paths into batches that fit in one command line. */
-export function chunkByCommandLength(files: string[], maxLength = MAX_COMMAND_LENGTH): string[][] {
-  const batches: string[][] = [];
-  let current: string[] = [];
-  let length = 0;
+/**
+ * The path Node's `fs` needs for a file git named relative to the worktree.
+ *
+ * Git reports `dir/file.txt` with forward slashes whatever the platform. For a
+ * WSL project the worktree is a Linux path the Windows host can only reach
+ * through its UNC mount, which is what `gitPlumbingCommands` does for the same
+ * reason.
+ *
+ * Going through `fs` at all is the point: the name comes from the repository
+ * and may contain a space, a quote, `$`, a backtick or a newline, all of which
+ * git allows. Interpolated into a shell command those stop being a filename.
+ */
+export function untrackedFilePath(
+  worktreePath: string,
+  file: string,
+  wslContext?: WSLContext | null
+): string {
+  if (wslContext) return linuxToUNCPath(posixJoin(worktreePath, file), wslContext.distribution);
+  return join(worktreePath, file);
+}
 
-  for (const file of files) {
-    // +3 covers the two quotes and the separating space.
-    const cost = file.length + 3;
-    if (current.length > 0 && length + cost > maxLength) {
-      batches.push(current);
-      current = [];
-      length = 0;
-    }
-    current.push(file);
-    length += cost;
-  }
+/**
+ * Newlines in a file, streamed so a large one costs bounded memory.
+ *
+ * Counts terminators rather than lines, which is what the `wc -l` this replaces
+ * reported, so the additions figure stays the number it always was.
+ */
+async function countNewlines(fsPath: string): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    let count = 0;
+    const stream = createReadStream(fsPath, { highWaterMark: 64 * 1024 });
 
-  if (current.length > 0) batches.push(current);
-  return batches;
+    stream.on('data', (chunk: string | Buffer) => {
+      const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      for (let i = 0; i < buffer.length; i++) {
+        if (buffer[i] === 0x0a) count++;
+      }
+    });
+    stream.on('error', reject);
+    stream.on('close', () => resolve(count));
+  });
 }
 
 interface NumstatEntry {
@@ -759,13 +796,26 @@ export class GitDiffManager {
   }
 
   // --- Working-directory capture (async) -----------------------------------
+  //
+  // Everything below runs off the main thread. The sync variants used to spawn
+  // one child process *per untracked file* — twice, once to read content and
+  // once to count lines — which on a worktree carrying an unignored build tree
+  // blocked the main process for minutes and froze every IPC channel with it.
+  // These versions list the files once with `git ls-files -z` and then go
+  // through `fs`, so there is no process per file and no filename in a shell.
 
-  /** Untracked paths, honouring .gitignore. */
+  /**
+   * Untracked paths, honouring .gitignore.
+   *
+   * `-z` is not optional here. Without it git delimits with newlines, which a
+   * filename may contain, and quotes anything non-ASCII into a C-style escape:
+   * `täst.txt` arrives as `"t\303\244st.txt"`, a name that matches no file on
+   * disk, so the file silently vanished from the diff and the stats.
+   */
   private async getUntrackedFilesAsync(worktreePath: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
-      const { stdout } = await commandRunner.execAsync('git ls-files --others --exclude-standard', worktreePath);
-      if (!stdout?.trim()) return [];
-      return stdout.trim().split('\n').map(file => file.trim()).filter(Boolean);
+      const { stdout } = await commandRunner.execAsync('git ls-files --others --exclude-standard -z', worktreePath);
+      return splitNulSeparated(stdout ?? '');
     } catch {
       this.logger?.warn(`Could not get untracked files in ${worktreePath}`);
       return [];
@@ -804,6 +854,11 @@ export class GitDiffManager {
     }
   }
 
+  /**
+   * Working-tree stats. Untracked line counts are read through `fs` rather than
+   * by spawning a process per file — the difference between a few reads and
+   * several thousand child processes.
+   */
   private async getDiffStatsAsync(
     worktreePath: string,
     untrackedFiles: string[],
@@ -819,7 +874,7 @@ export class GitDiffManager {
 
     if (untrackedFiles.length === 0) return trackedStats;
 
-    const untrackedAdditions = await this.countLinesBatched(worktreePath, untrackedFiles, commandRunner);
+    const untrackedAdditions = await this.countUntrackedLines(worktreePath, untrackedFiles, commandRunner);
     return {
       additions: trackedStats.additions + untrackedAdditions,
       deletions: trackedStats.deletions,
@@ -827,29 +882,40 @@ export class GitDiffManager {
     };
   }
 
-  private async countLinesBatched(
+  /**
+   * Total line count across the untracked files.
+   *
+   * Each file is streamed, so memory stays bounded whatever is in the worktree
+   * and nothing repository-controlled reaches a shell. Awaiting between files
+   * keeps the event loop free, which is what the synchronous version cost.
+   */
+  private async countUntrackedLines(
     worktreePath: string,
     files: string[],
     commandRunner: CommandRunner
   ): Promise<number> {
     let total = 0;
-    for (const batch of chunkByCommandLength(files)) {
-      const args = batch.map(file => `"${worktreePath}/${file}"`).join(' ');
+    for (const file of files) {
       try {
-        const { stdout } = await commandRunner.execAsync(`wc -l ${args}`, worktreePath);
-        for (const line of (stdout ?? '').trim().split('\n')) {
-          const match = line.trim().match(/^(\d+)\s+(.*)$/);
-          if (!match) continue;
-          if (batch.length > 1 && match[2].trim() === 'total') continue;
-          total += Number.parseInt(match[1], 10) || 0;
-        }
+        total += await countNewlines(untrackedFilePath(worktreePath, file, commandRunner.wslContext));
       } catch {
-        // Unreadable files do not contribute to the line count.
+        // Unreadable (permissions, a symlink to nowhere, deleted since the
+        // listing): its lines simply go uncounted, as before.
       }
     }
     return total;
   }
 
+  /**
+   * Synthesize `new file` patches for untracked files.
+   *
+   * Content is read through `fs`, never `cat`: a filename may legally contain
+   * a backtick or `$(…)`, and interpolating one into a shell command ran it.
+   *
+   * Still hard-bounded — the resulting patch is parsed with a regex in the
+   * renderer, so an unignored build tree would otherwise stall it. Files past
+   * the budget keep their place in `changedFiles`; only the inline content goes.
+   */
   private async createDiffForUntrackedFilesAsync(
     worktreePath: string,
     untrackedFiles: string[],
@@ -868,14 +934,17 @@ export class GitDiffManager {
       }
 
       try {
-        const { stdout } = await commandRunner.execAsync(
-          `cat "${worktreePath}/${file}"`,
-          worktreePath,
-          { maxBuffer: 1024 * 1024 }
-        );
+        const fsPath = untrackedFilePath(worktreePath, file, commandRunner.wslContext);
+
+        // Checked before reading rather than by letting a buffer overflow, so a
+        // huge file costs a stat instead of a gigabyte of string.
+        const { size } = await stat(fsPath);
+        if (size > MAX_UNTRACKED_INLINE_FILE_BYTES) continue;
+
+        const content = await readFile(fsPath, 'utf8');
         inlined++;
 
-        const lines = (stdout ?? '').split('\n');
+        const lines = content.split('\n');
         const header =
           `diff --git a/${file} b/${file}\n`
           + 'new file mode 100644\n'

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -7,6 +7,7 @@ import { CommandRunner } from '../utils/commandRunner';
 import { linuxToUNCPath, posixJoin, type WSLContext } from '../utils/wslUtils';
 import {
   MAX_FILES_PER_COMMIT,
+  WORKING_TREE_REF,
   type GitCommitFileChange,
   type GitCommitFilesResult,
   type GitFileChangeStatus,
@@ -47,9 +48,6 @@ export interface GitGraphCommit {
   deletions?: number;
 }
 
-/** Uncommitted working-tree changes are addressed by this pseudo-ref. */
-export const WORKING_TREE_REF = 'index';
-
 const COMMIT_OBJECT_ID_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 
 /**
@@ -59,7 +57,7 @@ const COMMIT_OBJECT_ID_PATTERN = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
  * build directory would otherwise hand it megabytes to chew through.
  */
 export const MAX_UNTRACKED_INLINE_FILES = 200;
-export const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
+const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
 
 /**
  * Per-file ceiling for inlining. Matches the buffer the previous `cat` had, so
@@ -114,8 +112,8 @@ async function countNewlines(fsPath: string): Promise<number> {
     let count = 0;
     const stream = createReadStream(fsPath, { highWaterMark: 64 * 1024 });
 
-    stream.on('data', (chunk: string | Buffer) => {
-      const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    stream.on('data', chunk => {
+      const buffer = Buffer.from(chunk);
       for (let i = 0; i < buffer.length; i++) {
         if (buffer[i] === 0x0a) count++;
       }
@@ -237,7 +235,7 @@ export function parseNameStatusZ(raw: string): NameStatusEntry[] {
         oldPath,
         path: path || oldPath,
         status,
-        similarity: Number.isNaN(similarity as number) ? undefined : similarity,
+        similarity: similarity !== undefined && Number.isNaN(similarity) ? undefined : similarity,
       });
     } else {
       const path = tokens[i] ?? '';
@@ -263,15 +261,16 @@ export function mergeFileChanges(
 
   return numstat.map(entry => {
     const match = statusByPath.get(entry.path);
-    return {
+    const fileChange: GitCommitFileChange = {
       path: entry.path,
       oldPath: match?.oldPath || entry.oldPath || entry.path,
       status: match?.status ?? 'modified',
       additions: entry.additions,
       deletions: entry.deletions,
       isBinary: entry.isBinary,
-      ...(match?.similarity !== undefined ? { similarity: match.similarity } : {}),
     };
+    if (match?.similarity !== undefined) fileChange.similarity = match.similarity;
+    return fileChange;
   });
 }
 

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -203,7 +203,6 @@ interface NameStatusEntry {
   oldPath: string;
   path: string;
   status: GitFileChangeStatus;
-  similarity?: number;
 }
 
 /**
@@ -222,9 +221,6 @@ export function parseNameStatusZ(raw: string): NameStatusEntry[] {
 
     const code = statusToken[0];
     const status = toFileChangeStatus(code);
-    const similarityRaw = statusToken.slice(1);
-    const similarity = similarityRaw ? Number.parseInt(similarityRaw, 10) : undefined;
-
     if (code === 'R' || code === 'C') {
       const oldPath = tokens[i] ?? '';
       i++;
@@ -235,7 +231,6 @@ export function parseNameStatusZ(raw: string): NameStatusEntry[] {
         oldPath,
         path: path || oldPath,
         status,
-        similarity: similarity !== undefined && Number.isNaN(similarity) ? undefined : similarity,
       });
     } else {
       const path = tokens[i] ?? '';
@@ -269,7 +264,6 @@ export function mergeFileChanges(
       deletions: entry.deletions,
       isBinary: entry.isBinary,
     };
-    if (match?.similarity !== undefined) fileChange.similarity = match.similarity;
     return fileChange;
   });
 }
@@ -850,8 +844,8 @@ export class GitDiffManager {
     commandRunner: CommandRunner
   ): Promise<string[]> {
     try {
-      const { stdout } = await commandRunner.execAsync('git diff --name-only HEAD', worktreePath);
-      const tracked = (stdout ?? '').trim().split('\n').map(file => file.trim()).filter(Boolean);
+      const { stdout } = await commandRunner.execAsync('git diff --name-only -z HEAD', worktreePath);
+      const tracked = splitNulSeparated(stdout ?? '');
       return [...tracked, ...untrackedFiles];
     } catch {
       this.logger?.warn(`Could not get changed files in ${worktreePath}`);

--- a/main/src/services/gitDiffManager.untracked.test.ts
+++ b/main/src/services/gitDiffManager.untracked.test.ts
@@ -138,6 +138,19 @@ describe('untracked files with hostile names', () => {
 
     await rm(join(repo, 'nested dir'), { recursive: true, force: true });
   });
+
+  it('keeps tracked filenames intact at the changed-files boundary', async () => {
+    const trackedName = 'tracked täst.txt';
+    await writeFile(join(repo, trackedName), 'before\n', 'utf8');
+    execFileSync('git', ['add', trackedName], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'add tracked path'], { cwd: repo });
+    await writeFile(join(repo, trackedName), 'after\n', 'utf8');
+
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    expect(result.changedFiles).toContain(trackedName);
+    expect(result.changedFiles.some(file => file.includes('\\303'))).toBe(false);
+  });
 });
 
 /**

--- a/main/src/services/gitDiffManager.untracked.test.ts
+++ b/main/src/services/gitDiffManager.untracked.test.ts
@@ -9,7 +9,7 @@ import {
   splitNulSeparated,
   untrackedFilePath,
 } from './gitDiffManager';
-import type { CommandRunner } from '../utils/commandRunner';
+import { CommandRunner } from '../utils/commandRunner';
 
 /**
  * Untracked files are the one place where a name that came out of the
@@ -42,11 +42,10 @@ const HOSTILE_NAMES = [
 
 /** A runner that answers git for real, as a host project would. */
 function realRunner(): CommandRunner {
-  return {
-    wslContext: null,
-    exec: vi.fn((command: string, cwd: string) => run(command, cwd)),
-    execAsync: vi.fn(async (command: string, cwd: string) => ({ stdout: run(command, cwd), stderr: '' })),
-  } as unknown as CommandRunner;
+  const runner = new CommandRunner({ path: '' });
+  vi.spyOn(runner, 'exec').mockImplementation((command, cwd) => run(command, cwd));
+  vi.spyOn(runner, 'execAsync').mockImplementation(async (command, cwd) => ({ stdout: run(command, cwd), stderr: '' }));
+  return runner;
 }
 
 /** Run a `git …` command without a shell, so the test itself cannot be the bug. */
@@ -173,12 +172,12 @@ describe('working-directory capture stays bounded and off the main thread', () =
     const runner = realRunner();
     await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
 
-    const asyncCalls = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls;
+    const asyncCalls = vi.mocked(runner.execAsync).mock.calls;
     expect(asyncCalls.length).toBeLessThan(10);
     // Nothing that reads or measures a file goes through a command any more.
     expect(asyncCalls.some(([command]) => /^(cat|wc) /.test(command))).toBe(false);
     expect(asyncCalls.filter(([command]) => command.includes('ls-files')).length).toBe(1);
-  });
+  }, 60_000);
 
   it('caps inlined content but still reports every file', async () => {
     const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
@@ -189,15 +188,15 @@ describe('working-directory capture stays bounded and off the main thread', () =
     expect(result.stats.filesChanged).toBe(fileCount);
     // Counting is not capped: every file's two lines are in the total.
     expect(result.stats.additions).toBe(fileCount * 2);
-  });
+  }, 60_000);
 
   it('keeps the synchronous path free of anything that scales with file count', async () => {
     const runner = realRunner();
     await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
 
-    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
+    const syncCalls = vi.mocked(runner.exec).mock.calls;
     expect(syncCalls.every(([command]) => command.includes('rev-parse'))).toBe(true);
-  });
+  }, 60_000);
 });
 
 describe('splitNulSeparated', () => {

--- a/main/src/services/gitDiffManager.untracked.test.ts
+++ b/main/src/services/gitDiffManager.untracked.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir, readdir } from 'fs/promises';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  GitDiffManager,
+  MAX_UNTRACKED_INLINE_FILES,
+  splitNulSeparated,
+  untrackedFilePath,
+} from './gitDiffManager';
+import type { CommandRunner } from '../utils/commandRunner';
+
+/**
+ * Untracked files are the one place where a name that came out of the
+ * repository used to be handed to a shell. Git allows a great deal in a
+ * filename — spaces, quotes, `$`, backticks, parentheses, a leading dash, even
+ * a newline — and the previous code built `cat "<worktree>/<file>"` and
+ * `wc -l "<worktree>/<file>"` by interpolation. Under bash the `$(…)` and the
+ * backticks in such a name were executed.
+ *
+ * The listing had a second problem of its own: without `-z`, git delimits with
+ * newlines and quotes anything non-ASCII into a C escape, so `täst.txt` came
+ * back as the literal `"t\303\244st.txt"` and the file disappeared from both
+ * the diff and the stats.
+ */
+
+/** Names git accepts. Some are illegal on Windows, so each is tried and checked. */
+const HOSTILE_NAMES = [
+  'plain.txt',
+  'with space.txt',
+  'täst.txt',
+  'dollar$(echo pwned).txt',
+  'back`echo pwned`.txt',
+  'quote".txt',
+  "single'.txt",
+  'paren(1).txt',
+  '-leading-dash.txt',
+  'semi;colon&pipe|.txt',
+  'new\nline.txt',
+];
+
+/** A runner that answers git for real, as a host project would. */
+function realRunner(): CommandRunner {
+  return {
+    wslContext: null,
+    exec: vi.fn((command: string, cwd: string) => run(command, cwd)),
+    execAsync: vi.fn(async (command: string, cwd: string) => ({ stdout: run(command, cwd), stderr: '' })),
+  } as unknown as CommandRunner;
+}
+
+/** Run a `git …` command without a shell, so the test itself cannot be the bug. */
+function run(command: string, cwd: string): string {
+  if (!command.startsWith('git ')) return '';
+  const args = command.slice(4).match(/"[^"]*"|\S+/g)?.map(a => a.replace(/^"|"$/g, '')) ?? [];
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  } catch {
+    return '';
+  }
+}
+
+describe('untracked files with hostile names', () => {
+  let repo: string;
+  const created: string[] = [];
+
+  beforeAll(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'pane-untracked-'));
+    execFileSync('git', ['init', '-q', '.'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    await writeFile(join(repo, 'tracked.txt'), 'tracked\n', 'utf8');
+    execFileSync('git', ['add', 'tracked.txt'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo });
+
+    // Two lines each, so the additions total is simply 2 per file.
+    for (const name of HOSTILE_NAMES) {
+      try {
+        await writeFile(join(repo, name), 'first\nsecond\n', 'utf8');
+        created.push(name);
+      } catch {
+        // NTFS rejects ", | and a newline in a name. Those cases run on CI.
+      }
+    }
+    // Guard against the whole set silently failing to materialise.
+    expect(created.length).toBeGreaterThan(4);
+  });
+
+  afterAll(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('lists every one of them, unquoted and unescaped', async () => {
+    const manager = new GitDiffManager();
+    const result = await manager.captureWorkingDirectoryDiff(repo, realRunner());
+
+    for (const name of created) {
+      expect(result.changedFiles).toContain(name);
+    }
+    // The regression: git's C-style quoting of a non-ASCII name.
+    expect(result.changedFiles.some(file => file.includes('\\303'))).toBe(false);
+    expect(result.changedFiles.some(file => file.startsWith('"'))).toBe(false);
+  });
+
+  it('reads their content instead of executing what is in the name', async () => {
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    for (const name of created) {
+      expect(result.diff).toContain(`diff --git a/${name} b/${name}`);
+    }
+    // Every file contributed its two lines: nothing was skipped for want of a
+    // readable path, and nothing came back as the output of a substituted
+    // command. `pwned` is what the embedded commands would have printed.
+    expect(result.diff).not.toContain('pwned\n+');
+    expect(result.stats.additions).toBe(created.length * 2);
+    expect(result.stats.filesChanged).toBe(created.length);
+  });
+
+  it('leaves no trace of a command having run', async () => {
+    await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    // A substituted `echo pwned` in the path would have made cat/wc read (or
+    // create) a different name. The directory is exactly what was written.
+    const onDisk = await readdir(repo);
+    for (const name of created) {
+      expect(onDisk).toContain(name);
+    }
+    expect(onDisk.filter(entry => entry.includes('pwned') && !created.includes(entry))).toEqual([]);
+  });
+
+  it('counts a file in a subdirectory through the right path', async () => {
+    await mkdir(join(repo, 'nested dir'), { recursive: true });
+    await writeFile(join(repo, 'nested dir', 'deep $file.txt'), 'a\nb\nc\n', 'utf8');
+
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    expect(result.changedFiles).toContain('nested dir/deep $file.txt');
+    expect(result.diff).toContain('+c');
+
+    await rm(join(repo, 'nested dir'), { recursive: true, force: true });
+  });
+});
+
+/**
+ * The other half of the change this PR made: capturing a working tree must not
+ * cost a child process per untracked file, which is what froze the app.
+ */
+describe('working-directory capture stays bounded and off the main thread', () => {
+  let repo: string;
+  const fileCount = 400;
+
+  beforeAll(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'pane-untracked-many-'));
+    execFileSync('git', ['init', '-q', '.'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    await writeFile(join(repo, 'tracked.txt'), 'tracked\n', 'utf8');
+    execFileSync('git', ['add', 'tracked.txt'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo });
+
+    await mkdir(join(repo, 'build'), { recursive: true });
+    await Promise.all(
+      Array.from({ length: fileCount }, (_, i) =>
+        writeFile(join(repo, 'build', `res-${i}.flat`), 'one\ntwo\n', 'utf8'))
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('spawns a fixed handful of commands regardless of how many files there are', async () => {
+    const runner = realRunner();
+    await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
+
+    const asyncCalls = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls;
+    expect(asyncCalls.length).toBeLessThan(10);
+    // Nothing that reads or measures a file goes through a command any more.
+    expect(asyncCalls.some(([command]) => /^(cat|wc) /.test(command))).toBe(false);
+    expect(asyncCalls.filter(([command]) => command.includes('ls-files')).length).toBe(1);
+  });
+
+  it('caps inlined content but still reports every file', async () => {
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    const inlined = result.diff.match(/^diff --git /gm)?.length ?? 0;
+    expect(inlined).toBeLessThanOrEqual(MAX_UNTRACKED_INLINE_FILES);
+    expect(result.changedFiles).toHaveLength(fileCount);
+    expect(result.stats.filesChanged).toBe(fileCount);
+    // Counting is not capped: every file's two lines are in the total.
+    expect(result.stats.additions).toBe(fileCount * 2);
+  });
+
+  it('keeps the synchronous path free of anything that scales with file count', async () => {
+    const runner = realRunner();
+    await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
+
+    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
+    expect(syncCalls.every(([command]) => command.includes('rev-parse'))).toBe(true);
+  });
+});
+
+describe('splitNulSeparated', () => {
+  it('keeps a name containing a newline in one piece', () => {
+    expect(splitNulSeparated('a\nb.txt\0c.txt\0')).toEqual(['a\nb.txt', 'c.txt']);
+  });
+
+  it('keeps the spaces that are part of a name', () => {
+    expect(splitNulSeparated(' leading.txt\0trailing .txt\0')).toEqual([' leading.txt', 'trailing .txt']);
+  });
+
+  it('is empty for empty output', () => {
+    expect(splitNulSeparated('')).toEqual([]);
+  });
+});
+
+describe('untrackedFilePath', () => {
+  it('reaches a WSL worktree through the mount Windows can see', () => {
+    const path = untrackedFilePath('/home/dev/project', 'src/new file.ts', {
+      enabled: true,
+      distribution: 'Ubuntu',
+      linuxPath: '/home/dev/project',
+    });
+
+    expect(path).toBe('\\\\wsl.localhost\\Ubuntu\\home\\dev\\project\\src\\new file.ts');
+  });
+
+  it('joins natively for a host project', () => {
+    const path = untrackedFilePath(join('repo', 'wt'), 'src/new.ts', null);
+    expect(path).toBe(join('repo', 'wt', 'src', 'new.ts'));
+  });
+});

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -16,6 +16,9 @@ export type GitFileChangeStatus =
   | 'unmerged'
   | 'unknown';
 
+/** Pseudo-ref used to address uncommitted working-tree changes. */
+export const WORKING_TREE_REF = 'index';
+
 export interface GitCommitFileChange {
   /** Post-change path (the new path for renames/copies). */
   path: string;

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -29,8 +29,6 @@ export interface GitCommitFileChange {
   additions: number | null;
   deletions: number | null;
   isBinary: boolean;
-  /** Rename/copy similarity 0-100, when git reports it. */
-  similarity?: number;
 }
 
 export interface GitCommitFilesResult {

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -1,0 +1,49 @@
+/**
+ * Wire types for per-file git change details.
+ *
+ * These describe *which* files a commit (or the working tree) touched and by
+ * how much, without carrying the patch text. The diff panel loads them lazily
+ * per commit so expanding one commit never costs a full `git show`.
+ */
+
+export type GitFileChangeStatus =
+  | 'added'
+  | 'modified'
+  | 'deleted'
+  | 'renamed'
+  | 'copied'
+  | 'typechange'
+  | 'unmerged'
+  | 'unknown';
+
+export interface GitCommitFileChange {
+  /** Post-change path (the new path for renames/copies). */
+  path: string;
+  /** Pre-change path; equals `path` unless renamed or copied. */
+  oldPath: string;
+  status: GitFileChangeStatus;
+  /** null for binary files — git numstat prints `-` for those. */
+  additions: number | null;
+  deletions: number | null;
+  isBinary: boolean;
+  /** Rename/copy similarity 0-100, when git reports it. */
+  similarity?: number;
+}
+
+export interface GitCommitFilesResult {
+  /** Commit hash, or `index` for uncommitted working-tree changes. */
+  ref: string;
+  files: GitCommitFileChange[];
+  /** Total files touched before truncation. */
+  totalFiles: number;
+  /** True when the commit exceeded the per-commit cap and `files` was clipped. */
+  truncated: boolean;
+  /**
+   * True when `ref` is a merge commit and the listing is the diff against the
+   * first parent only. Surfaced in the UI so the numbers are not misread.
+   */
+  isMergeAgainstFirstParent: boolean;
+}
+
+/** Hard cap on files returned for a single commit. */
+export const MAX_FILES_PER_COMMIT = 500;

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -45,6 +45,7 @@ type ElectronApiMockOptions = {
   }>;
   initialExecutions?: JsonObject[];
   initialCombinedDiff?: JsonObject | null;
+  initialCommitDiff?: JsonObject | null;
   initialCommitFiles?: JsonObject[];
   initialTerminalStates?: Record<string, JsonObject>;
   initialAgentUsage?: JsonObject;
@@ -590,6 +591,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         getResumable: () => success([]),
         getExecutions: () => success(clone(mockOptions.initialExecutions ?? [])),
         getCombinedDiff: () => success(clone(mockOptions.initialCombinedDiff ?? null)),
+        getCommitDiffByHash: () => success(clone(mockOptions.initialCommitDiff ?? mockOptions.initialCombinedDiff ?? null)),
         getCommitFiles: (_sessionId: string, ref: string) => success({
           ref,
           files: clone(mockOptions.initialCommitFiles ?? []),

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -45,6 +45,7 @@ type ElectronApiMockOptions = {
   }>;
   initialExecutions?: JsonObject[];
   initialCombinedDiff?: JsonObject | null;
+  initialCommitFiles?: JsonObject[];
   initialTerminalStates?: Record<string, JsonObject>;
   initialAgentUsage?: JsonObject;
   forcedAgentUsageError?: string;
@@ -589,6 +590,13 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         getResumable: () => success([]),
         getExecutions: () => success(clone(mockOptions.initialExecutions ?? [])),
         getCombinedDiff: () => success(clone(mockOptions.initialCombinedDiff ?? null)),
+        getCommitFiles: (_sessionId: string, ref: string) => success({
+          ref,
+          files: clone(mockOptions.initialCommitFiles ?? []),
+          totalFiles: (mockOptions.initialCommitFiles ?? []).length,
+          truncated: false,
+          isMergeAgainstFirstParent: false,
+        }),
       }),
       remoteDaemon: namespace({
         getConfig: () => success(clone(remoteDaemonConfig)),

--- a/tests/review-availability.spec.ts
+++ b/tests/review-availability.spec.ts
@@ -316,6 +316,44 @@ test('Review stays local until a newly discovered pull request is explicitly ope
   await expect(splitMode).toHaveClass(/bg-interactive/);
 });
 
+test('Review expands commit file details and reveals the selected file diff', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [createSession()],
+    initialPanels: panels,
+    initialExecutions: localExecutions,
+    initialCombinedDiff: localCombinedDiff,
+    initialCommitDiff: localCombinedDiff,
+    initialCommitFiles: [{
+      path: 'src/review.ts',
+      oldPath: 'src/review.ts',
+      status: 'modified',
+      additions: 8,
+      deletions: 3,
+      isBinary: false,
+    }],
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Review fixture$/ }).click();
+  await page.getByRole('button', { name: 'Review changes before PR', exact: true }).click();
+  await page.getByRole('tab', { name: 'Review', exact: true }).click();
+
+  const fileToggle = page.getByRole('button', { name: 'Show changed files', exact: true });
+  await fileToggle.click();
+  await expect(page.getByRole('button', { name: 'Hide changed files', exact: true })).toHaveAttribute('aria-expanded', 'true');
+
+  const fileRow = page.getByRole('button', { name: 'Modified: src/review.ts. Show diff.', exact: true });
+  await expect(fileRow).toBeVisible();
+  await expect(fileRow.getByText('+8', { exact: true })).toBeVisible();
+  await expect(fileRow.getByText('-3', { exact: true })).toBeVisible();
+  await capture(page, testInfo, '06-commit-file-details-expanded.png');
+
+  await fileRow.click();
+  await expect(page.getByRole('button', { name: 'Collapse diff for src/review.ts', exact: true })).toBeVisible();
+  await capture(page, testInfo, '07-selected-file-diff-revealed.png');
+});
+
 test('Review shows a clean local empty state before a pull request exists', async ({ page }) => {
   await openSession(page, baseGitStatus, { withLocalChanges: false });
 


### PR DESCRIPTION
## Description

Reviewing a session meant reading one combined patch: which files a commit
touched, and how much, was not visible anywhere. Two changes, both in the diff
path.

**Per-file detail.** Commit history rows expand to a per-file list with status and
line counts, and clicking a file opens that file's diff directly.

**The review freeze.** Reviewing a large working tree blocked the UI for seconds
at a time. It was real work, not a hang: capturing the working-directory diff
spawned one `cat` per untracked file and one `wc -l` per file, all synchronously
on the main thread — 800+ process spawns for a session with many untracked files.
That path is now async and batched, with the file list gathered once instead of
once per consumer.

The parsers for `--numstat -z`, `--name-status -z` and porcelain `-z` are pure
functions with their own tests; the `-z` format packs `XY path` into a single
token, which is easy to get wrong and impossible to notice by eye.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`
- [x] I have added tests that prove my fix is effective or that my feature works

## Critical Areas Modified
- [x] State management/IPC events (`sessions:get-commit-files`)

## Screenshots (if applicable)
<img width="3133" height="1978" alt="image" src="https://github.com/user-attachments/assets/6107dde4-7455-4ef2-a020-89543a435f2d" />

## Additional Notes

Tests: commit file changes (23) and the unified diff parser (11).

`frontend/src/utils/parseUnifiedDiff.ts` also appears in the commit-graph PR —
same file, same content, needed by both.

These four feature PRs are independent but all add an entry to the same
navigation plumbing (`navigationStore`'s `ActiveView`, the two sidebar
components, `preload.ts`, `api.ts`, `electron.d.ts`). Whichever lands first,
the others need a small rebase there — no logic overlaps.

Not done: the packaged-build check from CONTRIBUTING. I develop on Windows,
so `pnpm build:mac` was not run.
<!-- pr-test-automation-summary:start -->
## Automated QA

Status: passed on head `77c978c3` using an isolated Pane directory, unique Vite port, and Chromium.

- Expanded a commit to show its modified file with `+8/-3` counts.
- Clicked the file and verified the matching unified diff expanded.
- Static gates: `pnpm typecheck` and `pnpm lint` passed.

| Expanded file details | Selected file revealed |
| --- | --- |
| <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-385-77c978c3-99bf336aea1a-commit-file-details-expanded.png" width="420" alt="Expanded commit file details"> | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-385-77c978c3-79afb0989e87-selected-file-diff-revealed.png" width="420" alt="Selected file diff revealed"> |

Remaining human check: exercise the same flow in packaged Electron with a real repository and a very large untracked tree.
<!-- pr-test-automation-summary:end -->