### PR TITLE
Add scheduled recurring agent runs

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useMemo, useCallback, useRef, useId } from 'react';
-import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare, CalendarClock } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
 import { SETTINGS_PREFERENCE_KEYS, normalizeSidebarPaneRowLayout, type SidebarPaneRowLayout } from '../types/settings';
 import { CreateSessionDialog } from './CreateSessionDialog';
+import { ScheduledRunsDialog } from './schedule/ScheduledRunsDialog';
 import { AddProjectDialog } from './AddProjectDialog';
 import { Dropdown } from './ui/Dropdown';
 import { Tooltip } from './ui/Tooltip';
@@ -61,6 +62,8 @@ export function ProjectSessionList({
   remoteDesktopTooltip,
 }: ProjectSessionListProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  /** Project whose recurring runs are being edited, if any. */
+  const [schedulesFor, setSchedulesFor] = useState<{ id: number; name: string } | null>(null);
   const [createForProject, setCreateForProject] = useState<Project | null>(null);
   const [sidebarPaneRowLayout, setSidebarPaneRowLayout] = useState<SidebarPaneRowLayout>('single');
   const knownSessionIdsRef = useRef<Set<string> | null>(null);
@@ -414,6 +417,12 @@ export function ProjectSessionList({
               onClick: () => navigateToProject(project.id),
             },
             {
+              id: 'scheduled-runs',
+              label: 'Scheduled runs',
+              icon: CalendarClock,
+              onClick: () => setSchedulesFor({ id: project.id, name: project.name }),
+            },
+            {
               id: 'delete',
               label: 'Delete Project',
               icon: Trash2,
@@ -527,6 +536,16 @@ export function ProjectSessionList({
           }}
           projectName={createForProject.name}
           projectId={createForProject.id}
+        />
+      )}
+
+      {/* Recurring agent runs for one project */}
+      {schedulesFor && (
+        <ScheduledRunsDialog
+          isOpen
+          projectId={schedulesFor.id}
+          projectName={schedulesFor.name}
+          onClose={() => setSchedulesFor(null)}
         />
       )}
 

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -546,6 +546,10 @@ export function ProjectSessionList({
           projectId={schedulesFor.id}
           projectName={schedulesFor.name}
           onClose={() => setSchedulesFor(null)}
+          onOpenSession={(sessionId) => {
+            setSchedulesFor(null);
+            handleSessionClick(sessionId);
+          }}
         />
       )}
 

--- a/frontend/src/components/schedule/ScheduledRunsDialog.tsx
+++ b/frontend/src/components/schedule/ScheduledRunsDialog.tsx
@@ -1,0 +1,350 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CalendarClock, Loader2, Pause, Play, Plus, Trash2, Zap } from 'lucide-react';
+import { API } from '../../utils/api';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import {
+  MIN_INTERVAL_MINUTES,
+  type ScheduledRun,
+  type ScheduledRunInput,
+  type ScheduleKind,
+} from '../../../../shared/types/schedule';
+
+const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+/** Mirrors `describeSchedule` in the main process, for the list rows. */
+function describe(run: Pick<ScheduledRun, 'kind' | 'intervalMinutes' | 'timeOfDay' | 'weekday'>): string {
+  if (run.kind === 'interval') {
+    const minutes = run.intervalMinutes ?? MIN_INTERVAL_MINUTES;
+    if (minutes % (60 * 24) === 0) return `Every ${minutes / (60 * 24)} days`;
+    if (minutes % 60 === 0) return `Every ${minutes / 60} hours`;
+    return `Every ${minutes} minutes`;
+  }
+  if (run.kind === 'daily') return `Every day at ${run.timeOfDay}`;
+  return `Every ${WEEKDAYS[run.weekday ?? 0]} at ${run.timeOfDay}`;
+}
+
+function formatWhen(atMs: number | null): string {
+  if (!atMs) return '—';
+  const date = new Date(atMs);
+  const sameDay = new Date().toDateString() === date.toDateString();
+  return sameDay
+    ? date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+    : date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+const EMPTY_FORM: ScheduledRunInput = {
+  name: '',
+  projectId: 0,
+  prompt: '',
+  toolType: 'claude',
+  enabled: true,
+  kind: 'daily',
+  timeOfDay: '03:30',
+};
+
+export interface ScheduledRunsDialogProps {
+  projectId: number;
+  projectName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Recurring agent runs for one project.
+ *
+ * Three shapes rather than cron syntax — every day, every week, every N
+ * minutes — because each can be stated in a sentence and read back in the list,
+ * and because nobody debugs a cron expression at 3am to find out why the sweep
+ * did not run.
+ */
+export function ScheduledRunsDialog({ projectId, projectName, isOpen, onClose }: ScheduledRunsDialogProps) {
+  const [runs, setRuns] = useState<ScheduledRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<ScheduledRunInput>({ ...EMPTY_FORM, projectId });
+  const [showForm, setShowForm] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const response = await API.schedules.list(projectId);
+      if (!response.success || !response.data) throw new Error(response.error || 'Could not load schedules');
+      setRuns(response.data);
+      setError(null);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Could not load schedules');
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoading(true);
+    setShowForm(false);
+    setForm({ ...EMPTY_FORM, projectId });
+    void load();
+  }, [isOpen, projectId, load]);
+
+  const save = useCallback(async () => {
+    setError(null);
+    try {
+      const response = await API.schedules.save({ ...form, projectId });
+      if (!response.success) throw new Error(response.error || 'Could not save the schedule');
+      setShowForm(false);
+      setForm({ ...EMPTY_FORM, projectId });
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Could not save the schedule');
+    }
+  }, [form, projectId, load]);
+
+  const act = useCallback(async (id: string, action: () => Promise<{ success: boolean; error?: string }>) => {
+    setBusyId(id);
+    setError(null);
+    try {
+      const response = await action();
+      if (!response.success) throw new Error(response.error || 'That did not work');
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'That did not work');
+    } finally {
+      setBusyId(null);
+    }
+  }, [load]);
+
+  const canSave = form.prompt.trim().length > 0
+    && (form.kind !== 'interval' || (form.intervalMinutes ?? 0) >= MIN_INTERVAL_MINUTES);
+
+  const nextUp = useMemo(
+    () => runs.filter(run => run.enabled && run.nextRunAtMs).sort((a, b) => (a.nextRunAtMs ?? 0) - (b.nextRunAtMs ?? 0))[0],
+    [runs]
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" ariaLabel="Scheduled runs" showCloseButton={false}>
+      <ModalHeader
+        title="Scheduled runs"
+        icon={<CalendarClock className="h-4 w-4" />}
+        description={nextUp
+          ? `${projectName} — next: ${nextUp.name} at ${formatWhen(nextUp.nextRunAtMs)}`
+          : projectName}
+        onClose={onClose}
+      />
+
+      <ModalBody className="space-y-3">
+        {loading ? (
+          <div className="flex items-center justify-center gap-2 py-8 text-sm text-text-tertiary">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading…
+          </div>
+        ) : (
+          <>
+            {runs.length === 0 && !showForm && (
+              <p className="py-6 text-center text-sm text-text-secondary">
+                No scheduled runs yet. A schedule starts a session with a fixed prompt — a nightly bug sweep, a
+                weekly dependency check.
+              </p>
+            )}
+
+            <ul className="space-y-2">
+              {runs.map(run => (
+                <li
+                  key={run.id}
+                  className={`rounded border p-2 ${run.enabled ? 'border-border-primary' : 'border-border-secondary opacity-60'}`}
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-text-primary">{run.name}</p>
+                      <p className="text-[11px] text-text-tertiary">
+                        {describe(run)} · {run.toolType === 'none' ? 'terminal' : 'Claude'}
+                        {run.enabled && run.nextRunAtMs && <> · next {formatWhen(run.nextRunAtMs)}</>}
+                      </p>
+                      <p className="mt-0.5 truncate text-[11px] text-text-muted" title={run.prompt}>
+                        {run.prompt}
+                      </p>
+                      {run.lastRunAtMs && (
+                        <p className={`mt-0.5 text-[11px] ${run.lastRunStatus === 'failed' ? 'text-status-error' : 'text-text-muted'}`}>
+                          Last run {formatWhen(run.lastRunAtMs)} — {run.lastRunStatus}
+                          {run.lastRunError ? `: ${run.lastRunError}` : ''}
+                        </p>
+                      )}
+                    </div>
+
+                    <div className="flex flex-shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        title="Run now, without moving the schedule"
+                        disabled={busyId === run.id}
+                        onClick={() => { void act(run.id, () => API.schedules.runNow(run.id)); }}
+                        className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+                      >
+                        <Zap className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        title={run.enabled ? 'Pause' : 'Resume'}
+                        disabled={busyId === run.id}
+                        onClick={() => { void act(run.id, () => API.schedules.setEnabled(run.id, !run.enabled)); }}
+                        className="rounded p-1 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:opacity-50"
+                      >
+                        {run.enabled
+                          ? <Pause className="h-3.5 w-3.5" aria-hidden="true" />
+                          : <Play className="h-3.5 w-3.5" aria-hidden="true" />}
+                      </button>
+                      <button
+                        type="button"
+                        title="Delete this schedule"
+                        disabled={busyId === run.id}
+                        onClick={() => { void act(run.id, () => API.schedules.remove(run.id)); }}
+                        className="rounded p-1 text-text-muted transition-colors hover:bg-status-error/15 hover:text-status-error disabled:opacity-50"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            {showForm ? (
+              <div className="space-y-3 rounded border border-border-primary p-3">
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="block">
+                    <span className="text-[11px] uppercase tracking-wider text-text-muted">Name</span>
+                    <input
+                      value={form.name}
+                      placeholder="Nightly sweep"
+                      onChange={event => setForm({ ...form, name: event.target.value })}
+                      className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
+                    />
+                  </label>
+
+                  <label className="block">
+                    <span className="text-[11px] uppercase tracking-wider text-text-muted">Agent</span>
+                    <select
+                      value={form.toolType}
+                      onChange={event => setForm({ ...form, toolType: event.target.value as 'claude' | 'none' })}
+                      className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
+                    >
+                      <option value="claude">Claude</option>
+                      <option value="none">Terminal only</option>
+                    </select>
+                  </label>
+                </div>
+
+                <label className="block">
+                  <span className="text-[11px] uppercase tracking-wider text-text-muted">Prompt</span>
+                  <textarea
+                    value={form.prompt}
+                    rows={3}
+                    placeholder="Look for flaky tests and open an issue for each one you can reproduce."
+                    onChange={event => setForm({ ...form, prompt: event.target.value })}
+                    className="mt-1 w-full resize-y rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
+                  />
+                </label>
+
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <label className="block">
+                    <span className="text-[11px] uppercase tracking-wider text-text-muted">Repeats</span>
+                    <select
+                      value={form.kind}
+                      onChange={event => {
+                        const kind = event.target.value as ScheduleKind;
+                        setForm({
+                          ...form,
+                          kind,
+                          ...(kind === 'interval'
+                            ? { intervalMinutes: form.intervalMinutes ?? 60 }
+                            : { timeOfDay: form.timeOfDay ?? '03:30' }),
+                          ...(kind === 'weekly' ? { weekday: form.weekday ?? 1 } : {}),
+                        });
+                      }}
+                      className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
+                    >
+                      <option value="daily">Every day</option>
+                      <option value="weekly">Every week</option>
+                      <option value="interval">Every N minutes</option>
+                    </select>
+                  </label>
+
+                  {form.kind === 'interval' ? (
+                    <label className="block">
+                      <span className="text-[11px] uppercase tracking-wider text-text-muted">Minutes</span>
+                      <input
+                        type="number"
+                        min={MIN_INTERVAL_MINUTES}
+                        value={form.intervalMinutes ?? 60}
+                        onChange={event => setForm({ ...form, intervalMinutes: Number(event.target.value) })}
+                        className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm tabular-nums text-text-primary focus:border-interactive focus:outline-none"
+                      />
+                    </label>
+                  ) : (
+                    <label className="block">
+                      <span className="text-[11px] uppercase tracking-wider text-text-muted">At</span>
+                      <input
+                        type="time"
+                        value={form.timeOfDay ?? '03:30'}
+                        onChange={event => setForm({ ...form, timeOfDay: event.target.value })}
+                        className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm tabular-nums text-text-primary focus:border-interactive focus:outline-none"
+                      />
+                    </label>
+                  )}
+
+                  {form.kind === 'weekly' && (
+                    <label className="block">
+                      <span className="text-[11px] uppercase tracking-wider text-text-muted">On</span>
+                      <select
+                        value={form.weekday ?? 1}
+                        onChange={event => setForm({ ...form, weekday: Number(event.target.value) })}
+                        className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
+                      >
+                        {WEEKDAYS.map((day, index) => (
+                          <option key={day} value={index}>{day}</option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                </div>
+
+                <p className="text-[11px] text-text-muted">
+                  Each run creates a session in a fresh worktree. A run that comes due while Pane is closed is
+                  skipped rather than caught up later.
+                </p>
+
+                <div className="flex justify-end gap-2">
+                  <Button variant="ghost" size="sm" onClick={() => setShowForm(false)}>Cancel</Button>
+                  <Button variant="primary" size="sm" onClick={() => { void save(); }} disabled={!canSave}>
+                    Save schedule
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                variant="secondary"
+                size="sm"
+                icon={<Plus className="h-4 w-4" />}
+                onClick={() => setShowForm(true)}
+              >
+                New scheduled run
+              </Button>
+            )}
+
+            {error && (
+              <p role="alert" className="rounded border border-status-error/30 bg-status-error/10 p-2 text-xs text-status-error">
+                {error}
+              </p>
+            )}
+          </>
+        )}
+      </ModalBody>
+
+      <ModalFooter>
+        <Button variant="ghost" size="sm" onClick={onClose}>Close</Button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+export default ScheduledRunsDialog;

--- a/frontend/src/components/schedule/ScheduledRunsDialog.tsx
+++ b/frontend/src/components/schedule/ScheduledRunsDialog.tsx
@@ -12,7 +12,15 @@ import {
 
 const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
-/** Mirrors `describeSchedule` in the main process, for the list rows. */
+function isScheduleKind(value: string): value is ScheduleKind {
+  return value === 'interval' || value === 'daily' || value === 'weekly';
+}
+
+function isToolType(value: string): value is ScheduledRun['toolType'] {
+  return value === 'claude' || value === 'none';
+}
+
+/** One sentence describing a schedule for the list rows. */
 function describe(run: Pick<ScheduledRun, 'kind' | 'intervalMinutes' | 'timeOfDay' | 'weekday'>): string {
   if (run.kind === 'interval') {
     const minutes = run.intervalMinutes ?? MIN_INTERVAL_MINUTES;
@@ -235,7 +243,9 @@ export function ScheduledRunsDialog({ projectId, projectName, isOpen, onClose, o
                     <span className="text-[11px] uppercase tracking-wider text-text-muted">Agent</span>
                     <select
                       value={form.toolType}
-                      onChange={event => setForm({ ...form, toolType: event.target.value as 'claude' | 'none' })}
+                      onChange={event => {
+                        if (isToolType(event.target.value)) setForm({ ...form, toolType: event.target.value });
+                      }}
                       className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
                     >
                       <option value="claude">Claude</option>
@@ -261,15 +271,13 @@ export function ScheduledRunsDialog({ projectId, projectName, isOpen, onClose, o
                     <select
                       value={form.kind}
                       onChange={event => {
-                        const kind = event.target.value as ScheduleKind;
-                        setForm({
-                          ...form,
-                          kind,
-                          ...(kind === 'interval'
-                            ? { intervalMinutes: form.intervalMinutes ?? 60 }
-                            : { timeOfDay: form.timeOfDay ?? '03:30' }),
-                          ...(kind === 'weekly' ? { weekday: form.weekday ?? 1 } : {}),
-                        });
+                        const kind = event.target.value;
+                        if (!isScheduleKind(kind)) return;
+                        const nextForm = { ...form, kind };
+                        if (kind === 'interval') nextForm.intervalMinutes = form.intervalMinutes ?? 60;
+                        else nextForm.timeOfDay = form.timeOfDay ?? '03:30';
+                        if (kind === 'weekly') nextForm.weekday = form.weekday ?? 1;
+                        setForm(nextForm);
                       }}
                       className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
                     >
@@ -356,5 +364,3 @@ export function ScheduledRunsDialog({ projectId, projectName, isOpen, onClose, o
     </Modal>
   );
 }
-
-export default ScheduledRunsDialog;

--- a/frontend/src/components/schedule/ScheduledRunsDialog.tsx
+++ b/frontend/src/components/schedule/ScheduledRunsDialog.tsx
@@ -48,6 +48,7 @@ export interface ScheduledRunsDialogProps {
   projectName: string;
   isOpen: boolean;
   onClose: () => void;
+  onOpenSession: (sessionId: string) => void;
 }
 
 /**
@@ -58,7 +59,7 @@ export interface ScheduledRunsDialogProps {
  * and because nobody debugs a cron expression at 3am to find out why the sweep
  * did not run.
  */
-export function ScheduledRunsDialog({ projectId, projectName, isOpen, onClose }: ScheduledRunsDialogProps) {
+export function ScheduledRunsDialog({ projectId, projectName, isOpen, onClose, onOpenSession }: ScheduledRunsDialogProps) {
   const [runs, setRuns] = useState<ScheduledRun[]>([]);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -169,6 +170,15 @@ export function ScheduledRunsDialog({ projectId, projectName, isOpen, onClose }:
                           Last run {formatWhen(run.lastRunAtMs)} — {run.lastRunStatus}
                           {run.lastRunError ? `: ${run.lastRunError}` : ''}
                         </p>
+                      )}
+                      {run.lastSessionId && (
+                        <button
+                          type="button"
+                          onClick={() => run.lastSessionId && onOpenSession(run.lastSessionId)}
+                          className="mt-0.5 text-[11px] text-interactive hover:underline"
+                        >
+                          Open last session
+                        </button>
                       )}
                     </div>
 

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -36,7 +36,6 @@ import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
 import type { ScheduledRun, ScheduledRunInput } from '../../../shared/types/schedule';
-import type { GitDiffResult } from './diff';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -35,6 +35,8 @@ import type { JsonValue } from '../../../shared/validation/boundaryDecoder';
 import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
+import type { ScheduledRun, ScheduledRunInput } from '../../../shared/types/schedule';
+import type { GitDiffResult } from './diff';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
@@ -124,6 +126,14 @@ interface ElectronAPI {
     setAgent: (agent: PaneChatAgent) => Promise<IPCResponse<PaneChatState<Session>>>;
   };
 
+  // Recurring agent runs
+  schedules: {
+    list: (projectId?: number) => Promise<IPCResponse<ScheduledRun[]>>;
+    save: (input: ScheduledRunInput) => Promise<IPCResponse<ScheduledRun>>;
+    delete: (id: string) => Promise<IPCResponse<void>>;
+    setEnabled: (id: string, enabled: boolean) => Promise<IPCResponse<ScheduledRun>>;
+    runNow: (id: string) => Promise<IPCResponse<ScheduledRun>>;
+  };
   // Session management
   sessions: {
     getAll: () => Promise<IPCResponse>;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -4,6 +4,7 @@ import type { Project } from '../types/project';
 import type { UpdateConfigRequest } from '../types/config';
 import type { SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
+import type { ScheduledRunInput } from '../../../shared/types/schedule';
 import type {
   RemoteDaemonClientRecord,
   RemoteDaemonClientSettings,
@@ -64,6 +65,30 @@ export class API {
     },
   };
 
+  // Recurring agent runs
+  static schedules = {
+    async list(projectId?: number) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.schedules.list(projectId);
+    },
+    async save(input: ScheduledRunInput) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.schedules.save(input);
+    },
+    async remove(id: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.schedules.delete(id);
+    },
+    async setEnabled(id: string, enabled: boolean) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.schedules.setEnabled(id, enabled);
+    },
+    /** Start one now without moving its cadence. */
+    async runNow(id: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.schedules.runNow(id);
+    },
+  };
   // Session management
   static sessions = {
     async getAll() {

--- a/main/src/database/schema.sql
+++ b/main/src/database/schema.sql
@@ -59,6 +59,33 @@ CREATE TABLE IF NOT EXISTS session_git_status_cache (
   FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
 );
 
+-- Recurring agent runs. Each row creates one session when it comes due. The
+-- schedule is three shapes rather than cron syntax, so the UI can state it in
+-- a sentence. NOTE this file is split on the statement separator at startup,
+-- so a comment must never contain one.
+CREATE TABLE IF NOT EXISTS scheduled_runs (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  project_id INTEGER NOT NULL,
+  prompt TEXT NOT NULL,
+  tool_type TEXT NOT NULL DEFAULT 'claude',
+  worktree_template TEXT,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  kind TEXT NOT NULL,
+  interval_minutes INTEGER,
+  time_of_day TEXT,
+  weekday INTEGER,
+  last_run_at_ms INTEGER,
+  last_run_status TEXT,
+  last_run_error TEXT,
+  last_session_id TEXT,
+  next_run_at_ms INTEGER,
+  created_at_ms INTEGER NOT NULL,
+  FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_runs_next ON scheduled_runs(enabled, next_run_at_ms);
+
 -- Index for faster lookups
 CREATE INDEX IF NOT EXISTS idx_session_outputs_session_id ON session_outputs(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_outputs_timestamp ON session_outputs(timestamp);

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -12,10 +12,7 @@ import { registerPromptHandlers } from './prompt';
 import { registerScriptHandlers } from './script';
 import { registerSessionHandlers } from './session';
 import { registerVoiceHandlers } from './voice';
-import { registerFleetHandlers } from './fleet';
-import { registerPullRequestHandlers } from './pullRequest';
 import { registerScheduleHandlers } from './schedule';
-import { registerUsageHandlers } from './usage';
 import type { AppServices } from './types';
 
 const SCHEDULE_CHANNELS = [

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -12,8 +12,19 @@ import { registerPromptHandlers } from './prompt';
 import { registerScriptHandlers } from './script';
 import { registerSessionHandlers } from './session';
 import { registerVoiceHandlers } from './voice';
+import { registerFleetHandlers } from './fleet';
+import { registerPullRequestHandlers } from './pullRequest';
+import { registerScheduleHandlers } from './schedule';
+import { registerUsageHandlers } from './usage';
 import type { AppServices } from './types';
 
+const SCHEDULE_CHANNELS = [
+  'schedules:list',
+  'schedules:save',
+  'schedules:delete',
+  'schedules:set-enabled',
+  'schedules:run-now',
+] as const;
 const PROJECT_CHANNELS = [
   'projects:get-all',
   'projects:get-active',
@@ -342,6 +353,15 @@ describe('daemon registry IPC bindings', () => {
     expect(ipcMain.boundChannels.sort()).toEqual([...VOICE_CHANNELS].sort());
   });
 
+  it('binds daemon-owned schedule channels through the shared registry', () => {
+    const registry = new PaneCommandRegistry();
+    const ipcMain = createIpcMainStub();
+
+    registerScheduleHandlers(ipcMain, createServicesStub(), registry);
+
+    expect(registry.listChannels()).toEqual([...SCHEDULE_CHANNELS].sort());
+    expect(ipcMain.boundChannels.sort()).toEqual([...SCHEDULE_CHANNELS].sort());
+  });
   it('binds daemon-owned prompt channels through the shared registry', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -26,6 +26,7 @@ import { registerResourceMonitorHandlers } from './resourceMonitor';
 import { registerOnboardingHandlers } from './onboarding';
 import { registerVoiceHandlers } from './voice';
 import { registerPaneChatHandlers } from './paneChat';
+import { registerScheduleHandlers } from './schedule';
 import { createDaemonBridgeRouter, registerDaemonBridgeHandlers } from './daemon';
 import { registerPermissionHandlers } from './permissions';
 import { registerAgentUsageHandlers } from './agentUsage';
@@ -81,6 +82,9 @@ export function registerIpcHandlers(services: AppServices): PaneCommandRegistry 
   registerAgentUsageHandlers(ipcMain, services, commandRegistry);
   registerVoiceHandlers(ipcMain, services, commandRegistry);
   registerPaneChatHandlers(ipcMain, services, commandRegistry);
+  // Started here rather than in index.ts: the manager only exists once its
+  // handlers are registered, and it needs the task queue they close over.
+  registerScheduleHandlers(ipcMain, services, commandRegistry).start();
   registerOnboardingHandlers(ipcMain, services);
   registerDaemonBridgeHandlers(ipcMain, bridgeRouter);
 

--- a/main/src/ipc/schedule.ts
+++ b/main/src/ipc/schedule.ts
@@ -4,7 +4,7 @@ import type { PaneCommandRegistry } from '../daemon/commandRegistry';
 import { ScheduleManager } from '../services/scheduleManager';
 import { ScheduleRepository } from '../services/scheduleRepository';
 import { databaseService } from '../services/database';
-import { MIN_INTERVAL_MINUTES, type ScheduledRunInput } from '../../../shared/types/schedule';
+import { validateScheduledRunInput } from '../services/scheduleValidation';
 
 export const DAEMON_SCHEDULE_CHANNELS = [
   'schedules:list',
@@ -13,26 +13,6 @@ export const DAEMON_SCHEDULE_CHANNELS = [
   'schedules:set-enabled',
   'schedules:run-now',
 ] as const;
-
-/** Reject a schedule that could never run before it is stored. */
-function validate(input: ScheduledRunInput): string | null {
-  if (!input) return 'No schedule given';
-  if (!input.prompt?.trim()) return 'A prompt is required — it is what the agent starts with';
-  if (!Number.isFinite(input.projectId)) return 'A project is required';
-
-  if (input.kind === 'interval') {
-    if (!input.intervalMinutes || input.intervalMinutes < MIN_INTERVAL_MINUTES) {
-      return `The shortest interval is ${MIN_INTERVAL_MINUTES} minutes`;
-    }
-    return null;
-  }
-
-  if (!/^\d{1,2}:\d{2}$/.test(input.timeOfDay ?? '')) return 'A time of day is required, as HH:MM';
-  if (input.kind === 'weekly' && (input.weekday === undefined || input.weekday < 0 || input.weekday > 6)) {
-    return 'A weekday is required';
-  }
-  return null;
-}
 
 /**
  * Recurring agent runs.
@@ -77,11 +57,11 @@ export function registerScheduleHandlers(
     }
   });
 
-  commandRegistry.register('schedules:save', async (input: ScheduledRunInput) => {
+  commandRegistry.register('schedules:save', async (input: unknown) => {
     try {
-      const problem = validate(input);
-      if (problem) return { success: false, error: problem };
-      return { success: true, data: scheduleManager.save(input) };
+      const result = validateScheduledRunInput(input);
+      if (!result.success) return result;
+      return { success: true, data: scheduleManager.save(result.data) };
     } catch (error) {
       console.error('[Schedule] Failed to save schedule:', error);
       return { success: false, error: error instanceof Error ? error.message : 'Failed to save the schedule' };

--- a/main/src/ipc/schedule.ts
+++ b/main/src/ipc/schedule.ts
@@ -5,8 +5,11 @@ import { ScheduleManager } from '../services/scheduleManager';
 import { ScheduleRepository } from '../services/scheduleRepository';
 import { databaseService } from '../services/database';
 import { validateScheduledRunInput } from '../services/scheduleValidation';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+import { scheduledRunInputSchema } from '../../../shared/types/schedule';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
 
-export const DAEMON_SCHEDULE_CHANNELS = [
+const DAEMON_SCHEDULE_CHANNELS = [
   'schedules:list',
   'schedules:save',
   'schedules:delete',
@@ -45,11 +48,10 @@ export function registerScheduleHandlers(
     return { sessionId: result.sessionId };
   });
 
-  commandRegistry.register('schedules:list', async (projectId?: number) => {
+  commandRegistry.register('schedules:list', async (value?: PaneCommandValue) => {
     try {
-      const data = scheduleManager.list(
-        typeof projectId === 'number' && Number.isFinite(projectId) ? projectId : undefined
-      );
+      const projectId = decodeBoundary(value, boundary.optional(boundary.number));
+      const data = scheduleManager.list(Number.isFinite(projectId) ? projectId : undefined);
       return { success: true, data };
     } catch (error) {
       console.error('[Schedule] Failed to list schedules:', error);
@@ -57,8 +59,9 @@ export function registerScheduleHandlers(
     }
   });
 
-  commandRegistry.register('schedules:save', async (input: unknown) => {
+  commandRegistry.register('schedules:save', async (value: PaneCommandValue) => {
     try {
+      const input = decodeBoundary(value, scheduledRunInputSchema);
       const result = validateScheduledRunInput(input);
       if (!result.success) return result;
       return { success: true, data: scheduleManager.save(result.data) };

--- a/main/src/ipc/schedule.ts
+++ b/main/src/ipc/schedule.ts
@@ -1,0 +1,126 @@
+import type { IpcMain } from 'electron';
+import type { AppServices } from './types';
+import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { ScheduleManager } from '../services/scheduleManager';
+import { ScheduleRepository } from '../services/scheduleRepository';
+import { databaseService } from '../services/database';
+import { MIN_INTERVAL_MINUTES, type ScheduledRunInput } from '../../../shared/types/schedule';
+
+export const DAEMON_SCHEDULE_CHANNELS = [
+  'schedules:list',
+  'schedules:save',
+  'schedules:delete',
+  'schedules:set-enabled',
+  'schedules:run-now',
+] as const;
+
+/** Reject a schedule that could never run before it is stored. */
+function validate(input: ScheduledRunInput): string | null {
+  if (!input) return 'No schedule given';
+  if (!input.prompt?.trim()) return 'A prompt is required — it is what the agent starts with';
+  if (!Number.isFinite(input.projectId)) return 'A project is required';
+
+  if (input.kind === 'interval') {
+    if (!input.intervalMinutes || input.intervalMinutes < MIN_INTERVAL_MINUTES) {
+      return `The shortest interval is ${MIN_INTERVAL_MINUTES} minutes`;
+    }
+    return null;
+  }
+
+  if (!/^\d{1,2}:\d{2}$/.test(input.timeOfDay ?? '')) return 'A time of day is required, as HH:MM';
+  if (input.kind === 'weekly' && (input.weekday === undefined || input.weekday < 0 || input.weekday > 6)) {
+    return 'A weekday is required';
+  }
+  return null;
+}
+
+/**
+ * Recurring agent runs.
+ *
+ * Daemon-owned: a schedule starts a session in a worktree on the machine that
+ * runs the agents, and it has to keep firing while no window is open — which is
+ * exactly what the daemon is for.
+ */
+export function registerScheduleHandlers(
+  ipcMain: IpcMain,
+  { taskQueue }: AppServices,
+  commandRegistry: PaneCommandRegistry,
+): ScheduleManager {
+  const repository = new ScheduleRepository(() => databaseService.getDb());
+
+  const scheduleManager = new ScheduleManager(repository, async input => {
+    if (!taskQueue) throw new Error('Task queue not initialised');
+
+    // The same call the create dialog makes, so a scheduled session is
+    // indistinguishable from one started by hand — but waiting for the queue,
+    // because the job id is not a session id and the schedule list links to
+    // the session it produced.
+    const result = await taskQueue.createSessionAndWait({
+      prompt: input.prompt,
+      worktreeTemplate: input.worktreeTemplate,
+      projectId: input.projectId,
+      toolType: input.toolType,
+    });
+
+    return { sessionId: result.sessionId };
+  });
+
+  commandRegistry.register('schedules:list', async (projectId?: number) => {
+    try {
+      const data = scheduleManager.list(
+        typeof projectId === 'number' && Number.isFinite(projectId) ? projectId : undefined
+      );
+      return { success: true, data };
+    } catch (error) {
+      console.error('[Schedule] Failed to list schedules:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to list schedules' };
+    }
+  });
+
+  commandRegistry.register('schedules:save', async (input: ScheduledRunInput) => {
+    try {
+      const problem = validate(input);
+      if (problem) return { success: false, error: problem };
+      return { success: true, data: scheduleManager.save(input) };
+    } catch (error) {
+      console.error('[Schedule] Failed to save schedule:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to save the schedule' };
+    }
+  });
+
+  commandRegistry.register('schedules:delete', async (id: string) => {
+    try {
+      scheduleManager.delete(id);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to delete the schedule' };
+    }
+  });
+
+  commandRegistry.register('schedules:set-enabled', async (id: string, enabled: boolean) => {
+    try {
+      const data = scheduleManager.setEnabled(id, Boolean(enabled));
+      if (!data) return { success: false, error: 'Schedule not found' };
+      return { success: true, data };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to update the schedule' };
+    }
+  });
+
+  commandRegistry.register('schedules:run-now', async (id: string) => {
+    try {
+      const data = await scheduleManager.runNow(id);
+      if (!data) return { success: false, error: 'Schedule not found' };
+      if (data.lastRunStatus === 'failed') {
+        return { success: false, error: data.lastRunError ?? 'The run failed to start' };
+      }
+      return { success: true, data };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Failed to start the run' };
+    }
+  });
+
+  commandRegistry.bindChannels(ipcMain, DAEMON_SCHEDULE_CHANNELS);
+
+  return scheduleManager;
+}

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -132,7 +132,9 @@ const DAEMON_OWNED_CHANNEL_PREFIXES = [
   'projects:',
   'prompts:',
   'resource-monitor:',
+  'pr:',
   'runpane:',
+  'schedules:',
   'sessions:',
   'terminal:',
   'voice:',
@@ -473,6 +475,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     setAgent: (agent: 'claude' | 'codex' | 'cursor'): Promise<IPCResponse> => invokeIpc('pane-chat:set-agent', agent),
   },
 
+  // Recurring agent runs
+  schedules: {
+    list: (projectId?: number): Promise<IPCResponse> => invokeIpc('schedules:list', projectId),
+    save: (input: unknown): Promise<IPCResponse> => invokeIpc('schedules:save', input),
+    delete: (id: string): Promise<IPCResponse> => invokeIpc('schedules:delete', id),
+    setEnabled: (id: string, enabled: boolean): Promise<IPCResponse> => invokeIpc('schedules:set-enabled', id, enabled),
+    runNow: (id: string): Promise<IPCResponse> => invokeIpc('schedules:run-now', id),
+  },
   // Session management
   sessions: {
     getAll: (): Promise<IPCResponse> => invokeIpc('sessions:get-all'),

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -27,6 +27,7 @@ import type { AgentUsageSnapshot } from '../../shared/types/agentUsage';
 import type { CloudVmState } from '../../shared/types/cloud';
 import type { ResourceSnapshot } from '../../shared/types/resourceMonitor';
 import type { SubmitFeedbackRequest } from '../../shared/types/feedback';
+import type { ScheduledRunInput } from '../../shared/types/schedule';
 import type {
   PanePermissionRequest as PermissionRequest,
   PanePermissionResponse as PermissionResponse,
@@ -477,7 +478,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Recurring agent runs
   schedules: {
     list: (projectId?: number): Promise<IPCResponse> => invokeIpc('schedules:list', projectId),
-    save: (input: unknown): Promise<IPCResponse> => invokeIpc('schedules:save', input),
+    save: (input: ScheduledRunInput): Promise<IPCResponse> => invokeIpc('schedules:save', input),
     delete: (id: string): Promise<IPCResponse> => invokeIpc('schedules:delete', id),
     setEnabled: (id: string, enabled: boolean): Promise<IPCResponse> => invokeIpc('schedules:set-enabled', id, enabled),
     runNow: (id: string): Promise<IPCResponse> => invokeIpc('schedules:run-now', id),

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -132,7 +132,6 @@ const DAEMON_OWNED_CHANNEL_PREFIXES = [
   'projects:',
   'prompts:',
   'resource-monitor:',
-  'pr:',
   'runpane:',
   'schedules:',
   'sessions:',

--- a/main/src/services/scheduleCalculator.test.ts
+++ b/main/src/services/scheduleCalculator.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   computeNextRun,
-  describeSchedule,
   isDue,
   isMissed,
   parseTimeOfDay,
@@ -58,7 +57,9 @@ describe('computeNextRun — weekly', () => {
   it('finds the next matching weekday', () => {
     // 2026-08-11 is a Tuesday; asking for Friday (5).
     const next = computeNextRun({ kind: 'weekly', timeOfDay: '09:00', weekday: 5 }, at(2026, 8, 11, 10, 0));
-    expect(new Date(next as number).getDay()).toBe(5);
+    expect(next).not.toBeNull();
+    if (next === null) throw new Error('Expected a weekly run time');
+    expect(new Date(next).getDay()).toBe(5);
     expect(next).toBe(at(2026, 8, 14, 9, 0));
   });
 
@@ -135,15 +136,5 @@ describe('isDue and isMissed', () => {
     const overdue = now - SCHEDULE_MISS_GRACE_MS - 60_000;
     expect(isDue({ enabled: true, nextRunAtMs: overdue }, now)).toBe(false);
     expect(isMissed({ enabled: true, nextRunAtMs: overdue }, now)).toBe(true);
-  });
-});
-
-describe('describeSchedule', () => {
-  it('says what it does in one sentence', () => {
-    expect(describeSchedule({ kind: 'daily', timeOfDay: '03:30' })).toBe('Every day at 03:30');
-    expect(describeSchedule({ kind: 'weekly', timeOfDay: '09:00', weekday: 1 })).toBe('Every Monday at 09:00');
-    expect(describeSchedule({ kind: 'interval', intervalMinutes: 90 })).toBe('Every 90 minutes');
-    expect(describeSchedule({ kind: 'interval', intervalMinutes: 120 })).toBe('Every 2 hours');
-    expect(describeSchedule({ kind: 'interval', intervalMinutes: 2880 })).toBe('Every 2 days');
   });
 });

--- a/main/src/services/scheduleCalculator.test.ts
+++ b/main/src/services/scheduleCalculator.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeNextRun,
+  describeSchedule,
+  isDue,
+  isMissed,
+  parseTimeOfDay,
+} from './scheduleCalculator';
+import { SCHEDULE_MISS_GRACE_MS } from '../../../shared/types/schedule';
+
+/** Local time, because that is what "every day at 03:30" means to a person. */
+function at(year: number, month: number, day: number, hours: number, minutes: number): number {
+  return new Date(year, month - 1, day, hours, minutes, 0, 0).getTime();
+}
+
+describe('parseTimeOfDay', () => {
+  it('accepts the times a person types', () => {
+    expect(parseTimeOfDay('03:30')).toEqual({ hours: 3, minutes: 30 });
+    expect(parseTimeOfDay('3:05')).toEqual({ hours: 3, minutes: 5 });
+    expect(parseTimeOfDay(' 23:59 ')).toEqual({ hours: 23, minutes: 59 });
+  });
+
+  it('rejects impossible and malformed times', () => {
+    expect(parseTimeOfDay('24:00')).toBeNull();
+    expect(parseTimeOfDay('12:60')).toBeNull();
+    expect(parseTimeOfDay('midnight')).toBeNull();
+    expect(parseTimeOfDay(undefined)).toBeNull();
+  });
+});
+
+describe('computeNextRun — daily', () => {
+  it('runs later today when the time is still ahead', () => {
+    const next = computeNextRun({ kind: 'daily', timeOfDay: '03:30' }, at(2026, 8, 11, 1, 0));
+    expect(next).toBe(at(2026, 8, 11, 3, 30));
+  });
+
+  it('waits for tomorrow when today is already past', () => {
+    const next = computeNextRun({ kind: 'daily', timeOfDay: '03:30' }, at(2026, 8, 11, 9, 0));
+    expect(next).toBe(at(2026, 8, 12, 3, 30));
+  });
+
+  it('does not fire twice at the exact minute it just ran', () => {
+    const next = computeNextRun({ kind: 'daily', timeOfDay: '03:30' }, at(2026, 8, 11, 3, 30));
+    expect(next).toBe(at(2026, 8, 12, 3, 30));
+  });
+
+  it('rolls over the end of a month', () => {
+    const next = computeNextRun({ kind: 'daily', timeOfDay: '02:00' }, at(2026, 8, 31, 5, 0));
+    expect(next).toBe(at(2026, 9, 1, 2, 0));
+  });
+
+  it('is null without a usable time', () => {
+    expect(computeNextRun({ kind: 'daily', timeOfDay: 'nope' }, Date.now())).toBeNull();
+  });
+});
+
+describe('computeNextRun — weekly', () => {
+  it('finds the next matching weekday', () => {
+    // 2026-08-11 is a Tuesday; asking for Friday (5).
+    const next = computeNextRun({ kind: 'weekly', timeOfDay: '09:00', weekday: 5 }, at(2026, 8, 11, 10, 0));
+    expect(new Date(next as number).getDay()).toBe(5);
+    expect(next).toBe(at(2026, 8, 14, 9, 0));
+  });
+
+  it('uses today when the weekday matches and the time has not passed', () => {
+    const next = computeNextRun({ kind: 'weekly', timeOfDay: '23:00', weekday: 2 }, at(2026, 8, 11, 10, 0));
+    expect(next).toBe(at(2026, 8, 11, 23, 0));
+  });
+
+  it('waits a full week when today matches but the time has passed', () => {
+    const next = computeNextRun({ kind: 'weekly', timeOfDay: '09:00', weekday: 2 }, at(2026, 8, 11, 10, 0));
+    expect(next).toBe(at(2026, 8, 18, 9, 0));
+  });
+
+  it('is null for a weekday outside 0-6', () => {
+    expect(computeNextRun({ kind: 'weekly', timeOfDay: '09:00', weekday: 7 }, Date.now())).toBeNull();
+    expect(computeNextRun({ kind: 'weekly', timeOfDay: '09:00' }, Date.now())).toBeNull();
+  });
+});
+
+describe('computeNextRun — interval', () => {
+  it('counts from the last run, so the cadence does not drift', () => {
+    const lastRun = at(2026, 8, 11, 10, 0);
+    const next = computeNextRun(
+      { kind: 'interval', intervalMinutes: 60, lastRunAtMs: lastRun },
+      at(2026, 8, 11, 10, 5),
+    );
+    expect(next).toBe(at(2026, 8, 11, 11, 0));
+  });
+
+  it('starts from now when it has never run', () => {
+    const now = at(2026, 8, 11, 10, 0);
+    expect(computeNextRun({ kind: 'interval', intervalMinutes: 30 }, now)).toBe(at(2026, 8, 11, 10, 30));
+  });
+
+  /** Waking after a long sleep must not queue up every missed interval. */
+  it('skips whole missed intervals instead of firing repeatedly', () => {
+    const lastRun = at(2026, 8, 11, 0, 0);
+    const next = computeNextRun(
+      { kind: 'interval', intervalMinutes: 60, lastRunAtMs: lastRun },
+      at(2026, 8, 11, 9, 30),
+    );
+    expect(next).toBe(at(2026, 8, 11, 10, 0));
+  });
+
+  it('never schedules below the minimum interval', () => {
+    const now = at(2026, 8, 11, 10, 0);
+    const next = computeNextRun({ kind: 'interval', intervalMinutes: 1 }, now);
+    expect(next).toBe(at(2026, 8, 11, 10, 5));
+  });
+});
+
+describe('isDue and isMissed', () => {
+  const now = at(2026, 8, 11, 10, 0);
+
+  it('is due at its time and shortly after', () => {
+    expect(isDue({ enabled: true, nextRunAtMs: now }, now)).toBe(true);
+    expect(isDue({ enabled: true, nextRunAtMs: now - 60_000 }, now)).toBe(true);
+  });
+
+  it('is not due before its time', () => {
+    expect(isDue({ enabled: true, nextRunAtMs: now + 1000 }, now)).toBe(false);
+  });
+
+  it('is neither due nor missed while disabled', () => {
+    expect(isDue({ enabled: false, nextRunAtMs: now }, now)).toBe(false);
+    expect(isMissed({ enabled: false, nextRunAtMs: now - SCHEDULE_MISS_GRACE_MS - 1 }, now)).toBe(false);
+  });
+
+  /**
+   * The behaviour that keeps a closed laptop from starting a night's worth of
+   * agents at breakfast.
+   */
+  it('counts a long-overdue run as missed rather than due', () => {
+    const overdue = now - SCHEDULE_MISS_GRACE_MS - 60_000;
+    expect(isDue({ enabled: true, nextRunAtMs: overdue }, now)).toBe(false);
+    expect(isMissed({ enabled: true, nextRunAtMs: overdue }, now)).toBe(true);
+  });
+});
+
+describe('describeSchedule', () => {
+  it('says what it does in one sentence', () => {
+    expect(describeSchedule({ kind: 'daily', timeOfDay: '03:30' })).toBe('Every day at 03:30');
+    expect(describeSchedule({ kind: 'weekly', timeOfDay: '09:00', weekday: 1 })).toBe('Every Monday at 09:00');
+    expect(describeSchedule({ kind: 'interval', intervalMinutes: 90 })).toBe('Every 90 minutes');
+    expect(describeSchedule({ kind: 'interval', intervalMinutes: 120 })).toBe('Every 2 hours');
+    expect(describeSchedule({ kind: 'interval', intervalMinutes: 2880 })).toBe('Every 2 days');
+  });
+});

--- a/main/src/services/scheduleCalculator.ts
+++ b/main/src/services/scheduleCalculator.ts
@@ -15,7 +15,6 @@ import {
  */
 
 const MINUTE_MS = 60_000;
-const DAY_MS = 24 * 60 * MINUTE_MS;
 
 export interface ScheduleTiming {
   kind: ScheduleKind;
@@ -120,22 +119,3 @@ export function isMissed(schedule: Pick<ScheduledRun, 'enabled' | 'nextRunAtMs'>
   if (!schedule.enabled || schedule.nextRunAtMs === null) return false;
   return nowMs - schedule.nextRunAtMs > SCHEDULE_MISS_GRACE_MS;
 }
-
-/** One sentence describing a schedule, for the list and for accessibility. */
-export function describeSchedule(schedule: ScheduleTiming): string {
-  if (schedule.kind === 'interval') {
-    const minutes = Math.max(schedule.intervalMinutes ?? 0, MIN_INTERVAL_MINUTES);
-    if (minutes % (60 * 24) === 0) return `Every ${minutes / (60 * 24)} days`;
-    if (minutes % 60 === 0) return `Every ${minutes / 60} hours`;
-    return `Every ${minutes} minutes`;
-  }
-
-  const time = schedule.timeOfDay ?? '??:??';
-  if (schedule.kind === 'daily') return `Every day at ${time}`;
-
-  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-  const day = schedule.weekday !== undefined ? days[schedule.weekday] : 'a day';
-  return `Every ${day} at ${time}`;
-}
-
-export { DAY_MS as SCHEDULE_DAY_MS };

--- a/main/src/services/scheduleCalculator.ts
+++ b/main/src/services/scheduleCalculator.ts
@@ -1,0 +1,141 @@
+import {
+  MIN_INTERVAL_MINUTES,
+  SCHEDULE_MISS_GRACE_MS,
+  type ScheduledRun,
+  type ScheduleKind,
+} from '../../../shared/types/schedule';
+
+/**
+ * When a scheduled run is next due.
+ *
+ * Pure arithmetic on local time, kept out of the scheduler service so it can be
+ * tested against the awkward cases without a clock: a daily run whose time has
+ * already passed today, a weekly run on today's weekday, and the twice-yearly
+ * days that are 23 or 25 hours long.
+ */
+
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
+
+export interface ScheduleTiming {
+  kind: ScheduleKind;
+  intervalMinutes?: number;
+  timeOfDay?: string;
+  weekday?: number;
+  lastRunAtMs?: number | null;
+}
+
+/** `"03:30"` → `{ hours: 3, minutes: 30 }`; null when it is not a time. */
+export function parseTimeOfDay(value: string | undefined): { hours: number; minutes: number } | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec((value ?? '').trim());
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return null;
+
+  return { hours, minutes };
+}
+
+/**
+ * The next occurrence of a local wall-clock time, at least one tick away.
+ *
+ * Built by mutating a `Date` rather than adding milliseconds so it lands on the
+ * same wall-clock time across a daylight-saving change — the point of "every
+ * day at 03:30" is the 03:30, not the 24 hours.
+ */
+function nextAtTimeOfDay(
+  from: Date,
+  time: { hours: number; minutes: number },
+  isAcceptableDay: (candidate: Date) => boolean
+): number {
+  const candidate = new Date(from);
+  candidate.setHours(time.hours, time.minutes, 0, 0);
+
+  // Up to a week ahead covers daily and weekly; the guard is a stop, not a
+  // limit — an acceptable day always exists within seven.
+  for (let day = 0; day <= 7; day++) {
+    if (candidate.getTime() > from.getTime() && isAcceptableDay(candidate)) {
+      return candidate.getTime();
+    }
+    candidate.setDate(candidate.getDate() + 1);
+    candidate.setHours(time.hours, time.minutes, 0, 0);
+  }
+
+  return candidate.getTime();
+}
+
+/**
+ * Next run time for a schedule, or null when it can never run.
+ *
+ * `fromMs` is "now" for a fresh calculation; after a run it is that run's time,
+ * which is what keeps an interval schedule on its cadence instead of drifting
+ * by however long the run took to start.
+ */
+export function computeNextRun(schedule: ScheduleTiming, fromMs: number): number | null {
+  const from = new Date(fromMs);
+
+  if (schedule.kind === 'interval') {
+    const minutes = Math.max(schedule.intervalMinutes ?? 0, MIN_INTERVAL_MINUTES);
+    // Counting from the last run keeps the cadence; counting from now would
+    // let a schedule drift later every time the app was closed at the moment.
+    const anchor = schedule.lastRunAtMs ?? fromMs;
+    let next = anchor + minutes * MINUTE_MS;
+    if (next <= fromMs) {
+      // Skip whole intervals rather than firing repeatedly to catch up.
+      const missed = Math.ceil((fromMs - next) / (minutes * MINUTE_MS));
+      next += missed * minutes * MINUTE_MS;
+      if (next <= fromMs) next += minutes * MINUTE_MS;
+    }
+    return next;
+  }
+
+  const time = parseTimeOfDay(schedule.timeOfDay);
+  if (!time) return null;
+
+  if (schedule.kind === 'daily') {
+    return nextAtTimeOfDay(from, time, () => true);
+  }
+
+  const weekday = schedule.weekday;
+  if (weekday === undefined || weekday < 0 || weekday > 6) return null;
+
+  return nextAtTimeOfDay(from, time, candidate => candidate.getDay() === weekday);
+}
+
+/**
+ * Should this schedule run now?
+ *
+ * A run that came due while the app was closed is skipped once it is more than
+ * the grace period late: starting a nightly sweep at lunchtime because the
+ * laptop was shut is worse than not running it at all.
+ */
+export function isDue(schedule: Pick<ScheduledRun, 'enabled' | 'nextRunAtMs'>, nowMs: number): boolean {
+  if (!schedule.enabled || schedule.nextRunAtMs === null) return false;
+  return schedule.nextRunAtMs <= nowMs && nowMs - schedule.nextRunAtMs <= SCHEDULE_MISS_GRACE_MS;
+}
+
+/** True when the run is past due beyond the grace period and must be skipped. */
+export function isMissed(schedule: Pick<ScheduledRun, 'enabled' | 'nextRunAtMs'>, nowMs: number): boolean {
+  if (!schedule.enabled || schedule.nextRunAtMs === null) return false;
+  return nowMs - schedule.nextRunAtMs > SCHEDULE_MISS_GRACE_MS;
+}
+
+/** One sentence describing a schedule, for the list and for accessibility. */
+export function describeSchedule(schedule: ScheduleTiming): string {
+  if (schedule.kind === 'interval') {
+    const minutes = Math.max(schedule.intervalMinutes ?? 0, MIN_INTERVAL_MINUTES);
+    if (minutes % (60 * 24) === 0) return `Every ${minutes / (60 * 24)} days`;
+    if (minutes % 60 === 0) return `Every ${minutes / 60} hours`;
+    return `Every ${minutes} minutes`;
+  }
+
+  const time = schedule.timeOfDay ?? '??:??';
+  if (schedule.kind === 'daily') return `Every day at ${time}`;
+
+  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  const day = schedule.weekday !== undefined ? days[schedule.weekday] : 'a day';
+  return `Every ${day} at ${time}`;
+}
+
+export { DAY_MS as SCHEDULE_DAY_MS };

--- a/main/src/services/scheduleManager.start.test.ts
+++ b/main/src/services/scheduleManager.start.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ScheduleManager, type ScheduleStore, type SessionStarter } from './scheduleManager';
+import { SCHEDULE_MISS_GRACE_MS, SCHEDULE_TICK_MS, type ScheduledRun } from '../../../shared/types/schedule';
+
+/**
+ * What happens to a schedule that came due while Pane was closed.
+ *
+ * The tick has always handled an overdue row correctly, but nothing exercised
+ * the sequence that actually runs at launch. start() called rescheduleAll(),
+ * which recomputed every enabled schedule's next run from now — so a stored
+ * time in the past was replaced with a future one before any tick could see
+ * it. The missed occurrence was never recorded as skipped, and a run only
+ * slightly late, which the grace period exists to let through, was dropped
+ * without a trace.
+ */
+
+function createStore(initial: ScheduledRun[] = []): ScheduleStore & { rows: Map<string, ScheduledRun> } {
+  const rows = new Map(initial.map(row => [row.id, { ...row }]));
+  return {
+    rows,
+    list: (projectId?: number) => [...rows.values()]
+      .filter(row => projectId === undefined || row.projectId === projectId)
+      .map(row => ({ ...row })),
+    get: (id: string) => {
+      const row = rows.get(id);
+      return row ? { ...row } : null;
+    },
+    listRunnable: () => [...rows.values()]
+      .filter(row => row.enabled && row.nextRunAtMs !== null)
+      .map(row => ({ ...row })),
+    upsert: (schedule: ScheduledRun) => { rows.set(schedule.id, { ...schedule }); },
+    delete: (id: string) => { rows.delete(id); },
+  };
+}
+
+function schedule(overrides: Partial<ScheduledRun> = {}): ScheduledRun {
+  return {
+    id: 'sched-1',
+    name: 'Nightly sweep',
+    projectId: 1,
+    prompt: 'Look for flaky tests',
+    toolType: 'claude',
+    enabled: true,
+    kind: 'daily',
+    timeOfDay: '03:30',
+    lastRunAtMs: null,
+    lastRunStatus: null,
+    lastRunError: null,
+    lastSessionId: null,
+    nextRunAtMs: null,
+    createdAtMs: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('ScheduleManager.start', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  /** start() plus the first tick, which is what a launch really consists of. */
+  async function launch(store: ScheduleStore, start: SessionStarter) {
+    const manager = new ScheduleManager(store, start);
+    manager.start();
+    await manager.tick();
+    manager.stop();
+    return manager;
+  }
+
+  it('records the run it slept through instead of quietly moving on', async () => {
+    const start = vi.fn<SessionStarter>();
+    const overdue = Date.now() - SCHEDULE_MISS_GRACE_MS - 60 * 60_000;
+    const store = createStore([schedule({ nextRunAtMs: overdue })]);
+
+    await launch(store, start);
+
+    expect(start).not.toHaveBeenCalled();
+
+    const after = store.rows.get('sched-1')!;
+    expect(after.lastRunStatus).toBe('skipped');
+    expect(after.lastRunError).toBe('Came due while Pane was closed');
+    expect(after.nextRunAtMs).toBeGreaterThan(Date.now());
+    // The next 03:30, not some point rounded off from the missed one.
+    expect(new Date(after.nextRunAtMs!).getHours()).toBe(3);
+    expect(new Date(after.nextRunAtMs!).getMinutes()).toBe(30);
+  });
+
+  it('writes off one occurrence, not one per interval of downtime', async () => {
+    const start = vi.fn<SessionStarter>();
+    const store = createStore([schedule({
+      kind: 'interval',
+      intervalMinutes: 60,
+      timeOfDay: undefined,
+      // Three days of downtime: 72 intervals came and went.
+      nextRunAtMs: Date.now() - 3 * 24 * 60 * 60_000,
+      lastRunAtMs: Date.now() - 3 * 24 * 60 * 60_000 - 60 * 60_000,
+    })]);
+
+    const upserts: ScheduledRun[] = [];
+    const spied = { ...store, upsert: (row: ScheduledRun) => { upserts.push({ ...row }); store.upsert(row); } };
+
+    await launch(spied, start);
+
+    expect(start).not.toHaveBeenCalled();
+    expect(upserts.filter(row => row.lastRunStatus === 'skipped')).toHaveLength(1);
+    expect(store.rows.get('sched-1')!.nextRunAtMs).toBe(Date.now() + 60 * 60_000);
+  });
+
+  /**
+   * The grace period is the whole point: a laptop opened two minutes after a
+   * run was due should still get that run.
+   */
+  it('still runs a schedule that is late but inside the grace period', async () => {
+    const start = vi.fn<SessionStarter>().mockResolvedValue({ sessionId: 'new-session' });
+    const store = createStore([schedule({ nextRunAtMs: Date.now() - 2 * 60_000 })]);
+
+    await launch(store, start);
+
+    expect(start).toHaveBeenCalledTimes(1);
+    const after = store.rows.get('sched-1')!;
+    expect(after.lastRunStatus).toBe('ok');
+    expect(after.lastSessionId).toBe('new-session');
+    expect(after.nextRunAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it('leaves a schedule that is not due yet exactly where it was', async () => {
+    const start = vi.fn<SessionStarter>();
+    const nextRun = Date.now() + 5 * 60 * 60_000;
+    const store = createStore([schedule({ nextRunAtMs: nextRun, lastRunStatus: 'ok' })]);
+
+    await launch(store, start);
+
+    expect(start).not.toHaveBeenCalled();
+    const after = store.rows.get('sched-1')!;
+    expect(after.nextRunAtMs).toBe(nextRun);
+    expect(after.lastRunStatus).toBe('ok');
+  });
+
+  it('does not touch a disabled schedule, however overdue it looks', async () => {
+    const start = vi.fn<SessionStarter>();
+    const overdue = Date.now() - SCHEDULE_MISS_GRACE_MS - 60_000;
+    const store = createStore([schedule({ enabled: false, nextRunAtMs: overdue })]);
+
+    await launch(store, start);
+
+    expect(start).not.toHaveBeenCalled();
+    const after = store.rows.get('sched-1')!;
+    expect(after.nextRunAtMs).toBe(overdue);
+    expect(after.lastRunStatus).toBeNull();
+  });
+
+  it('gives an enabled schedule a next run when it has none', async () => {
+    const start = vi.fn<SessionStarter>();
+    const store = createStore([schedule({ nextRunAtMs: null })]);
+
+    await launch(store, start);
+
+    expect(start).not.toHaveBeenCalled();
+    expect(store.rows.get('sched-1')!.nextRunAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it('keeps ticking after the reconciliation', async () => {
+    const start = vi.fn<SessionStarter>().mockResolvedValue({ sessionId: 's' });
+    const store = createStore([schedule({ nextRunAtMs: Date.now() + SCHEDULE_TICK_MS / 2 })]);
+    const manager = new ScheduleManager(store, start);
+
+    manager.start();
+    await vi.advanceTimersByTimeAsync(SCHEDULE_TICK_MS + 1);
+    manager.stop();
+
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets Run now start a session at launch without shifting the cadence', async () => {
+    const start = vi.fn<SessionStarter>().mockResolvedValue({ sessionId: 'manual' });
+    const nextRun = Date.now() + 5 * 60 * 60_000;
+    const store = createStore([schedule({ nextRunAtMs: nextRun })]);
+    const manager = new ScheduleManager(store, start);
+
+    manager.start();
+    await manager.runNow('sched-1');
+    manager.stop();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(store.rows.get('sched-1')!.nextRunAtMs).toBe(nextRun);
+  });
+});

--- a/main/src/services/scheduleManager.start.test.ts
+++ b/main/src/services/scheduleManager.start.test.ts
@@ -60,11 +60,11 @@ describe('ScheduleManager.start', () => {
   });
   afterEach(() => vi.useRealTimers());
 
-  /** start() plus the first tick, which is what a launch really consists of. */
+  /** start() includes the first tick, before the interval begins. */
   async function launch(store: ScheduleStore, start: SessionStarter) {
     const manager = new ScheduleManager(store, start);
     manager.start();
-    await manager.tick();
+    await vi.advanceTimersByTimeAsync(0);
     manager.stop();
     return manager;
   }
@@ -123,6 +123,16 @@ describe('ScheduleManager.start', () => {
     expect(after.lastRunStatus).toBe('ok');
     expect(after.lastSessionId).toBe('new-session');
     expect(after.nextRunAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it('runs immediately when the grace window is about to expire', async () => {
+    const start = vi.fn<SessionStarter>().mockResolvedValue({ sessionId: 'new-session' });
+    const store = createStore([schedule({ nextRunAtMs: Date.now() - SCHEDULE_MISS_GRACE_MS + 1 })]);
+
+    await launch(store, start);
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(store.rows.get('sched-1')!.lastRunStatus).toBe('ok');
   });
 
   it('leaves a schedule that is not due yet exactly where it was', async () => {

--- a/main/src/services/scheduleManager.test.ts
+++ b/main/src/services/scheduleManager.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ScheduleManager, type ScheduleStore, type SessionStarter } from './scheduleManager';
+import { SCHEDULE_MISS_GRACE_MS, type ScheduledRun } from '../../../shared/types/schedule';
+
+/** In-memory store: the scheduling behaviour is what these tests are about. */
+function createStore(initial: ScheduledRun[] = []): ScheduleStore & { rows: Map<string, ScheduledRun> } {
+  const rows = new Map(initial.map(row => [row.id, { ...row }]));
+  return {
+    rows,
+    list: (projectId?: number) => [...rows.values()]
+      .filter(row => projectId === undefined || row.projectId === projectId),
+    get: (id: string) => {
+      const row = rows.get(id);
+      return row ? { ...row } : null;
+    },
+    listRunnable: () => [...rows.values()]
+      .filter(row => row.enabled && row.nextRunAtMs !== null)
+      .map(row => ({ ...row })),
+    upsert: (schedule: ScheduledRun) => { rows.set(schedule.id, { ...schedule }); },
+    delete: (id: string) => { rows.delete(id); },
+  };
+}
+
+function schedule(overrides: Partial<ScheduledRun> = {}): ScheduledRun {
+  return {
+    id: 'sched-1',
+    name: 'Nightly sweep',
+    projectId: 1,
+    prompt: 'Look for flaky tests',
+    toolType: 'claude',
+    enabled: true,
+    kind: 'daily',
+    timeOfDay: '03:30',
+    lastRunAtMs: null,
+    lastRunStatus: null,
+    lastRunError: null,
+    lastSessionId: null,
+    nextRunAtMs: null,
+    createdAtMs: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('ScheduleManager.save', () => {
+  it('computes the next run when a schedule is created', () => {
+    const store = createStore();
+    const manager = new ScheduleManager(store, vi.fn());
+
+    const saved = manager.save({
+      name: 'Nightly sweep',
+      projectId: 1,
+      prompt: 'Look for flaky tests',
+      toolType: 'claude',
+      enabled: true,
+      kind: 'daily',
+      timeOfDay: '03:30',
+    });
+
+    expect(saved.id).toBeTruthy();
+    expect(saved.nextRunAtMs).toBeGreaterThan(Date.now());
+    expect(store.rows.get(saved.id)?.name).toBe('Nightly sweep');
+  });
+
+  it('leaves a disabled schedule without a next run', () => {
+    const manager = new ScheduleManager(createStore(), vi.fn());
+    const saved = manager.save({
+      name: 'Off for now',
+      projectId: 1,
+      prompt: 'x',
+      toolType: 'none',
+      enabled: false,
+      kind: 'daily',
+      timeOfDay: '03:30',
+    });
+
+    expect(saved.nextRunAtMs).toBeNull();
+  });
+
+  it('keeps the run history when a schedule is edited', () => {
+    const existing = schedule({ lastRunAtMs: 1000, lastRunStatus: 'ok', lastSessionId: 'sess-9' });
+    const store = createStore([existing]);
+    const manager = new ScheduleManager(store, vi.fn());
+
+    const saved = manager.save({
+      id: existing.id,
+      name: 'Renamed',
+      projectId: 1,
+      prompt: 'Different prompt',
+      toolType: 'claude',
+      enabled: true,
+      kind: 'daily',
+      timeOfDay: '04:00',
+    });
+
+    expect(saved.name).toBe('Renamed');
+    expect(saved.lastRunAtMs).toBe(1000);
+    expect(saved.lastSessionId).toBe('sess-9');
+  });
+
+  it('refuses to schedule faster than the minimum interval', () => {
+    const manager = new ScheduleManager(createStore(), vi.fn());
+    const saved = manager.save({
+      name: 'Too eager',
+      projectId: 1,
+      prompt: 'x',
+      toolType: 'none',
+      enabled: true,
+      kind: 'interval',
+      intervalMinutes: 1,
+    });
+
+    expect(saved.intervalMinutes).toBe(5);
+  });
+});
+
+describe('ScheduleManager.tick', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('starts a session when a schedule is due', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    const start = vi.fn<SessionStarter>().mockResolvedValue({ sessionId: 'new-session' });
+    const store = createStore([schedule({ nextRunAtMs: Date.now() - 1000 })]);
+    const manager = new ScheduleManager(store, start);
+
+    await manager.tick();
+
+    expect(start).toHaveBeenCalledWith({
+      prompt: 'Look for flaky tests',
+      worktreeTemplate: '',
+      projectId: 1,
+      toolType: 'claude',
+    });
+
+    const after = store.rows.get('sched-1')!;
+    expect(after.lastRunStatus).toBe('ok');
+    expect(after.lastSessionId).toBe('new-session');
+    expect(after.nextRunAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it('does nothing before a schedule is due', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    const start = vi.fn<SessionStarter>();
+    const store = createStore([schedule({ nextRunAtMs: Date.now() + 60_000 })]);
+
+    await new ScheduleManager(store, start).tick();
+
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('ignores disabled schedules', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    const start = vi.fn<SessionStarter>();
+    const store = createStore([schedule({ enabled: false, nextRunAtMs: Date.now() - 1000 })]);
+
+    await new ScheduleManager(store, start).tick();
+
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The behaviour that matters after a weekend: opening the laptop must not
+   * start every run that came due while it was shut.
+   */
+  it('skips a run that came due while Pane was closed', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    const start = vi.fn<SessionStarter>();
+    const overdue = Date.now() - SCHEDULE_MISS_GRACE_MS - 60_000;
+    const store = createStore([schedule({ nextRunAtMs: overdue })]);
+    const manager = new ScheduleManager(store, start);
+
+    await manager.tick();
+
+    expect(start).not.toHaveBeenCalled();
+    const after = store.rows.get('sched-1')!;
+    expect(after.lastRunStatus).toBe('skipped');
+    expect(after.nextRunAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it('records why a run failed and still moves to the next slot', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    const start = vi.fn<SessionStarter>().mockRejectedValue(new Error('worktree is locked'));
+    const store = createStore([schedule({ nextRunAtMs: Date.now() - 1000 })]);
+
+    await new ScheduleManager(store, start).tick();
+
+    const after = store.rows.get('sched-1')!;
+    expect(after.lastRunStatus).toBe('failed');
+    expect(after.lastRunError).toBe('worktree is locked');
+    expect(after.nextRunAtMs).toBeGreaterThan(Date.now());
+  });
+
+  it('does not start the same schedule twice when ticks overlap', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    let resolveStart: (value: { sessionId: string }) => void = () => {};
+    const start = vi.fn<SessionStarter>().mockImplementation(
+      () => new Promise(resolve => { resolveStart = resolve; })
+    );
+    const store = createStore([schedule({ nextRunAtMs: Date.now() - 1000 })]);
+    const manager = new ScheduleManager(store, start);
+
+    const first = manager.tick();
+    await manager.tick();          // arrives while the first is still starting
+    resolveStart({ sessionId: 's' });
+    await first;
+
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs an interval schedule on its cadence, counted from the run', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    const start = vi.fn<SessionStarter>().mockResolvedValue({ sessionId: 's' });
+    const store = createStore([schedule({
+      kind: 'interval',
+      intervalMinutes: 60,
+      timeOfDay: undefined,
+      nextRunAtMs: Date.now() - 1000,
+    })]);
+
+    await new ScheduleManager(store, start).tick();
+
+    const after = store.rows.get('sched-1')!;
+    expect(after.nextRunAtMs).toBe(Date.now() + 60 * 60_000);
+  });
+});
+
+describe('ScheduleManager.runNow', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('starts immediately without moving the schedule', async () => {
+    vi.setSystemTime(new Date('2026-08-11T10:00:00'));
+    const nextRun = Date.now() + 5 * 60 * 60_000;
+    const start = vi.fn<SessionStarter>().mockResolvedValue({ sessionId: 'manual' });
+    const store = createStore([schedule({ nextRunAtMs: nextRun })]);
+
+    const result = await new ScheduleManager(store, start).runNow('sched-1');
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(result?.lastSessionId).toBe('manual');
+    expect(store.rows.get('sched-1')!.nextRunAtMs).toBe(nextRun);
+  });
+
+  it('reports nothing for an id that no longer exists', async () => {
+    const manager = new ScheduleManager(createStore(), vi.fn());
+    expect(await manager.runNow('gone')).toBeNull();
+  });
+});
+
+describe('ScheduleManager.setEnabled', () => {
+  it('gives a re-enabled schedule a next run again', () => {
+    const store = createStore([schedule({ enabled: false, nextRunAtMs: null })]);
+    const manager = new ScheduleManager(store, vi.fn());
+
+    const enabled = manager.setEnabled('sched-1', true);
+    expect(enabled?.nextRunAtMs).toBeGreaterThan(Date.now());
+
+    const disabled = manager.setEnabled('sched-1', false);
+    expect(disabled?.nextRunAtMs).toBeNull();
+  });
+});

--- a/main/src/services/scheduleManager.test.ts
+++ b/main/src/services/scheduleManager.test.ts
@@ -245,6 +245,59 @@ describe('ScheduleManager.runNow', () => {
     const manager = new ScheduleManager(createStore(), vi.fn());
     expect(await manager.runNow('gone')).toBeNull();
   });
+
+  it('rejects a second run while the same schedule is starting', async () => {
+    let resolveStart: (value: { sessionId: string }) => void = () => {};
+    const start = vi.fn<SessionStarter>().mockImplementation(
+      () => new Promise(resolve => { resolveStart = resolve; })
+    );
+    const manager = new ScheduleManager(createStore([schedule()]), start);
+
+    const first = manager.runNow('sched-1');
+    await expect(manager.runNow('sched-1')).rejects.toThrow('already running');
+    resolveStart({ sessionId: 'manual' });
+    await first;
+
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resurrect a schedule deleted while its session is starting', async () => {
+    let resolveStart: (value: { sessionId: string }) => void = () => {};
+    const start = vi.fn<SessionStarter>().mockImplementation(
+      () => new Promise(resolve => { resolveStart = resolve; })
+    );
+    const store = createStore([schedule()]);
+    const manager = new ScheduleManager(store, start);
+
+    const run = manager.runNow('sched-1');
+    manager.delete('sched-1');
+    resolveStart({ sessionId: 'manual' });
+    await run;
+
+    expect(store.rows.has('sched-1')).toBe(false);
+  });
+});
+
+describe('ScheduleManager concurrent mutations', () => {
+  it('preserves a disable made while an automatic run is starting', async () => {
+    let resolveStart: (value: { sessionId: string }) => void = () => {};
+    const start = vi.fn<SessionStarter>().mockImplementation(
+      () => new Promise(resolve => { resolveStart = resolve; })
+    );
+    const store = createStore([schedule({ nextRunAtMs: Date.now() - 1000 })]);
+    const manager = new ScheduleManager(store, start);
+
+    const tick = manager.tick();
+    manager.setEnabled('sched-1', false);
+    resolveStart({ sessionId: 'scheduled' });
+    await tick;
+
+    expect(store.rows.get('sched-1')).toMatchObject({
+      enabled: false,
+      nextRunAtMs: null,
+      lastSessionId: 'scheduled',
+    });
+  });
 });
 
 describe('ScheduleManager.setEnabled', () => {

--- a/main/src/services/scheduleManager.ts
+++ b/main/src/services/scheduleManager.ts
@@ -99,14 +99,8 @@ export class ScheduleManager {
       projectId: input.projectId,
       prompt: input.prompt,
       toolType: input.toolType,
-      ...(input.worktreeTemplate ? { worktreeTemplate: input.worktreeTemplate } : {}),
       enabled: input.enabled,
       kind: input.kind,
-      ...(input.intervalMinutes !== undefined
-        ? { intervalMinutes: Math.max(input.intervalMinutes, MIN_INTERVAL_MINUTES) }
-        : {}),
-      ...(input.timeOfDay !== undefined ? { timeOfDay: input.timeOfDay } : {}),
-      ...(input.weekday !== undefined ? { weekday: input.weekday } : {}),
       lastRunAtMs: existing?.lastRunAtMs ?? null,
       lastRunStatus: existing?.lastRunStatus ?? null,
       lastRunError: existing?.lastRunError ?? null,
@@ -115,8 +109,15 @@ export class ScheduleManager {
       createdAtMs: existing?.createdAtMs ?? nowMs,
     };
 
+    if (input.worktreeTemplate) schedule.worktreeTemplate = input.worktreeTemplate;
+    if (input.intervalMinutes !== undefined) {
+      schedule.intervalMinutes = Math.max(input.intervalMinutes, MIN_INTERVAL_MINUTES);
+    }
+    if (input.timeOfDay !== undefined) schedule.timeOfDay = input.timeOfDay;
+    if (input.weekday !== undefined) schedule.weekday = input.weekday;
+
     schedule.nextRunAtMs = schedule.enabled
-      ? computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, nowMs)
+      ? computeNextRun(schedule, nowMs)
       : null;
 
     this.repo.upsert(schedule);
@@ -133,7 +134,7 @@ export class ScheduleManager {
 
     schedule.enabled = enabled;
     schedule.nextRunAtMs = enabled
-      ? computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, Date.now())
+      ? computeNextRun(schedule, Date.now())
       : null;
     this.repo.upsert(schedule);
     return schedule;
@@ -189,7 +190,7 @@ export class ScheduleManager {
       if (!schedule.enabled) continue;
 
       if (schedule.nextRunAtMs === null) {
-        schedule.nextRunAtMs = computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, nowMs);
+        schedule.nextRunAtMs = computeNextRun(schedule, nowMs);
         this.repo.upsert(schedule);
         continue;
       }
@@ -255,7 +256,7 @@ export class ScheduleManager {
       // time from now on".
       if (!options.manual) {
         result.nextRunAtMs = result.enabled
-          ? computeNextRun({ ...result, lastRunAtMs: startedAtMs }, startedAtMs)
+          ? computeNextRun(result, startedAtMs)
           : null;
       }
 

--- a/main/src/services/scheduleManager.ts
+++ b/main/src/services/scheduleManager.ts
@@ -33,7 +33,7 @@ export type SessionStarter = (input: {
 export interface ScheduleStore {
   list(projectId?: number): ScheduledRun[];
   get(id: string): ScheduledRun | null;
-  listRunnable(): ScheduledRun[];
+  listRunnable(nowMs: number): ScheduledRun[];
   upsert(schedule: ScheduledRun): void;
   delete(id: string): void;
 }
@@ -155,7 +155,7 @@ export class ScheduleManager {
 
     try {
       const nowMs = Date.now();
-      for (const schedule of this.repo.listRunnable()) {
+      for (const schedule of this.repo.listRunnable(nowMs)) {
         if (this.executingIds.has(schedule.id)) continue;
         if (isDue(schedule, nowMs)) {
           await this.execute(schedule, { manual: false });

--- a/main/src/services/scheduleManager.ts
+++ b/main/src/services/scheduleManager.ts
@@ -41,6 +41,7 @@ export interface ScheduleStore {
 export class ScheduleManager {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
+  private readonly executingIds = new Set<string>();
 
   /**
    * The store is injected rather than reached for: importing the database
@@ -64,6 +65,10 @@ export class ScheduleManager {
     } catch (error) {
       this.logger?.error('[Schedule] Failed to prime schedules', error instanceof Error ? error : undefined);
     }
+
+    void this.tick().catch(error => {
+      this.logger?.error('[Schedule] Initial tick failed', error instanceof Error ? error : undefined);
+    });
 
     this.timer = setInterval(() => {
       void this.tick().catch(error => {
@@ -138,6 +143,7 @@ export class ScheduleManager {
   async runNow(id: string): Promise<ScheduledRun | null> {
     const schedule = this.repo.get(id);
     if (!schedule) return null;
+    if (this.executingIds.has(id)) throw new Error('This schedule is already running');
     return this.execute(schedule, { manual: true });
   }
 
@@ -149,6 +155,7 @@ export class ScheduleManager {
     try {
       const nowMs = Date.now();
       for (const schedule of this.repo.listRunnable()) {
+        if (this.executingIds.has(schedule.id)) continue;
         if (isDue(schedule, nowMs)) {
           await this.execute(schedule, { manual: false });
         } else if (isMissed(schedule, nowMs)) {
@@ -207,36 +214,55 @@ export class ScheduleManager {
   }
 
   private async execute(schedule: ScheduledRun, options: { manual: boolean }): Promise<ScheduledRun> {
+    if (this.executingIds.has(schedule.id)) throw new Error('This schedule is already running');
+    this.executingIds.add(schedule.id);
     const startedAtMs = Date.now();
+    let lastRunStatus: ScheduledRun['lastRunStatus'];
+    let lastRunError: string | null;
+    let lastSessionId = schedule.lastSessionId;
 
     try {
-      const result = await this.startSession({
-        prompt: schedule.prompt,
-        worktreeTemplate: schedule.worktreeTemplate ?? '',
-        projectId: schedule.projectId,
-        toolType: schedule.toolType,
-      });
+      try {
+        const result = await this.startSession({
+          prompt: schedule.prompt,
+          worktreeTemplate: schedule.worktreeTemplate ?? '',
+          projectId: schedule.projectId,
+          toolType: schedule.toolType,
+        });
 
-      schedule.lastRunStatus = 'ok';
-      schedule.lastRunError = null;
-      schedule.lastSessionId = result.sessionId ?? null;
-      this.logger?.info(`[Schedule] Started "${schedule.name}"`);
-    } catch (error) {
-      schedule.lastRunStatus = 'failed';
-      schedule.lastRunError = error instanceof Error ? error.message : String(error);
-      this.logger?.error(`[Schedule] "${schedule.name}" failed to start: ${schedule.lastRunError}`);
+        lastRunStatus = 'ok';
+        lastRunError = null;
+        lastSessionId = result.sessionId ?? null;
+        this.logger?.info(`[Schedule] Started "${schedule.name}"`);
+      } catch (error) {
+        lastRunStatus = 'failed';
+        lastRunError = error instanceof Error ? error.message : String(error);
+        this.logger?.error(`[Schedule] "${schedule.name}" failed to start: ${lastRunError}`);
+      }
+
+      // The schedule may have been edited, disabled, or deleted while session
+      // creation was pending. Apply execution history only to the latest row.
+      const latest = this.repo.get(schedule.id);
+      const result = latest ?? { ...schedule };
+      result.lastRunAtMs = startedAtMs;
+      result.lastRunStatus = lastRunStatus;
+      result.lastRunError = lastRunError;
+      result.lastSessionId = lastSessionId;
+
+      if (!latest) return result;
+
+      // A manual run must not shift the cadence: "run now" is not "run at this
+      // time from now on".
+      if (!options.manual) {
+        result.nextRunAtMs = result.enabled
+          ? computeNextRun({ ...result, lastRunAtMs: startedAtMs }, startedAtMs)
+          : null;
+      }
+
+      this.repo.upsert(result);
+      return result;
+    } finally {
+      this.executingIds.delete(schedule.id);
     }
-
-    schedule.lastRunAtMs = startedAtMs;
-    // A manual run must not shift the cadence: "run now" is not "run at this
-    // time from now on".
-    if (!options.manual) {
-      schedule.nextRunAtMs = schedule.enabled
-        ? computeNextRun({ ...schedule, lastRunAtMs: startedAtMs }, startedAtMs)
-        : null;
-    }
-
-    this.repo.upsert(schedule);
-    return schedule;
   }
 }

--- a/main/src/services/scheduleManager.ts
+++ b/main/src/services/scheduleManager.ts
@@ -54,17 +54,13 @@ export class ScheduleManager {
   ) {}
 
   /**
-   * Begin ticking.
-   *
-   * Every schedule's next run is recomputed at startup: the app may have been
-   * closed for a week, and a stored time in the past would otherwise fire the
-   * moment the window opens.
+   * Begin ticking, once what happened while Pane was closed has been settled.
    */
   start(): void {
     if (this.timer) return;
 
     try {
-      this.rescheduleAll();
+      this.reconcileOnStart();
     } catch (error) {
       this.logger?.error('[Schedule] Failed to prime schedules', error instanceof Error ? error : undefined);
     }
@@ -156,11 +152,7 @@ export class ScheduleManager {
         if (isDue(schedule, nowMs)) {
           await this.execute(schedule, { manual: false });
         } else if (isMissed(schedule, nowMs)) {
-          this.logger?.info(`[Schedule] Skipping "${schedule.name}" — it came due while Pane was not running.`);
-          schedule.lastRunStatus = 'skipped';
-          schedule.lastRunError = 'Came due while Pane was closed';
-          schedule.nextRunAtMs = computeNextRun({ ...schedule, lastRunAtMs: nowMs }, nowMs);
-          this.repo.upsert(schedule);
+          this.recordMissed(schedule, nowMs);
         }
       }
     } finally {
@@ -168,17 +160,50 @@ export class ScheduleManager {
     }
   }
 
-  /** Recompute every enabled schedule's next run from now. */
-  private rescheduleAll(): void {
+  /**
+   * Settle the schedules Pane slept through, before the first tick looks at them.
+   *
+   * This used to recompute every enabled schedule's next run from now, which
+   * quietly erased the evidence: a stored time in the past was replaced with a
+   * future one, so the tick that followed saw nothing overdue and never marked
+   * the occurrence skipped. A run that came due two minutes before the app
+   * opened — well inside the grace period, and meant to happen — disappeared
+   * the same way.
+   *
+   * So only two things are decided here. A schedule with no next run at all
+   * gets one, and one that is late beyond the grace period is written off as
+   * missed. Everything else keeps the time it was stored with and the tick
+   * decides, which is where that decision belongs.
+   */
+  private reconcileOnStart(): void {
     const nowMs = Date.now();
+
     for (const schedule of this.repo.list()) {
       if (!schedule.enabled) continue;
-      const next = computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, nowMs);
-      if (next !== schedule.nextRunAtMs) {
-        schedule.nextRunAtMs = next;
+
+      if (schedule.nextRunAtMs === null) {
+        schedule.nextRunAtMs = computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, nowMs);
         this.repo.upsert(schedule);
+        continue;
       }
+
+      if (isMissed(schedule, nowMs)) this.recordMissed(schedule, nowMs);
     }
+  }
+
+  /**
+   * Write off one occurrence that came and went unattended.
+   *
+   * One, not one per interval that elapsed: `computeNextRun` counts from now,
+   * so a weekend of downtime leaves a single skipped entry rather than a
+   * backlog nobody wants run.
+   */
+  private recordMissed(schedule: ScheduledRun, nowMs: number): void {
+    this.logger?.info(`[Schedule] Skipping "${schedule.name}" — it came due while Pane was not running.`);
+    schedule.lastRunStatus = 'skipped';
+    schedule.lastRunError = 'Came due while Pane was closed';
+    schedule.nextRunAtMs = computeNextRun({ ...schedule, lastRunAtMs: nowMs }, nowMs);
+    this.repo.upsert(schedule);
   }
 
   private async execute(schedule: ScheduledRun, options: { manual: boolean }): Promise<ScheduledRun> {

--- a/main/src/services/scheduleManager.ts
+++ b/main/src/services/scheduleManager.ts
@@ -1,0 +1,217 @@
+import { randomUUID } from 'crypto';
+import { computeNextRun, isDue, isMissed } from './scheduleCalculator';
+import {
+  MIN_INTERVAL_MINUTES,
+  SCHEDULE_TICK_MS,
+  type ScheduledRun,
+  type ScheduledRunInput,
+} from '../../../shared/types/schedule';
+import type { Logger } from '../utils/logger';
+
+/**
+ * Runs schedules when they come due.
+ *
+ * Deliberately dumb about time: one timer, one pass over the table, all the
+ * arithmetic in `scheduleCalculator`. A timer per schedule would drift, would
+ * need rebuilding on every edit, and would silently do nothing after a laptop
+ * sleeps — which is precisely when a nightly run matters.
+ */
+
+/** Starts a session; the same call the create dialog makes. */
+export type SessionStarter = (input: {
+  prompt: string;
+  worktreeTemplate: string;
+  projectId: number;
+  toolType: 'claude' | 'none';
+}) => Promise<{ sessionId?: string }>;
+
+/**
+ * The storage this needs, named as an interface so tests can supply a plain
+ * in-memory one — the scheduling behaviour is the part worth testing, and it
+ * has nothing to do with SQLite.
+ */
+export interface ScheduleStore {
+  list(projectId?: number): ScheduledRun[];
+  get(id: string): ScheduledRun | null;
+  listRunnable(): ScheduledRun[];
+  upsert(schedule: ScheduledRun): void;
+  delete(id: string): void;
+}
+
+export class ScheduleManager {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+
+  /**
+   * The store is injected rather than reached for: importing the database
+   * module loads a native SQLite binding, and a scheduling test has no
+   * business doing that.
+   */
+  constructor(
+    private repo: ScheduleStore,
+    private startSession: SessionStarter,
+    private logger?: Logger,
+  ) {}
+
+  /**
+   * Begin ticking.
+   *
+   * Every schedule's next run is recomputed at startup: the app may have been
+   * closed for a week, and a stored time in the past would otherwise fire the
+   * moment the window opens.
+   */
+  start(): void {
+    if (this.timer) return;
+
+    try {
+      this.rescheduleAll();
+    } catch (error) {
+      this.logger?.error('[Schedule] Failed to prime schedules', error instanceof Error ? error : undefined);
+    }
+
+    this.timer = setInterval(() => {
+      void this.tick().catch(error => {
+        this.logger?.error('[Schedule] Tick failed', error instanceof Error ? error : undefined);
+      });
+    }, SCHEDULE_TICK_MS);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  list(projectId?: number): ScheduledRun[] {
+    return this.repo.list(projectId);
+  }
+
+  /** Create or update a schedule; the next run is always recomputed here. */
+  save(input: ScheduledRunInput): ScheduledRun {
+    const existing = input.id ? this.repo.get(input.id) : null;
+    const nowMs = Date.now();
+
+    const schedule: ScheduledRun = {
+      id: input.id ?? randomUUID(),
+      name: input.name.trim() || 'Scheduled run',
+      projectId: input.projectId,
+      prompt: input.prompt,
+      toolType: input.toolType,
+      ...(input.worktreeTemplate ? { worktreeTemplate: input.worktreeTemplate } : {}),
+      enabled: input.enabled,
+      kind: input.kind,
+      ...(input.intervalMinutes !== undefined
+        ? { intervalMinutes: Math.max(input.intervalMinutes, MIN_INTERVAL_MINUTES) }
+        : {}),
+      ...(input.timeOfDay !== undefined ? { timeOfDay: input.timeOfDay } : {}),
+      ...(input.weekday !== undefined ? { weekday: input.weekday } : {}),
+      lastRunAtMs: existing?.lastRunAtMs ?? null,
+      lastRunStatus: existing?.lastRunStatus ?? null,
+      lastRunError: existing?.lastRunError ?? null,
+      lastSessionId: existing?.lastSessionId ?? null,
+      nextRunAtMs: null,
+      createdAtMs: existing?.createdAtMs ?? nowMs,
+    };
+
+    schedule.nextRunAtMs = schedule.enabled
+      ? computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, nowMs)
+      : null;
+
+    this.repo.upsert(schedule);
+    return schedule;
+  }
+
+  delete(id: string): void {
+    this.repo.delete(id);
+  }
+
+  setEnabled(id: string, enabled: boolean): ScheduledRun | null {
+    const schedule = this.repo.get(id);
+    if (!schedule) return null;
+
+    schedule.enabled = enabled;
+    schedule.nextRunAtMs = enabled
+      ? computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, Date.now())
+      : null;
+    this.repo.upsert(schedule);
+    return schedule;
+  }
+
+  /** Run one schedule now, without touching its cadence. */
+  async runNow(id: string): Promise<ScheduledRun | null> {
+    const schedule = this.repo.get(id);
+    if (!schedule) return null;
+    return this.execute(schedule, { manual: true });
+  }
+
+  /** One pass: start what is due, skip what is too late, keep the rest. */
+  async tick(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    try {
+      const nowMs = Date.now();
+      for (const schedule of this.repo.listRunnable()) {
+        if (isDue(schedule, nowMs)) {
+          await this.execute(schedule, { manual: false });
+        } else if (isMissed(schedule, nowMs)) {
+          this.logger?.info(`[Schedule] Skipping "${schedule.name}" — it came due while Pane was not running.`);
+          schedule.lastRunStatus = 'skipped';
+          schedule.lastRunError = 'Came due while Pane was closed';
+          schedule.nextRunAtMs = computeNextRun({ ...schedule, lastRunAtMs: nowMs }, nowMs);
+          this.repo.upsert(schedule);
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  /** Recompute every enabled schedule's next run from now. */
+  private rescheduleAll(): void {
+    const nowMs = Date.now();
+    for (const schedule of this.repo.list()) {
+      if (!schedule.enabled) continue;
+      const next = computeNextRun({ ...schedule, lastRunAtMs: schedule.lastRunAtMs }, nowMs);
+      if (next !== schedule.nextRunAtMs) {
+        schedule.nextRunAtMs = next;
+        this.repo.upsert(schedule);
+      }
+    }
+  }
+
+  private async execute(schedule: ScheduledRun, options: { manual: boolean }): Promise<ScheduledRun> {
+    const startedAtMs = Date.now();
+
+    try {
+      const result = await this.startSession({
+        prompt: schedule.prompt,
+        worktreeTemplate: schedule.worktreeTemplate ?? '',
+        projectId: schedule.projectId,
+        toolType: schedule.toolType,
+      });
+
+      schedule.lastRunStatus = 'ok';
+      schedule.lastRunError = null;
+      schedule.lastSessionId = result.sessionId ?? null;
+      this.logger?.info(`[Schedule] Started "${schedule.name}"`);
+    } catch (error) {
+      schedule.lastRunStatus = 'failed';
+      schedule.lastRunError = error instanceof Error ? error.message : String(error);
+      this.logger?.error(`[Schedule] "${schedule.name}" failed to start: ${schedule.lastRunError}`);
+    }
+
+    schedule.lastRunAtMs = startedAtMs;
+    // A manual run must not shift the cadence: "run now" is not "run at this
+    // time from now on".
+    if (!options.manual) {
+      schedule.nextRunAtMs = schedule.enabled
+        ? computeNextRun({ ...schedule, lastRunAtMs: startedAtMs }, startedAtMs)
+        : null;
+    }
+
+    this.repo.upsert(schedule);
+    return schedule;
+  }
+}

--- a/main/src/services/scheduleRepository.test.ts
+++ b/main/src/services/scheduleRepository.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Database } from 'better-sqlite3-multiple-ciphers';
+import { ScheduleRepository } from './scheduleRepository';
+
+describe('ScheduleRepository', () => {
+  it('uses the indexed deadline boundary when listing runnable schedules', () => {
+    const all = vi.fn(() => []);
+    const prepare = vi.fn(() => ({ all }));
+    // SAFETY: The repository test exercises only the prepare().all() surface supplied by this stub.
+    const database = { prepare } as Database;
+    const repository = new ScheduleRepository(() => database);
+
+    repository.listRunnable(123_456);
+
+    expect(prepare).toHaveBeenCalledWith(
+      'SELECT * FROM scheduled_runs WHERE enabled = 1 AND next_run_at_ms <= ? ORDER BY next_run_at_ms ASC'
+    );
+    expect(all).toHaveBeenCalledWith(123_456);
+  });
+});

--- a/main/src/services/scheduleRepository.ts
+++ b/main/src/services/scheduleRepository.ts
@@ -83,11 +83,11 @@ export class ScheduleRepository {
   }
 
   /** Everything enabled with a due time, newest deadline last. */
-  listRunnable(): ScheduledRun[] {
+  listRunnable(nowMs: number): ScheduledRun[] {
     // SAFETY: This SELECT reads rows from the scheduled_runs schema represented by ScheduleRow.
     const rows = this.db.prepare(
-      'SELECT * FROM scheduled_runs WHERE enabled = 1 AND next_run_at_ms IS NOT NULL ORDER BY next_run_at_ms ASC'
-    ).all() as ScheduleRow[];
+      'SELECT * FROM scheduled_runs WHERE enabled = 1 AND next_run_at_ms <= ? ORDER BY next_run_at_ms ASC'
+    ).all(nowMs) as ScheduleRow[];
     return rows.map(toSchedule);
   }
 

--- a/main/src/services/scheduleRepository.ts
+++ b/main/src/services/scheduleRepository.ts
@@ -30,25 +30,31 @@ interface ScheduleRow {
 }
 
 function toSchedule(row: ScheduleRow): ScheduledRun {
-  return {
+  // SAFETY: Schedule writes persist only ScheduleKind values.
+  const kind = row.kind as ScheduleKind;
+  // SAFETY: Schedule writes persist only ScheduleRunStatus values or null.
+  const lastRunStatus = row.last_run_status as ScheduleRunStatus | null;
+  const schedule: ScheduledRun = {
     id: row.id,
     name: row.name,
     projectId: row.project_id,
     prompt: row.prompt,
     toolType: row.tool_type === 'none' ? 'none' : 'claude',
-    ...(row.worktree_template ? { worktreeTemplate: row.worktree_template } : {}),
     enabled: row.enabled === 1,
-    kind: row.kind as ScheduleKind,
-    ...(row.interval_minutes !== null ? { intervalMinutes: row.interval_minutes } : {}),
-    ...(row.time_of_day !== null ? { timeOfDay: row.time_of_day } : {}),
-    ...(row.weekday !== null ? { weekday: row.weekday } : {}),
+    kind,
     lastRunAtMs: row.last_run_at_ms,
-    lastRunStatus: (row.last_run_status as ScheduleRunStatus | null) ?? null,
+    lastRunStatus,
     lastRunError: row.last_run_error,
     lastSessionId: row.last_session_id,
     nextRunAtMs: row.next_run_at_ms,
     createdAtMs: row.created_at_ms,
   };
+
+  if (row.worktree_template) schedule.worktreeTemplate = row.worktree_template;
+  if (row.interval_minutes !== null) schedule.intervalMinutes = row.interval_minutes;
+  if (row.time_of_day !== null) schedule.timeOfDay = row.time_of_day;
+  if (row.weekday !== null) schedule.weekday = row.weekday;
+  return schedule;
 }
 
 export class ScheduleRepository {
@@ -66,16 +72,19 @@ export class ScheduleRepository {
     const rows = projectId === undefined
       ? this.db.prepare('SELECT * FROM scheduled_runs ORDER BY created_at_ms DESC').all()
       : this.db.prepare('SELECT * FROM scheduled_runs WHERE project_id = ? ORDER BY created_at_ms DESC').all(projectId);
+    // SAFETY: Both SELECT statements enumerate rows from the scheduled_runs schema represented by ScheduleRow.
     return (rows as ScheduleRow[]).map(toSchedule);
   }
 
   get(id: string): ScheduledRun | null {
+    // SAFETY: This SELECT reads one row from the scheduled_runs schema represented by ScheduleRow.
     const row = this.db.prepare('SELECT * FROM scheduled_runs WHERE id = ?').get(id) as ScheduleRow | undefined;
     return row ? toSchedule(row) : null;
   }
 
   /** Everything enabled with a due time, newest deadline last. */
   listRunnable(): ScheduledRun[] {
+    // SAFETY: This SELECT reads rows from the scheduled_runs schema represented by ScheduleRow.
     const rows = this.db.prepare(
       'SELECT * FROM scheduled_runs WHERE enabled = 1 AND next_run_at_ms IS NOT NULL ORDER BY next_run_at_ms ASC'
     ).all() as ScheduleRow[];

--- a/main/src/services/scheduleRepository.ts
+++ b/main/src/services/scheduleRepository.ts
@@ -1,0 +1,133 @@
+import type { Database } from 'better-sqlite3-multiple-ciphers';
+import type { ScheduledRun, ScheduleKind, ScheduleRunStatus } from '../../../shared/types/schedule';
+
+/**
+ * Persistence for scheduled runs.
+ *
+ * Uses the raw better-sqlite3 handle rather than growing the ~5,000-line
+ * `DatabaseService` facade — the same escape hatch the usage index and the
+ * scrollback sweeper use.
+ */
+
+interface ScheduleRow {
+  id: string;
+  name: string;
+  project_id: number;
+  prompt: string;
+  tool_type: string;
+  worktree_template: string | null;
+  enabled: number;
+  kind: string;
+  interval_minutes: number | null;
+  time_of_day: string | null;
+  weekday: number | null;
+  last_run_at_ms: number | null;
+  last_run_status: string | null;
+  last_run_error: string | null;
+  last_session_id: string | null;
+  next_run_at_ms: number | null;
+  created_at_ms: number;
+}
+
+function toSchedule(row: ScheduleRow): ScheduledRun {
+  return {
+    id: row.id,
+    name: row.name,
+    projectId: row.project_id,
+    prompt: row.prompt,
+    toolType: row.tool_type === 'none' ? 'none' : 'claude',
+    ...(row.worktree_template ? { worktreeTemplate: row.worktree_template } : {}),
+    enabled: row.enabled === 1,
+    kind: row.kind as ScheduleKind,
+    ...(row.interval_minutes !== null ? { intervalMinutes: row.interval_minutes } : {}),
+    ...(row.time_of_day !== null ? { timeOfDay: row.time_of_day } : {}),
+    ...(row.weekday !== null ? { weekday: row.weekday } : {}),
+    lastRunAtMs: row.last_run_at_ms,
+    lastRunStatus: (row.last_run_status as ScheduleRunStatus | null) ?? null,
+    lastRunError: row.last_run_error,
+    lastSessionId: row.last_session_id,
+    nextRunAtMs: row.next_run_at_ms,
+    createdAtMs: row.created_at_ms,
+  };
+}
+
+export class ScheduleRepository {
+  /**
+   * Takes a getter rather than a handle: the database is opened during app
+   * start-up, and this is constructed while IPC handlers are being registered.
+   */
+  constructor(private getDb: () => Database) {}
+
+  private get db(): Database {
+    return this.getDb();
+  }
+
+  list(projectId?: number): ScheduledRun[] {
+    const rows = projectId === undefined
+      ? this.db.prepare('SELECT * FROM scheduled_runs ORDER BY created_at_ms DESC').all()
+      : this.db.prepare('SELECT * FROM scheduled_runs WHERE project_id = ? ORDER BY created_at_ms DESC').all(projectId);
+    return (rows as ScheduleRow[]).map(toSchedule);
+  }
+
+  get(id: string): ScheduledRun | null {
+    const row = this.db.prepare('SELECT * FROM scheduled_runs WHERE id = ?').get(id) as ScheduleRow | undefined;
+    return row ? toSchedule(row) : null;
+  }
+
+  /** Everything enabled with a due time, newest deadline last. */
+  listRunnable(): ScheduledRun[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM scheduled_runs WHERE enabled = 1 AND next_run_at_ms IS NOT NULL ORDER BY next_run_at_ms ASC'
+    ).all() as ScheduleRow[];
+    return rows.map(toSchedule);
+  }
+
+  upsert(schedule: ScheduledRun): void {
+    this.db.prepare(`
+      INSERT INTO scheduled_runs (
+        id, name, project_id, prompt, tool_type, worktree_template, enabled,
+        kind, interval_minutes, time_of_day, weekday,
+        last_run_at_ms, last_run_status, last_run_error, last_session_id,
+        next_run_at_ms, created_at_ms
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        name = excluded.name,
+        project_id = excluded.project_id,
+        prompt = excluded.prompt,
+        tool_type = excluded.tool_type,
+        worktree_template = excluded.worktree_template,
+        enabled = excluded.enabled,
+        kind = excluded.kind,
+        interval_minutes = excluded.interval_minutes,
+        time_of_day = excluded.time_of_day,
+        weekday = excluded.weekday,
+        last_run_at_ms = excluded.last_run_at_ms,
+        last_run_status = excluded.last_run_status,
+        last_run_error = excluded.last_run_error,
+        last_session_id = excluded.last_session_id,
+        next_run_at_ms = excluded.next_run_at_ms
+    `).run(
+      schedule.id,
+      schedule.name,
+      schedule.projectId,
+      schedule.prompt,
+      schedule.toolType,
+      schedule.worktreeTemplate ?? null,
+      schedule.enabled ? 1 : 0,
+      schedule.kind,
+      schedule.intervalMinutes ?? null,
+      schedule.timeOfDay ?? null,
+      schedule.weekday ?? null,
+      schedule.lastRunAtMs,
+      schedule.lastRunStatus,
+      schedule.lastRunError,
+      schedule.lastSessionId,
+      schedule.nextRunAtMs,
+      schedule.createdAtMs,
+    );
+  }
+
+  delete(id: string): void {
+    this.db.prepare('DELETE FROM scheduled_runs WHERE id = ?').run(id);
+  }
+}

--- a/main/src/services/scheduleValidation.test.ts
+++ b/main/src/services/scheduleValidation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { validateScheduledRunInput } from './scheduleValidation';
+
+const validInput = {
+  name: 'Nightly sweep',
+  projectId: 1,
+  prompt: 'Review the latest changes',
+  toolType: 'claude',
+  enabled: true,
+  kind: 'daily',
+  timeOfDay: '03:30',
+} as const;
+
+describe('validateScheduledRunInput', () => {
+  it('accepts each supported shape', () => {
+    expect(validateScheduledRunInput(validInput).success).toBe(true);
+    expect(validateScheduledRunInput({ ...validInput, kind: 'weekly', weekday: 2 }).success).toBe(true);
+    expect(validateScheduledRunInput({ ...validInput, kind: 'interval', intervalMinutes: 15 }).success).toBe(true);
+  });
+
+  it.each([
+    [{ ...validInput, kind: 'monthly' }, 'Schedule kind'],
+    [{ ...validInput, timeOfDay: '99:99' }, 'valid time'],
+    [{ ...validInput, kind: 'weekly', weekday: 7 }, 'weekday'],
+    [{ ...validInput, kind: 'interval', intervalMinutes: 5.5 }, 'shortest interval'],
+    [{ ...validInput, toolType: 'shell' }, 'supported agent'],
+    [{ ...validInput, projectId: 1.5 }, 'project'],
+  ])('rejects malformed daemon input %#', (input, message) => {
+    const result = validateScheduledRunInput(input);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain(message);
+  });
+});

--- a/main/src/services/scheduleValidation.test.ts
+++ b/main/src/services/scheduleValidation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { validateScheduledRunInput } from './scheduleValidation';
+import { decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+import { scheduledRunInputSchema } from '../../../shared/types/schedule';
 
 const validInput = {
   name: 'Nightly sweep',
@@ -19,15 +21,20 @@ describe('validateScheduledRunInput', () => {
   });
 
   it.each([
-    [{ ...validInput, kind: 'monthly' }, 'Schedule kind'],
     [{ ...validInput, timeOfDay: '99:99' }, 'valid time'],
     [{ ...validInput, kind: 'weekly', weekday: 7 }, 'weekday'],
     [{ ...validInput, kind: 'interval', intervalMinutes: 5.5 }, 'shortest interval'],
-    [{ ...validInput, toolType: 'shell' }, 'supported agent'],
     [{ ...validInput, projectId: 1.5 }, 'project'],
   ])('rejects malformed daemon input %#', (input, message) => {
-    const result = validateScheduledRunInput(input);
+    const result = validateScheduledRunInput(decodeBoundary(input, scheduledRunInputSchema));
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error).toContain(message);
+  });
+
+  it.each([
+    { ...validInput, kind: 'monthly' },
+    { ...validInput, toolType: 'shell' },
+  ])('rejects unsupported boundary values %#', (input) => {
+    expect(() => decodeBoundary(input, scheduledRunInputSchema)).toThrow();
   });
 });

--- a/main/src/services/scheduleValidation.ts
+++ b/main/src/services/scheduleValidation.ts
@@ -2,32 +2,19 @@ import type { ScheduledRunInput } from '../../../shared/types/schedule';
 import { MIN_INTERVAL_MINUTES } from '../../../shared/types/schedule';
 import { parseTimeOfDay } from './scheduleCalculator';
 
-export type ScheduleValidationResult =
+type ScheduleValidationResult =
   | { success: true; data: ScheduledRunInput }
   | { success: false; error: string };
 
-export function validateScheduledRunInput(value: unknown): ScheduleValidationResult {
-  if (typeof value !== 'object' || value === null) {
-    return { success: false, error: 'No schedule given' };
-  }
-
-  const input = value as Partial<ScheduledRunInput>;
-  if (typeof input.name !== 'string') return { success: false, error: 'A name is required' };
-  if (typeof input.prompt !== 'string' || !input.prompt.trim()) {
+export function validateScheduledRunInput(input: ScheduledRunInput): ScheduleValidationResult {
+  if (!input.prompt.trim()) {
     return { success: false, error: 'A prompt is required because it is what the agent starts with' };
   }
-  if (!Number.isInteger(input.projectId) || (input.projectId ?? 0) <= 0) {
+  if (!Number.isInteger(input.projectId) || input.projectId <= 0) {
     return { success: false, error: 'A project is required' };
   }
-  if (input.toolType !== 'claude' && input.toolType !== 'none') {
-    return { success: false, error: 'A supported agent is required' };
-  }
-  if (typeof input.enabled !== 'boolean') return { success: false, error: 'Enabled must be true or false' };
-  if (input.id !== undefined && (typeof input.id !== 'string' || !input.id.trim())) {
+  if (input.id !== undefined && !input.id.trim()) {
     return { success: false, error: 'Schedule id must be a non-empty string' };
-  }
-  if (input.worktreeTemplate !== undefined && typeof input.worktreeTemplate !== 'string') {
-    return { success: false, error: 'Worktree template must be text' };
   }
 
   if (input.kind === 'interval') {
@@ -45,5 +32,5 @@ export function validateScheduledRunInput(value: unknown): ScheduleValidationRes
     return { success: false, error: 'Schedule kind must be interval, daily, or weekly' };
   }
 
-  return { success: true, data: input as ScheduledRunInput };
+  return { success: true, data: input };
 }

--- a/main/src/services/scheduleValidation.ts
+++ b/main/src/services/scheduleValidation.ts
@@ -1,0 +1,49 @@
+import type { ScheduledRunInput } from '../../../shared/types/schedule';
+import { MIN_INTERVAL_MINUTES } from '../../../shared/types/schedule';
+import { parseTimeOfDay } from './scheduleCalculator';
+
+export type ScheduleValidationResult =
+  | { success: true; data: ScheduledRunInput }
+  | { success: false; error: string };
+
+export function validateScheduledRunInput(value: unknown): ScheduleValidationResult {
+  if (typeof value !== 'object' || value === null) {
+    return { success: false, error: 'No schedule given' };
+  }
+
+  const input = value as Partial<ScheduledRunInput>;
+  if (typeof input.name !== 'string') return { success: false, error: 'A name is required' };
+  if (typeof input.prompt !== 'string' || !input.prompt.trim()) {
+    return { success: false, error: 'A prompt is required because it is what the agent starts with' };
+  }
+  if (!Number.isInteger(input.projectId) || (input.projectId ?? 0) <= 0) {
+    return { success: false, error: 'A project is required' };
+  }
+  if (input.toolType !== 'claude' && input.toolType !== 'none') {
+    return { success: false, error: 'A supported agent is required' };
+  }
+  if (typeof input.enabled !== 'boolean') return { success: false, error: 'Enabled must be true or false' };
+  if (input.id !== undefined && (typeof input.id !== 'string' || !input.id.trim())) {
+    return { success: false, error: 'Schedule id must be a non-empty string' };
+  }
+  if (input.worktreeTemplate !== undefined && typeof input.worktreeTemplate !== 'string') {
+    return { success: false, error: 'Worktree template must be text' };
+  }
+
+  if (input.kind === 'interval') {
+    if (!Number.isInteger(input.intervalMinutes) || (input.intervalMinutes ?? 0) < MIN_INTERVAL_MINUTES) {
+      return { success: false, error: `The shortest interval is ${MIN_INTERVAL_MINUTES} minutes` };
+    }
+  } else if (input.kind === 'daily' || input.kind === 'weekly') {
+    if (!parseTimeOfDay(input.timeOfDay)) {
+      return { success: false, error: 'A valid time of day is required, as HH:MM' };
+    }
+    if (input.kind === 'weekly' && (!Number.isInteger(input.weekday) || (input.weekday ?? -1) < 0 || (input.weekday ?? 7) > 6)) {
+      return { success: false, error: 'A weekday is required' };
+    }
+  } else {
+    return { success: false, error: 'Schedule kind must be interval, daily, or weekly' };
+  }
+
+  return { success: true, data: input as ScheduledRunInput };
+}

--- a/shared/types/daemon.ts
+++ b/shared/types/daemon.ts
@@ -92,6 +92,7 @@ export const DAEMON_OWNED_CHANNEL_PREFIXES = [
   'prompts:',
   'resource-monitor:',
   'runpane:',
+  'schedules:',
   'sessions:',
   'terminal:',
   'voice:',

--- a/shared/types/schedule.ts
+++ b/shared/types/schedule.ts
@@ -1,0 +1,61 @@
+/**
+ * Recurring agent runs.
+ *
+ * A scheduled run creates a session — the same way the create dialog does —
+ * with a fixed prompt, at a fixed time. Nightly bug sweeps, a weekly
+ * dependency check, a "review yesterday's diffs" pass every morning.
+ *
+ * Deliberately not cron syntax. Three shapes cover what people actually ask
+ * for, and each one can be stated in a sentence the UI can render back.
+ */
+
+export type ScheduleKind = 'interval' | 'daily' | 'weekly';
+
+export type ScheduleRunStatus = 'ok' | 'failed' | 'skipped';
+
+export interface ScheduledRun {
+  id: string;
+  name: string;
+  projectId: number;
+  /** Sent to the agent as the session's opening prompt. */
+  prompt: string;
+  /** Which agent to start; `none` opens a plain terminal. */
+  toolType: 'claude' | 'none';
+  /** Optional worktree/branch name template, as in the create dialog. */
+  worktreeTemplate?: string;
+  enabled: boolean;
+
+  kind: ScheduleKind;
+  /** `interval`: minutes between runs. */
+  intervalMinutes?: number;
+  /** `daily` and `weekly`: local time of day, `HH:MM`. */
+  timeOfDay?: string;
+  /** `weekly`: 0 = Sunday … 6 = Saturday. */
+  weekday?: number;
+
+  lastRunAtMs: number | null;
+  lastRunStatus: ScheduleRunStatus | null;
+  lastRunError: string | null;
+  /** Session created by the last successful run, for a link in the UI. */
+  lastSessionId: string | null;
+  nextRunAtMs: number | null;
+  createdAtMs: number;
+}
+
+export type ScheduledRunInput = Omit<
+  ScheduledRun,
+  'id' | 'lastRunAtMs' | 'lastRunStatus' | 'lastRunError' | 'lastSessionId' | 'nextRunAtMs' | 'createdAtMs'
+> & { id?: string };
+
+/** How often the scheduler wakes to look for due runs. */
+export const SCHEDULE_TICK_MS = 30_000;
+
+/**
+ * A run more than this late is not worth starting.
+ *
+ * Missed runs are skipped rather than caught up: waking a laptop after a
+ * weekend should not start three days of nightly sweeps at once.
+ */
+export const SCHEDULE_MISS_GRACE_MS = 15 * 60 * 1000;
+
+export const MIN_INTERVAL_MINUTES = 5;

--- a/shared/types/schedule.ts
+++ b/shared/types/schedule.ts
@@ -1,3 +1,6 @@
+import { boundary } from '../validation/boundaryDecoder';
+import type { BoundarySchema } from '../validation/boundaryDecoder';
+
 /**
  * Recurring agent runs.
  *
@@ -46,6 +49,20 @@ export type ScheduledRunInput = Omit<
   ScheduledRun,
   'id' | 'lastRunAtMs' | 'lastRunStatus' | 'lastRunError' | 'lastSessionId' | 'nextRunAtMs' | 'createdAtMs'
 > & { id?: string };
+
+export const scheduledRunInputSchema = boundary.object({
+  id: boundary.optional(boundary.string),
+  name: boundary.string,
+  projectId: boundary.number,
+  prompt: boundary.string,
+  toolType: boundary.enumeration('claude', 'none'),
+  worktreeTemplate: boundary.optional(boundary.string),
+  enabled: boundary.boolean,
+  kind: boundary.enumeration('interval', 'daily', 'weekly'),
+  intervalMinutes: boundary.optional(boundary.number),
+  timeOfDay: boundary.optional(boundary.string),
+  weekday: boundary.optional(boundary.number),
+}) satisfies BoundarySchema<ScheduledRunInput>;
 
 /** How often the scheduler wakes to look for due runs. */
 export const SCHEDULE_TICK_MS = 30_000;

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -10,6 +10,7 @@ import type {
   RemotePaneConnectionState,
 } from '../shared/types/remoteDaemon';
 import type { SubmitFeedbackRequest } from '../shared/types/feedback';
+import type { ScheduledRun, ScheduledRunInput } from '../shared/types/schedule';
 import type { JsonObject, JsonValue } from '../shared/validation/boundaryDecoder';
 
 type MockEventValue = JsonValue | object | undefined;
@@ -35,6 +36,7 @@ type ElectronApiMockOptions = {
   mainAnalyticsEvents?: AnalyticsMainEvent[];
   initialProjects?: JsonObject[];
   initialSessions?: JsonObject[];
+  initialSchedules?: ScheduledRun[];
   initialPanels?: JsonObject[];
   initialUiState?: Partial<{
     expandedProjects: number[];
@@ -211,6 +213,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     };
     let mockProjects = clone(mockOptions.initialProjects ?? []);
     let mockSessions = clone(mockOptions.initialSessions ?? []);
+    let mockSchedules = clone(mockOptions.initialSchedules ?? []);
     let mockPanels = clone(mockOptions.initialPanels ?? []);
     const uiState = {
       expandedProjects: [] satisfies number[],
@@ -560,6 +563,50 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         startActive: () => success(),
         stopActive: () => success(),
       }),
+      schedules: namespace({
+        list: (projectId?: number) => success(clone(
+          mockSchedules.filter((schedule) => projectId === undefined || schedule.projectId === projectId),
+        )),
+        save: (input: ScheduledRunInput) => {
+          const existingIndex = input.id
+            ? mockSchedules.findIndex((schedule) => schedule.id === input.id)
+            : -1;
+          const existing = existingIndex >= 0 ? mockSchedules[existingIndex] : undefined;
+          const schedule: ScheduledRun = {
+            ...input,
+            id: input.id ?? `schedule-${mockSchedules.length + 1}`,
+            lastRunAtMs: existing?.lastRunAtMs ?? null,
+            lastRunStatus: existing?.lastRunStatus ?? null,
+            lastRunError: existing?.lastRunError ?? null,
+            lastSessionId: existing?.lastSessionId ?? null,
+            nextRunAtMs: input.enabled ? Date.now() + 60 * 60_000 : null,
+            createdAtMs: existing?.createdAtMs ?? Date.now(),
+          };
+          if (existingIndex >= 0) mockSchedules[existingIndex] = schedule;
+          else mockSchedules.push(schedule);
+          return success(clone(schedule));
+        },
+        delete: (id: string) => {
+          mockSchedules = mockSchedules.filter((schedule) => schedule.id !== id);
+          return success();
+        },
+        setEnabled: (id: string, enabled: boolean) => {
+          const schedule = mockSchedules.find((candidate) => candidate.id === id);
+          if (!schedule) return Promise.resolve({ success: false, error: 'Schedule not found' });
+          schedule.enabled = enabled;
+          schedule.nextRunAtMs = enabled ? Date.now() + 60 * 60_000 : null;
+          return success(clone(schedule));
+        },
+        runNow: (id: string) => {
+          const schedule = mockSchedules.find((candidate) => candidate.id === id);
+          if (!schedule) return Promise.resolve({ success: false, error: 'Schedule not found' });
+          schedule.lastRunAtMs = Date.now();
+          schedule.lastRunStatus = 'ok';
+          schedule.lastRunError = null;
+          schedule.lastSessionId = 'scheduled-session-1';
+          return success(clone(schedule));
+        },
+      }),
       sessions: namespace({
         getOrCreateMainRepoSession: async (projectId: number) => {
           const delayMs = mockOptions.mainRepoSessionDelayByProjectId?.[projectId] ?? 0;
@@ -876,6 +923,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         getSessionsReadCount() {
           return sessionsGetCount;
+        },
+        getSchedules() {
+          return clone(mockSchedules);
         },
         getSessionDeleteCalls() {
           return clone(sessionDeleteCalls);

--- a/tests/scheduled-runs.spec.ts
+++ b/tests/scheduled-runs.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+const project = {
+  id: 1,
+  name: 'Scheduled QA',
+  path: '/tmp/scheduled-qa',
+  active: true,
+  created_at: '2026-08-23T00:00:00.000Z',
+  updated_at: '2026-08-23T00:00:00.000Z',
+};
+
+const scheduledSession = {
+  id: 'scheduled-session-1',
+  name: 'Scheduled result',
+  projectId: 1,
+  worktreePath: '/tmp/scheduled-result',
+  prompt: 'Review the latest changes',
+  status: 'stopped',
+  createdAt: '2026-08-23T00:00:00.000Z',
+  lastActivity: '2026-08-23T00:00:00.000Z',
+  output: [],
+  jsonMessages: [],
+  permissionMode: 'ignore',
+  toolType: 'claude',
+  archived: false,
+  isHidden: false,
+  isFavorite: false,
+};
+
+test('manages a scheduled run and opens its resulting session', async ({ page }) => {
+  await page.setViewportSize({ width: 1_440, height: 900 });
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [scheduledSession],
+    activeProjectId: project.id,
+    initialUiState: {
+      expandedProjects: [project.id],
+      repositoriesSectionExpanded: true,
+    },
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await page.getByRole('button', { name: `Repository actions for ${project.name}` }).click();
+  await page.getByText('Scheduled runs', { exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Scheduled runs' });
+  await expect(dialog).toBeVisible();
+  await expect(page.getByText('No scheduled runs yet.')).toBeVisible();
+  await page.screenshot({ path: 'tmp/pr-386-qa/01-empty-scheduled-runs.png' });
+
+  await page.getByRole('button', { name: 'New scheduled run' }).click();
+  await page.getByPlaceholder('Nightly sweep').fill('QA sweep');
+  await page.getByPlaceholder('Look for flaky tests and open an issue for each one you can reproduce.')
+    .fill('Review the latest changes');
+  await page.getByLabel('Repeats').selectOption('weekly');
+  await dialog.getByRole('combobox').nth(2).selectOption('2');
+  await dialog.getByRole('textbox', { name: 'At', exact: true }).fill('09:15');
+  await page.screenshot({ path: 'tmp/pr-386-qa/02-weekly-schedule-form.png' });
+  await page.getByRole('button', { name: 'Save schedule' }).click();
+
+  await expect(page.getByText('QA sweep', { exact: true })).toBeVisible();
+  await expect(page.getByText(/Every Tuesday at 09:15/)).toBeVisible();
+  await page.getByTitle('Pause').click();
+  await expect(page.getByTitle('Resume')).toBeVisible();
+  await page.getByTitle('Run now, without moving the schedule').click();
+  await expect(page.getByRole('button', { name: 'Open last session' })).toBeVisible();
+  await page.screenshot({ path: 'tmp/pr-386-qa/03-run-complete-and-paused.png' });
+
+  await page.getByRole('button', { name: 'Open last session' }).click();
+  await expect(page.getByText('Scheduled result', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+});


### PR DESCRIPTION
## Description

Let a project start agent sessions on a schedule: a fixed prompt, at a fixed time, in a fresh worktree.

<img width="3648" height="1870" alt="image" src="https://github.com/user-attachments/assets/b9dc90ea-9a83-4abe-871a-366aa6e95cc8" />


Pane already knows how to create a session from a prompt — this makes that repeatable without a person present. Nightly bug sweeps, a weekly dependency check, a "review yesterday's diffs" pass every morning: the work that is worth doing regularly but never worth remembering.

A new **Scheduled runs** entry in the project's menu manages them.

### What it does

- Three schedule shapes rather than cron syntax: **every N minutes**, **daily at HH:MM**, **weekly on a weekday at HH:MM**. Each one can be stated in a sentence, which is what the dialog shows back to you (`Every day at 03:00 — next run in 4h 12m`). Cron is more expressive than anyone actually needs here and impossible to render as a sentence.
- Each run creates a real session, exactly as the create dialog would: prompt, agent (`claude`, or `none` for a plain terminal) and an optional worktree/branch template.
- Per-run state is visible: last run, its outcome, the error if it failed, and a link to the session it created.
- Enable/disable without deleting, and **Run now** — which starts one immediately *without* moving the cadence, so testing a schedule at 15:00 does not shift the nightly run.
- Missed runs are **skipped, not caught up**. Waking a laptop after a weekend must not start three days of nightly sweeps at once; a run more than 15 minutes late is recorded as skipped and the schedule moves on.
- Deleting a project deletes its schedules (`ON DELETE CASCADE`).

### How it works

- `scheduleCalculator.ts` is pure and holds every decision about *when*: `computeNextRun`, `isDue`, `isMissed`. Time zones, daylight saving and "the next weekly run when today already passed" are the parts that break silently, so they are unit-tested directly rather than through the scheduler.
- `ScheduleManager` ticks every 30s and asks the calculator; it talks to storage through a small `ScheduleStore` interface, so its behaviour is tested without a database.
- Sessions are created through the existing task queue with `createSessionAndWait`, so `lastSessionId` is the real session id rather than a queue job id — the difference only shows up when you click the link.
- Persistence is one table, `scheduled_runs`, plus an index on `(enabled, next_run_at_ms)` so the tick is a single indexed lookup.
- Channels are daemon-owned (`schedules:*`): the schedule belongs to the machine that runs the agents.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
- [x] State management/IPC events

## Additional Notes

Schema note: `schema.sql` is split on the statement separator at startup, so a `;` inside a comment breaks the database. The new block is written accordingly.

Tested in the running app, not only in unit tests: a schedule was created, fired on its own tick, produced a real session in a fresh worktree, recorded its outcome, and was then disabled and deleted. Missed-run handling was exercised by moving a schedule's due time into the past.


<!-- pr-test-automation-summary:start -->
## Automated QA

Status: Passed on `d14e9878` with synthetic project `Scheduled QA`.

- Playwright covered empty state, weekly form entry, save, pause/resume, Run now, persisted success state, and opening the resulting session.
- Node 22 gates passed: root typecheck, full lint, and 65 focused main-process tests.
- Native Electron dev launch succeeded with isolated data at `/tmp/pane-pr386-qa`. macOS accessibility automation was unavailable, so renderer interaction used the repository Playwright Electron API mock.

| Empty state | Weekly schedule form | Run complete and paused |
| --- | --- | --- |
| <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-386-d14e9878-866d39c72db9-01-empty-scheduled-runs.png" width="360" alt="Empty scheduled runs dialog"> | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-386-d14e9878-a9ffde848a3f-02-weekly-schedule-form.png" width="360" alt="Filled weekly scheduled run form"> | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-386-d14e9878-ec4d9e181d73-03-run-complete-and-paused.png" width="360" alt="Paused scheduled run after successful Run now"> |

Remaining human check: allow one real scheduled run to fire in a fresh worktree with the preferred installed agent.
<!-- pr-test-automation-summary:end -->

