### PR TITLE
Open pull requests from Pane, and follow them from the review panel

### DIFF
--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -23,6 +23,7 @@ interface DetailPanelProps {
   onSwapLayout?: () => void;
   terminalShortcuts?: React.ReactNode;
   onCommitClick?: (hash: string) => void;
+  onCommitFileClick?: (hash: string, path: string) => void;
 }
 
 const sidebarButtonClass = 'w-full justify-start text-sm !px-2';

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -53,6 +53,7 @@ export function DetailPanel({
   onSwapLayout,
   terminalShortcuts,
   onCommitClick,
+  onCommitFileClick,
 }: DetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(state => state.immersiveMode);
@@ -90,6 +91,7 @@ export function DetailPanel({
         onSwapLayout={onSwapLayout}
         terminalShortcuts={terminalShortcuts}
         onCommitClick={onCommitClick}
+        onCommitFileClick={onCommitFileClick}
       />
     );
   }
@@ -251,6 +253,8 @@ export function DetailPanel({
                 sessionId={session.id}
                 baseBranch={session.baseBranch || 'main'}
                 onCommitClick={onCommitClick}
+                expandable
+                onFileClick={onCommitFileClick}
               />
             </div>
           </div>

--- a/frontend/src/components/ExecutionList.tsx
+++ b/frontend/src/components/ExecutionList.tsx
@@ -1,8 +1,18 @@
-import React, { useState, memo } from 'react';
-import { RotateCcw, GitCommitHorizontal } from 'lucide-react';
-import type { ExecutionListProps } from '../types/diff';
+import React, { useState, memo, useCallback } from 'react';
+import { RotateCcw, GitCommitHorizontal, ChevronRight, ChevronDown } from 'lucide-react';
+import type { ExecutionListProps, ExecutionDiff } from '../types/diff';
+import { CommitFileList } from './git/CommitFileList';
 import { useScrollSurface } from '../hooks/useScrollSurface';
 
+/** Pseudo-ref the backend understands for uncommitted working-tree changes. */
+const WORKING_TREE_REF = 'index';
+
+function executionRef(execution: ExecutionDiff): string | null {
+  if (execution.id === 0) return WORKING_TREE_REF;
+  const hash = execution.after_commit_hash;
+  if (!hash || hash === 'UNCOMMITTED') return null;
+  return hash;
+}
 const ExecutionList: React.FC<ExecutionListProps> = memo(({
   sessionId,
   executions,
@@ -12,9 +22,11 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
   onRevert,
   onRestore,
   historyLimitReached = false,
-  historyLimit
+  historyLimit,
+  onFileClick
 }) => {
   const [rangeStart, setRangeStart] = useState<number | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const limitDisplay = historyLimit ?? 50;
   const executionListRef = React.useRef<HTMLDivElement>(null);
   const scrollSurfaceRef = useScrollSurface<HTMLDivElement>({
@@ -23,6 +35,15 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
     priority: 80,
     ownerElement: () => executionListRef.current,
   });
+
+  const toggleExpanded = useCallback((executionId: number) => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(executionId)) next.delete(executionId);
+      else next.add(executionId);
+      return next;
+    });
+  }, []);
 
   const handleCommitClick = (executionId: number, event: React.MouseEvent) => {
     if (event.shiftKey && rangeStart !== null) {
@@ -89,10 +110,14 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
           const isUncommitted = execution.id === 0;
           const isFirst = idx === 0;
           const isLast = idx === executions.length - 1;
+          const commitRef = executionRef(execution);
+          const isExpanded = expandedIds.has(execution.id);
+          const canExpand = commitRef !== null && execution.stats_files_changed > 0;
+          const filesPanelId = `execution-files-${execution.id}`;
 
           return (
+            <div key={execution.id}>
             <div
-              key={execution.id}
               className={`
                 group relative flex items-stretch gap-2 px-3 transition-colors
                 ${isSelected ? 'bg-interactive/10 border-l-2 border-l-interactive' : 'border-l-2 border-l-transparent hover:bg-surface-hover'}
@@ -138,17 +163,35 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
 
                 {/* Stats + actions */}
                 <div className="flex items-start justify-between mt-0.5">
-                  <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
-                    {execution.stats_files_changed > 0 ? (
-                      <>
-                        <span className="text-status-success">+{execution.stats_additions}</span>
-                        <span className="text-status-error">-{execution.stats_deletions}</span>
-                        <span>{execution.stats_files_changed} {execution.stats_files_changed === 1 ? 'file' : 'files'}</span>
-                      </>
-                    ) : (
-                      <span>No changes</span>
-                    )}
-                  </div>
+                  {canExpand ? (
+                    <button
+                      type="button"
+                      aria-expanded={isExpanded}
+                      aria-controls={filesPanelId}
+                      aria-label={`${isExpanded ? 'Hide' : 'Show'} changed files`}
+                      onClick={(e) => { e.stopPropagation(); toggleExpanded(execution.id); }}
+                      className="pointer-events-auto -ml-0.5 flex items-center gap-1 rounded px-0.5 text-[10px] text-text-muted transition-colors hover:text-text-secondary focus:outline-none focus:ring-1 focus:ring-interactive"
+                    >
+                      {isExpanded
+                        ? <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                        : <ChevronRight className="h-3 w-3 flex-shrink-0" aria-hidden="true" />}
+                      <span className="text-status-success">+{execution.stats_additions}</span>
+                      <span className="text-status-error">-{execution.stats_deletions}</span>
+                      <span>{execution.stats_files_changed} {execution.stats_files_changed === 1 ? 'file' : 'files'}</span>
+                    </button>
+                  ) : (
+                    <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
+                      {execution.stats_files_changed > 0 ? (
+                        <>
+                          <span className="text-status-success">+{execution.stats_additions}</span>
+                          <span className="text-status-error">-{execution.stats_deletions}</span>
+                          <span>{execution.stats_files_changed} {execution.stats_files_changed === 1 ? 'file' : 'files'}</span>
+                        </>
+                      ) : (
+                        <span>No changes</span>
+                      )}
+                    </div>
+                  )}
                   <div className="pointer-events-auto flex flex-col items-end gap-0.5 flex-shrink-0">
                     {isUncommitted && onCommit && execution.stats_files_changed > 0 && (
                       <button
@@ -182,6 +225,19 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
                   </div>
                 </div>
               </div>
+            </div>
+            {isExpanded && commitRef && (
+              <div
+                id={filesPanelId}
+                className={`border-l-2 ${isSelected ? 'border-l-interactive bg-interactive/5' : 'border-l-transparent'} pl-3`}
+              >
+                <CommitFileList
+                  sessionId={sessionId}
+                  commitRef={commitRef}
+                  onFileClick={onFileClick}
+                />
+              </div>
+            )}
             </div>
           );
         })}

--- a/frontend/src/components/GitHistoryGraph.tsx
+++ b/frontend/src/components/GitHistoryGraph.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, memo } from 'react';
 import { API } from '../utils/api';
-import { Loader2, GitCommitHorizontal, FileText, Plus, Minus, User, Clock, Hash, GitFork } from 'lucide-react';
+import { Loader2, GitCommitHorizontal, FileText, Plus, Minus, User, Clock, Hash, GitFork, ChevronRight, ChevronDown } from 'lucide-react';
 import { Tooltip } from './ui/Tooltip';
 import { CopyableField } from './ui/CopyableField';
+import { CommitFileList } from './git/CommitFileList';
 
 interface GitGraphCommitData {
   hash: string;
@@ -27,6 +28,13 @@ interface GitHistoryGraphProps {
   baseBranch: string;
   layout?: 'compact' | 'wide';
   onCommitClick?: (hash: string) => void;
+  /**
+   * Show a per-commit toggle that lists the files the commit touched.
+   * Only meaningful in the `wide` layout — the compact sidebar has no room.
+   */
+  expandable?: boolean;
+  /** Called when a file inside an expanded commit is activated. */
+  onFileClick?: (hash: string, path: string) => void;
 }
 
 function CommitTooltipContent({ entry }: { entry: GitGraphCommitData }) {
@@ -92,11 +100,21 @@ const CommitRow = memo(function CommitRow({
   isLast,
   layout = 'compact',
   onClick,
+  sessionId,
+  expandable = false,
+  isExpanded = false,
+  onToggleExpand,
+  onFileClick,
 }: {
   entry: GitGraphCommitData;
   isLast: boolean;
   layout?: 'compact' | 'wide';
   onClick?: (hash: string) => void;
+  sessionId: string;
+  expandable?: boolean;
+  isExpanded?: boolean;
+  onToggleExpand?: (hash: string) => void;
+  onFileClick?: (hash: string, path: string) => void;
 }) {
   const isIndex = entry.hash === 'index';
   const date = new Date(entry.committerDate);
@@ -183,7 +201,39 @@ const CommitRow = memo(function CommitRow({
       </Row>
   );
 
-  if (layout === 'wide') return row;
+  if (layout === 'wide') {
+    if (!expandable) return row;
+
+    const filesPanelId = `git-history-files-${entry.hash}`;
+    return (
+      <div>
+        <div className="flex items-stretch">
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            aria-controls={filesPanelId}
+            aria-label={`${isExpanded ? 'Hide' : 'Show'} files changed in ${entry.hash === 'index' ? 'uncommitted changes' : entry.hash.slice(0, 7)}`}
+            onClick={() => onToggleExpand?.(entry.hash)}
+            className="flex flex-shrink-0 items-center rounded-sm px-0.5 text-text-muted transition-colors hover:text-text-secondary focus:outline-none focus:ring-1 focus:ring-inset focus:ring-interactive"
+          >
+            {isExpanded
+              ? <ChevronDown className="h-3 w-3" aria-hidden="true" />
+              : <ChevronRight className="h-3 w-3" aria-hidden="true" />}
+          </button>
+          <div className="min-w-0 flex-1">{row}</div>
+        </div>
+        {isExpanded && (
+          <div id={filesPanelId} className="ml-4 border-l border-border-secondary">
+            <CommitFileList
+              sessionId={sessionId}
+              commitRef={entry.hash}
+              onFileClick={onFileClick}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <Tooltip content={<CommitTooltipContent entry={entry} />} side="left" interactive>
@@ -192,11 +242,28 @@ const CommitRow = memo(function CommitRow({
   );
 });
 
-export function GitHistoryGraph({ sessionId, baseBranch, layout = 'compact', onCommitClick }: GitHistoryGraphProps) {
+export function GitHistoryGraph({
+  sessionId,
+  baseBranch,
+  layout = 'compact',
+  onCommitClick,
+  expandable = false,
+  onFileClick,
+}: GitHistoryGraphProps) {
   const [rawEntries, setRawEntries] = useState<GitGraphCommitData[]>([]);
   const [currentBranch, setCurrentBranch] = useState(baseBranch);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [expandedHashes, setExpandedHashes] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = useCallback((hash: string) => {
+    setExpandedHashes(prev => {
+      const next = new Set(prev);
+      if (next.has(hash)) next.delete(hash);
+      else next.add(hash);
+      return next;
+    });
+  }, []);
 
   const fetchGraph = useCallback(async () => {
     try {
@@ -288,6 +355,11 @@ export function GitHistoryGraph({ sessionId, baseBranch, layout = 'compact', onC
             isLast={i === rawEntries.length - 1}
             layout={layout}
             onClick={onCommitClick}
+            sessionId={sessionId}
+            expandable={expandable}
+            isExpanded={expandedHashes.has(entry.hash)}
+            onToggleExpand={toggleExpanded}
+            onFileClick={onFileClick}
           />
         ))}
       </div>

--- a/frontend/src/components/HorizontalDetailPanel.tsx
+++ b/frontend/src/components/HorizontalDetailPanel.tsx
@@ -17,6 +17,7 @@ interface HorizontalDetailPanelProps {
   onSwapLayout?: () => void;
   terminalShortcuts?: React.ReactNode;
   onCommitClick?: (hash: string) => void;
+  onCommitFileClick?: (hash: string, path: string) => void;
 }
 
 export function HorizontalDetailPanel({
@@ -28,6 +29,7 @@ export function HorizontalDetailPanel({
   onSwapLayout,
   terminalShortcuts,
   onCommitClick,
+  onCommitFileClick,
 }: HorizontalDetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(state => state.immersiveMode);
@@ -191,6 +193,8 @@ export function HorizontalDetailPanel({
               baseBranch={session.baseBranch || 'main'}
               layout="wide"
               onCommitClick={onCommitClick}
+              expandable
+              onFileClick={onCommitFileClick}
             />
           </div>
         )}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -578,23 +578,31 @@ export const SessionView = memo(() => {
   );
 
   const handleCommitClick = useCallback(
-    async (commitHash: string) => {
+    async (commitHash: string, filePath?: string) => {
       if (!activeSession || sessionPanels.length === 0) return;
       const diffPanel = sessionPanels.find(p => p.type === 'diff');
       if (!diffPanel) return;
       // Store pending hash before dispatching — if the diff panel is not
       // currently active, CombinedDiffView is unmounted and will read this
       // module-level variable when it mounts after the panel switch.
-      setPendingViewCommit(activeSession.id, commitHash);
+      setPendingViewCommit(activeSession.id, commitHash, filePath);
       requestLocalReviewMode(activeSession.id);
       await handlePanelSelect(diffPanel);
       window.setTimeout(() => {
         window.dispatchEvent(new CustomEvent('diff:view-commit', {
-          detail: { sessionId: activeSession.id, commitHash },
+          detail: { sessionId: activeSession.id, commitHash, filePath },
         }));
       }, 0);
     },
     [activeSession, sessionPanels, handlePanelSelect]
+  );
+
+  // A file inside an expanded commit in the history graph was clicked.
+  const handleCommitFileClick = useCallback(
+    (commitHash: string, filePath: string) => {
+      void handleCommitClick(commitHash, filePath);
+    },
+    [handleCommitClick]
   );
 
   // Tab cycling: navigates between panels in the focused group using
@@ -1727,6 +1735,7 @@ export const SessionView = memo(() => {
                   onToggleCollapse={toggleDetailCollapse}
                   onSwapLayout={toggleLayoutSwap}
                   onCommitClick={handleCommitClick}
+                  onCommitFileClick={handleCommitFileClick}
                   terminalShortcuts={
                     <>
                       {agentPresets.map(preset => (
@@ -1936,6 +1945,7 @@ export const SessionView = memo(() => {
                 mergeError={hook.mergeError}
                 onSwapLayout={toggleLayoutSwap}
                 onCommitClick={handleCommitClick}
+                onCommitFileClick={handleCommitFileClick}
               />
             </>
           )}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -16,6 +16,7 @@ import { CommitMessageDialog } from './session/CommitMessageDialog';
 import { FolderArchiveDialog } from './session/FolderArchiveDialog';
 import { ConfirmDialog } from './ConfirmDialog';
 import { ProjectView } from './ProjectView';
+import { CreatePullRequestDialog } from './git/CreatePullRequestDialog';
 import { API } from '../utils/api';
 import { useResizable } from '../hooks/useResizable';
 import { useResizableHeight } from '../hooks/useResizableHeight';
@@ -47,7 +48,7 @@ import {
   mergeAllGroups,
   type DropZone,
 } from '../utils/panelLayout';
-import { Download, Upload, GitMerge, GitPullRequestArrow, Terminal, ChevronDown, ChevronUp, RefreshCw, Archive, ArchiveRestore, GitCommitHorizontal, TerminalSquare, Undo2, X } from 'lucide-react';
+import { Download, Upload, GitMerge, GitPullRequest, GitPullRequestArrow, Terminal, ChevronDown, ChevronUp, RefreshCw, Archive, ArchiveRestore, GitCommitHorizontal, TerminalSquare, Undo2, X } from 'lucide-react';
 import { getCliBrandIcon } from './ui/brandIconRegistry';
 import { visibleAgentPresets } from '../utils/agentPresets';
 import type { Project } from '../types/project';
@@ -73,6 +74,7 @@ export const SessionView = memo(() => {
   const [isProjectLoading, setIsProjectLoading] = useState(false);
   const [sessionProject, setSessionProject] = useState<Project | null>(null);
   const [showSetTrackingDialog, setShowSetTrackingDialog] = useState(false);
+  const [showCreatePrDialog, setShowCreatePrDialog] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
   const [currentUpstream, setCurrentUpstream] = useState<string | null>(null);
 
@@ -1590,6 +1592,25 @@ export const SessionView = memo(() => {
           : 'No commits to push',
         disabledReason: busyReason ?? (activeSession.gitStatus?.ahead ? undefined : 'No commits to push'),
       },
+      {
+        id: 'create-pull-request',
+        label: activeSession.gitStatus?.prNumber ? `Pull Request #${activeSession.gitStatus.prNumber}` : 'Create Pull Request',
+        icon: GitPullRequest,
+        onClick: () => {
+          // An existing pull request is a link, not a form.
+          if (activeSession.gitStatus?.prUrl) {
+            void window.electronAPI.openExternal(activeSession.gitStatus.prUrl);
+            return;
+          }
+          setShowCreatePrDialog(true);
+        },
+        disabled: hook.isMerging || activeSession.status === 'initializing',
+        variant: 'default' as const,
+        description: activeSession.gitStatus?.prNumber
+          ? 'Open this branch’s pull request on GitHub'
+          : 'Push this branch and open a pull request',
+        disabledReason: busyReason,
+      },
       // --- Main branch operations (last) ---
       {
         id: 'rebase-from-main',
@@ -1953,6 +1974,15 @@ export const SessionView = memo(() => {
 
       </SessionProvider>
 
+      {activeSession && (
+        <CreatePullRequestDialog
+          sessionId={activeSession.id}
+          sessionName={activeSession.name}
+          isOpen={showCreatePrDialog}
+          onClose={() => setShowCreatePrDialog(false)}
+          onCreated={(url) => { void window.electronAPI.openExternal(url); }}
+        />
+      )}
       <CommitMessageDialog
         isOpen={hook.showCommitMessageDialog}
         onClose={() => hook.setShowCommitMessageDialog(false)}

--- a/frontend/src/components/git/BranchCombobox.tsx
+++ b/frontend/src/components/git/BranchCombobox.tsx
@@ -106,6 +106,7 @@ export function BranchCombobox({
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: MouseEvent) => {
+      // SAFETY: DOM mouse events always expose a Node target while dispatched from document.
       const target = event.target as Node;
       if (inputRef.current?.contains(target) || menuRef.current?.contains(target)) return;
       setOpen(false);
@@ -247,5 +248,3 @@ export function BranchCombobox({
     </div>
   );
 }
-
-export default BranchCombobox;

--- a/frontend/src/components/git/BranchCombobox.tsx
+++ b/frontend/src/components/git/BranchCombobox.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronDown, Loader2 } from 'lucide-react';
+import { filterBranches } from './branchFilter';
+import { usePortalContainer } from '../../contexts/PortalContainerContext';
+
+export interface BranchComboboxProps {
+  value: string;
+  branches: string[];
+  /**
+   * The short list shown first — the branches this clone knows. The rest stay
+   * one click away; an upstream with 191 branches is not a menu.
+   */
+  primaryBranches?: string[];
+  /** Named in the "show all" row, e.g. `dcouple/Pane`. */
+  allLabel?: string;
+  onChange: (branch: string) => void;
+  loading?: boolean;
+  placeholder?: string;
+  id?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Pick a branch from a long list, or type one that is not in it yet.
+ *
+ * Deliberately not a `<datalist>`: the browser filters those against the text
+ * already in the field, so a field holding "main" offers only `main*` and hides
+ * every other branch — which looks like the list itself is broken. Here the
+ * full list opens on click and typing *ranks* it instead of cutting it down.
+ *
+ * The menu is portalled into the dialog's own portal container: the dialog body
+ * scrolls, so an absolutely positioned list would be clipped by it — but a
+ * portal to `document.body` lands *behind* the modal and outside its pointer
+ * scope, which looks exactly like a dropdown that refuses to open.
+ */
+export function BranchCombobox({
+  value,
+  branches,
+  primaryBranches,
+  allLabel,
+  onChange,
+  loading = false,
+  placeholder = 'main',
+  id,
+  'aria-label': ariaLabel = 'Base branch',
+}: BranchComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState<string | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [showAll, setShowAll] = useState(false);
+  const [rect, setRect] = useState<{ top: number; left: number; width: number; flip: boolean } | null>(null);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  // The modal's container sits inside its stacking and pointer scope; falling
+  // back to the body keeps the component usable outside a modal.
+  const portalContainer = usePortalContainer();
+
+  // `query === null` means "untouched since opening", which shows the list as
+  // it is; the moment the user types, ranking takes over.
+  const shortList = primaryBranches?.length ? primaryBranches : branches;
+  const visible = showAll ? branches : shortList;
+
+  const matches = useMemo(
+    () => filterBranches(visible, query ?? ''),
+    [visible, query]
+  );
+
+  /**
+   * How many further branches the target has that the short list hides. Shown
+   * as a row rather than silently dropped — a hidden branch reads as a bug.
+   */
+  const hiddenCount = useMemo(() => {
+    if (showAll || visible === branches) return 0;
+    return Math.max(0, filterBranches(branches, query ?? '', Number.MAX_SAFE_INTEGER).length - matches.length);
+  }, [showAll, visible, branches, query, matches.length]);
+
+  const position = useCallback(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    const box = input.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - box.bottom;
+    setRect({
+      top: spaceBelow < 220 ? box.top : box.bottom,
+      left: box.left,
+      width: box.width,
+      flip: spaceBelow < 220,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    position();
+
+    const onScrollOrResize = () => position();
+    window.addEventListener('resize', onScrollOrResize);
+    // Capture phase: the dialog body is the element that actually scrolls.
+    window.addEventListener('scroll', onScrollOrResize, true);
+    return () => {
+      window.removeEventListener('resize', onScrollOrResize);
+      window.removeEventListener('scroll', onScrollOrResize, true);
+    };
+  }, [open, position]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (inputRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
+      setQuery(null);
+      setShowAll(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [open]);
+
+  const commit = useCallback((branch: string) => {
+    onChange(branch);
+    setQuery(null);
+    setOpen(false);
+    setShowAll(false);
+    inputRef.current?.focus();
+  }, [onChange]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) {
+        setOpen(true);
+        setActiveIndex(0);
+        return;
+      }
+      const step = event.key === 'ArrowDown' ? 1 : -1;
+      setActiveIndex(current => {
+        if (matches.length === 0) return 0;
+        return (current + step + matches.length) % matches.length;
+      });
+      return;
+    }
+
+    if (event.key === 'Enter' && open && matches[activeIndex]) {
+      event.preventDefault();
+      commit(matches[activeIndex]);
+      return;
+    }
+
+    if (event.key === 'Escape' && open) {
+      // Swallowed on purpose: closing the menu must not also close the dialog.
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+      setQuery(null);
+    }
+  };
+
+  // Keep the highlighted row in view while arrowing through a long list.
+  useEffect(() => {
+    if (!open) return;
+    menuRef.current
+      ?.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`)
+      ?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, open]);
+
+  // pointer-events-auto on the menu itself: the modal's container is
+  // click-through so it does not swallow clicks meant for the dialog.
+  const menu = open && rect && createPortal(
+    <div
+      ref={menuRef}
+      role="listbox"
+      aria-label={ariaLabel}
+      style={{
+        position: 'fixed',
+        top: rect.flip ? undefined : rect.top,
+        bottom: rect.flip ? window.innerHeight - rect.top : undefined,
+        left: rect.left,
+        width: rect.width,
+      }}
+      className="pointer-events-auto z-[1000] max-h-56 overflow-y-auto rounded border border-border-primary bg-surface-primary py-1 shadow-lg"
+    >
+      {matches.length === 0 && hiddenCount === 0 ? (
+        <div className="px-2 py-1.5 text-xs text-text-muted">
+          {branches.length === 0 ? 'No branches loaded' : 'No branch matches'}
+        </div>
+      ) : (
+        matches.map((branch, index) => (
+          <button
+            key={branch}
+            type="button"
+            role="option"
+            data-index={index}
+            aria-selected={branch === value}
+            onMouseEnter={() => setActiveIndex(index)}
+            onClick={() => commit(branch)}
+            className={`block w-full truncate px-2 py-1 text-left text-xs ${
+              index === activeIndex ? 'bg-surface-hover text-text-primary' : 'text-text-secondary'
+            } ${branch === value ? 'font-semibold' : ''}`}
+          >
+            {branch}
+          </button>
+        ))
+      )}
+
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={() => { setShowAll(true); setActiveIndex(0); }}
+          className="mt-1 block w-full border-t border-border-secondary px-2 py-1.5 text-left text-[11px] text-text-muted transition-colors hover:bg-surface-hover hover:text-text-secondary"
+        >
+          Show {hiddenCount} more{allLabel ? ` in ${allLabel}` : ''}
+        </button>
+      )}
+    </div>,
+    portalContainer ?? document.body
+  );
+
+  return (
+    <div className="relative">
+      <input
+        id={id}
+        ref={inputRef}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={open ? `${id ?? 'branch'}-listbox` : undefined}
+        aria-autocomplete="list"
+        aria-label={ariaLabel}
+        value={query ?? value}
+        placeholder={placeholder}
+        onChange={event => {
+          setQuery(event.target.value);
+          onChange(event.target.value);
+          setActiveIndex(0);
+          setOpen(true);
+        }}
+        onFocus={() => { setOpen(true); setActiveIndex(0); }}
+        onClick={() => { setOpen(true); }}
+        onKeyDown={handleKeyDown}
+        className="w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 pr-7 text-sm text-text-primary focus:border-interactive focus:outline-none"
+      />
+      <span className="pointer-events-none absolute inset-y-0 right-1.5 flex items-center text-text-muted">
+        {loading
+          ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          : <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />}
+      </span>
+      {menu}
+    </div>
+  );
+}
+
+export default BranchCombobox;

--- a/frontend/src/components/git/CommitFileList.tsx
+++ b/frontend/src/components/git/CommitFileList.tsx
@@ -1,109 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { API } from '../../utils/api';
-import type { GitCommitFileChange, GitCommitFilesResult, GitFileChangeStatus } from '../../../../shared/types/git';
+import type { GitCommitFilesResult } from '../../../../shared/types/git';
 import { readCommitFileCache, writeCommitFileCache } from './commitFileCache';
-
-const STATUS_LABEL: Record<GitFileChangeStatus, string> = {
-  added: 'A',
-  modified: 'M',
-  deleted: 'D',
-  renamed: 'R',
-  copied: 'C',
-  typechange: 'T',
-  unmerged: 'U',
-  unknown: '?',
-};
-
-const STATUS_CLASS: Record<GitFileChangeStatus, string> = {
-  added: 'text-status-success',
-  modified: 'text-interactive',
-  deleted: 'text-status-error',
-  renamed: 'text-interactive',
-  copied: 'text-interactive',
-  typechange: 'text-status-warning',
-  unmerged: 'text-status-warning',
-  unknown: 'text-text-muted',
-};
-
-const STATUS_TITLE: Record<GitFileChangeStatus, string> = {
-  added: 'Added',
-  modified: 'Modified',
-  deleted: 'Deleted',
-  renamed: 'Renamed',
-  copied: 'Copied',
-  typechange: 'Type changed',
-  unmerged: 'Unmerged',
-  unknown: 'Unknown change',
-};
-
-function splitPath(path: string): { dir: string; name: string } {
-  const idx = path.lastIndexOf('/');
-  if (idx < 0) return { dir: '', name: path };
-  return { dir: path.slice(0, idx + 1), name: path.slice(idx + 1) };
-}
-
-function FileRow({
-  file,
-  onClick,
-}: {
-  file: GitCommitFileChange;
-  onClick?: () => void;
-}) {
-  const { dir, name } = splitPath(file.path);
-  const statusTitle = STATUS_TITLE[file.status];
-  const title = file.status === 'renamed' || file.status === 'copied'
-    ? `${statusTitle} from ${file.oldPath} to ${file.path}`
-    : `${statusTitle}: ${file.path}`;
-
-  const body = (
-    <>
-      <span
-        className={`w-3 flex-shrink-0 font-mono text-[10px] leading-none ${STATUS_CLASS[file.status]}`}
-        aria-hidden="true"
-      >
-        {STATUS_LABEL[file.status]}
-      </span>
-      <span className="min-w-0 flex-1 truncate text-left text-[11px] leading-snug">
-        {dir && <span className="text-text-muted">{dir}</span>}
-        <span className="text-text-secondary">{name}</span>
-      </span>
-      <span className="flex flex-shrink-0 items-center gap-1 font-mono text-[10px] leading-none">
-        {file.isBinary ? (
-          <span className="text-text-muted">bin</span>
-        ) : (
-          <>
-            {(file.additions ?? 0) > 0 && <span className="text-status-success">+{file.additions}</span>}
-            {(file.deletions ?? 0) > 0 && <span className="text-status-error">-{file.deletions}</span>}
-            {file.additions === null && file.deletions === null && (
-              <span className="text-text-muted">new</span>
-            )}
-          </>
-        )}
-      </span>
-    </>
-  );
-
-  if (!onClick) {
-    return (
-      <div className="flex items-center gap-1.5 py-0.5 pl-6 pr-2" title={title}>
-        {body}
-      </div>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      aria-label={`${statusTitle}: ${file.path}. Show diff.`}
-      className="flex w-full items-center gap-1.5 rounded-sm py-0.5 pl-6 pr-2 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-inset focus:ring-interactive"
-    >
-      {body}
-    </button>
-  );
-}
+import { FileChangeList } from './FileChangeList';
 
 export interface CommitFileListProps {
   sessionId: string;
@@ -187,13 +87,10 @@ export function CommitFileList({ sessionId, commitRef, onFileClick, className = 
           Merge commit — showing changes against the first parent
         </div>
       )}
-      {result.files.map(file => (
-        <FileRow
-          key={`${file.status}-${file.oldPath}-${file.path}`}
-          file={file}
-          onClick={onFileClick ? () => onFileClick(commitRef, file.path) : undefined}
-        />
-      ))}
+      <FileChangeList
+        files={result.files}
+        onFileClick={onFileClick ? path => onFileClick(commitRef, path) : undefined}
+      />
       {result.truncated && (
         <div className="py-0.5 pl-6 pr-2 text-[10px] text-text-muted">
           Showing {result.files.length} of {result.totalFiles} files

--- a/frontend/src/components/git/CommitFileList.tsx
+++ b/frontend/src/components/git/CommitFileList.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { API } from '../../utils/api';
+import type { GitCommitFileChange, GitCommitFilesResult, GitFileChangeStatus } from '../../../../shared/types/git';
+import { readCommitFileCache, writeCommitFileCache } from './commitFileCache';
+
+const STATUS_LABEL: Record<GitFileChangeStatus, string> = {
+  added: 'A',
+  modified: 'M',
+  deleted: 'D',
+  renamed: 'R',
+  copied: 'C',
+  typechange: 'T',
+  unmerged: 'U',
+  unknown: '?',
+};
+
+const STATUS_CLASS: Record<GitFileChangeStatus, string> = {
+  added: 'text-status-success',
+  modified: 'text-interactive',
+  deleted: 'text-status-error',
+  renamed: 'text-interactive',
+  copied: 'text-interactive',
+  typechange: 'text-status-warning',
+  unmerged: 'text-status-warning',
+  unknown: 'text-text-muted',
+};
+
+const STATUS_TITLE: Record<GitFileChangeStatus, string> = {
+  added: 'Added',
+  modified: 'Modified',
+  deleted: 'Deleted',
+  renamed: 'Renamed',
+  copied: 'Copied',
+  typechange: 'Type changed',
+  unmerged: 'Unmerged',
+  unknown: 'Unknown change',
+};
+
+function splitPath(path: string): { dir: string; name: string } {
+  const idx = path.lastIndexOf('/');
+  if (idx < 0) return { dir: '', name: path };
+  return { dir: path.slice(0, idx + 1), name: path.slice(idx + 1) };
+}
+
+function FileRow({
+  file,
+  onClick,
+}: {
+  file: GitCommitFileChange;
+  onClick?: () => void;
+}) {
+  const { dir, name } = splitPath(file.path);
+  const statusTitle = STATUS_TITLE[file.status];
+  const title = file.status === 'renamed' || file.status === 'copied'
+    ? `${statusTitle} from ${file.oldPath} to ${file.path}`
+    : `${statusTitle}: ${file.path}`;
+
+  const body = (
+    <>
+      <span
+        className={`w-3 flex-shrink-0 font-mono text-[10px] leading-none ${STATUS_CLASS[file.status]}`}
+        aria-hidden="true"
+      >
+        {STATUS_LABEL[file.status]}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-left text-[11px] leading-snug">
+        {dir && <span className="text-text-muted">{dir}</span>}
+        <span className="text-text-secondary">{name}</span>
+      </span>
+      <span className="flex flex-shrink-0 items-center gap-1 font-mono text-[10px] leading-none">
+        {file.isBinary ? (
+          <span className="text-text-muted">bin</span>
+        ) : (
+          <>
+            {(file.additions ?? 0) > 0 && <span className="text-status-success">+{file.additions}</span>}
+            {(file.deletions ?? 0) > 0 && <span className="text-status-error">-{file.deletions}</span>}
+            {file.additions === null && file.deletions === null && (
+              <span className="text-text-muted">new</span>
+            )}
+          </>
+        )}
+      </span>
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div className="flex items-center gap-1.5 py-0.5 pl-6 pr-2" title={title}>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={`${statusTitle}: ${file.path}. Show diff.`}
+      className="flex w-full items-center gap-1.5 rounded-sm py-0.5 pl-6 pr-2 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-inset focus:ring-interactive"
+    >
+      {body}
+    </button>
+  );
+}
+
+export interface CommitFileListProps {
+  sessionId: string;
+  /** Commit hash, or `index` for uncommitted working-tree changes. */
+  commitRef: string;
+  /** Called when a file row is activated; wire this to reveal the file's diff. */
+  onFileClick?: (commitRef: string, path: string) => void;
+  className?: string;
+}
+
+/**
+ * Lazily loads and renders the files a single commit touched, with per-file
+ * change kind and +/- counts. Mounted only when a commit row is expanded, so
+ * a 50-commit history costs nothing until the user asks for detail.
+ */
+export function CommitFileList({ sessionId, commitRef, onFileClick, className = '' }: CommitFileListProps) {
+  const [result, setResult] = useState<GitCommitFilesResult | null>(
+    () => readCommitFileCache(sessionId, commitRef) ?? null
+  );
+  const [loading, setLoading] = useState(!result);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const cached = readCommitFileCache(sessionId, commitRef);
+    if (cached) {
+      setResult(cached);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    API.sessions.getCommitFiles(sessionId, commitRef)
+      .then(response => {
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          throw new Error(response.error || 'Failed to load changed files');
+        }
+        writeCommitFileCache(sessionId, commitRef, response.data);
+        setResult(response.data);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load changed files');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [commitRef, sessionId]);
+
+  if (loading) {
+    return (
+      <div className={`flex items-center gap-1.5 py-1 pl-6 text-[10px] text-text-muted ${className}`}>
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        Loading files…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={`py-1 pl-6 pr-2 text-[10px] text-status-error ${className}`}>{error}</div>
+    );
+  }
+
+  if (!result || result.files.length === 0) {
+    return (
+      <div className={`py-1 pl-6 pr-2 text-[10px] text-text-muted ${className}`}>No files changed</div>
+    );
+  }
+
+  return (
+    <div className={`pb-1 ${className}`}>
+      {result.isMergeAgainstFirstParent && (
+        <div className="py-0.5 pl-6 pr-2 text-[10px] italic text-text-muted">
+          Merge commit — showing changes against the first parent
+        </div>
+      )}
+      {result.files.map(file => (
+        <FileRow
+          key={`${file.status}-${file.oldPath}-${file.path}`}
+          file={file}
+          onClick={onFileClick ? () => onFileClick(commitRef, file.path) : undefined}
+        />
+      ))}
+      {result.truncated && (
+        <div className="py-0.5 pl-6 pr-2 text-[10px] text-text-muted">
+          Showing {result.files.length} of {result.totalFiles} files
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CommitFileList;

--- a/frontend/src/components/git/CommitFileList.tsx
+++ b/frontend/src/components/git/CommitFileList.tsx
@@ -48,7 +48,7 @@ export function CommitFileList({ sessionId, commitRef, onFileClick, className = 
         writeCommitFileCache(sessionId, commitRef, response.data);
         setResult(response.data);
       })
-      .catch((err: unknown) => {
+      .catch(err => {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : 'Failed to load changed files');
       })
@@ -99,5 +99,3 @@ export function CommitFileList({ sessionId, commitRef, onFileClick, className = 
     </div>
   );
 }
-
-export default CommitFileList;

--- a/frontend/src/components/git/CreatePullRequestDialog.tsx
+++ b/frontend/src/components/git/CreatePullRequestDialog.tsx
@@ -65,7 +65,7 @@ export function CreatePullRequestDialog({
         setBaseBranches(response.data.baseBranches);
         setLocalBaseBranches(response.data.localBaseBranches);
       })
-      .catch((err: unknown) => {
+      .catch(err => {
         if (!cancelled) setError(err instanceof Error ? err.message : 'Could not prepare the pull request');
       })
       .finally(() => {
@@ -337,5 +337,3 @@ export function CreatePullRequestDialog({
     </Modal>
   );
 }
-
-export default CreatePullRequestDialog;

--- a/frontend/src/components/git/CreatePullRequestDialog.tsx
+++ b/frontend/src/components/git/CreatePullRequestDialog.tsx
@@ -147,7 +147,8 @@ export function CreatePullRequestDialog({
   );
 
   const blocked = (draft?.blockers.length ?? 0) > 0;
-  const canSubmit = Boolean(draft) && !blocked && !submitting && title.trim().length > 0 && targetRepo.length > 0 && baseBranch.trim().length > 0;
+  const canSubmit = Boolean(draft) && !blocked && !baseIsUnknown && !submitting
+    && title.trim().length > 0 && targetRepo.length > 0 && baseBranch.trim().length > 0;
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg" ariaLabel="Create pull request" showCloseButton={false}>

--- a/frontend/src/components/git/CreatePullRequestDialog.tsx
+++ b/frontend/src/components/git/CreatePullRequestDialog.tsx
@@ -1,0 +1,340 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AlertTriangle, ExternalLink, GitPullRequest, Loader2 } from 'lucide-react';
+import { API } from '../../utils/api';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../ui/Modal';
+import { Button } from '../ui/Button';
+import { BranchCombobox } from './BranchCombobox';
+import { PullRequestChanges } from './PullRequestChanges';
+import type { PullRequestDraft } from '../../../../shared/types/pullRequest';
+
+export interface CreatePullRequestDialogProps {
+  sessionId: string;
+  sessionName: string;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called with the new pull request's URL once GitHub has it. */
+  onCreated?: (url: string) => void;
+}
+
+/**
+ * Open a pull request for a session's branch.
+ *
+ * The session already is a branch in a worktree, so the only real decisions are
+ * the target repository — a fork has two, and picking your own by accident is a
+ * silent mistake — and the text. Everything else is gathered by the main
+ * process in one call and shown here as the starting point.
+ */
+export function CreatePullRequestDialog({
+  sessionId,
+  sessionName,
+  isOpen,
+  onClose,
+  onCreated,
+}: CreatePullRequestDialogProps) {
+  const [draft, setDraft] = useState<PullRequestDraft | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [targetRepo, setTargetRepo] = useState('');
+  const [baseBranch, setBaseBranch] = useState('');
+  const [baseBranches, setBaseBranches] = useState<string[]>([]);
+  const [localBaseBranches, setLocalBaseBranches] = useState<string[]>([]);
+  const [isDraftPr, setIsDraftPr] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    API.pullRequests.getDraft(sessionId)
+      .then(response => {
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          throw new Error(response.error || 'Could not prepare the pull request');
+        }
+        setDraft(response.data);
+        setTitle(response.data.title || sessionName);
+        setBody(response.data.body);
+        setTargetRepo(response.data.defaultTarget);
+        setBaseBranch(response.data.baseBranch);
+        setBaseBranches(response.data.baseBranches);
+        setLocalBaseBranches(response.data.localBaseBranches);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Could not prepare the pull request');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [isOpen, sessionId, sessionName]);
+
+  /**
+   * The base has to exist in the *target* repository, and a fork's branches are
+   * not the upstream's — so the list is reloaded whenever the target changes.
+   */
+  const [loadingBranches, setLoadingBranches] = useState(false);
+  useEffect(() => {
+    if (!isOpen || !targetRepo || !draft) return;
+    if (targetRepo === draft.defaultTarget && draft.baseBranches.length > 0) {
+      setBaseBranches(draft.baseBranches);
+      setLocalBaseBranches(draft.localBaseBranches);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingBranches(true);
+    API.pullRequests.listBaseBranches(sessionId, targetRepo)
+      .then(response => {
+        if (cancelled || !response.success || !response.data) return;
+        const { all, local } = response.data;
+        setBaseBranches(all);
+        setLocalBaseBranches(local);
+        // Keep the current base when the new target also has it; otherwise fall
+        // back to that repository's default.
+        setBaseBranch(current => (all.includes(current)
+          ? current
+          : all.find(name => name === 'main' || name === 'master') ?? current));
+      })
+      .catch(() => { /* the field stays editable, so this is not fatal */ })
+      .finally(() => { if (!cancelled) setLoadingBranches(false); });
+
+    return () => { cancelled = true; };
+  }, [isOpen, targetRepo, draft, sessionId]);
+
+  const submit = useCallback(async () => {
+    if (!draft) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await API.pullRequests.create({
+        sessionId,
+        title: title.trim(),
+        body,
+        baseBranch,
+        targetRepo,
+        draft: isDraftPr,
+      });
+
+      if (!response.success || !response.data) {
+        throw new Error(response.error || 'Could not create the pull request');
+      }
+
+      onCreated?.(response.data.url);
+      onClose();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Could not create the pull request');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [draft, sessionId, title, body, baseBranch, targetRepo, isDraftPr, onCreated, onClose]);
+
+  /**
+   * A base has to exist in the *target*. Your own feature branches live in your
+   * fork, so basing on one only works with the fork as the target — worth
+   * saying here rather than letting GitHub reject the push.
+   */
+  const otherTarget = draft?.targets.find(target => target.nameWithOwner !== targetRepo)?.nameWithOwner;
+  const baseIsUnknown = Boolean(
+    baseBranch.trim() && baseBranches.length > 0 && !baseBranches.includes(baseBranch.trim())
+  );
+
+  const blocked = (draft?.blockers.length ?? 0) > 0;
+  const canSubmit = Boolean(draft) && !blocked && !submitting && title.trim().length > 0 && targetRepo.length > 0 && baseBranch.trim().length > 0;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" ariaLabel="Create pull request" showCloseButton={false}>
+      <ModalHeader
+        title="Create pull request"
+        icon={<GitPullRequest className="h-4 w-4" />}
+        description={draft ? `${draft.branch} → ${targetRepo}:${baseBranch}` : sessionName}
+        onClose={onClose}
+      />
+
+      <ModalBody className="space-y-3">
+        {loading ? (
+          <div className="flex items-center justify-center gap-2 py-8 text-sm text-text-tertiary">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Reading the branch…
+          </div>
+        ) : (
+          <>
+            {/*
+              An existing pull request is the most useful thing to say: there is
+              nothing to create, and the link is what the user actually wants.
+            */}
+            {draft?.existing && (
+              <div className="flex items-start gap-2 rounded border border-interactive/40 bg-interactive/10 p-2 text-xs text-text-secondary">
+                <ExternalLink className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-interactive" aria-hidden="true" />
+                <span>
+                  This branch already has a pull request:{' '}
+                  <a
+                    href={draft.existing.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-interactive underline"
+                  >
+                    #{draft.existing.number} {draft.existing.title}
+                  </a>{' '}
+                  ({draft.existing.state.toLowerCase()}). Pushing again updates it — creating a second one is not possible.
+                </span>
+              </div>
+            )}
+
+            {draft?.blockers.map(blocker => (
+              <div
+                key={blocker}
+                className="flex items-start gap-2 rounded border border-status-warning/40 bg-status-warning/10 p-2 text-xs text-status-warning"
+              >
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                <span>{blocker}</span>
+              </div>
+            ))}
+
+            {draft?.hasUncommittedChanges && (
+              <p className="rounded border border-border-secondary bg-surface-tertiary p-2 text-xs text-text-tertiary">
+                This worktree has uncommitted changes. They stay behind — only what is committed goes into the
+                pull request.
+              </p>
+            )}
+
+            {/*
+              Which branch is proposed, spelled out. "Base" is where the work
+              goes *into*, and reading it as "the branch I built" is the easiest
+              mistake to make in this dialog.
+            */}
+            {draft?.branch && (
+              <p className="rounded border border-border-secondary bg-surface-tertiary px-2 py-1.5 text-xs text-text-tertiary">
+                Sending <span className="font-mono text-text-secondary">{draft.branch}</span>
+                {' '}— this session&rsquo;s branch, with the commits below —{' '}
+                to <span className="font-mono text-text-secondary">{targetRepo}</span>, to be merged into{' '}
+                <span className="font-mono text-text-secondary">{baseBranch || '…'}</span>.
+              </p>
+            )}
+
+            <label className="block">
+              <span className="text-[11px] uppercase tracking-wider text-text-muted">Title</span>
+              <input
+                value={title}
+                onChange={event => setTitle(event.target.value)}
+                className="mt-1 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
+              />
+            </label>
+
+            {/*
+              One destination, spelled as one thing: "into repository" and "base
+              branch" are two halves of a single address (`owner/repo:branch`),
+              and naming them separately made them read as two decisions.
+            */}
+            <div className="rounded border border-border-secondary p-2">
+              <span className="text-[11px] uppercase tracking-wider text-text-muted">Merge destination</span>
+              <div className="mt-1 grid gap-3 sm:grid-cols-2">
+                <label className="block">
+                  <span className="text-[11px] text-text-muted">Repository</span>
+                  <select
+                    value={targetRepo}
+                    onChange={event => setTargetRepo(event.target.value)}
+                    className="mt-0.5 w-full rounded border border-border-secondary bg-surface-primary px-2 py-1 text-sm text-text-primary focus:border-interactive focus:outline-none"
+                  >
+                    {(draft?.targets ?? []).map(target => (
+                      <option key={target.nameWithOwner} value={target.nameWithOwner}>
+                        {target.nameWithOwner}{target.isParent ? ' (upstream)' : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <div>
+                  <label htmlFor="pane-pr-base-branch" className="block text-[11px] text-text-muted">
+                    Branch in that repository
+                  </label>
+                  {/*
+                    Editable as well as selectable: the list comes from the
+                    target repository, and a branch pushed a minute ago may not
+                    be in it yet.
+                  */}
+                  <div className="mt-0.5">
+                    <BranchCombobox
+                      id="pane-pr-base-branch"
+                      value={baseBranch}
+                      branches={baseBranches}
+                      primaryBranches={localBaseBranches}
+                      allLabel={targetRepo}
+                      loading={loadingBranches}
+                      onChange={setBaseBranch}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {baseIsUnknown && (
+              <p className="rounded border border-status-warning/40 bg-status-warning/10 p-2 text-xs text-status-warning">
+                <strong className="font-medium">{baseBranch}</strong> is not a branch in {targetRepo}
+                {otherTarget ? `, so GitHub would reject it. Branches you pushed yourself live in ${otherTarget} — switch the target repository above to base on one of them.` : ', so GitHub would reject it.'}
+              </p>
+            )}
+
+            <PullRequestChanges sessionId={sessionId} baseBranch={baseBranch} />
+
+            <label className="block">
+              <span className="text-[11px] uppercase tracking-wider text-text-muted">
+                Description
+                {draft && draft.commitCount > 0 && (
+                  <span className="ml-2 normal-case tracking-normal text-text-muted">
+                    from {draft.commitCount} {draft.commitCount === 1 ? 'commit' : 'commits'}
+                    {draft.body.includes('##') ? ' and the repository template' : ''}
+                  </span>
+                )}
+              </span>
+              <textarea
+                value={body}
+                onChange={event => setBody(event.target.value)}
+                rows={8}
+                className="mt-1 w-full resize-y rounded border border-border-secondary bg-surface-primary px-2 py-1 font-mono text-xs text-text-primary focus:border-interactive focus:outline-none"
+              />
+            </label>
+
+            <label className="flex items-center gap-2 text-xs text-text-secondary">
+              <input
+                type="checkbox"
+                checked={isDraftPr}
+                onChange={event => setIsDraftPr(event.target.checked)}
+                className="h-3 w-3 accent-[color:var(--color-interactive,#4f8ef7)]"
+              />
+              Open as a draft
+            </label>
+
+            {error && (
+              <p role="alert" className="rounded border border-status-error/30 bg-status-error/10 p-2 text-xs text-status-error">
+                {error}
+              </p>
+            )}
+          </>
+        )}
+      </ModalBody>
+
+      <ModalFooter>
+        <Button variant="ghost" size="sm" onClick={onClose} disabled={submitting}>Cancel</Button>
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => { void submit(); }}
+          disabled={!canSubmit}
+          icon={submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <GitPullRequest className="h-4 w-4" />}
+        >
+          {submitting ? 'Pushing and opening…' : 'Create pull request'}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+export default CreatePullRequestDialog;

--- a/frontend/src/components/git/FileChangeList.tsx
+++ b/frontend/src/components/git/FileChangeList.tsx
@@ -1,0 +1,138 @@
+import type { GitCommitFileChange, GitFileChangeStatus } from '../../../../shared/types/git';
+
+/**
+ * Rows of changed files with their change kind and +/- counts.
+ *
+ * Presentational only — it never fetches. A commit expands into one of these
+ * ({@link CommitFileList}), and so does a pull request, which compares against
+ * a base branch instead of a parent commit; both want the identical row.
+ */
+
+const STATUS_LABEL: Record<GitFileChangeStatus, string> = {
+  added: 'A',
+  modified: 'M',
+  deleted: 'D',
+  renamed: 'R',
+  copied: 'C',
+  typechange: 'T',
+  unmerged: 'U',
+  unknown: '?',
+};
+
+const STATUS_CLASS: Record<GitFileChangeStatus, string> = {
+  added: 'text-status-success',
+  modified: 'text-interactive',
+  deleted: 'text-status-error',
+  renamed: 'text-interactive',
+  copied: 'text-interactive',
+  typechange: 'text-status-warning',
+  unmerged: 'text-status-warning',
+  unknown: 'text-text-muted',
+};
+
+const STATUS_TITLE: Record<GitFileChangeStatus, string> = {
+  added: 'Added',
+  modified: 'Modified',
+  deleted: 'Deleted',
+  renamed: 'Renamed',
+  copied: 'Copied',
+  typechange: 'Type changed',
+  unmerged: 'Unmerged',
+  unknown: 'Unknown change',
+};
+
+function splitPath(path: string): { dir: string; name: string } {
+  const idx = path.lastIndexOf('/');
+  if (idx < 0) return { dir: '', name: path };
+  return { dir: path.slice(0, idx + 1), name: path.slice(idx + 1) };
+}
+
+export function FileChangeRow({
+  file,
+  onClick,
+  indentClass = 'pl-6',
+}: {
+  file: GitCommitFileChange;
+  onClick?: () => void;
+  indentClass?: string;
+}) {
+  const { dir, name } = splitPath(file.path);
+  const statusTitle = STATUS_TITLE[file.status];
+  const title = file.status === 'renamed' || file.status === 'copied'
+    ? `${statusTitle} from ${file.oldPath} to ${file.path}`
+    : `${statusTitle}: ${file.path}`;
+
+  const body = (
+    <>
+      <span
+        className={`w-3 flex-shrink-0 font-mono text-[10px] leading-none ${STATUS_CLASS[file.status]}`}
+        aria-hidden="true"
+      >
+        {STATUS_LABEL[file.status]}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-left text-[11px] leading-snug">
+        {dir && <span className="text-text-muted">{dir}</span>}
+        <span className="text-text-secondary">{name}</span>
+      </span>
+      <span className="flex flex-shrink-0 items-center gap-1 font-mono text-[10px] leading-none">
+        {file.isBinary ? (
+          <span className="text-text-muted">bin</span>
+        ) : (
+          <>
+            {(file.additions ?? 0) > 0 && <span className="text-status-success">+{file.additions}</span>}
+            {(file.deletions ?? 0) > 0 && <span className="text-status-error">-{file.deletions}</span>}
+            {file.additions === null && file.deletions === null && (
+              <span className="text-text-muted">new</span>
+            )}
+          </>
+        )}
+      </span>
+    </>
+  );
+
+  if (!onClick) {
+    return (
+      <div className={`flex items-center gap-1.5 py-0.5 pr-2 ${indentClass}`} title={title}>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={`${statusTitle}: ${file.path}. Show diff.`}
+      className={`flex w-full items-center gap-1.5 rounded-sm py-0.5 pr-2 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-inset focus:ring-interactive ${indentClass}`}
+    >
+      {body}
+    </button>
+  );
+}
+
+export interface FileChangeListProps {
+  files: GitCommitFileChange[];
+  /** Called when a row is activated; wire this to reveal the file's diff. */
+  onFileClick?: (path: string) => void;
+  /** Row indentation — nested under a commit, or flush in a dialog. */
+  indentClass?: string;
+  className?: string;
+}
+
+export function FileChangeList({ files, onFileClick, indentClass, className = '' }: FileChangeListProps) {
+  return (
+    <div className={className}>
+      {files.map(file => (
+        <FileChangeRow
+          key={`${file.status}-${file.oldPath}-${file.path}`}
+          file={file}
+          indentClass={indentClass}
+          onClick={onFileClick ? () => onFileClick(file.path) : undefined}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default FileChangeList;

--- a/frontend/src/components/git/FileChangeList.tsx
+++ b/frontend/src/components/git/FileChangeList.tsx
@@ -8,7 +8,7 @@ import type { GitCommitFileChange, GitFileChangeStatus } from '../../../../share
  * a base branch instead of a parent commit; both want the identical row.
  */
 
-const STATUS_LABEL: Record<GitFileChangeStatus, string> = {
+const STATUS_LABEL = {
   added: 'A',
   modified: 'M',
   deleted: 'D',
@@ -17,9 +17,9 @@ const STATUS_LABEL: Record<GitFileChangeStatus, string> = {
   typechange: 'T',
   unmerged: 'U',
   unknown: '?',
-};
+} satisfies Record<GitFileChangeStatus, string>;
 
-const STATUS_CLASS: Record<GitFileChangeStatus, string> = {
+const STATUS_CLASS = {
   added: 'text-status-success',
   modified: 'text-interactive',
   deleted: 'text-status-error',
@@ -28,9 +28,9 @@ const STATUS_CLASS: Record<GitFileChangeStatus, string> = {
   typechange: 'text-status-warning',
   unmerged: 'text-status-warning',
   unknown: 'text-text-muted',
-};
+} satisfies Record<GitFileChangeStatus, string>;
 
-const STATUS_TITLE: Record<GitFileChangeStatus, string> = {
+const STATUS_TITLE = {
   added: 'Added',
   modified: 'Modified',
   deleted: 'Deleted',
@@ -39,15 +39,15 @@ const STATUS_TITLE: Record<GitFileChangeStatus, string> = {
   typechange: 'Type changed',
   unmerged: 'Unmerged',
   unknown: 'Unknown change',
-};
+} satisfies Record<GitFileChangeStatus, string>;
 
-function splitPath(path: string): { dir: string; name: string } {
+function splitPath(path: string) {
   const idx = path.lastIndexOf('/');
   if (idx < 0) return { dir: '', name: path };
   return { dir: path.slice(0, idx + 1), name: path.slice(idx + 1) };
 }
 
-export function FileChangeRow({
+function FileChangeRow({
   file,
   onClick,
   indentClass = 'pl-6',
@@ -134,5 +134,3 @@ export function FileChangeList({ files, onFileClick, indentClass, className = ''
     </div>
   );
 }
-
-export default FileChangeList;

--- a/frontend/src/components/git/PullRequestChanges.tsx
+++ b/frontend/src/components/git/PullRequestChanges.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight, FileDiff, Loader2 } from 'lucide-react';
+import { API } from '../../utils/api';
+import { parseUnifiedDiffToFiles } from '../../utils/parseUnifiedDiff';
+import DiffViewer from '../panels/diff/DiffViewer';
+import { FileChangeList } from './FileChangeList';
+import type { PullRequestChanges as Changes } from '../../../../shared/types/pullRequest';
+
+/** Typing in the base field must not fire a git command per keystroke. */
+const RELOAD_DEBOUNCE_MS = 350;
+
+export interface PullRequestChangesProps {
+  sessionId: string;
+  /** Base the pull request would target; changing it reloads the comparison. */
+  baseBranch: string;
+}
+
+/**
+ * What the pull request actually contains, shown before it is opened.
+ *
+ * Two levels, because they cost very different things: the file list is a
+ * numstat and loads with the dialog, while the patch is only fetched once the
+ * diff is opened.
+ */
+export function PullRequestChanges({ sessionId, baseBranch }: PullRequestChangesProps) {
+  const [changes, setChanges] = useState<Changes | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [showDiff, setShowDiff] = useState(false);
+  const [diff, setDiff] = useState<{ text: string; truncated: boolean } | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    // A new base means a different comparison: whatever patch is on screen is
+    // no longer the one that would be opened.
+    setDiff(null);
+    setDiffError(null);
+
+    const timer = setTimeout(() => {
+      API.pullRequests.getChanges(sessionId, baseBranch)
+        .then(response => {
+          if (cancelled) return;
+          if (!response.success || !response.data) {
+            throw new Error(response.error || 'Could not read the changed files');
+          }
+          setChanges(response.data);
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : 'Could not read the changed files');
+        })
+        .finally(() => { if (!cancelled) setLoading(false); });
+    }, RELOAD_DEBOUNCE_MS);
+
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, [sessionId, baseBranch]);
+
+  useEffect(() => {
+    if (!showDiff || diff || diffLoading) return;
+
+    let cancelled = false;
+    setDiffLoading(true);
+    setDiffError(null);
+
+    API.pullRequests.getDiff(sessionId, baseBranch)
+      .then(response => {
+        if (cancelled) return;
+        if (!response.success || !response.data) {
+          throw new Error(response.error || 'Could not read the diff');
+        }
+        setDiff({ text: response.data.diff, truncated: response.data.truncated });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setDiffError(err instanceof Error ? err.message : 'Could not read the diff');
+      })
+      .finally(() => { if (!cancelled) setDiffLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [showDiff, diff, diffLoading, sessionId, baseBranch]);
+
+  const diffFiles = useMemo(() => (diff ? parseUnifiedDiffToFiles(diff.text) : []), [diff]);
+
+  const fileCount = changes?.totalFiles ?? 0;
+
+  return (
+    <section className="rounded border border-border-secondary">
+      <header className="flex items-center gap-2 border-b border-border-secondary px-2 py-1.5">
+        <span className="text-[11px] uppercase tracking-wider text-text-muted">Changes</span>
+
+        {loading ? (
+          <span className="flex items-center gap-1.5 text-xs text-text-tertiary">
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+            comparing…
+          </span>
+        ) : error ? (
+          <span className="text-xs text-status-error">{error}</span>
+        ) : (
+          <>
+            <span className="text-xs text-text-secondary">
+              {fileCount} {fileCount === 1 ? 'file' : 'files'}
+            </span>
+            {changes && (changes.additions > 0 || changes.deletions > 0) && (
+              <span className="font-mono text-xs">
+                <span className="text-status-success">+{changes.additions}</span>{' '}
+                <span className="text-status-error">-{changes.deletions}</span>
+              </span>
+            )}
+            {changes?.baseRef && (
+              <span className="truncate text-[11px] text-text-muted" title={`Compared against ${changes.baseRef}`}>
+                vs {changes.baseRef}
+              </span>
+            )}
+          </>
+        )}
+
+        {fileCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowDiff(current => !current)}
+            className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+          >
+            {showDiff
+              ? <ChevronDown className="h-3 w-3" aria-hidden="true" />
+              : <ChevronRight className="h-3 w-3" aria-hidden="true" />}
+            <FileDiff className="h-3 w-3" aria-hidden="true" />
+            {showDiff ? 'Hide diff' : 'Show diff'}
+          </button>
+        )}
+      </header>
+
+      {!loading && !error && (
+        changes && changes.files.length > 0 ? (
+          <div className="max-h-40 overflow-y-auto py-1">
+            <FileChangeList files={changes.files} indentClass="pl-2" />
+            {changes.truncated && (
+              <div className="px-2 py-0.5 text-[10px] text-text-muted">
+                Showing {changes.files.length} of {changes.totalFiles} files
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="px-2 py-2 text-xs text-text-muted">
+            {changes?.baseRef
+              ? 'This branch has no changes against the base — there would be nothing to review.'
+              : `No ref for "${baseBranch}" exists locally, so the comparison could not run. The pull request itself is unaffected.`}
+          </p>
+        )
+      )}
+
+      {showDiff && (
+        <div className="border-t border-border-secondary">
+          {diffLoading ? (
+            <div className="flex items-center justify-center gap-2 py-6 text-xs text-text-tertiary">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              Reading the patch…
+            </div>
+          ) : diffError ? (
+            <p className="p-2 text-xs text-status-error">{diffError}</p>
+          ) : diffFiles.length === 0 ? (
+            <p className="p-2 text-xs text-text-muted">The patch is empty.</p>
+          ) : (
+            <>
+              {diff?.truncated && (
+                <p className="border-b border-border-secondary px-2 py-1 text-[10px] text-status-warning">
+                  This diff is too large to show in full — the rest is on GitHub once the pull request exists.
+                </p>
+              )}
+              <div className="max-h-80 overflow-auto">
+                <DiffViewer files={diffFiles} />
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default PullRequestChanges;

--- a/frontend/src/components/git/PullRequestChanges.tsx
+++ b/frontend/src/components/git/PullRequestChanges.tsx
@@ -50,7 +50,7 @@ export function PullRequestChanges({ sessionId, baseBranch }: PullRequestChanges
           }
           setChanges(response.data);
         })
-        .catch((err: unknown) => {
+        .catch(err => {
           if (!cancelled) setError(err instanceof Error ? err.message : 'Could not read the changed files');
         })
         .finally(() => { if (!cancelled) setLoading(false); });
@@ -74,7 +74,7 @@ export function PullRequestChanges({ sessionId, baseBranch }: PullRequestChanges
         }
         setDiff({ text: response.data.diff, truncated: response.data.truncated });
       })
-      .catch((err: unknown) => {
+      .catch(err => {
         if (!cancelled) setDiffError(err instanceof Error ? err.message : 'Could not read the diff');
       })
       .finally(() => { if (!cancelled) setDiffLoading(false); });
@@ -179,5 +179,3 @@ export function PullRequestChanges({ sessionId, baseBranch }: PullRequestChanges
     </section>
   );
 }
-
-export default PullRequestChanges;

--- a/frontend/src/components/git/PullRequestChanges.tsx
+++ b/frontend/src/components/git/PullRequestChanges.tsx
@@ -60,7 +60,7 @@ export function PullRequestChanges({ sessionId, baseBranch }: PullRequestChanges
   }, [sessionId, baseBranch]);
 
   useEffect(() => {
-    if (!showDiff || diff || diffLoading) return;
+    if (!showDiff || diff) return;
 
     let cancelled = false;
     setDiffLoading(true);
@@ -80,7 +80,7 @@ export function PullRequestChanges({ sessionId, baseBranch }: PullRequestChanges
       .finally(() => { if (!cancelled) setDiffLoading(false); });
 
     return () => { cancelled = true; };
-  }, [showDiff, diff, diffLoading, sessionId, baseBranch]);
+  }, [showDiff, diff, sessionId, baseBranch]);
 
   const diffFiles = useMemo(() => (diff ? parseUnifiedDiffToFiles(diff.text) : []), [diff]);
 

--- a/frontend/src/components/git/PullRequestChecks.test.ts
+++ b/frontend/src/components/git/PullRequestChecks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parsePullRequestUrl } from './PullRequestChecks';
+import { parsePullRequestUrl } from './pullRequestUrl';
 
 describe('parsePullRequestUrl', () => {
   it('reads the repository and number from a pull request url', () => {

--- a/frontend/src/components/git/PullRequestChecks.test.ts
+++ b/frontend/src/components/git/PullRequestChecks.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { parsePullRequestUrl } from './PullRequestChecks';
+
+describe('parsePullRequestUrl', () => {
+  it('reads the repository and number from a pull request url', () => {
+    expect(parsePullRequestUrl('https://github.com/dcouple/Pane/pull/382')).toEqual({
+      repo: 'dcouple/Pane',
+      number: 382,
+    });
+  });
+
+  it('ignores anything appended to the url', () => {
+    expect(parsePullRequestUrl('https://github.com/o/r/pull/7/files#diff-abc')).toEqual({
+      repo: 'o/r',
+      number: 7,
+    });
+  });
+
+  it('returns null for urls that are not pull requests', () => {
+    expect(parsePullRequestUrl('https://github.com/dcouple/Pane/issues/12')).toBeNull();
+    expect(parsePullRequestUrl('https://example.com/whatever')).toBeNull();
+    expect(parsePullRequestUrl(undefined)).toBeNull();
+    expect(parsePullRequestUrl('')).toBeNull();
+  });
+});

--- a/frontend/src/components/git/PullRequestChecks.tsx
+++ b/frontend/src/components/git/PullRequestChecks.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react';
+import { CircleCheck, CircleDot, CircleSlash, CircleX, Loader2 } from 'lucide-react';
+import { API } from '../../utils/api';
+import type { PullRequestChecksResult } from '../../../../shared/types/pullRequest';
+
+/** How often CI state is re-read while a review panel is on screen. */
+const POLL_MS = 60_000;
+
+/**
+ * `https://github.com/owner/repo/pull/382` → `{ repo: 'owner/repo', number: 382 }`.
+ *
+ * The pull request URL is already stored on the session, so deriving the
+ * repository from it avoids carrying a second field through the git status
+ * cache, the database and the IPC layer for something git already knows.
+ */
+export function parsePullRequestUrl(url: string | undefined): { repo: string; number: number } | null {
+  const match = /github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/.exec(url ?? '');
+  if (!match) return null;
+  return { repo: match[1], number: Number(match[2]) };
+}
+
+const ICONS = {
+  pass: CircleCheck,
+  fail: CircleX,
+  pending: CircleDot,
+  skipped: CircleSlash,
+  cancelled: CircleSlash,
+  none: CircleSlash,
+} as const;
+
+const TONES = {
+  pass: 'text-status-success',
+  fail: 'text-status-error',
+  pending: 'text-status-warning',
+  skipped: 'text-text-muted',
+  cancelled: 'text-text-muted',
+  none: 'text-text-muted',
+} as const;
+
+export interface PullRequestChecksProps {
+  sessionId: string;
+  /** The session's pull request URL; nothing renders without one. */
+  prUrl?: string;
+}
+
+/**
+ * CI state for the session's pull request.
+ *
+ * The point is not to replace GitHub's checks page but to answer "did my agent
+ * break the build" without leaving the review panel — which is the moment the
+ * question actually comes up.
+ */
+export function PullRequestChecks({ sessionId, prUrl }: PullRequestChecksProps) {
+  const target = parsePullRequestUrl(prUrl);
+  const [result, setResult] = useState<PullRequestChecksResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const repo = target?.repo;
+  const number = target?.number;
+
+  const load = useCallback(async () => {
+    if (!repo || !number) return;
+    setLoading(true);
+    try {
+      const response = await API.pullRequests.getChecks(sessionId, repo, number);
+      if (response.success && response.data) setResult(response.data);
+    } catch {
+      // CI state is garnish; a failed read must not disturb the review panel.
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId, repo, number]);
+
+  useEffect(() => {
+    if (!repo || !number) return;
+    void load();
+    const timer = window.setInterval(() => { void load(); }, POLL_MS);
+    return () => window.clearInterval(timer);
+  }, [load, repo, number]);
+
+  if (!target) return null;
+  if (!result && loading) {
+    return <Loader2 className="h-3 w-3 flex-shrink-0 animate-spin text-text-muted" aria-label="Reading checks" />;
+  }
+  if (!result || result.summary === 'none') return null;
+
+  const Icon = ICONS[result.summary];
+  const passed = result.checks.filter(check => check.state === 'pass').length;
+
+  return (
+    <button
+      type="button"
+      onClick={() => { if (prUrl) void window.electronAPI.openExternal(prUrl); }}
+      title={result.checks.map(check => `${check.state.padEnd(9)} ${check.name}`).join('\n')}
+      className={`inline-flex flex-shrink-0 items-center gap-1 rounded px-1 text-xs transition-colors hover:bg-surface-hover ${TONES[result.summary]}`}
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      <span className="tabular-nums">{passed}/{result.checks.length}</span>
+    </button>
+  );
+}
+
+export default PullRequestChecks;

--- a/frontend/src/components/git/PullRequestChecks.tsx
+++ b/frontend/src/components/git/PullRequestChecks.tsx
@@ -1,23 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { CircleCheck, CircleDot, CircleSlash, CircleX, Loader2 } from 'lucide-react';
 import { API } from '../../utils/api';
+import { parsePullRequestUrl } from './pullRequestUrl';
 import type { PullRequestChecksResult } from '../../../../shared/types/pullRequest';
 
 /** How often CI state is re-read while a review panel is on screen. */
 const POLL_MS = 60_000;
-
-/**
- * `https://github.com/owner/repo/pull/382` → `{ repo: 'owner/repo', number: 382 }`.
- *
- * The pull request URL is already stored on the session, so deriving the
- * repository from it avoids carrying a second field through the git status
- * cache, the database and the IPC layer for something git already knows.
- */
-export function parsePullRequestUrl(url: string | undefined): { repo: string; number: number } | null {
-  const match = /github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/.exec(url ?? '');
-  if (!match) return null;
-  return { repo: match[1], number: Number(match[2]) };
-}
 
 const ICONS = {
   pass: CircleCheck,
@@ -99,5 +87,3 @@ export function PullRequestChecks({ sessionId, prUrl }: PullRequestChecksProps) 
     </button>
   );
 }
-
-export default PullRequestChecks;

--- a/frontend/src/components/git/PullRequestStatusBar.tsx
+++ b/frontend/src/components/git/PullRequestStatusBar.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  CircleDot,
+  ExternalLink,
+  GitMerge,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+  Loader2,
+  MessageSquare,
+  RefreshCw,
+  TriangleAlert,
+  UserCheck,
+} from 'lucide-react';
+import { API } from '../../utils/api';
+import { parsePullRequestUrl } from './PullRequestChecks';
+import type { PullRequestStatus } from '../../../../shared/types/pullRequest';
+
+/** Re-read while the review panel is on screen; GitHub state changes slowly. */
+const POLL_MS = 90_000;
+
+const DECISION_LABEL = {
+  approved: 'Approved',
+  changes_requested: 'Changes requested',
+  review_required: 'Review required',
+  none: 'No review yet',
+} as const;
+
+const DECISION_TONE = {
+  approved: 'text-status-success',
+  changes_requested: 'text-status-error',
+  review_required: 'text-status-warning',
+  none: 'text-text-muted',
+} as const;
+
+function stateVisual(status: PullRequestStatus) {
+  if (status.state === 'MERGED') return { Icon: GitMerge, tone: 'text-[#a371f7]', label: 'Merged' };
+  if (status.state === 'CLOSED') return { Icon: GitPullRequestClosed, tone: 'text-status-error', label: 'Closed' };
+  if (status.isDraft) return { Icon: GitPullRequestDraft, tone: 'text-text-muted', label: 'Draft' };
+  return { Icon: CircleDot, tone: 'text-status-success', label: 'Open' };
+}
+
+export interface PullRequestStatusBarProps {
+  sessionId: string;
+  /** The session's pull request URL; nothing renders without one. */
+  prUrl?: string;
+}
+
+/**
+ * What became of the pull request, next to the review it belongs to.
+ *
+ * Creating one is a single action and lives in the git menu; *watching* one is
+ * what you keep coming back to — whether anyone approved it, whether it still
+ * merges, how much it grew. That belongs where the changes are reviewed rather
+ * than behind a browser tab.
+ */
+export function PullRequestStatusBar({ sessionId, prUrl }: PullRequestStatusBarProps) {
+  const target = parsePullRequestUrl(prUrl);
+  const repo = target?.repo;
+  const number = target?.number;
+
+  const [status, setStatus] = useState<PullRequestStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!repo || !number) return;
+    setLoading(true);
+    try {
+      const response = await API.pullRequests.getStatus(sessionId, repo, number);
+      if (response.success && response.data) setStatus(response.data);
+    } catch {
+      // Leave the previous state on screen: a failed refresh is not news.
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId, repo, number]);
+
+  useEffect(() => {
+    setStatus(null);
+    if (!repo || !number) return;
+
+    void load();
+    const timer = setInterval(() => { void load(); }, POLL_MS);
+    return () => clearInterval(timer);
+  }, [load, repo, number]);
+
+  if (!repo || !number) return null;
+
+  if (!status) {
+    return loading ? (
+      <div className="flex items-center gap-1.5 border-b border-border-primary bg-surface-secondary px-3 py-1 text-[11px] text-text-muted">
+        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+        Reading pull request #{number}…
+      </div>
+    ) : null;
+  }
+
+  const { Icon, tone, label } = stateVisual(status);
+  const conflicting = status.mergeable === 'CONFLICTING';
+
+  return (
+    <div className="border-b border-border-primary bg-surface-secondary text-[11px]">
+      <div className="flex items-center gap-2 px-3 py-1">
+        <button
+          type="button"
+          onClick={() => setExpanded(current => !current)}
+          aria-expanded={expanded}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left transition-colors hover:text-text-primary"
+        >
+          {expanded
+            ? <ChevronDown className="h-3 w-3 flex-shrink-0 text-text-muted" aria-hidden="true" />
+            : <ChevronRight className="h-3 w-3 flex-shrink-0 text-text-muted" aria-hidden="true" />}
+          <Icon className={`h-3.5 w-3.5 flex-shrink-0 ${tone}`} aria-hidden="true" />
+          <span className={`flex-shrink-0 font-medium ${tone}`}>{label}</span>
+          <span className="flex-shrink-0 text-text-muted">#{status.number}</span>
+          <span className="truncate text-text-secondary">{status.title}</span>
+        </button>
+
+        <span className={`flex flex-shrink-0 items-center gap-1 ${DECISION_TONE[status.reviewDecision]}`}>
+          <UserCheck className="h-3 w-3" aria-hidden="true" />
+          {DECISION_LABEL[status.reviewDecision]}
+        </span>
+
+        {status.commentCount > 0 && (
+          <span className="flex flex-shrink-0 items-center gap-1 text-text-muted">
+            <MessageSquare className="h-3 w-3" aria-hidden="true" />
+            {status.commentCount}
+          </span>
+        )}
+
+        {conflicting && (
+          <span className="flex flex-shrink-0 items-center gap-1 text-status-error" title="This branch has conflicts with its base">
+            <TriangleAlert className="h-3 w-3" aria-hidden="true" />
+            Conflicts
+          </span>
+        )}
+
+        <button
+          type="button"
+          onClick={() => { void load(); }}
+          title="Refresh pull request state"
+          aria-label="Refresh pull request state"
+          className="flex-shrink-0 rounded p-0.5 text-text-muted transition-colors hover:bg-surface-hover hover:text-text-secondary"
+        >
+          <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-t border-border-secondary px-3 py-1.5 text-text-muted">
+          <span className="font-mono">
+            {status.headRepositoryOwner ? `${status.headRepositoryOwner}:` : ''}{status.headRefName}
+            {' → '}
+            {repo}:{status.baseRefName}
+          </span>
+
+          <span>
+            {status.changedFiles} {status.changedFiles === 1 ? 'file' : 'files'}
+            {' '}
+            <span className="text-status-success">+{status.additions}</span>{' '}
+            <span className="text-status-error">-{status.deletions}</span>
+          </span>
+
+          {status.reviewers.length > 0 && (
+            <span className="truncate">
+              Reviewed by {status.reviewers.map(reviewer => `${reviewer.login} (${reviewer.state.toLowerCase().replace('_', ' ')})`).join(', ')}
+            </span>
+          )}
+
+          {status.url && (
+            <a
+              href={status.url}
+              target="_blank"
+              rel="noreferrer"
+              className="ml-auto flex items-center gap-1 text-interactive hover:underline"
+            >
+              <ExternalLink className="h-3 w-3" aria-hidden="true" />
+              Open on GitHub
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PullRequestStatusBar;

--- a/frontend/src/components/git/PullRequestStatusBar.tsx
+++ b/frontend/src/components/git/PullRequestStatusBar.tsx
@@ -14,7 +14,7 @@ import {
   UserCheck,
 } from 'lucide-react';
 import { API } from '../../utils/api';
-import { parsePullRequestUrl } from './PullRequestChecks';
+import { parsePullRequestUrl } from './pullRequestUrl';
 import type { PullRequestStatus } from '../../../../shared/types/pullRequest';
 
 /** Re-read while the review panel is on screen; GitHub state changes slowly. */
@@ -185,5 +185,3 @@ export function PullRequestStatusBar({ sessionId, prUrl }: PullRequestStatusBarP
     </div>
   );
 }
-
-export default PullRequestStatusBar;

--- a/frontend/src/components/git/branchFilter.test.ts
+++ b/frontend/src/components/git/branchFilter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { filterBranches } from './branchFilter';
+
+describe('filterBranches', () => {
+  const branches = [
+    'main',
+    'develop',
+    'feature/maintenance-window',
+    'fix/main-thread-hang',
+    'release/2.4',
+    'main-3',
+  ];
+
+  it('shows everything up to the limit when nothing is typed', () => {
+    expect(filterBranches(branches, '')).toEqual(branches);
+    expect(filterBranches(branches, '   ')).toEqual(branches);
+    expect(filterBranches(branches, '', 2)).toEqual(['main', 'develop']);
+  });
+
+  it('puts the exact match first, then prefixes, then the rest', () => {
+    // The bug this replaced: a native datalist filtered "main" down to
+    // main-3/main-4 and hid every other branch entirely.
+    expect(filterBranches(branches, 'main')).toEqual([
+      'main',
+      'main-3',
+      // Both of these match right after a "/", so they keep their input order.
+      'feature/maintenance-window',
+      'fix/main-thread-hang',
+    ]);
+  });
+
+  it('treats a match after a separator as a prefix', () => {
+    expect(filterBranches(branches, 'thread')).toEqual(['fix/main-thread-hang']);
+    expect(filterBranches(['a/beta', 'alphabeta'], 'beta')).toEqual(['a/beta', 'alphabeta']);
+  });
+
+  it('ignores case and keeps the incoming order within a rank', () => {
+    expect(filterBranches(branches, 'RELEASE')).toEqual(['release/2.4']);
+    expect(filterBranches(['b-x', 'a-x'], 'x')).toEqual(['b-x', 'a-x']);
+  });
+
+  it('returns nothing when there is no match', () => {
+    expect(filterBranches(branches, 'nope')).toEqual([]);
+  });
+});

--- a/frontend/src/components/git/branchFilter.ts
+++ b/frontend/src/components/git/branchFilter.ts
@@ -7,7 +7,7 @@
  */
 
 /** Rendering more than this at once is wasted work — nobody scrolls that far. */
-export const MAX_VISIBLE_BRANCHES = 200;
+const MAX_VISIBLE_BRANCHES = 200;
 
 export function filterBranches(
   branches: string[],

--- a/frontend/src/components/git/branchFilter.ts
+++ b/frontend/src/components/git/branchFilter.ts
@@ -1,0 +1,41 @@
+/**
+ * Narrowing a branch list down to what the user is typing.
+ *
+ * Pure and separate from the combobox so the ranking rules can be checked
+ * directly: with hundreds of branches, *which* ten are shown first is the whole
+ * usefulness of the picker.
+ */
+
+/** Rendering more than this at once is wasted work — nobody scrolls that far. */
+export const MAX_VISIBLE_BRANCHES = 200;
+
+export function filterBranches(
+  branches: string[],
+  query: string,
+  limit: number = MAX_VISIBLE_BRANCHES,
+): string[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return branches.slice(0, limit);
+
+  // Rank rather than merely filter: typing "main" must not bury `main` itself
+  // under `feature/maintenance-window`.
+  const scored: Array<{ name: string; score: number; index: number }> = [];
+  branches.forEach((name, index) => {
+    const haystack = name.toLowerCase();
+    const at = haystack.indexOf(needle);
+    if (at < 0) return;
+
+    const score = haystack === needle ? 0
+      : at === 0 ? 1
+        // A match right after a separator reads as a prefix too: "fix" in
+        // "feature/fix-thing".
+        : /[/\-_]/.test(haystack[at - 1]) ? 2
+          : 3;
+    scored.push({ name, score, index });
+  });
+
+  return scored
+    .sort((a, b) => (a.score - b.score) || (a.index - b.index))
+    .slice(0, limit)
+    .map(entry => entry.name);
+}

--- a/frontend/src/components/git/commitFileCache.ts
+++ b/frontend/src/components/git/commitFileCache.ts
@@ -1,0 +1,36 @@
+import type { GitCommitFilesResult } from '../../../../shared/types/git';
+
+/**
+ * Per-commit file listings are immutable, so they are cached for the lifetime
+ * of the renderer. The working tree (`index`) is deliberately never cached —
+ * it changes constantly and must always be re-read.
+ */
+const cache = new Map<string, GitCommitFilesResult>();
+
+export const WORKING_TREE_REF = 'index';
+
+export function commitFileCacheKey(sessionId: string, commitRef: string): string {
+  return `${sessionId}:${commitRef}`;
+}
+
+export function readCommitFileCache(sessionId: string, commitRef: string): GitCommitFilesResult | undefined {
+  if (commitRef === WORKING_TREE_REF) return undefined;
+  return cache.get(commitFileCacheKey(sessionId, commitRef));
+}
+
+export function writeCommitFileCache(sessionId: string, commitRef: string, value: GitCommitFilesResult): void {
+  if (commitRef === WORKING_TREE_REF) return;
+  cache.set(commitFileCacheKey(sessionId, commitRef), value);
+}
+
+/** Drop cached listings after a git operation rewrites history. */
+export function invalidateCommitFileCache(sessionId?: string): void {
+  if (!sessionId) {
+    cache.clear();
+    return;
+  }
+  const prefix = `${sessionId}:`;
+  for (const key of Array.from(cache.keys())) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}

--- a/frontend/src/components/git/commitFileCache.ts
+++ b/frontend/src/components/git/commitFileCache.ts
@@ -7,9 +7,9 @@ import type { GitCommitFilesResult } from '../../../../shared/types/git';
  */
 const cache = new Map<string, GitCommitFilesResult>();
 
-export const WORKING_TREE_REF = 'index';
+const WORKING_TREE_REF = 'index';
 
-export function commitFileCacheKey(sessionId: string, commitRef: string): string {
+function commitFileCacheKey(sessionId: string, commitRef: string): string {
   return `${sessionId}:${commitRef}`;
 }
 

--- a/frontend/src/components/git/pullRequestUrl.ts
+++ b/frontend/src/components/git/pullRequestUrl.ts
@@ -1,0 +1,6 @@
+/** Read `owner/repo` and the number from a stored GitHub pull request URL. */
+export function parsePullRequestUrl(url: string | undefined): { repo: string; number: number } | null {
+  const match = /github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/.exec(url ?? '');
+  if (!match) return null;
+  return { repo: match[1], number: Number(match[2]) };
+}

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -473,7 +473,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     commitDiffRequestIdRef.current += 1;
     setViewingCommitHash(commitRef);
     setSelectedExecutions([]);
-  }, []);
+  }, [viewingCommitHashRef]);
 
   const handleManualRefresh = () => {
     triggerSoftRefresh();

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect, memo, useCallback, useRef, useMemo, forwardRef, useImperativeHandle } from 'react';
 import DiffViewer, { DiffViewerHandle } from './DiffViewer';
 import ExecutionList from '../../ExecutionList';
+import { invalidateCommitFileCache } from '../../git/commitFileCache';
 import { CommitDialog } from '../../CommitDialog';
 import { API } from '../../../utils/api';
+import { parseUnifiedDiffToFiles } from '../../../utils/parseUnifiedDiff';
 import type { CombinedDiffViewProps, FileDiff } from '../../../types/diff';
 import type { ExecutionDiff, GitDiffResult } from '../../../types/diff';
 import { RefreshCw } from 'lucide-react';
@@ -36,34 +38,6 @@ async function loadCommitDiff(sessionId: string, commitHash: string): Promise<Co
     };
   }
 }
-
-// --- Unified diff parser (single pass, shared between FileList and DiffViewer) ---
-
-function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
-  if (!diff?.trim()) return [];
-
-  const fileChunks = diff.match(/diff --git[\s\S]*?(?=diff --git|$)/g);
-  if (!fileChunks) return [];
-
-  return fileChunks.flatMap(chunk => {
-    const nameMatch = chunk.match(/diff --git a\/(.*?) b\/(.*?)(?:\n|$)/);
-    if (!nameMatch) return [];
-    const oldPath = nameMatch[1];
-    const newPath = nameMatch[2];
-    const isBinary = chunk.includes('Binary files') || chunk.includes('GIT binary patch');
-
-    let type: FileDiff['type'] = 'modified';
-    if (chunk.includes('new file mode')) type = 'added';
-    else if (chunk.includes('deleted file mode')) type = 'deleted';
-    else if (chunk.includes('rename from') && chunk.includes('rename to')) type = 'renamed';
-
-    const additions = (chunk.match(/^\+(?!\+\+)/gm) || []).length;
-    const deletions = (chunk.match(/^-(?!--)/gm) || []).length;
-
-    return [{ path: newPath || oldPath, oldPath, type, isBinary, additions, deletions, rawDiff: chunk }];
-  });
-}
-
 // --- CombinedDiffView ---
 
 export interface CombinedDiffViewHandle {
@@ -118,6 +92,8 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
   const [isResizing, setIsResizing] = useState(false);
 
   const diffViewerRef = useRef<DiffViewerHandle>(null);
+  // Path a file-row click asked us to reveal once the matching diff has loaded.
+  const pendingRevealPathRef = useRef<string | null>(null);
 
   const isAnyLoading = executionsLoading || diffLoading || commitDiffLoading;
   const showInitialSkeleton = executionsLoading && executions.length === 0;
@@ -319,11 +295,12 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
 
   const triggerSoftRefresh = useCallback(() => {
     diffCacheRef.current.clear();
+    invalidateCommitFileCache(sessionId);
     commitDiffRequestIdRef.current += 1;
     combinedDiffRequestIdRef.current += 1;
     setViewingCommitHash(null);
     setExecutionRefreshNonce(prev => prev + 1);
-  }, []);
+  }, [sessionId]);
 
   // Expose refresh() to parent (DiffPanel) via ref.
   // Same-session refresh keeps current diff visible while refreshed data loads.
@@ -336,18 +313,21 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
   // fired while this component was unmounted (non-active panels are not rendered).
   useEffect(() => {
     // Consume any pending hash written before this component mounted
-    const pendingCommitHash = takePendingViewCommit(sessionId);
-    if (pendingCommitHash !== null) {
+    const pendingCommit = takePendingViewCommit(sessionId);
+    if (pendingCommit !== null) {
       combinedDiffRequestIdRef.current += 1;
-      setViewingCommitHash(pendingCommitHash);
+      pendingRevealPathRef.current = pendingCommit.filePath ?? null;
+      setViewingCommitHash(pendingCommit.commitHash);
       setSelectedExecutions([]);
     }
 
     const handler = (event: Event) => {
       // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
-      const { sessionId: eventSessionId, commitHash } = (event as CustomEvent<{ sessionId: string; commitHash: string }>).detail;
+      const { sessionId: eventSessionId, commitHash, filePath } =
+        (event as CustomEvent<{ sessionId: string; commitHash: string; filePath?: string }>).detail;
       if (eventSessionId !== sessionId) return;
       combinedDiffRequestIdRef.current += 1;
+      pendingRevealPathRef.current = filePath ?? null;
       setViewingCommitHash(commitHash);
       setSelectedExecutions([]);
       clearPendingViewCommit();
@@ -471,9 +451,29 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
 
   const handleSelectionChange = (newSelection: number[]) => {
     commitDiffRequestIdRef.current += 1;
+    pendingRevealPathRef.current = null;
     setViewingCommitHash(null); // exit hash mode
     setSelectedExecutions(newSelection);
   };
+
+  // A file row inside an expanded commit was clicked: switch the diff pane to
+  // that commit (if it is not already showing it) and remember which file to
+  // scroll to once the patch has been parsed.
+  const handleFileClick = useCallback((commitRef: string, path: string) => {
+    pendingRevealPathRef.current = path;
+    if (viewingCommitHashRef.current === commitRef) {
+      // Already showing this commit — reveal immediately.
+      const index = parsedFilesRef.current.findIndex(file => file.path === path);
+      if (index >= 0) {
+        pendingRevealPathRef.current = null;
+        diffViewerRef.current?.scrollToFile(index);
+      }
+      return;
+    }
+    commitDiffRequestIdRef.current += 1;
+    setViewingCommitHash(commitRef);
+    setSelectedExecutions([]);
+  }, []);
 
   const handleManualRefresh = () => {
     triggerSoftRefresh();
@@ -525,6 +525,26 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     if (!combinedDiff?.diff) return [];
     return parseUnifiedDiffToFiles(combinedDiff.diff);
   }, [combinedDiff]);
+
+  const parsedFilesRef = useRef(parsedFiles);
+  parsedFilesRef.current = parsedFiles;
+
+  // Consume a pending file reveal once the newly requested diff has parsed.
+  // DiffViewer resets its expanded set on a file-list change, so the reveal is
+  // deferred by a frame to land after that reset.
+  useEffect(() => {
+    const path = pendingRevealPathRef.current;
+    if (!path || parsedFiles.length === 0) return;
+
+    const index = parsedFiles.findIndex(file => file.path === path);
+    pendingRevealPathRef.current = null;
+    if (index < 0) return;
+
+    const frame = requestAnimationFrame(() => {
+      diffViewerRef.current?.scrollToFile(index);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [parsedFiles]);
 
   const handleRestore = useCallback(async () => {
     if (!window.confirm('Are you sure you want to restore all uncommitted changes? This will discard all your local modifications.')) {
@@ -653,6 +673,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
                   onRestore={handleRestore}
                   historyLimitReached={limitReached}
                   historyLimit={HISTORY_LIMIT}
+                  onFileClick={handleFileClick}
                 />
               </div>
             </div>

--- a/frontend/src/components/panels/diff/DiffPanel.tsx
+++ b/frontend/src/components/panels/diff/DiffPanel.tsx
@@ -5,6 +5,8 @@ import type { ToolPanel, DiffPanelState } from '../../../../../shared/types/pane
 import type { GitStatus } from '../../../types/session';
 import { AlertCircle, GitBranch, Globe } from 'lucide-react';
 import { useSession } from '../../../contexts/SessionContext';
+import { PullRequestChecks } from '../../git/PullRequestChecks';
+import { PullRequestStatusBar } from '../../git/PullRequestStatusBar';
 import { cn } from '../../../utils/cn';
 import BrowserSurface from '../browser/BrowserSurface';
 import {
@@ -230,6 +232,10 @@ const DiffPanel: React.FC<DiffPanelProps> = ({
           {session?.gitStatus?.prTitle && (
             <span className="text-xs text-text-tertiary truncate">{session.gitStatus.prTitle}</span>
           )}
+          {/* Did the agent break the build? Asked here because this is where it comes up. */}
+          {sessionId && (
+            <PullRequestChecks sessionId={sessionId} prUrl={session?.gitStatus?.prUrl} />
+          )}
         </div>
 
         <div className="inline-flex items-center rounded border border-border-primary bg-bg-primary p-0.5 flex-shrink-0">
@@ -267,6 +273,14 @@ const DiffPanel: React.FC<DiffPanelProps> = ({
           </button>
         </div>
       </div>
+
+      {/*
+        State of the pull request these changes belong to. Creating one is a
+        one-off action in the git menu; watching it is what happens here.
+      */}
+      {sessionId && (
+        <PullRequestStatusBar sessionId={sessionId} prUrl={session?.gitStatus?.prUrl} />
+      )}
 
       {/* Stale indicator bar */}
       {reviewMode === 'local' && isStale && !isActive && (

--- a/frontend/src/components/panels/diff/pendingViewCommit.ts
+++ b/frontend/src/components/panels/diff/pendingViewCommit.ts
@@ -1,20 +1,21 @@
 interface PendingViewCommit {
   sessionId: string;
   commitHash: string;
+  filePath?: string;
 }
 
 let pendingViewCommit: PendingViewCommit | null = null;
 
 /** Called by SessionView before dispatching 'diff:view-commit'. */
-export function setPendingViewCommit(sessionId: string, commitHash: string): void {
-  pendingViewCommit = { sessionId, commitHash };
+export function setPendingViewCommit(sessionId: string, commitHash: string, filePath?: string): void {
+  pendingViewCommit = { sessionId, commitHash, filePath };
 }
 
-export function takePendingViewCommit(sessionId: string): string | null {
+export function takePendingViewCommit(sessionId: string): PendingViewCommit | null {
   if (pendingViewCommit?.sessionId !== sessionId) return null;
-  const { commitHash } = pendingViewCommit;
+  const pending = pendingViewCommit;
   pendingViewCommit = null;
-  return commitHash;
+  return pending;
 }
 
 export function clearPendingViewCommit(): void {

--- a/frontend/src/types/diff.ts
+++ b/frontend/src/types/diff.ts
@@ -60,6 +60,11 @@ export interface ExecutionListProps {
   onRestore?: () => void;
   historyLimitReached?: boolean;
   historyLimit?: number;
+  /**
+   * Called when a file inside an expanded commit is activated.
+   * `commitRef` is a commit hash, or `index` for uncommitted changes.
+   */
+  onFileClick?: (commitRef: string, path: string) => void;
 }
 
 export interface CombinedDiffViewProps {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -35,6 +35,7 @@ import type { JsonValue } from '../../../shared/validation/boundaryDecoder';
 import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
+import type { GitCommitFilesResult } from '../../../shared/types/git';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
@@ -154,6 +155,7 @@ interface ElectronAPI {
     gitDiff: (sessionId: string) => Promise<IPCResponse>;
     getCombinedDiff: (sessionId: string, executionIds?: number[]) => Promise<IPCResponse>;
     getCommitDiffByHash: (sessionId: string, commitHash: string) => Promise<IPCResponse>;
+    getCommitFiles: (sessionId: string, ref: string) => Promise<IPCResponse<GitCommitFilesResult>>;
 
     // Script operations
     hasRunScript: (sessionId: string) => Promise<IPCResponse>;

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -36,6 +36,17 @@ import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
 import type { GitCommitFilesResult } from '../../../shared/types/git';
+import type {
+  CreatePullRequestRequest,
+  CreatePullRequestResult,
+  BaseBranchOptions,
+  PullRequestChanges,
+  PullRequestChecksResult,
+  PullRequestDiff,
+  PullRequestDraft,
+  PullRequestStatus,
+} from '../../../shared/types/pullRequest';
+import type { GitDiffResult } from './diff';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
@@ -125,6 +136,16 @@ interface ElectronAPI {
     setAgent: (agent: PaneChatAgent) => Promise<IPCResponse<PaneChatState<Session>>>;
   };
 
+  // Pull requests, opened from a session's branch
+  pullRequests: {
+    getDraft: (sessionId: string) => Promise<IPCResponse<PullRequestDraft>>;
+    create: (request: CreatePullRequestRequest) => Promise<IPCResponse<CreatePullRequestResult>>;
+    getChecks: (sessionId: string, repo: string, number: number) => Promise<IPCResponse<PullRequestChecksResult>>;
+    listBaseBranches: (sessionId: string, repo: string) => Promise<IPCResponse<BaseBranchOptions>>;
+    getChanges: (sessionId: string, baseBranch?: string) => Promise<IPCResponse<PullRequestChanges>>;
+    getDiff: (sessionId: string, baseBranch?: string) => Promise<IPCResponse<PullRequestDiff>>;
+    getStatus: (sessionId: string, repo: string, number: number) => Promise<IPCResponse<PullRequestStatus | null>>;
+  };
   // Session management
   sessions: {
     getAll: () => Promise<IPCResponse>;

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -46,7 +46,6 @@ import type {
   PullRequestDraft,
   PullRequestStatus,
 } from '../../../shared/types/pullRequest';
-import type { GitDiffResult } from './diff';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -190,6 +190,12 @@ export class API {
       return window.electronAPI.sessions.getCommitDiffByHash(sessionId, commitHash);
     },
 
+    /** Per-file change details for one commit, or `index` for the working tree. */
+    async getCommitFiles(sessionId: string, ref: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.sessions.getCommitFiles(sessionId, ref);
+    },
+
     // Main repo session
     async getOrCreateMainRepoSession(projectId: number) {
       if (!isElectron()) throw new Error('Electron API not available');

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -4,6 +4,7 @@ import type { Project } from '../types/project';
 import type { UpdateConfigRequest } from '../types/config';
 import type { SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
+import type { CreatePullRequestRequest } from '../../../shared/types/pullRequest';
 import type {
   RemoteDaemonClientRecord,
   RemoteDaemonClientSettings,
@@ -64,6 +65,43 @@ export class API {
     },
   };
 
+  // Pull requests, opened from a session's branch
+  static pullRequests = {
+    /** Everything the create dialog opens with, in one round trip. */
+    async getDraft(sessionId: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.pullRequests.getDraft(sessionId);
+    },
+    async create(request: CreatePullRequestRequest) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.pullRequests.create(request);
+    },
+    /** CI state for an open pull request. */
+    async getChecks(sessionId: string, repo: string, number: number) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.pullRequests.getChecks(sessionId, repo, number);
+    },
+    /** Base branch candidates for a repository. */
+    async listBaseBranches(sessionId: string, repo: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.pullRequests.listBaseBranches(sessionId, repo);
+    },
+    /** Files the pull request would carry, against the given base. */
+    async getChanges(sessionId: string, baseBranch?: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.pullRequests.getChanges(sessionId, baseBranch);
+    },
+    /** State, reviews and mergeability of an existing pull request. */
+    async getStatus(sessionId: string, repo: string, number: number) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.pullRequests.getStatus(sessionId, repo, number);
+    },
+    /** The patch itself — only fetched when the diff is opened. */
+    async getDiff(sessionId: string, baseBranch?: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.pullRequests.getDiff(sessionId, baseBranch);
+    },
+  };
   // Session management
   static sessions = {
     async getAll() {

--- a/frontend/src/utils/parseUnifiedDiff.test.ts
+++ b/frontend/src/utils/parseUnifiedDiff.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { parseUnifiedDiffToFiles } from './parseUnifiedDiff';
+
+const SAMPLE = `diff --git a/src/a.ts b/src/a.ts
+index 111..222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,4 @@
+ context
+-removed line
++added line
++another added
+diff --git a/src/new.ts b/src/new.ts
+new file mode 100644
+index 0000000..333
+--- /dev/null
++++ b/src/new.ts
+@@ -0,0 +1,2 @@
++first
++second
+`;
+
+describe('parseUnifiedDiffToFiles', () => {
+  it('returns nothing for empty input', () => {
+    expect(parseUnifiedDiffToFiles('')).toEqual([]);
+    expect(parseUnifiedDiffToFiles('   ')).toEqual([]);
+    expect(parseUnifiedDiffToFiles('not a diff')).toEqual([]);
+  });
+
+  it('splits one entry per file and classifies the change', () => {
+    const files = parseUnifiedDiffToFiles(SAMPLE);
+    expect(files.map(f => f.path)).toEqual(['src/a.ts', 'src/new.ts']);
+    expect(files[0].type).toBe('modified');
+    expect(files[1].type).toBe('added');
+  });
+
+  it('counts changed lines without counting the +++/--- headers', () => {
+    const files = parseUnifiedDiffToFiles(SAMPLE);
+    expect(files[0].additions).toBe(2);
+    expect(files[0].deletions).toBe(1);
+    expect(files[1].additions).toBe(2);
+    expect(files[1].deletions).toBe(0);
+  });
+
+  it('detects deletions and renames', () => {
+    const deleted = parseUnifiedDiffToFiles(
+      'diff --git a/gone.ts b/gone.ts\ndeleted file mode 100644\n--- a/gone.ts\n+++ /dev/null\n@@ -1 +0,0 @@\n-bye\n'
+    );
+    expect(deleted[0].type).toBe('deleted');
+    expect(deleted[0].deletions).toBe(1);
+
+    const renamed = parseUnifiedDiffToFiles(
+      'diff --git a/old.ts b/new.ts\nsimilarity index 100%\nrename from old.ts\nrename to new.ts\n'
+    );
+    expect(renamed[0].type).toBe('renamed');
+    expect(renamed[0].oldPath).toBe('old.ts');
+    expect(renamed[0].path).toBe('new.ts');
+  });
+
+  it('flags binary files', () => {
+    const files = parseUnifiedDiffToFiles(
+      'diff --git a/logo.png b/logo.png\nindex 1..2 100644\nBinary files a/logo.png and b/logo.png differ\n'
+    );
+    expect(files[0].isBinary).toBe(true);
+  });
+
+  it('handles a large diff without pathological cost', () => {
+    // 50k added lines in one file — the shape that made Review crawl.
+    const body = Array.from({ length: 50_000 }, (_, i) => `+line ${i}`).join('\n');
+    const huge = `diff --git a/big.ts b/big.ts\nnew file mode 100644\n--- /dev/null\n+++ b/big.ts\n@@ -0,0 +1,50000 @@\n${body}\n`;
+
+    const started = performance.now();
+    const files = parseUnifiedDiffToFiles(huge);
+    const elapsed = performance.now() - started;
+
+    expect(files).toHaveLength(1);
+    expect(files[0].additions).toBe(50_000);
+    // Generous bound: the point is that it is milliseconds, not seconds.
+    expect(elapsed).toBeLessThan(1000);
+  });
+});

--- a/frontend/src/utils/parseUnifiedDiff.ts
+++ b/frontend/src/utils/parseUnifiedDiff.ts
@@ -7,7 +7,7 @@ import type { FileDiff } from '../types/diff';
  * changed line — on a 50k-line uncommitted diff that is 50k throwaway strings
  * per file, on the UI thread. Scanning line starts directly costs nothing.
  */
-function countChangedLines(chunk: string): { additions: number; deletions: number } {
+function countChangedLines(chunk: string) {
   let additions = 0;
   let deletions = 0;
   let lineStart = 0;

--- a/frontend/src/utils/parseUnifiedDiff.ts
+++ b/frontend/src/utils/parseUnifiedDiff.ts
@@ -1,0 +1,62 @@
+import type { FileDiff } from '../types/diff';
+
+/**
+ * Count added/removed lines without allocating a match array.
+ *
+ * `chunk.match(/^\+(?!\+\+)/gm).length` builds an array with one entry per
+ * changed line — on a 50k-line uncommitted diff that is 50k throwaway strings
+ * per file, on the UI thread. Scanning line starts directly costs nothing.
+ */
+function countChangedLines(chunk: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  let lineStart = 0;
+
+  while (lineStart < chunk.length) {
+    let lineEnd = chunk.indexOf('\n', lineStart);
+    if (lineEnd === -1) lineEnd = chunk.length;
+
+    const first = chunk[lineStart];
+    if (first === '+') {
+      // Skip the `+++ b/path` file header.
+      if (!(chunk[lineStart + 1] === '+' && chunk[lineStart + 2] === '+')) additions++;
+    } else if (first === '-') {
+      // Skip the `--- a/path` file header.
+      if (!(chunk[lineStart + 1] === '-' && chunk[lineStart + 2] === '-')) deletions++;
+    }
+
+    lineStart = lineEnd + 1;
+  }
+
+  return { additions, deletions };
+}
+
+/**
+ * Split a unified diff into one {@link FileDiff} per `diff --git` chunk.
+ *
+ * Single pass, no allocation per hunk: each chunk keeps its raw patch text so
+ * the renderer can hand it straight to `@git-diff-view/react`.
+ */
+export function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
+  if (!diff?.trim()) return [];
+
+  const fileChunks = diff.match(/diff --git[\s\S]*?(?=diff --git|$)/g);
+  if (!fileChunks) return [];
+
+  return fileChunks.flatMap(chunk => {
+    const nameMatch = chunk.match(/diff --git a\/(.*?) b\/(.*?)(?:\n|$)/);
+    if (!nameMatch) return [];
+    const oldPath = nameMatch[1];
+    const newPath = nameMatch[2];
+    const isBinary = chunk.includes('Binary files') || chunk.includes('GIT binary patch');
+
+    let type: FileDiff['type'] = 'modified';
+    if (chunk.includes('new file mode')) type = 'added';
+    else if (chunk.includes('deleted file mode')) type = 'deleted';
+    else if (chunk.includes('rename from') && chunk.includes('rename to')) type = 'renamed';
+
+    const { additions, deletions } = countChangedLines(chunk);
+
+    return [{ path: newPath || oldPath, oldPath, type, isBinary, additions, deletions, rawDiff: chunk }];
+  });
+}

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -12,8 +12,21 @@ import { registerPromptHandlers } from './prompt';
 import { registerScriptHandlers } from './script';
 import { registerSessionHandlers } from './session';
 import { registerVoiceHandlers } from './voice';
+import { registerFleetHandlers } from './fleet';
+import { registerPullRequestHandlers } from './pullRequest';
+import { registerScheduleHandlers } from './schedule';
+import { registerUsageHandlers } from './usage';
 import type { AppServices } from './types';
 
+const PULL_REQUEST_CHANNELS = [
+  'pr:get-draft',
+  'pr:create',
+  'pr:get-checks',
+  'pr:list-base-branches',
+  'pr:get-changes',
+  'pr:get-diff',
+  'pr:get-status',
+] as const;
 const PROJECT_CHANNELS = [
   'projects:get-all',
   'projects:get-active',
@@ -343,6 +356,7 @@ describe('daemon registry IPC bindings', () => {
     expect(ipcMain.boundChannels.sort()).toEqual([...VOICE_CHANNELS].sort());
   });
 
+    registerPullRequestHandlers(ipcMain, createServicesStub(), registry);
   it('binds daemon-owned prompt channels through the shared registry', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -173,6 +173,7 @@ const GIT_STATUS_CHANNELS = [
   'git:file-status',
   'sessions:git-diff',
   'sessions:get-commit-diff-by-hash',
+  'sessions:get-commit-files',
   'sessions:get-combined-diff',
   'sessions:check-rebase-conflicts',
   'sessions:has-stash',

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -12,10 +12,7 @@ import { registerPromptHandlers } from './prompt';
 import { registerScriptHandlers } from './script';
 import { registerSessionHandlers } from './session';
 import { registerVoiceHandlers } from './voice';
-import { registerFleetHandlers } from './fleet';
 import { registerPullRequestHandlers } from './pullRequest';
-import { registerScheduleHandlers } from './schedule';
-import { registerUsageHandlers } from './usage';
 import type { AppServices } from './types';
 
 const PULL_REQUEST_CHANNELS = [
@@ -356,7 +353,16 @@ describe('daemon registry IPC bindings', () => {
     expect(ipcMain.boundChannels.sort()).toEqual([...VOICE_CHANNELS].sort());
   });
 
+  it('binds daemon-owned pull request channels through the shared registry', () => {
+    const registry = new PaneCommandRegistry();
+    const ipcMain = createIpcMainStub();
+
     registerPullRequestHandlers(ipcMain, createServicesStub(), registry);
+
+    expect(registry.listChannels()).toEqual([...PULL_REQUEST_CHANNELS].sort());
+    expect(ipcMain.boundChannels.sort()).toEqual([...PULL_REQUEST_CHANNELS].sort());
+  });
+
   it('binds daemon-owned prompt channels through the shared registry', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -12,18 +12,9 @@ import { registerPromptHandlers } from './prompt';
 import { registerScriptHandlers } from './script';
 import { registerSessionHandlers } from './session';
 import { registerVoiceHandlers } from './voice';
-import { registerPullRequestHandlers } from './pullRequest';
+import { DAEMON_PULL_REQUEST_CHANNELS, registerPullRequestHandlers } from './pullRequest';
 import type { AppServices } from './types';
 
-const PULL_REQUEST_CHANNELS = [
-  'pr:get-draft',
-  'pr:create',
-  'pr:get-checks',
-  'pr:list-base-branches',
-  'pr:get-changes',
-  'pr:get-diff',
-  'pr:get-status',
-] as const;
 const PROJECT_CHANNELS = [
   'projects:get-all',
   'projects:get-active',
@@ -359,8 +350,8 @@ describe('daemon registry IPC bindings', () => {
 
     registerPullRequestHandlers(ipcMain, createServicesStub(), registry);
 
-    expect(registry.listChannels()).toEqual([...PULL_REQUEST_CHANNELS].sort());
-    expect(ipcMain.boundChannels.sort()).toEqual([...PULL_REQUEST_CHANNELS].sort());
+    expect(registry.listChannels()).toEqual([...DAEMON_PULL_REQUEST_CHANNELS].sort());
+    expect(ipcMain.boundChannels.sort()).toEqual([...DAEMON_PULL_REQUEST_CHANNELS].sort());
   });
 
   it('binds daemon-owned prompt channels through the shared registry', () => {

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -71,6 +71,7 @@ const DAEMON_GIT_STATUS_CHANNELS = [
   'git:file-status',
   'sessions:git-diff',
   'sessions:get-commit-diff-by-hash',
+  'sessions:get-commit-files',
   'sessions:get-combined-diff',
   'sessions:check-rebase-conflicts',
   'sessions:has-stash',
@@ -563,6 +564,33 @@ export function registerGitHandlers(
       console.error('Failed to get commit diff by hash:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to get commit diff';
       return { success: false, error: errorMessage };
+    }
+  });
+
+  commandRegistry.register('sessions:get-commit-files', async (sessionId: string, ref: string) => {
+    try {
+      const session = await sessionManager.getSession(sessionId);
+      if (!session || !session.worktreePath) {
+        return { success: false, error: 'Session or worktree path not found' };
+      }
+
+      if (session.archived) {
+        return { success: false, error: 'Cannot list changed files for an archived session' };
+      }
+
+      const ctx = sessionManager.getProjectContext(sessionId);
+      if (!ctx) {
+        return { success: false, error: 'Project context not found for session' };
+      }
+
+      const data = gitDiffManager.getCommitFileChanges(session.worktreePath, ref, ctx.commandRunner);
+      return { success: true, data };
+    } catch (error) {
+      console.error('Failed to list commit files:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to list commit files',
+      };
     }
   });
 

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -26,6 +26,7 @@ import { registerResourceMonitorHandlers } from './resourceMonitor';
 import { registerOnboardingHandlers } from './onboarding';
 import { registerVoiceHandlers } from './voice';
 import { registerPaneChatHandlers } from './paneChat';
+import { registerPullRequestHandlers } from './pullRequest';
 import { createDaemonBridgeRouter, registerDaemonBridgeHandlers } from './daemon';
 import { registerPermissionHandlers } from './permissions';
 import { registerAgentUsageHandlers } from './agentUsage';
@@ -81,6 +82,7 @@ export function registerIpcHandlers(services: AppServices): PaneCommandRegistry 
   registerAgentUsageHandlers(ipcMain, services, commandRegistry);
   registerVoiceHandlers(ipcMain, services, commandRegistry);
   registerPaneChatHandlers(ipcMain, services, commandRegistry);
+  registerPullRequestHandlers(ipcMain, services, commandRegistry);
   registerOnboardingHandlers(ipcMain, services);
   registerDaemonBridgeHandlers(ipcMain, bridgeRouter);
 

--- a/main/src/ipc/pullRequest.ts
+++ b/main/src/ipc/pullRequest.ts
@@ -1,0 +1,175 @@
+import type { IpcMain } from 'electron';
+import type { AppServices } from './types';
+import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { PullRequestManager } from '../services/pullRequestManager';
+import type { CreatePullRequestRequest } from '../../../shared/types/pullRequest';
+
+export const DAEMON_PULL_REQUEST_CHANNELS = [
+  'pr:get-draft',
+  'pr:create',
+  'pr:get-checks',
+  'pr:list-base-branches',
+  'pr:get-changes',
+  'pr:get-diff',
+  'pr:get-status',
+] as const;
+
+/**
+ * Opening pull requests from a session.
+ *
+ * Daemon-owned: the branch, its remote and the `gh` binary all live on the
+ * machine that runs the agents, so a remote runtime must answer these itself
+ * rather than have the laptop push a branch it does not have.
+ */
+export function registerPullRequestHandlers(
+  ipcMain: IpcMain,
+  { sessionManager, worktreeManager, gitStatusManager }: AppServices,
+  commandRegistry: PaneCommandRegistry,
+): void {
+  const pullRequestManager = new PullRequestManager();
+
+  /**
+   * Resolve the pieces a session needs for any pull request operation.
+   *
+   * The comparison branch is the one the session was branched from, which is
+   * what a pull request should target — not the project's main branch, which
+   * may be something else entirely for a stacked session.
+   */
+  const resolveContext = async (sessionId: string) => {
+    const session = await sessionManager.getSession(sessionId);
+    if (!session?.worktreePath) throw new Error('Session or worktree path not found');
+    if (session.archived) throw new Error('This session is archived');
+
+    const ctx = sessionManager.getProjectContext(sessionId);
+    if (!ctx?.project?.path) throw new Error('Project context not found for session');
+
+    const baseBranch = await worktreeManager.getSessionComparisonBranch(session, ctx);
+
+    return { session, ctx, baseBranch };
+  };
+
+  commandRegistry.register('pr:get-draft', async (sessionId: string) => {
+    try {
+      const { session, ctx, baseBranch } = await resolveContext(sessionId);
+      const data = await pullRequestManager.getDraft(
+        session.worktreePath,
+        ctx.project.path,
+        baseBranch,
+        ctx.commandRunner,
+      );
+      return { success: true, data };
+    } catch (error) {
+      console.error('[PullRequest] Failed to build draft:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to prepare the pull request',
+      };
+    }
+  });
+
+  commandRegistry.register('pr:create', async (request: CreatePullRequestRequest) => {
+    try {
+      if (!request?.title?.trim()) return { success: false, error: 'A title is required' };
+      if (!request?.targetRepo) return { success: false, error: 'A target repository is required' };
+
+      const { session, ctx } = await resolveContext(request.sessionId);
+      const data = await pullRequestManager.create(
+        request,
+        session.worktreePath,
+        ctx.project.path,
+        ctx.commandRunner,
+      );
+
+      // The session list shows pull request state from a cache with a 20s miss
+      // TTL. Drop it so the new pull request appears now, not eventually.
+      gitStatusManager.invalidatePrCache(ctx.project.path);
+      void gitStatusManager.refreshSessionGitStatus(request.sessionId, false).catch(() => {});
+
+      return { success: true, data };
+    } catch (error) {
+      console.error('[PullRequest] Failed to create pull request:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to create the pull request',
+      };
+    }
+  });
+
+  commandRegistry.register('pr:get-status', async (sessionId: string, repo: string, number: number) => {
+    try {
+      const { ctx } = await resolveContext(sessionId);
+      const data = await pullRequestManager.getStatus(repo, Number(number), ctx.project.path, ctx.commandRunner);
+      return { success: true, data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to read the pull request',
+      };
+    }
+  });
+
+  commandRegistry.register('pr:get-checks', async (sessionId: string, repo: string, number: number) => {
+    try {
+      const { ctx } = await resolveContext(sessionId);
+      const data = await pullRequestManager.getChecks(repo, Number(number), ctx.project.path, ctx.commandRunner);
+      return { success: true, data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to read pull request checks',
+      };
+    }
+  });
+
+  /** Base candidates for a repository — reloaded when the target changes. */
+  commandRegistry.register('pr:list-base-branches', async (sessionId: string, repo: string) => {
+    try {
+      const { ctx } = await resolveContext(sessionId);
+      const data = await pullRequestManager.listBaseBranches(repo, ctx.project.path, ctx.commandRunner);
+      return { success: true, data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to list branches',
+      };
+    }
+  });
+
+  /** Which files the pull request would carry — counts only, no patch. */
+  commandRegistry.register('pr:get-changes', async (sessionId: string, baseBranch?: string) => {
+    try {
+      const { session, ctx, baseBranch: fallback } = await resolveContext(sessionId);
+      const data = await pullRequestManager.getChanges(
+        session.worktreePath,
+        baseBranch?.trim() || fallback,
+        ctx.commandRunner,
+      );
+      return { success: true, data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to list the changed files',
+      };
+    }
+  });
+
+  /** The patch itself, loaded only when the user opens the diff. */
+  commandRegistry.register('pr:get-diff', async (sessionId: string, baseBranch?: string) => {
+    try {
+      const { session, ctx, baseBranch: fallback } = await resolveContext(sessionId);
+      const data = await pullRequestManager.getDiff(
+        session.worktreePath,
+        baseBranch?.trim() || fallback,
+        ctx.commandRunner,
+      );
+      return { success: true, data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to read the diff',
+      };
+    }
+  });
+
+  commandRegistry.bindChannels(ipcMain, DAEMON_PULL_REQUEST_CHANNELS);
+}

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -27,6 +27,7 @@ import type { AgentUsageSnapshot } from '../../shared/types/agentUsage';
 import type { CloudVmState } from '../../shared/types/cloud';
 import type { ResourceSnapshot } from '../../shared/types/resourceMonitor';
 import type { SubmitFeedbackRequest } from '../../shared/types/feedback';
+import type { CreatePullRequestRequest } from '../../shared/types/pullRequest';
 import type {
   PanePermissionRequest as PermissionRequest,
   PanePermissionResponse as PermissionResponse,
@@ -478,7 +479,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Pull requests, opened from a session's branch
   pullRequests: {
     getDraft: (sessionId: string): Promise<IPCResponse> => invokeIpc('pr:get-draft', sessionId),
-    create: (request: unknown): Promise<IPCResponse> => invokeIpc('pr:create', request),
+    create: (request: CreatePullRequestRequest): Promise<IPCResponse> => invokeIpc('pr:create', request),
     getChecks: (sessionId: string, repo: string, number: number): Promise<IPCResponse> => invokeIpc('pr:get-checks', sessionId, repo, number),
     listBaseBranches: (sessionId: string, repo: string): Promise<IPCResponse> => invokeIpc('pr:list-base-branches', sessionId, repo),
     getChanges: (sessionId: string, baseBranch?: string): Promise<IPCResponse> => invokeIpc('pr:get-changes', sessionId, baseBranch),

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -503,6 +503,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     gitDiff: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-diff', sessionId),
     getCombinedDiff: (sessionId: string, executionIds?: number[]): Promise<IPCResponse> => invokeIpc('sessions:get-combined-diff', sessionId, executionIds),
     getCommitDiffByHash: (sessionId: string, commitHash: string): Promise<IPCResponse> => invokeIpc('sessions:get-commit-diff-by-hash', sessionId, commitHash),
+    getCommitFiles: (sessionId: string, ref: string): Promise<IPCResponse> => invokeIpc('sessions:get-commit-files', sessionId, ref),
 
     // Main repo session
     getOrCreateMainRepoSession: (projectId: number): Promise<IPCResponse> => invokeIpc('sessions:get-or-create-main-repo', projectId),

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -132,7 +132,9 @@ const DAEMON_OWNED_CHANNEL_PREFIXES = [
   'projects:',
   'prompts:',
   'resource-monitor:',
+  'pr:',
   'runpane:',
+  'schedules:',
   'sessions:',
   'terminal:',
   'voice:',
@@ -473,6 +475,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     setAgent: (agent: 'claude' | 'codex' | 'cursor'): Promise<IPCResponse> => invokeIpc('pane-chat:set-agent', agent),
   },
 
+  // Pull requests, opened from a session's branch
+  pullRequests: {
+    getDraft: (sessionId: string): Promise<IPCResponse> => invokeIpc('pr:get-draft', sessionId),
+    create: (request: unknown): Promise<IPCResponse> => invokeIpc('pr:create', request),
+    getChecks: (sessionId: string, repo: string, number: number): Promise<IPCResponse> => invokeIpc('pr:get-checks', sessionId, repo, number),
+    listBaseBranches: (sessionId: string, repo: string): Promise<IPCResponse> => invokeIpc('pr:list-base-branches', sessionId, repo),
+    getChanges: (sessionId: string, baseBranch?: string): Promise<IPCResponse> => invokeIpc('pr:get-changes', sessionId, baseBranch),
+    getDiff: (sessionId: string, baseBranch?: string): Promise<IPCResponse> => invokeIpc('pr:get-diff', sessionId, baseBranch),
+    getStatus: (sessionId: string, repo: string, number: number): Promise<IPCResponse> => invokeIpc('pr:get-status', sessionId, repo, number),
+  },
   // Session management
   sessions: {
     getAll: (): Promise<IPCResponse> => invokeIpc('sessions:get-all'),

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   GitDiffManager,
-  parseNumstatZ,
-  parseNameStatusZ,
-  parseUntrackedPathsZ,
-  mergeFileChanges,
   WORKING_TREE_REF,
 } from './gitDiffManager';
+import { mergeFileChanges, parseNameStatusZ, parseNumstatZ, parseUntrackedPathsZ } from './gitDiffParsers';
 import type { CommandRunner } from '../utils/commandRunner';
 
 /**

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  GitDiffManager,
+  parseNumstatZ,
+  parseNameStatusZ,
+  parseUntrackedPathsZ,
+  mergeFileChanges,
+  WORKING_TREE_REF,
+  MAX_UNTRACKED_INLINE_FILES,
+  chunkByCommandLength,
+} from './gitDiffManager';
+import type { CommandRunner } from '../utils/commandRunner';
+
+/**
+ * Builds a CommandRunner stub whose `exec` dispatches on a substring of the
+ * command, so each test only has to describe the outputs it cares about.
+ */
+function stubRunner(responses: Array<[match: string, output: string]>): CommandRunner {
+  const exec = vi.fn((command: string) => {
+    for (const [match, output] of responses) {
+      if (command.includes(match)) return output;
+    }
+    return '';
+  });
+  return { exec } as unknown as CommandRunner;
+}
+
+describe('parseNumstatZ', () => {
+  it('parses plain add/modify/delete records', () => {
+    const raw = '10\t2\tsrc/a.ts\0' + '0\t7\tsrc/b.ts\0' + '3\t0\tREADME.md\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'src/a.ts', path: 'src/a.ts', additions: 10, deletions: 2, isBinary: false },
+      { oldPath: 'src/b.ts', path: 'src/b.ts', additions: 0, deletions: 7, isBinary: false },
+      { oldPath: 'README.md', path: 'README.md', additions: 3, deletions: 0, isBinary: false },
+    ]);
+  });
+
+  it('parses a rename record with its two trailing path tokens', () => {
+    const raw = '1\t1\t\0old/name.ts\0new/name.ts\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'old/name.ts', path: 'new/name.ts', additions: 1, deletions: 1, isBinary: false },
+    ]);
+  });
+
+  it('marks binary files with null counts', () => {
+    const raw = '-\t-\tassets/logo.png\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'assets/logo.png', path: 'assets/logo.png', additions: null, deletions: null, isBinary: true },
+    ]);
+  });
+
+  it('keeps paths containing spaces, quotes and tabs intact', () => {
+    const raw = '2\t0\tsrc/my "odd"\tname.ts\0';
+    expect(parseNumstatZ(raw)).toEqual([
+      { oldPath: 'src/my "odd"\tname.ts', path: 'src/my "odd"\tname.ts', additions: 2, deletions: 0, isBinary: false },
+    ]);
+  });
+
+  it('returns an empty list for empty output', () => {
+    expect(parseNumstatZ('')).toEqual([]);
+  });
+});
+
+describe('parseNameStatusZ', () => {
+  it('parses single-path statuses', () => {
+    const raw = 'M\0src/a.ts\0' + 'A\0src/new.ts\0' + 'D\0src/gone.ts\0';
+    expect(parseNameStatusZ(raw)).toEqual([
+      { oldPath: 'src/a.ts', path: 'src/a.ts', status: 'modified' },
+      { oldPath: 'src/new.ts', path: 'src/new.ts', status: 'added' },
+      { oldPath: 'src/gone.ts', path: 'src/gone.ts', status: 'deleted' },
+    ]);
+  });
+
+  it('parses renames with a similarity score and two paths', () => {
+    const raw = 'R100\0old/name.ts\0new/name.ts\0';
+    expect(parseNameStatusZ(raw)).toEqual([
+      { oldPath: 'old/name.ts', path: 'new/name.ts', status: 'renamed', similarity: 100 },
+    ]);
+  });
+
+  it('maps unknown status letters to "unknown"', () => {
+    expect(parseNameStatusZ('X\0weird.ts\0')).toEqual([
+      { oldPath: 'weird.ts', path: 'weird.ts', status: 'unknown' },
+    ]);
+  });
+});
+
+describe('parseUntrackedPathsZ', () => {
+  it('returns only untracked entries and skips rename originals', () => {
+    // Porcelain v1 with -z packs `XY path` into one token; renames add a
+    // second token holding the original path.
+    const raw = ' M tracked.ts\0' + 'R  renamed-new.ts\0renamed-old.ts\0' + '?? brand-new.ts\0';
+    expect(parseUntrackedPathsZ(raw)).toEqual(['brand-new.ts']);
+  });
+
+  it('handles empty output', () => {
+    expect(parseUntrackedPathsZ('')).toEqual([]);
+  });
+});
+
+describe('mergeFileChanges', () => {
+  it('takes counts from numstat and the change kind from name-status', () => {
+    const numstat = parseNumstatZ('1\t1\t\0old.ts\0new.ts\0');
+    const nameStatus = parseNameStatusZ('R95\0old.ts\0new.ts\0');
+    expect(mergeFileChanges(numstat, nameStatus)).toEqual([
+      {
+        path: 'new.ts',
+        oldPath: 'old.ts',
+        status: 'renamed',
+        additions: 1,
+        deletions: 1,
+        isBinary: false,
+        similarity: 95,
+      },
+    ]);
+  });
+
+  it('falls back to "modified" when name-status has no matching path', () => {
+    const merged = mergeFileChanges(parseNumstatZ('4\t1\tsrc/a.ts\0'), []);
+    expect(merged[0].status).toBe('modified');
+  });
+});
+
+describe('GitDiffManager.getCommitFileChanges', () => {
+  it('lists files for a normal commit', () => {
+    const runner = stubRunner([
+      ['rev-list', 'abc123 parent1\n'],
+      ['--numstat', '10\t2\tsrc/a.ts\0'],
+      ['--name-status', 'M\0src/a.ts\0'],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'abc123', runner);
+
+    expect(result.ref).toBe('abc123');
+    expect(result.isMergeAgainstFirstParent).toBe(false);
+    expect(result.truncated).toBe(false);
+    expect(result.totalFiles).toBe(1);
+    expect(result.files[0]).toMatchObject({ path: 'src/a.ts', status: 'modified', additions: 10, deletions: 2 });
+  });
+
+  it('flags merge commits and diffs them against the first parent', () => {
+    const runner = stubRunner([
+      ['rev-list', 'merge1 parent1 parent2\n'],
+      ['--numstat', '1\t0\tsrc/a.ts\0'],
+      ['--name-status', 'M\0src/a.ts\0'],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'merge1', runner);
+
+    expect(result.isMergeAgainstFirstParent).toBe(true);
+    const commands = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+    expect(commands.some(cmd => cmd.includes('--numstat') && cmd.includes('--first-parent'))).toBe(true);
+  });
+
+  it('truncates commits above the per-commit cap', () => {
+    const numstat = Array.from({ length: 600 }, (_, i) => `1\t0\tfile${i}.ts\0`).join('');
+    const runner = stubRunner([
+      ['rev-list', 'big1 parent1\n'],
+      ['--numstat', numstat],
+      ['--name-status', ''],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'big1', runner);
+
+    expect(result.totalFiles).toBe(600);
+    expect(result.files).toHaveLength(500);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('includes untracked files without counts for the working tree', () => {
+    const runner = stubRunner([
+      ['git diff --numstat', '3\t1\ttracked.ts\0'],
+      ['git diff --name-status', 'M\0tracked.ts\0'],
+      ['status --porcelain', '?? untracked.ts\0'],
+    ]);
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', WORKING_TREE_REF, runner);
+
+    expect(result.ref).toBe(WORKING_TREE_REF);
+    expect(result.files).toHaveLength(2);
+    expect(result.files[1]).toMatchObject({
+      path: 'untracked.ts',
+      status: 'added',
+      additions: null,
+      deletions: null,
+    });
+  });
+
+  it('returns an empty result instead of throwing on git failure', () => {
+    const runner = {
+      exec: vi.fn(() => {
+        throw new Error('fatal: bad revision');
+      }),
+    } as unknown as CommandRunner;
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
+
+    expect(result.files).toEqual([]);
+    expect(result.totalFiles).toBe(0);
+  });
+});
+
+describe('chunkByCommandLength', () => {
+  it('keeps every file and preserves order', () => {
+    const files = Array.from({ length: 500 }, (_, i) => `src/some/nested/path/file-${i}.ts`);
+    const batches = chunkByCommandLength(files);
+    expect(batches.flat()).toEqual(files);
+  });
+
+  it('keeps each batch within the command-line budget', () => {
+    const files = Array.from({ length: 500 }, (_, i) => `src/file-${i}.ts`);
+    for (const batch of chunkByCommandLength(files, 200)) {
+      const rendered = batch.map(f => `"${f}"`).join(' ');
+      // One over-long path may exceed the budget on its own; more may not.
+      if (batch.length > 1) expect(rendered.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it('never drops a path longer than the whole budget', () => {
+    const long = 'a'.repeat(500);
+    expect(chunkByCommandLength([long], 100).flat()).toEqual([long]);
+  });
+
+  it('returns nothing for no files', () => {
+    expect(chunkByCommandLength([])).toEqual([]);
+  });
+});
+
+/**
+ * These guard the freeze: a worktree carrying an unignored build tree used to
+ * cost one child process per untracked file — twice over — on the main process.
+ */
+describe('working-directory capture is bounded and off the main thread', () => {
+  function asyncRunner(untracked: string[], counters: { cat: number; wc: number; lsFiles: number }) {
+    return {
+      exec: vi.fn(() => ''),
+      execAsync: vi.fn(async (command: string) => {
+        if (command.startsWith('cat ')) {
+          counters.cat++;
+          return { stdout: 'hello\nworld', stderr: '' };
+        }
+        if (command.startsWith('wc -l ')) {
+          counters.wc++;
+          const paths = command.match(/"/g)?.length ?? 0;
+          const fileCount = paths / 2;
+          const lines = Array.from({ length: fileCount }, (_, i) => `  2 file${i}`).join('\n');
+          return { stdout: `${lines}\n  ${fileCount * 2} total`, stderr: '' };
+        }
+        if (command.includes('ls-files --others')) {
+          counters.lsFiles++;
+          return { stdout: untracked.join('\n'), stderr: '' };
+        }
+        return { stdout: '', stderr: '' };
+      }),
+    } as unknown as CommandRunner;
+  }
+
+  it('caps content reads and batches line counts for a huge untracked set', async () => {
+    const untracked = Array.from({ length: 5000 }, (_, i) => `app/build/res/values-${i}.arsc.flat`);
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(untracked, counters));
+
+    // Content inlining is capped...
+    expect(counters.cat).toBeLessThanOrEqual(MAX_UNTRACKED_INLINE_FILES);
+    // ...and 5000 line counts collapse into a handful of batched spawns,
+    // where the old code spawned one process per file.
+    expect(counters.wc).toBeGreaterThan(0);
+    expect(counters.wc).toBeLessThan(100);
+    // Every untracked file is still reported, even when its content is not.
+    expect(result.changedFiles).toHaveLength(5000);
+    expect(result.stats.filesChanged).toBe(5000);
+  });
+
+  it('lists untracked files exactly once per capture', async () => {
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(['a.ts', 'b.ts'], counters));
+    expect(counters.lsFiles).toBe(1);
+  });
+
+  it('still inlines content for an ordinary number of untracked files', async () => {
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(
+      '/repo',
+      asyncRunner(['README.md', 'src/new.ts', 'notes.txt'], counters)
+    );
+
+    expect(counters.cat).toBe(3);
+    expect(result.diff).toContain('README.md');
+    expect(result.diff).toContain('+hello');
+  });
+
+  it('never blocks on the synchronous exec path', async () => {
+    const counters = { cat: 0, wc: 0, lsFiles: 0 };
+    const runner = asyncRunner(['a.ts'], counters);
+
+    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', runner);
+
+    // Only getCurrentCommitHash stays sync; nothing that scales with file count.
+    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
+    expect(syncCalls.every(call => call[0].includes('rev-parse'))).toBe(true);
+  });
+});
+
+describe('GitDiffManager.getCommitFileChanges error handling', () => {
+  it('returns an empty result instead of throwing on git failure', () => {
+    const runner = {
+      exec: vi.fn(() => {
+        throw new Error('fatal: bad revision');
+      }),
+    } as unknown as CommandRunner;
+
+    const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
+
+    expect(result.files).toEqual([]);
+    expect(result.totalFiles).toBe(0);
+  });
+});

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -6,8 +6,6 @@ import {
   parseUntrackedPathsZ,
   mergeFileChanges,
   WORKING_TREE_REF,
-  MAX_UNTRACKED_INLINE_FILES,
-  chunkByCommandLength,
 } from './gitDiffManager';
 import type { CommandRunner } from '../utils/commandRunner';
 
@@ -197,108 +195,6 @@ describe('GitDiffManager.getCommitFileChanges', () => {
 
     expect(result.files).toEqual([]);
     expect(result.totalFiles).toBe(0);
-  });
-});
-
-describe('chunkByCommandLength', () => {
-  it('keeps every file and preserves order', () => {
-    const files = Array.from({ length: 500 }, (_, i) => `src/some/nested/path/file-${i}.ts`);
-    const batches = chunkByCommandLength(files);
-    expect(batches.flat()).toEqual(files);
-  });
-
-  it('keeps each batch within the command-line budget', () => {
-    const files = Array.from({ length: 500 }, (_, i) => `src/file-${i}.ts`);
-    for (const batch of chunkByCommandLength(files, 200)) {
-      const rendered = batch.map(f => `"${f}"`).join(' ');
-      // One over-long path may exceed the budget on its own; more may not.
-      if (batch.length > 1) expect(rendered.length).toBeLessThanOrEqual(200);
-    }
-  });
-
-  it('never drops a path longer than the whole budget', () => {
-    const long = 'a'.repeat(500);
-    expect(chunkByCommandLength([long], 100).flat()).toEqual([long]);
-  });
-
-  it('returns nothing for no files', () => {
-    expect(chunkByCommandLength([])).toEqual([]);
-  });
-});
-
-/**
- * These guard the freeze: a worktree carrying an unignored build tree used to
- * cost one child process per untracked file — twice over — on the main process.
- */
-describe('working-directory capture is bounded and off the main thread', () => {
-  function asyncRunner(untracked: string[], counters: { cat: number; wc: number; lsFiles: number }) {
-    return {
-      exec: vi.fn(() => ''),
-      execAsync: vi.fn(async (command: string) => {
-        if (command.startsWith('cat ')) {
-          counters.cat++;
-          return { stdout: 'hello\nworld', stderr: '' };
-        }
-        if (command.startsWith('wc -l ')) {
-          counters.wc++;
-          const paths = command.match(/"/g)?.length ?? 0;
-          const fileCount = paths / 2;
-          const lines = Array.from({ length: fileCount }, (_, i) => `  2 file${i}`).join('\n');
-          return { stdout: `${lines}\n  ${fileCount * 2} total`, stderr: '' };
-        }
-        if (command.includes('ls-files --others')) {
-          counters.lsFiles++;
-          return { stdout: untracked.join('\n'), stderr: '' };
-        }
-        return { stdout: '', stderr: '' };
-      }),
-    } as unknown as CommandRunner;
-  }
-
-  it('caps content reads and batches line counts for a huge untracked set', async () => {
-    const untracked = Array.from({ length: 5000 }, (_, i) => `app/build/res/values-${i}.arsc.flat`);
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-
-    const result = await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(untracked, counters));
-
-    // Content inlining is capped...
-    expect(counters.cat).toBeLessThanOrEqual(MAX_UNTRACKED_INLINE_FILES);
-    // ...and 5000 line counts collapse into a handful of batched spawns,
-    // where the old code spawned one process per file.
-    expect(counters.wc).toBeGreaterThan(0);
-    expect(counters.wc).toBeLessThan(100);
-    // Every untracked file is still reported, even when its content is not.
-    expect(result.changedFiles).toHaveLength(5000);
-    expect(result.stats.filesChanged).toBe(5000);
-  });
-
-  it('lists untracked files exactly once per capture', async () => {
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', asyncRunner(['a.ts', 'b.ts'], counters));
-    expect(counters.lsFiles).toBe(1);
-  });
-
-  it('still inlines content for an ordinary number of untracked files', async () => {
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-    const result = await new GitDiffManager().captureWorkingDirectoryDiff(
-      '/repo',
-      asyncRunner(['README.md', 'src/new.ts', 'notes.txt'], counters)
-    );
-
-    expect(counters.cat).toBe(3);
-    expect(result.diff).toContain('README.md');
-    expect(result.diff).toContain('+hello');
-  });
-
-  it('never blocks on the synchronous exec path', async () => {
-    const counters = { cat: 0, wc: 0, lsFiles: 0 };
-    const runner = asyncRunner(['a.ts'], counters);
-
-    await new GitDiffManager().captureWorkingDirectoryDiff('/repo', runner);
-
-    // Only getCurrentCommitHash stays sync; nothing that scales with file count.
-    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
-    expect(syncCalls.every(call => call[0].includes('rev-parse'))).toBe(true);
   });
 });
 

--- a/main/src/services/gitDiffManager.commitFiles.test.ts
+++ b/main/src/services/gitDiffManager.commitFiles.test.ts
@@ -20,7 +20,8 @@ function stubRunner(responses: Array<[match: string, output: string]>): CommandR
     }
     return '';
   });
-  return { exec } as unknown as CommandRunner;
+  // SAFETY: These unit tests exercise only the synchronous exec member supplied here.
+  return { exec } as CommandRunner;
 }
 
 describe('parseNumstatZ', () => {
@@ -146,7 +147,7 @@ describe('GitDiffManager.getCommitFileChanges', () => {
     const result = new GitDiffManager().getCommitFileChanges('/repo', 'merge1', runner);
 
     expect(result.isMergeAgainstFirstParent).toBe(true);
-    const commands = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+    const commands = vi.mocked(runner.exec).mock.calls.map(call => call[0]);
     expect(commands.some(cmd => cmd.includes('--numstat') && cmd.includes('--first-parent'))).toBe(true);
   });
 
@@ -185,11 +186,12 @@ describe('GitDiffManager.getCommitFileChanges', () => {
   });
 
   it('returns an empty result instead of throwing on git failure', () => {
+    // SAFETY: This failure fixture intentionally implements only the exec path under test.
     const runner = {
       exec: vi.fn(() => {
         throw new Error('fatal: bad revision');
       }),
-    } as unknown as CommandRunner;
+    } as CommandRunner;
 
     const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
 
@@ -200,11 +202,12 @@ describe('GitDiffManager.getCommitFileChanges', () => {
 
 describe('GitDiffManager.getCommitFileChanges error handling', () => {
   it('returns an empty result instead of throwing on git failure', () => {
+    // SAFETY: This failure fixture intentionally implements only the exec path under test.
     const runner = {
       exec: vi.fn(() => {
         throw new Error('fatal: bad revision');
       }),
-    } as unknown as CommandRunner;
+    } as CommandRunner;
 
     const result = new GitDiffManager().getCommitFileChanges('/repo', 'nope', runner);
 

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -57,7 +57,7 @@ export const WORKING_TREE_REF = 'index';
  * build directory would otherwise hand it megabytes to chew through.
  */
 export const MAX_UNTRACKED_INLINE_FILES = 200;
-export const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
+const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
 
 /**
  * Per-file ceiling for inlining. Matches the buffer the previous `cat` had, so
@@ -113,7 +113,7 @@ async function countNewlines(fsPath: string): Promise<number> {
     const stream = createReadStream(fsPath, { highWaterMark: 64 * 1024 });
 
     stream.on('data', (chunk: string | Buffer) => {
-      const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       for (let i = 0; i < buffer.length; i++) {
         if (buffer[i] === 0x0a) count++;
       }
@@ -235,7 +235,7 @@ export function parseNameStatusZ(raw: string): NameStatusEntry[] {
         oldPath,
         path: path || oldPath,
         status,
-        similarity: Number.isNaN(similarity as number) ? undefined : similarity,
+        similarity: similarity === undefined || Number.isNaN(similarity) ? undefined : similarity,
       });
     } else {
       const path = tokens[i] ?? '';
@@ -261,15 +261,16 @@ export function mergeFileChanges(
 
   return numstat.map(entry => {
     const match = statusByPath.get(entry.path);
-    return {
+    const file: GitCommitFileChange = {
       path: entry.path,
       oldPath: match?.oldPath || entry.oldPath || entry.path,
       status: match?.status ?? 'modified',
       additions: entry.additions,
       deletions: entry.deletions,
       isBinary: entry.isBinary,
-      ...(match?.similarity !== undefined ? { similarity: match.similarity } : {}),
     };
+    if (match?.similarity !== undefined) file.similarity = match.similarity;
+    return file;
   });
 }
 

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -1,6 +1,12 @@
 import type { Logger } from '../utils/logger';
 import type { AnalyticsManager } from './analyticsManager';
 import { CommandRunner } from '../utils/commandRunner';
+import {
+  MAX_FILES_PER_COMMIT,
+  type GitCommitFileChange,
+  type GitCommitFilesResult,
+  type GitFileChangeStatus,
+} from '../../../shared/types/git';
 
 export interface GitDiffStats {
   additions: number;
@@ -37,6 +43,225 @@ export interface GitGraphCommit {
   deletions?: number;
 }
 
+/** Uncommitted working-tree changes are addressed by this pseudo-ref. */
+export const WORKING_TREE_REF = 'index';
+
+/**
+ * Caps on inlining untracked file content into a synthesized diff.
+ *
+ * Reading an untracked file costs one synchronous child process on the main
+ * process, so an unignored build directory would otherwise stall the whole app.
+ */
+export const MAX_UNTRACKED_INLINE_FILES = 200;
+export const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
+
+/** A working-tree diff can be large; don't truncate it at Node's 1MB default. */
+const MAX_DIFF_BUFFER_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Windows caps a command line at ~32k characters. Batches stay well under it so
+ * a single oversized path can never push a command over the edge.
+ */
+const MAX_COMMAND_LENGTH = 6000;
+
+/** Split paths into batches that fit in one command line. */
+export function chunkByCommandLength(files: string[], maxLength = MAX_COMMAND_LENGTH): string[][] {
+  const batches: string[][] = [];
+  let current: string[] = [];
+  let length = 0;
+
+  for (const file of files) {
+    // +3 covers the two quotes and the separating space.
+    const cost = file.length + 3;
+    if (current.length > 0 && length + cost > maxLength) {
+      batches.push(current);
+      current = [];
+      length = 0;
+    }
+    current.push(file);
+    length += cost;
+  }
+
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+interface NumstatEntry {
+  oldPath: string;
+  path: string;
+  additions: number | null;
+  deletions: number | null;
+  isBinary: boolean;
+}
+
+/**
+ * Parse `--numstat -z` output.
+ *
+ * With `-z` each record is `<add>\t<del>\t<path>\0`, except renames/copies
+ * which emit an empty path field followed by two NUL-separated paths:
+ * `<add>\t<del>\t\0<oldPath>\0<newPath>\0`. Binary files report `-` for both
+ * counts. Paths are never quoted under `-z`, so a tab or quote inside a
+ * filename is safe as long as we only split on the first two tabs.
+ */
+export function parseNumstatZ(raw: string): NumstatEntry[] {
+  const tokens = raw.split('\0');
+  const entries: NumstatEntry[] = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+    i++;
+    if (!token) continue;
+
+    const firstTab = token.indexOf('\t');
+    if (firstTab < 0) continue;
+    const secondTab = token.indexOf('\t', firstTab + 1);
+    if (secondTab < 0) continue;
+
+    const addRaw = token.slice(0, firstTab);
+    const delRaw = token.slice(firstTab + 1, secondTab);
+    const pathField = token.slice(secondTab + 1);
+
+    let oldPath: string;
+    let path: string;
+    if (pathField === '') {
+      // Rename/copy: the two paths follow as separate NUL-delimited tokens.
+      oldPath = tokens[i] ?? '';
+      i++;
+      path = tokens[i] ?? '';
+      i++;
+      if (!path) path = oldPath;
+    } else {
+      oldPath = pathField;
+      path = pathField;
+    }
+
+    const isBinary = addRaw === '-' || delRaw === '-';
+    entries.push({
+      oldPath,
+      path,
+      additions: isBinary ? null : Number.parseInt(addRaw, 10) || 0,
+      deletions: isBinary ? null : Number.parseInt(delRaw, 10) || 0,
+      isBinary,
+    });
+  }
+
+  return entries;
+}
+
+function toFileChangeStatus(code: string): GitFileChangeStatus {
+  switch (code) {
+    case 'A': return 'added';
+    case 'M': return 'modified';
+    case 'D': return 'deleted';
+    case 'R': return 'renamed';
+    case 'C': return 'copied';
+    case 'T': return 'typechange';
+    case 'U': return 'unmerged';
+    default: return 'unknown';
+  }
+}
+
+interface NameStatusEntry {
+  oldPath: string;
+  path: string;
+  status: GitFileChangeStatus;
+  similarity?: number;
+}
+
+/**
+ * Parse `--name-status -z` output: `M\0path\0`, `A\0path\0`,
+ * `R100\0oldPath\0newPath\0`. Only `R` and `C` carry two paths.
+ */
+export function parseNameStatusZ(raw: string): NameStatusEntry[] {
+  const tokens = raw.split('\0');
+  const entries: NameStatusEntry[] = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    const statusToken = tokens[i];
+    i++;
+    if (!statusToken) continue;
+
+    const code = statusToken[0];
+    const status = toFileChangeStatus(code);
+    const similarityRaw = statusToken.slice(1);
+    const similarity = similarityRaw ? Number.parseInt(similarityRaw, 10) : undefined;
+
+    if (code === 'R' || code === 'C') {
+      const oldPath = tokens[i] ?? '';
+      i++;
+      const path = tokens[i] ?? '';
+      i++;
+      if (!oldPath && !path) continue;
+      entries.push({
+        oldPath,
+        path: path || oldPath,
+        status,
+        similarity: Number.isNaN(similarity as number) ? undefined : similarity,
+      });
+    } else {
+      const path = tokens[i] ?? '';
+      i++;
+      if (!path) continue;
+      entries.push({ oldPath: path, path, status });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Zip numstat counts with name-status change kinds, keyed by post-change path.
+ * numstat is the source of truth for the file set; a path missing from
+ * name-status falls back to `modified`.
+ */
+export function mergeFileChanges(
+  numstat: NumstatEntry[],
+  nameStatus: NameStatusEntry[]
+): GitCommitFileChange[] {
+  const statusByPath = new Map(nameStatus.map(entry => [entry.path, entry]));
+
+  return numstat.map(entry => {
+    const match = statusByPath.get(entry.path);
+    return {
+      path: entry.path,
+      oldPath: match?.oldPath || entry.oldPath || entry.path,
+      status: match?.status ?? 'modified',
+      additions: entry.additions,
+      deletions: entry.deletions,
+      isBinary: entry.isBinary,
+      ...(match?.similarity !== undefined ? { similarity: match.similarity } : {}),
+    };
+  });
+}
+
+/**
+ * Parse untracked paths out of `git status --porcelain -z`.
+ *
+ * Porcelain v1 with `-z` emits `XY <path>\0`; rename entries emit a second
+ * path token which we skip. Only `??` records are returned.
+ */
+export function parseUntrackedPathsZ(raw: string): string[] {
+  const tokens = raw.split('\0');
+  const paths: string[] = [];
+  let i = 0;
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+    i++;
+    if (!token || token.length < 4) continue;
+
+    const code = token.slice(0, 2);
+    const path = token.slice(3);
+    // Rename/copy records carry the original path as an extra token.
+    if (code[0] === 'R' || code[0] === 'C') i++;
+    if (code === '??') paths.push(path);
+  }
+
+  return paths;
+}
+
 export class GitDiffManager {
   constructor(
     private logger?: Logger,
@@ -54,15 +279,19 @@ export class GitDiffManager {
       // Get current commit hash
       const beforeHash = this.getCurrentCommitHash(worktreePath, commandRunner);
 
+      // Listed once and threaded through: each `git ls-files` is a process
+      // spawn, and the three consumers below used to ask for it separately.
+      const untrackedFiles = await this.getUntrackedFilesAsync(worktreePath, commandRunner);
+
       // Get diff of working directory vs HEAD
-      const diff = this.getGitDiffString(worktreePath, commandRunner);
+      const diff = await this.getGitDiffStringAsync(worktreePath, untrackedFiles, commandRunner);
       console.log(`Captured diff length: ${diff.length}`);
 
       // Get changed files
-      const changedFiles = this.getChangedFiles(worktreePath, commandRunner);
+      const changedFiles = await this.getChangedFilesAsync(worktreePath, untrackedFiles, commandRunner);
 
       // Get diff stats
-      const stats = this.getDiffStats(worktreePath, commandRunner);
+      const stats = await this.getDiffStatsAsync(worktreePath, untrackedFiles, commandRunner);
 
       this.logger?.verbose(`Captured diff: ${stats.filesChanged} files, +${stats.additions} -${stats.deletions}`);
       console.log(`Diff stats:`, stats);
@@ -270,6 +499,113 @@ export class GitDiffManager {
   }
 
   /**
+   * List the files touched by a single commit — or by the working tree when
+   * `ref` is {@link WORKING_TREE_REF} — with per-file +/- counts and change kind.
+   *
+   * Deliberately patch-free: the diff panel calls this lazily when one commit
+   * row is expanded, so listing 50 commits never costs 50 `git show`s.
+   */
+  getCommitFileChanges(
+    worktreePath: string,
+    ref: string,
+    commandRunner: CommandRunner
+  ): GitCommitFilesResult {
+    const empty: GitCommitFilesResult = {
+      ref,
+      files: [],
+      totalFiles: 0,
+      truncated: false,
+      isMergeAgainstFirstParent: false,
+    };
+
+    try {
+      if (ref === WORKING_TREE_REF || ref === 'UNCOMMITTED') {
+        return this.getWorkingTreeFileChanges(worktreePath, commandRunner);
+      }
+
+      // `git show` prints nothing for a merge commit unless we ask for a
+      // specific parent. Detect the merge first so the UI can say so.
+      const parents = this.getCommitParents(worktreePath, ref, commandRunner);
+      const isMerge = parents.length > 1;
+      const mergeFlags = isMerge ? ' -m --first-parent' : '';
+
+      const numstatRaw = commandRunner.exec(
+        `git show --format= --numstat -M -z${mergeFlags} ${ref}`,
+        worktreePath
+      );
+      const nameStatusRaw = commandRunner.exec(
+        `git show --format= --name-status -M -z${mergeFlags} ${ref}`,
+        worktreePath
+      );
+
+      const files = mergeFileChanges(parseNumstatZ(numstatRaw), parseNameStatusZ(nameStatusRaw));
+      return this.clampFileChanges(ref, files, isMerge);
+    } catch (error) {
+      this.logger?.error(
+        `Failed to list changed files for ${ref} in ${worktreePath}`,
+        error instanceof Error ? error : undefined
+      );
+      return empty;
+    }
+  }
+
+  private getWorkingTreeFileChanges(
+    worktreePath: string,
+    commandRunner: CommandRunner
+  ): GitCommitFilesResult {
+    const numstatRaw = commandRunner.exec('git diff --numstat -M -z HEAD', worktreePath);
+    const nameStatusRaw = commandRunner.exec('git diff --name-status -M -z HEAD', worktreePath);
+    const files = mergeFileChanges(parseNumstatZ(numstatRaw), parseNameStatusZ(nameStatusRaw));
+
+    // Untracked files are invisible to `git diff`. Counting their lines would
+    // mean reading every file, so they are listed without counts instead.
+    try {
+      const statusRaw = commandRunner.exec('git status --porcelain -z', worktreePath);
+      const known = new Set(files.map(file => file.path));
+      for (const path of parseUntrackedPathsZ(statusRaw)) {
+        if (known.has(path)) continue;
+        files.push({
+          path,
+          oldPath: path,
+          status: 'added',
+          additions: null,
+          deletions: null,
+          isBinary: false,
+        });
+      }
+    } catch {
+      // An unreadable status is not worth failing the whole listing over.
+    }
+
+    return this.clampFileChanges(WORKING_TREE_REF, files, false);
+  }
+
+  private getCommitParents(worktreePath: string, ref: string, commandRunner: CommandRunner): string[] {
+    try {
+      const output = commandRunner.exec(`git rev-list --parents -n 1 ${ref} --`, worktreePath);
+      // Output is "<commit> <parent1> <parent2> ...".
+      return output.trim().split(/\s+/).filter(Boolean).slice(1);
+    } catch {
+      return [];
+    }
+  }
+
+  private clampFileChanges(
+    ref: string,
+    files: GitCommitFileChange[],
+    isMergeAgainstFirstParent: boolean
+  ): GitCommitFilesResult {
+    const truncated = files.length > MAX_FILES_PER_COMMIT;
+    return {
+      ref,
+      files: truncated ? files.slice(0, MAX_FILES_PER_COMMIT) : files,
+      totalFiles: files.length,
+      truncated,
+      isMergeAgainstFirstParent,
+    };
+  }
+
+  /**
    * Parse numstat output to get diff statistics
    */
   private parseNumstatOutput(lines: string[]): GitDiffStats {
@@ -402,42 +738,6 @@ export class GitDiffManager {
     return result;
   }
 
-  private getGitDiffString(worktreePath: string, commandRunner: CommandRunner): string {
-    try {
-      // First check if we're in a valid git repository
-      try {
-        commandRunner.exec('git rev-parse --git-dir', worktreePath);
-      } catch {
-        console.error(`Not a git repository: ${worktreePath}`);
-        return '';
-      }
-
-      // Check git status to see what files have changes
-      const status = commandRunner.exec('git status --porcelain', worktreePath);
-      console.log(`Git status in ${worktreePath}:`, status || '(no changes)');
-
-      // Get diff of both staged and unstaged changes against HEAD
-      // Using 'git diff HEAD' to include both staged and unstaged changes
-      let diff = commandRunner.exec('git diff HEAD', worktreePath);
-      console.log(`Git diff in ${worktreePath}: ${diff.length} characters`);
-
-      // Get untracked files and create diff-like output for them
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
-      if (untrackedFiles.length > 0) {
-        console.log(`Found ${untrackedFiles.length} untracked files`);
-        const untrackedDiff = this.createDiffForUntrackedFiles(worktreePath, untrackedFiles, commandRunner);
-        if (untrackedDiff) {
-          diff = diff ? diff + '\n' + untrackedDiff : untrackedDiff;
-        }
-      }
-      
-      return diff;
-    } catch (error) {
-      this.logger?.warn(`Could not get git diff in ${worktreePath}`, error instanceof Error ? error : undefined);
-      console.error(`Error getting git diff:`, error);
-      return '';
-    }
-  }
 
   private getGitCommitDiff(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): string {
     try {
@@ -445,23 +745,6 @@ export class GitDiffManager {
     } catch {
       this.logger?.warn(`Could not get git commit diff in ${worktreePath}`);
       return '';
-    }
-  }
-
-  private getChangedFiles(worktreePath: string, commandRunner: CommandRunner): string[] {
-    try {
-      // Get tracked changed files
-      const trackedOutput = commandRunner.exec('git diff --name-only HEAD', worktreePath);
-      const trackedFiles = trackedOutput.trim().split('\n').filter((f: string) => f.length > 0);
-
-      // Get untracked files
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
-      
-      // Combine both lists
-      return [...trackedFiles, ...untrackedFiles];
-    } catch {
-      this.logger?.warn(`Could not get changed files in ${worktreePath}`);
-      return [];
     }
   }
 
@@ -475,45 +758,172 @@ export class GitDiffManager {
     }
   }
 
-  private getDiffStats(worktreePath: string, commandRunner: CommandRunner): GitDiffStats {
+  // --- Working-directory capture (async) -----------------------------------
+  //
+  // Everything below runs off the main thread via `execAsync`. The sync
+  // variants used to spawn one child process *per untracked file* — twice, once
+  // to read content and once to count lines — which on a worktree carrying an
+  // unignored build tree blocked the main process for minutes and froze every
+  // IPC channel with it. These versions list the files once, batch the reads,
+  // and never block the event loop.
+
+  /** Untracked paths, honouring .gitignore. */
+  private async getUntrackedFilesAsync(worktreePath: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
-      const output = commandRunner.exec('git diff --stat HEAD', worktreePath);
-
-      const trackedStats = this.parseDiffStats(output);
-
-      // Add stats for untracked files
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
-      if (untrackedFiles.length > 0) {
-        let untrackedAdditions = 0;
-        for (const file of untrackedFiles) {
-          // Skip invalid filenames
-          if (!file || file.trim().length === 0) {
-            continue;
-          }
-
-          try {
-            const cleanFile = file.trim();
-            const filePath = `${worktreePath}/${cleanFile}`;
-            const lines = commandRunner.exec(`wc -l < "${filePath}"`, worktreePath);
-            untrackedAdditions += parseInt(lines.trim()) || 0;
-          } catch {
-            // Skip files that can't be counted
-          }
-        }
-        
-        return {
-          additions: trackedStats.additions + untrackedAdditions,
-          deletions: trackedStats.deletions,
-          filesChanged: trackedStats.filesChanged + untrackedFiles.length
-        };
-      }
-      
-      return trackedStats;
+      const { stdout } = await commandRunner.execAsync('git ls-files --others --exclude-standard', worktreePath);
+      if (!stdout?.trim()) return [];
+      return stdout.trim().split('\n').map(f => f.trim()).filter(Boolean);
     } catch {
-      this.logger?.warn(`Could not get diff stats in ${worktreePath}`);
-      return { additions: 0, deletions: 0, filesChanged: 0 };
+      this.logger?.warn(`Could not get untracked files in ${worktreePath}`);
+      return [];
     }
   }
+
+  private async getGitDiffStringAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<string> {
+    let diff = '';
+    try {
+      const { stdout } = await commandRunner.execAsync('git diff HEAD', worktreePath, { maxBuffer: MAX_DIFF_BUFFER_BYTES });
+      diff = stdout ?? '';
+    } catch (error) {
+      this.logger?.warn(`Could not get tracked diff in ${worktreePath}: ${error instanceof Error ? error.message : error}`);
+    }
+
+    if (untrackedFiles.length === 0) return diff;
+    return diff + await this.createDiffForUntrackedFilesAsync(worktreePath, untrackedFiles, commandRunner);
+  }
+
+  private async getChangedFilesAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<string[]> {
+    try {
+      const { stdout } = await commandRunner.execAsync('git diff --name-only HEAD', worktreePath);
+      const tracked = (stdout ?? '').trim().split('\n').map(f => f.trim()).filter(Boolean);
+      return [...tracked, ...untrackedFiles];
+    } catch {
+      this.logger?.warn(`Could not get changed files in ${worktreePath}`);
+      return [...untrackedFiles];
+    }
+  }
+
+  /**
+   * Working-tree stats. Untracked line counts come from batched `wc -l` calls
+   * rather than one spawn per file — the difference between a handful of
+   * processes and several thousand.
+   */
+  private async getDiffStatsAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<GitDiffStats> {
+    let trackedStats: GitDiffStats = { additions: 0, deletions: 0, filesChanged: 0 };
+    try {
+      const { stdout } = await commandRunner.execAsync('git diff --shortstat HEAD', worktreePath);
+      trackedStats = this.parseDiffStats((stdout ?? '').trim());
+    } catch {
+      this.logger?.warn(`Could not get diff stats in ${worktreePath}`);
+    }
+
+    if (untrackedFiles.length === 0) return trackedStats;
+
+    const untrackedAdditions = await this.countLinesBatched(worktreePath, untrackedFiles, commandRunner);
+    return {
+      additions: trackedStats.additions + untrackedAdditions,
+      deletions: trackedStats.deletions,
+      filesChanged: trackedStats.filesChanged + untrackedFiles.length,
+    };
+  }
+
+  /**
+   * Total line count across many files, using as few `wc -l` invocations as the
+   * platform's command-line length allows.
+   */
+  private async countLinesBatched(
+    worktreePath: string,
+    files: string[],
+    commandRunner: CommandRunner
+  ): Promise<number> {
+    let total = 0;
+
+    for (const batch of chunkByCommandLength(files)) {
+      const args = batch.map(file => `"${worktreePath}/${file}"`).join(' ');
+      try {
+        const { stdout } = await commandRunner.execAsync(`wc -l ${args}`, worktreePath);
+        // `wc` prints "<count> <path>" per file, plus a "<total> total" line for
+        // multiple files. Summing the per-file counts avoids depending on that
+        // trailing line, which is absent for a single file.
+        for (const line of (stdout ?? '').trim().split('\n')) {
+          const match = line.trim().match(/^(\d+)\s+(.*)$/);
+          if (!match) continue;
+          if (batch.length > 1 && match[2].trim() === 'total') continue;
+          total += Number.parseInt(match[1], 10) || 0;
+        }
+      } catch {
+        // Unreadable batch (binary, permissions); its lines simply go uncounted.
+      }
+    }
+
+    return total;
+  }
+
+  /**
+   * Synthesize `new file` patches for untracked files.
+   *
+   * Hard-bounded: each file costs a child process, and the resulting patch is
+   * parsed with a regex in the renderer, so an unignored build tree would
+   * otherwise stall both processes. Files past the budget still appear in
+   * `changedFiles`; only their inline content is omitted.
+   */
+  private async createDiffForUntrackedFilesAsync(
+    worktreePath: string,
+    untrackedFiles: string[],
+    commandRunner: CommandRunner
+  ): Promise<string> {
+    const parts: string[] = [];
+    let bytes = 0;
+    let inlined = 0;
+
+    for (const file of untrackedFiles) {
+      if (inlined >= MAX_UNTRACKED_INLINE_FILES || bytes >= MAX_UNTRACKED_INLINE_BYTES) {
+        this.logger?.warn(
+          `Untracked diff truncated in ${worktreePath}: ${untrackedFiles.length} untracked files exceed the inline budget`
+        );
+        break;
+      }
+
+      try {
+        const { stdout } = await commandRunner.execAsync(
+          `cat "${worktreePath}/${file}"`,
+          worktreePath,
+          { maxBuffer: 1024 * 1024 }
+        );
+        inlined++;
+
+        const lines = (stdout ?? '').split('\n');
+        const header =
+          `diff --git a/${file} b/${file}\n`
+          + 'new file mode 100644\n'
+          + 'index 0000000..0000000\n'
+          + '--- /dev/null\n'
+          + `+++ b/${file}\n`
+          + `@@ -0,0 +1,${lines.length} @@\n`;
+        const body = lines.map(line => `+${line}`).join('\n') + '\n';
+
+        parts.push(header, body);
+        bytes += header.length + body.length;
+      } catch {
+        // Binary or unreadable: skipped, exactly as before.
+      }
+    }
+
+    return parts.join('');
+  }
+
 
   private getCommitDiffStats(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): GitDiffStats {
     try {
@@ -555,64 +965,4 @@ export class GitDiffManager {
     }
   }
 
-  /**
-   * Get list of untracked files
-   */
-  private getUntrackedFiles(worktreePath: string, commandRunner: CommandRunner): string[] {
-    try {
-      const output = commandRunner.exec('git ls-files --others --exclude-standard', worktreePath);
-      
-      // Handle empty output case
-      if (!output || output.trim().length === 0) {
-        return [];
-      }
-      
-      return output.trim().split('\n').filter((f: string) => f && f.trim().length > 0);
-    } catch {
-      this.logger?.warn(`Could not get untracked files in ${worktreePath}`);
-      return [];
-    }
-  }
-
-  /**
-   * Create diff-like output for untracked files
-   */
-  private createDiffForUntrackedFiles(worktreePath: string, untrackedFiles: string[], commandRunner: CommandRunner): string {
-    let diffOutput = '';
-    
-    for (const file of untrackedFiles) {
-      // Skip invalid filenames
-      if (!file || file.trim().length === 0) {
-        continue;
-      }
-      
-      try {
-        const cleanFile = file.trim();
-        const filePath = `${worktreePath}/${cleanFile}`;
-        const fileContent = commandRunner.exec(`cat "${filePath}"`, worktreePath, { maxBuffer: 1024 * 1024 });
-        
-        // Create a diff-like format for the new file
-        diffOutput += `diff --git a/${cleanFile} b/${cleanFile}\n`;
-        diffOutput += `new file mode 100644\n`;
-        diffOutput += `index 0000000..0000000\n`;
-        diffOutput += `--- /dev/null\n`;
-        diffOutput += `+++ b/${cleanFile}\n`;
-        
-        // Add the file content with '+' prefix for each line
-        const lines = fileContent.split('\n');
-        if (lines.length > 0) {
-          diffOutput += `@@ -0,0 +1,${lines.length} @@\n`;
-          for (const line of lines) {
-            diffOutput += `+${line}\n`;
-          }
-        }
-      } catch (error) {
-        // Skip files that can't be read (binary files, etc.)
-        const cleanFile = file.trim();
-        this.logger?.verbose(`Could not read untracked file ${cleanFile}: ${error}`);
-      }
-    }
-    
-    return diffOutput;
-  }
 }

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -1,6 +1,10 @@
+import { createReadStream } from 'fs';
+import { readFile, stat } from 'fs/promises';
+import { join } from 'path';
 import type { Logger } from '../utils/logger';
 import type { AnalyticsManager } from './analyticsManager';
 import { CommandRunner } from '../utils/commandRunner';
+import { linuxToUNCPath, posixJoin, type WSLContext } from '../utils/wslUtils';
 import {
   MAX_FILES_PER_COMMIT,
   type GitCommitFileChange,
@@ -49,41 +53,74 @@ export const WORKING_TREE_REF = 'index';
 /**
  * Caps on inlining untracked file content into a synthesized diff.
  *
- * Reading an untracked file costs one synchronous child process on the main
- * process, so an unignored build directory would otherwise stall the whole app.
+ * The resulting patch is parsed with a regex in the renderer, so an unignored
+ * build directory would otherwise hand it megabytes to chew through.
  */
 export const MAX_UNTRACKED_INLINE_FILES = 200;
 export const MAX_UNTRACKED_INLINE_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Per-file ceiling for inlining. Matches the buffer the previous `cat` had, so
+ * the same oversized files are left out of the patch as before.
+ */
+const MAX_UNTRACKED_INLINE_FILE_BYTES = 1024 * 1024;
 
 /** A working-tree diff can be large; don't truncate it at Node's 1MB default. */
 const MAX_DIFF_BUFFER_BYTES = 64 * 1024 * 1024;
 
 /**
- * Windows caps a command line at ~32k characters. Batches stay well under it so
- * a single oversized path can never push a command over the edge.
+ * Split NUL-separated git output.
+ *
+ * Git only quotes and escapes a path when it has to delimit it with a newline;
+ * under `-z` the bytes come through exactly as they are on disk. Nothing is
+ * trimmed here for the same reason — a leading or trailing space is part of the
+ * name, not padding.
  */
-const MAX_COMMAND_LENGTH = 6000;
+export function splitNulSeparated(raw: string): string[] {
+  return raw.split('\0').filter(entry => entry.length > 0);
+}
 
-/** Split paths into batches that fit in one command line. */
-export function chunkByCommandLength(files: string[], maxLength = MAX_COMMAND_LENGTH): string[][] {
-  const batches: string[][] = [];
-  let current: string[] = [];
-  let length = 0;
+/**
+ * The path Node's `fs` needs for a file git named relative to the worktree.
+ *
+ * Git reports `dir/file.txt` with forward slashes whatever the platform. For a
+ * WSL project the worktree is a Linux path the Windows host can only reach
+ * through its UNC mount, which is what `gitPlumbingCommands` does for the same
+ * reason.
+ *
+ * Going through `fs` at all is the point: the name comes from the repository
+ * and may contain a space, a quote, `$`, a backtick or a newline, all of which
+ * git allows. Interpolated into a shell command those stop being a filename.
+ */
+export function untrackedFilePath(
+  worktreePath: string,
+  file: string,
+  wslContext?: WSLContext | null
+): string {
+  if (wslContext) return linuxToUNCPath(posixJoin(worktreePath, file), wslContext.distribution);
+  return join(worktreePath, file);
+}
 
-  for (const file of files) {
-    // +3 covers the two quotes and the separating space.
-    const cost = file.length + 3;
-    if (current.length > 0 && length + cost > maxLength) {
-      batches.push(current);
-      current = [];
-      length = 0;
-    }
-    current.push(file);
-    length += cost;
-  }
+/**
+ * Newlines in a file, streamed so a large one costs bounded memory.
+ *
+ * Counts terminators rather than lines, which is what the `wc -l` this replaces
+ * reported, so the additions figure stays the number it always was.
+ */
+async function countNewlines(fsPath: string): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    let count = 0;
+    const stream = createReadStream(fsPath, { highWaterMark: 64 * 1024 });
 
-  if (current.length > 0) batches.push(current);
-  return batches;
+    stream.on('data', (chunk: string | Buffer) => {
+      const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+      for (let i = 0; i < buffer.length; i++) {
+        if (buffer[i] === 0x0a) count++;
+      }
+    });
+    stream.on('error', reject);
+    stream.on('close', () => resolve(count));
+  });
 }
 
 interface NumstatEntry {
@@ -760,19 +797,25 @@ export class GitDiffManager {
 
   // --- Working-directory capture (async) -----------------------------------
   //
-  // Everything below runs off the main thread via `execAsync`. The sync
-  // variants used to spawn one child process *per untracked file* — twice, once
-  // to read content and once to count lines — which on a worktree carrying an
-  // unignored build tree blocked the main process for minutes and froze every
-  // IPC channel with it. These versions list the files once, batch the reads,
-  // and never block the event loop.
+  // Everything below runs off the main thread. The sync variants used to spawn
+  // one child process *per untracked file* — twice, once to read content and
+  // once to count lines — which on a worktree carrying an unignored build tree
+  // blocked the main process for minutes and froze every IPC channel with it.
+  // These versions list the files once with `git ls-files -z` and then go
+  // through `fs`, so there is no process per file and no filename in a shell.
 
-  /** Untracked paths, honouring .gitignore. */
+  /**
+   * Untracked paths, honouring .gitignore.
+   *
+   * `-z` is not optional here. Without it git delimits with newlines, which a
+   * filename may contain, and quotes anything non-ASCII into a C-style escape:
+   * `täst.txt` arrives as `"t\303\244st.txt"`, a name that matches no file on
+   * disk, so the file silently vanished from the diff and the stats.
+   */
   private async getUntrackedFilesAsync(worktreePath: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
-      const { stdout } = await commandRunner.execAsync('git ls-files --others --exclude-standard', worktreePath);
-      if (!stdout?.trim()) return [];
-      return stdout.trim().split('\n').map(f => f.trim()).filter(Boolean);
+      const { stdout } = await commandRunner.execAsync('git ls-files --others --exclude-standard -z', worktreePath);
+      return splitNulSeparated(stdout ?? '');
     } catch {
       this.logger?.warn(`Could not get untracked files in ${worktreePath}`);
       return [];
@@ -812,9 +855,9 @@ export class GitDiffManager {
   }
 
   /**
-   * Working-tree stats. Untracked line counts come from batched `wc -l` calls
-   * rather than one spawn per file — the difference between a handful of
-   * processes and several thousand.
+   * Working-tree stats. Untracked line counts are read through `fs` rather than
+   * by spawning a process per file — the difference between a few reads and
+   * several thousand child processes.
    */
   private async getDiffStatsAsync(
     worktreePath: string,
@@ -831,7 +874,7 @@ export class GitDiffManager {
 
     if (untrackedFiles.length === 0) return trackedStats;
 
-    const untrackedAdditions = await this.countLinesBatched(worktreePath, untrackedFiles, commandRunner);
+    const untrackedAdditions = await this.countUntrackedLines(worktreePath, untrackedFiles, commandRunner);
     return {
       additions: trackedStats.additions + untrackedAdditions,
       deletions: trackedStats.deletions,
@@ -840,31 +883,25 @@ export class GitDiffManager {
   }
 
   /**
-   * Total line count across many files, using as few `wc -l` invocations as the
-   * platform's command-line length allows.
+   * Total line count across the untracked files.
+   *
+   * Each file is streamed, so memory stays bounded whatever is in the worktree
+   * and nothing repository-controlled reaches a shell. Awaiting between files
+   * keeps the event loop free, which is what the synchronous version cost.
    */
-  private async countLinesBatched(
+  private async countUntrackedLines(
     worktreePath: string,
     files: string[],
     commandRunner: CommandRunner
   ): Promise<number> {
     let total = 0;
 
-    for (const batch of chunkByCommandLength(files)) {
-      const args = batch.map(file => `"${worktreePath}/${file}"`).join(' ');
+    for (const file of files) {
       try {
-        const { stdout } = await commandRunner.execAsync(`wc -l ${args}`, worktreePath);
-        // `wc` prints "<count> <path>" per file, plus a "<total> total" line for
-        // multiple files. Summing the per-file counts avoids depending on that
-        // trailing line, which is absent for a single file.
-        for (const line of (stdout ?? '').trim().split('\n')) {
-          const match = line.trim().match(/^(\d+)\s+(.*)$/);
-          if (!match) continue;
-          if (batch.length > 1 && match[2].trim() === 'total') continue;
-          total += Number.parseInt(match[1], 10) || 0;
-        }
+        total += await countNewlines(untrackedFilePath(worktreePath, file, commandRunner.wslContext));
       } catch {
-        // Unreadable batch (binary, permissions); its lines simply go uncounted.
+        // Unreadable (permissions, a symlink to nowhere, deleted since the
+        // listing): its lines simply go uncounted, as before.
       }
     }
 
@@ -874,10 +911,12 @@ export class GitDiffManager {
   /**
    * Synthesize `new file` patches for untracked files.
    *
-   * Hard-bounded: each file costs a child process, and the resulting patch is
-   * parsed with a regex in the renderer, so an unignored build tree would
-   * otherwise stall both processes. Files past the budget still appear in
-   * `changedFiles`; only their inline content is omitted.
+   * Content is read through `fs`, never `cat`: a filename may legally contain
+   * a backtick or `$(…)`, and interpolating one into a shell command ran it.
+   *
+   * Still hard-bounded — the resulting patch is parsed with a regex in the
+   * renderer, so an unignored build tree would otherwise stall it. Files past
+   * the budget keep their place in `changedFiles`; only the inline content goes.
    */
   private async createDiffForUntrackedFilesAsync(
     worktreePath: string,
@@ -897,14 +936,17 @@ export class GitDiffManager {
       }
 
       try {
-        const { stdout } = await commandRunner.execAsync(
-          `cat "${worktreePath}/${file}"`,
-          worktreePath,
-          { maxBuffer: 1024 * 1024 }
-        );
+        const fsPath = untrackedFilePath(worktreePath, file, commandRunner.wslContext);
+
+        // Checked before reading rather than by letting a buffer overflow, so a
+        // huge file costs a stat instead of a gigabyte of string.
+        const { size } = await stat(fsPath);
+        if (size > MAX_UNTRACKED_INLINE_FILE_BYTES) continue;
+
+        const content = await readFile(fsPath, 'utf8');
         inlined++;
 
-        const lines = (stdout ?? '').split('\n');
+        const lines = content.split('\n');
         const header =
           `diff --git a/${file} b/${file}\n`
           + 'new file mode 100644\n'

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -9,8 +9,14 @@ import {
   MAX_FILES_PER_COMMIT,
   type GitCommitFileChange,
   type GitCommitFilesResult,
-  type GitFileChangeStatus,
 } from '../../../shared/types/git';
+import {
+  mergeFileChanges,
+  parseNameStatusZ,
+  parseNumstatZ,
+  parseUntrackedPathsZ,
+  splitNulSeparated,
+} from './gitDiffParsers';
 
 export interface GitDiffStats {
   additions: number;
@@ -76,10 +82,6 @@ const MAX_DIFF_BUFFER_BYTES = 64 * 1024 * 1024;
  * trimmed here for the same reason — a leading or trailing space is part of the
  * name, not padding.
  */
-export function splitNulSeparated(raw: string): string[] {
-  return raw.split('\0').filter(entry => entry.length > 0);
-}
-
 /**
  * The path Node's `fs` needs for a file git named relative to the worktree.
  *
@@ -121,183 +123,6 @@ async function countNewlines(fsPath: string): Promise<number> {
     stream.on('error', reject);
     stream.on('close', () => resolve(count));
   });
-}
-
-interface NumstatEntry {
-  oldPath: string;
-  path: string;
-  additions: number | null;
-  deletions: number | null;
-  isBinary: boolean;
-}
-
-/**
- * Parse `--numstat -z` output.
- *
- * With `-z` each record is `<add>\t<del>\t<path>\0`, except renames/copies
- * which emit an empty path field followed by two NUL-separated paths:
- * `<add>\t<del>\t\0<oldPath>\0<newPath>\0`. Binary files report `-` for both
- * counts. Paths are never quoted under `-z`, so a tab or quote inside a
- * filename is safe as long as we only split on the first two tabs.
- */
-export function parseNumstatZ(raw: string): NumstatEntry[] {
-  const tokens = raw.split('\0');
-  const entries: NumstatEntry[] = [];
-  let i = 0;
-
-  while (i < tokens.length) {
-    const token = tokens[i];
-    i++;
-    if (!token) continue;
-
-    const firstTab = token.indexOf('\t');
-    if (firstTab < 0) continue;
-    const secondTab = token.indexOf('\t', firstTab + 1);
-    if (secondTab < 0) continue;
-
-    const addRaw = token.slice(0, firstTab);
-    const delRaw = token.slice(firstTab + 1, secondTab);
-    const pathField = token.slice(secondTab + 1);
-
-    let oldPath: string;
-    let path: string;
-    if (pathField === '') {
-      // Rename/copy: the two paths follow as separate NUL-delimited tokens.
-      oldPath = tokens[i] ?? '';
-      i++;
-      path = tokens[i] ?? '';
-      i++;
-      if (!path) path = oldPath;
-    } else {
-      oldPath = pathField;
-      path = pathField;
-    }
-
-    const isBinary = addRaw === '-' || delRaw === '-';
-    entries.push({
-      oldPath,
-      path,
-      additions: isBinary ? null : Number.parseInt(addRaw, 10) || 0,
-      deletions: isBinary ? null : Number.parseInt(delRaw, 10) || 0,
-      isBinary,
-    });
-  }
-
-  return entries;
-}
-
-function toFileChangeStatus(code: string): GitFileChangeStatus {
-  switch (code) {
-    case 'A': return 'added';
-    case 'M': return 'modified';
-    case 'D': return 'deleted';
-    case 'R': return 'renamed';
-    case 'C': return 'copied';
-    case 'T': return 'typechange';
-    case 'U': return 'unmerged';
-    default: return 'unknown';
-  }
-}
-
-interface NameStatusEntry {
-  oldPath: string;
-  path: string;
-  status: GitFileChangeStatus;
-  similarity?: number;
-}
-
-/**
- * Parse `--name-status -z` output: `M\0path\0`, `A\0path\0`,
- * `R100\0oldPath\0newPath\0`. Only `R` and `C` carry two paths.
- */
-export function parseNameStatusZ(raw: string): NameStatusEntry[] {
-  const tokens = raw.split('\0');
-  const entries: NameStatusEntry[] = [];
-  let i = 0;
-
-  while (i < tokens.length) {
-    const statusToken = tokens[i];
-    i++;
-    if (!statusToken) continue;
-
-    const code = statusToken[0];
-    const status = toFileChangeStatus(code);
-    const similarityRaw = statusToken.slice(1);
-    const similarity = similarityRaw ? Number.parseInt(similarityRaw, 10) : undefined;
-
-    if (code === 'R' || code === 'C') {
-      const oldPath = tokens[i] ?? '';
-      i++;
-      const path = tokens[i] ?? '';
-      i++;
-      if (!oldPath && !path) continue;
-      entries.push({
-        oldPath,
-        path: path || oldPath,
-        status,
-        similarity: similarity === undefined || Number.isNaN(similarity) ? undefined : similarity,
-      });
-    } else {
-      const path = tokens[i] ?? '';
-      i++;
-      if (!path) continue;
-      entries.push({ oldPath: path, path, status });
-    }
-  }
-
-  return entries;
-}
-
-/**
- * Zip numstat counts with name-status change kinds, keyed by post-change path.
- * numstat is the source of truth for the file set; a path missing from
- * name-status falls back to `modified`.
- */
-export function mergeFileChanges(
-  numstat: NumstatEntry[],
-  nameStatus: NameStatusEntry[]
-): GitCommitFileChange[] {
-  const statusByPath = new Map(nameStatus.map(entry => [entry.path, entry]));
-
-  return numstat.map(entry => {
-    const match = statusByPath.get(entry.path);
-    const file: GitCommitFileChange = {
-      path: entry.path,
-      oldPath: match?.oldPath || entry.oldPath || entry.path,
-      status: match?.status ?? 'modified',
-      additions: entry.additions,
-      deletions: entry.deletions,
-      isBinary: entry.isBinary,
-    };
-    if (match?.similarity !== undefined) file.similarity = match.similarity;
-    return file;
-  });
-}
-
-/**
- * Parse untracked paths out of `git status --porcelain -z`.
- *
- * Porcelain v1 with `-z` emits `XY <path>\0`; rename entries emit a second
- * path token which we skip. Only `??` records are returned.
- */
-export function parseUntrackedPathsZ(raw: string): string[] {
-  const tokens = raw.split('\0');
-  const paths: string[] = [];
-  let i = 0;
-
-  while (i < tokens.length) {
-    const token = tokens[i];
-    i++;
-    if (!token || token.length < 4) continue;
-
-    const code = token.slice(0, 2);
-    const path = token.slice(3);
-    // Rename/copy records carry the original path as an extra token.
-    if (code[0] === 'R' || code[0] === 'C') i++;
-    if (code === '??') paths.push(path);
-  }
-
-  return paths;
 }
 
 export class GitDiffManager {

--- a/main/src/services/gitDiffManager.untracked.test.ts
+++ b/main/src/services/gitDiffManager.untracked.test.ts
@@ -6,9 +6,9 @@ import { join } from 'path';
 import {
   GitDiffManager,
   MAX_UNTRACKED_INLINE_FILES,
-  splitNulSeparated,
   untrackedFilePath,
 } from './gitDiffManager';
+import { splitNulSeparated } from './gitDiffParsers';
 import type { CommandRunner } from '../utils/commandRunner';
 
 /**

--- a/main/src/services/gitDiffManager.untracked.test.ts
+++ b/main/src/services/gitDiffManager.untracked.test.ts
@@ -42,11 +42,12 @@ const HOSTILE_NAMES = [
 
 /** A runner that answers git for real, as a host project would. */
 function realRunner(): CommandRunner {
+  // SAFETY: The integration fixture supplies every CommandRunner member used by working-tree capture.
   return {
     wslContext: null,
     exec: vi.fn((command: string, cwd: string) => run(command, cwd)),
     execAsync: vi.fn(async (command: string, cwd: string) => ({ stdout: run(command, cwd), stderr: '' })),
-  } as unknown as CommandRunner;
+  } as CommandRunner;
 }
 
 /** Run a `git …` command without a shell, so the test itself cannot be the bug. */
@@ -173,7 +174,7 @@ describe('working-directory capture stays bounded and off the main thread', () =
     const runner = realRunner();
     await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
 
-    const asyncCalls = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls;
+    const asyncCalls = vi.mocked(runner.execAsync).mock.calls;
     expect(asyncCalls.length).toBeLessThan(10);
     // Nothing that reads or measures a file goes through a command any more.
     expect(asyncCalls.some(([command]) => /^(cat|wc) /.test(command))).toBe(false);
@@ -195,7 +196,7 @@ describe('working-directory capture stays bounded and off the main thread', () =
     const runner = realRunner();
     await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
 
-    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
+    const syncCalls = vi.mocked(runner.exec).mock.calls;
     expect(syncCalls.every(([command]) => command.includes('rev-parse'))).toBe(true);
   });
 });

--- a/main/src/services/gitDiffManager.untracked.test.ts
+++ b/main/src/services/gitDiffManager.untracked.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir, readdir } from 'fs/promises';
+import { execFileSync } from 'child_process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  GitDiffManager,
+  MAX_UNTRACKED_INLINE_FILES,
+  splitNulSeparated,
+  untrackedFilePath,
+} from './gitDiffManager';
+import type { CommandRunner } from '../utils/commandRunner';
+
+/**
+ * Untracked files are the one place where a name that came out of the
+ * repository used to be handed to a shell. Git allows a great deal in a
+ * filename — spaces, quotes, `$`, backticks, parentheses, a leading dash, even
+ * a newline — and the previous code built `cat "<worktree>/<file>"` and
+ * `wc -l "<worktree>/<file>"` by interpolation. Under bash the `$(…)` and the
+ * backticks in such a name were executed.
+ *
+ * The listing had a second problem of its own: without `-z`, git delimits with
+ * newlines and quotes anything non-ASCII into a C escape, so `täst.txt` came
+ * back as the literal `"t\303\244st.txt"` and the file disappeared from both
+ * the diff and the stats.
+ */
+
+/** Names git accepts. Some are illegal on Windows, so each is tried and checked. */
+const HOSTILE_NAMES = [
+  'plain.txt',
+  'with space.txt',
+  'täst.txt',
+  'dollar$(echo pwned).txt',
+  'back`echo pwned`.txt',
+  'quote".txt',
+  "single'.txt",
+  'paren(1).txt',
+  '-leading-dash.txt',
+  'semi;colon&pipe|.txt',
+  'new\nline.txt',
+];
+
+/** A runner that answers git for real, as a host project would. */
+function realRunner(): CommandRunner {
+  return {
+    wslContext: null,
+    exec: vi.fn((command: string, cwd: string) => run(command, cwd)),
+    execAsync: vi.fn(async (command: string, cwd: string) => ({ stdout: run(command, cwd), stderr: '' })),
+  } as unknown as CommandRunner;
+}
+
+/** Run a `git …` command without a shell, so the test itself cannot be the bug. */
+function run(command: string, cwd: string): string {
+  if (!command.startsWith('git ')) return '';
+  const args = command.slice(4).match(/"[^"]*"|\S+/g)?.map(a => a.replace(/^"|"$/g, '')) ?? [];
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  } catch {
+    return '';
+  }
+}
+
+describe('untracked files with hostile names', () => {
+  let repo: string;
+  const created: string[] = [];
+
+  beforeAll(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'pane-untracked-'));
+    execFileSync('git', ['init', '-q', '.'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    await writeFile(join(repo, 'tracked.txt'), 'tracked\n', 'utf8');
+    execFileSync('git', ['add', 'tracked.txt'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo });
+
+    // Two lines each, so the additions total is simply 2 per file.
+    for (const name of HOSTILE_NAMES) {
+      try {
+        await writeFile(join(repo, name), 'first\nsecond\n', 'utf8');
+        created.push(name);
+      } catch {
+        // NTFS rejects ", | and a newline in a name. Those cases run on CI.
+      }
+    }
+    // Guard against the whole set silently failing to materialise.
+    expect(created.length).toBeGreaterThan(4);
+  });
+
+  afterAll(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('lists every one of them, unquoted and unescaped', async () => {
+    const manager = new GitDiffManager();
+    const result = await manager.captureWorkingDirectoryDiff(repo, realRunner());
+
+    for (const name of created) {
+      expect(result.changedFiles).toContain(name);
+    }
+    // The regression: git's C-style quoting of a non-ASCII name.
+    expect(result.changedFiles.some(file => file.includes('\\303'))).toBe(false);
+    expect(result.changedFiles.some(file => file.startsWith('"'))).toBe(false);
+  });
+
+  it('reads their content instead of executing what is in the name', async () => {
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    for (const name of created) {
+      expect(result.diff).toContain(`diff --git a/${name} b/${name}`);
+    }
+    // Every file contributed its two lines: nothing was skipped for want of a
+    // readable path, and nothing came back as the output of a substituted
+    // command. `pwned` is what the embedded commands would have printed.
+    expect(result.diff).not.toContain('pwned\n+');
+    expect(result.stats.additions).toBe(created.length * 2);
+    expect(result.stats.filesChanged).toBe(created.length);
+  });
+
+  it('leaves no trace of a command having run', async () => {
+    await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    // A substituted `echo pwned` in the path would have made cat/wc read (or
+    // create) a different name. The directory is exactly what was written.
+    const onDisk = await readdir(repo);
+    for (const name of created) {
+      expect(onDisk).toContain(name);
+    }
+    expect(onDisk.filter(entry => entry.includes('pwned') && !created.includes(entry))).toEqual([]);
+  });
+
+  it('counts a file in a subdirectory through the right path', async () => {
+    await mkdir(join(repo, 'nested dir'), { recursive: true });
+    await writeFile(join(repo, 'nested dir', 'deep $file.txt'), 'a\nb\nc\n', 'utf8');
+
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    expect(result.changedFiles).toContain('nested dir/deep $file.txt');
+    expect(result.diff).toContain('+c');
+
+    await rm(join(repo, 'nested dir'), { recursive: true, force: true });
+  });
+});
+
+/**
+ * The other half of the change this PR made: capturing a working tree must not
+ * cost a child process per untracked file, which is what froze the app.
+ */
+describe('working-directory capture stays bounded and off the main thread', () => {
+  let repo: string;
+  const fileCount = 400;
+
+  beforeAll(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'pane-untracked-many-'));
+    execFileSync('git', ['init', '-q', '.'], { cwd: repo });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repo });
+    await writeFile(join(repo, 'tracked.txt'), 'tracked\n', 'utf8');
+    execFileSync('git', ['add', 'tracked.txt'], { cwd: repo });
+    execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo });
+
+    await mkdir(join(repo, 'build'), { recursive: true });
+    await Promise.all(
+      Array.from({ length: fileCount }, (_, i) =>
+        writeFile(join(repo, 'build', `res-${i}.flat`), 'one\ntwo\n', 'utf8'))
+    );
+  }, 30_000);
+
+  afterAll(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('spawns a fixed handful of commands regardless of how many files there are', async () => {
+    const runner = realRunner();
+    await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
+
+    const asyncCalls = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls;
+    expect(asyncCalls.length).toBeLessThan(10);
+    // Nothing that reads or measures a file goes through a command any more.
+    expect(asyncCalls.some(([command]) => /^(cat|wc) /.test(command))).toBe(false);
+    expect(asyncCalls.filter(([command]) => command.includes('ls-files')).length).toBe(1);
+  });
+
+  it('caps inlined content but still reports every file', async () => {
+    const result = await new GitDiffManager().captureWorkingDirectoryDiff(repo, realRunner());
+
+    const inlined = result.diff.match(/^diff --git /gm)?.length ?? 0;
+    expect(inlined).toBeLessThanOrEqual(MAX_UNTRACKED_INLINE_FILES);
+    expect(result.changedFiles).toHaveLength(fileCount);
+    expect(result.stats.filesChanged).toBe(fileCount);
+    // Counting is not capped: every file's two lines are in the total.
+    expect(result.stats.additions).toBe(fileCount * 2);
+  });
+
+  it('keeps the synchronous path free of anything that scales with file count', async () => {
+    const runner = realRunner();
+    await new GitDiffManager().captureWorkingDirectoryDiff(repo, runner);
+
+    const syncCalls = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls;
+    expect(syncCalls.every(([command]) => command.includes('rev-parse'))).toBe(true);
+  });
+});
+
+describe('splitNulSeparated', () => {
+  it('keeps a name containing a newline in one piece', () => {
+    expect(splitNulSeparated('a\nb.txt\0c.txt\0')).toEqual(['a\nb.txt', 'c.txt']);
+  });
+
+  it('keeps the spaces that are part of a name', () => {
+    expect(splitNulSeparated(' leading.txt\0trailing .txt\0')).toEqual([' leading.txt', 'trailing .txt']);
+  });
+
+  it('is empty for empty output', () => {
+    expect(splitNulSeparated('')).toEqual([]);
+  });
+});
+
+describe('untrackedFilePath', () => {
+  it('reaches a WSL worktree through the mount Windows can see', () => {
+    const path = untrackedFilePath('/home/dev/project', 'src/new file.ts', {
+      enabled: true,
+      distribution: 'Ubuntu',
+      linuxPath: '/home/dev/project',
+    });
+
+    expect(path).toBe('\\\\wsl.localhost\\Ubuntu\\home\\dev\\project\\src\\new file.ts');
+  });
+
+  it('joins natively for a host project', () => {
+    const path = untrackedFilePath(join('repo', 'wt'), 'src/new.ts', null);
+    expect(path).toBe(join('repo', 'wt', 'src', 'new.ts'));
+  });
+});

--- a/main/src/services/gitDiffParsers.ts
+++ b/main/src/services/gitDiffParsers.ts
@@ -1,0 +1,134 @@
+import type { GitCommitFileChange, GitFileChangeStatus } from '../../../shared/types/git';
+
+interface NumstatEntry {
+  oldPath: string;
+  path: string;
+  additions: number | null;
+  deletions: number | null;
+  isBinary: boolean;
+}
+
+interface NameStatusEntry {
+  oldPath: string;
+  path: string;
+  status: GitFileChangeStatus;
+  similarity?: number;
+}
+
+/** Split NUL-delimited Git output without altering repository-controlled paths. */
+export function splitNulSeparated(raw: string): string[] {
+  return raw.split('\0').filter(entry => entry.length > 0);
+}
+
+/** Parse `--numstat -z`, including rename records and binary markers. */
+export function parseNumstatZ(raw: string): NumstatEntry[] {
+  const tokens = raw.split('\0');
+  const entries: NumstatEntry[] = [];
+  let index = 0;
+
+  while (index < tokens.length) {
+    const token = tokens[index++];
+    if (!token) continue;
+
+    const firstTab = token.indexOf('\t');
+    const secondTab = token.indexOf('\t', firstTab + 1);
+    if (firstTab < 0 || secondTab < 0) continue;
+
+    const addRaw = token.slice(0, firstTab);
+    const deleteRaw = token.slice(firstTab + 1, secondTab);
+    const pathField = token.slice(secondTab + 1);
+    const oldPath = pathField || tokens[index++] || '';
+    const path = pathField || tokens[index++] || oldPath;
+    const isBinary = addRaw === '-' || deleteRaw === '-';
+
+    entries.push({
+      oldPath,
+      path,
+      additions: isBinary ? null : Number.parseInt(addRaw, 10) || 0,
+      deletions: isBinary ? null : Number.parseInt(deleteRaw, 10) || 0,
+      isBinary,
+    });
+  }
+
+  return entries;
+}
+
+function toFileChangeStatus(code: string): GitFileChangeStatus {
+  switch (code) {
+    case 'A': return 'added';
+    case 'M': return 'modified';
+    case 'D': return 'deleted';
+    case 'R': return 'renamed';
+    case 'C': return 'copied';
+    case 'T': return 'typechange';
+    case 'U': return 'unmerged';
+    default: return 'unknown';
+  }
+}
+
+/** Parse `--name-status -z`, retaining rename and copy similarity. */
+export function parseNameStatusZ(raw: string): NameStatusEntry[] {
+  const tokens = raw.split('\0');
+  const entries: NameStatusEntry[] = [];
+  let index = 0;
+
+  while (index < tokens.length) {
+    const statusToken = tokens[index++];
+    if (!statusToken) continue;
+
+    const code = statusToken[0];
+    const status = toFileChangeStatus(code);
+    if (code === 'R' || code === 'C') {
+      const oldPath = tokens[index++] ?? '';
+      const path = tokens[index++] || oldPath;
+      if (!oldPath && !path) continue;
+      const similarity = Number.parseInt(statusToken.slice(1), 10);
+      entries.push({ oldPath, path, status });
+      if (!Number.isNaN(similarity)) entries.at(-1)!.similarity = similarity;
+      continue;
+    }
+
+    const path = tokens[index++] ?? '';
+    if (path) entries.push({ oldPath: path, path, status });
+  }
+
+  return entries;
+}
+
+/** Combine Git counts and status records by their post-change path. */
+export function mergeFileChanges(
+  numstat: NumstatEntry[],
+  nameStatus: NameStatusEntry[],
+): GitCommitFileChange[] {
+  const statusByPath = new Map(nameStatus.map(entry => [entry.path, entry]));
+  return numstat.map(entry => {
+    const match = statusByPath.get(entry.path);
+    const file: GitCommitFileChange = {
+      path: entry.path,
+      oldPath: match?.oldPath || entry.oldPath || entry.path,
+      status: match?.status ?? 'modified',
+      additions: entry.additions,
+      deletions: entry.deletions,
+      isBinary: entry.isBinary,
+    };
+    if (match?.similarity !== undefined) file.similarity = match.similarity;
+    return file;
+  });
+}
+
+/** Read untracked paths from `git status --porcelain -z`. */
+export function parseUntrackedPathsZ(raw: string): string[] {
+  const tokens = raw.split('\0');
+  const paths: string[] = [];
+  let index = 0;
+
+  while (index < tokens.length) {
+    const token = tokens[index++];
+    if (!token || token.length < 4) continue;
+    const code = token.slice(0, 2);
+    if (code[0] === 'R' || code[0] === 'C') index++;
+    if (code === '??') paths.push(token.slice(3));
+  }
+
+  return paths;
+}

--- a/main/src/services/pullRequestManager.test.ts
+++ b/main/src/services/pullRequestManager.test.ts
@@ -210,8 +210,8 @@ describe('parsePullRequestStatus', () => {
     reviewDecision: 'CHANGES_REQUESTED',
     mergeable: 'CONFLICTING',
     reviews: [
-      { author: { login: 'parsa' }, state: 'CHANGES_REQUESTED' },
-      { author: { login: 'parsa' }, state: 'APPROVED' },
+      { author: { login: 'parsa' }, state: 'CHANGES_REQUESTED', submittedAt: '2026-08-20T10:00:00Z' },
+      { author: { login: 'parsa' }, state: 'APPROVED', submittedAt: '2026-08-21T10:00:00Z' },
       { author: { login: 'someone' }, state: 'COMMENTED' },
     ],
     comments: [{}, {}],
@@ -243,6 +243,18 @@ describe('parsePullRequestStatus', () => {
       { login: 'parsa', state: 'APPROVED' },
       { login: 'someone', state: 'COMMENTED' },
     ]);
+  });
+
+  it('uses submission time when reviews arrive out of order', () => {
+    const status = parsePullRequestStatus(JSON.stringify({
+      number: 382,
+      reviews: [
+        { author: { login: 'parsa' }, state: 'APPROVED', submittedAt: '2026-08-21T10:00:00Z' },
+        { author: { login: 'parsa' }, state: 'CHANGES_REQUESTED', submittedAt: '2026-08-20T10:00:00Z' },
+      ],
+    }));
+
+    expect(status?.reviewers).toEqual([{ login: 'parsa', state: 'APPROVED' }]);
   });
 
   it('fills in what gh left out rather than throwing', () => {

--- a/main/src/services/pullRequestManager.test.ts
+++ b/main/src/services/pullRequestManager.test.ts
@@ -485,6 +485,11 @@ describe('PullRequestManager.getDraft', () => {
 
     expect(draft.existing?.number).toBe(382);
     expect(draft.defaultTarget).toBe('dcouple/Pane');
+    const commands = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+      .map(call => call[0].replace(/["']/g, ''));
+    expect(commands).toContainEqual(expect.stringContaining(
+      'pr list --repo dcouple/Pane --head 0x92:feature/x'
+    ));
   });
 
   it('reports uncommitted work so the dialog can offer to commit first', async () => {
@@ -548,6 +553,24 @@ describe('PullRequestManager.create', () => {
       { sessionId: 's1', title: 't', body: 'b', baseBranch: 'main', targetRepo: 'dcouple/Pane' },
       '/wt', '/repo', runner,
     )).rejects.toThrow(/did not return a pull request URL/);
+  });
+
+  it('rejects a missing target base before pushing the branch', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git remote', 'origin\n'],
+      ['--version', 'gh version 2.97.0'],
+      ['repos/dcouple/Pane/branches/missing', new Error('HTTP 404')],
+    ]);
+
+    await expect(new PullRequestManager().create(
+      { sessionId: 's1', title: 't', body: 'b', baseBranch: 'missing', targetRepo: 'dcouple/Pane' },
+      '/wt', '/repo', runner,
+    )).rejects.toThrow(/Base branch missing was not found in dcouple\/Pane/);
+
+    const commands = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+      .map(call => call[0]);
+    expect(commands.some(command => command.includes('git push'))).toBe(false);
   });
 });
 
@@ -781,4 +804,3 @@ describe('PullRequestManager.getDiff', () => {
       .toEqual({ baseRef: 'ghost', diff: '', truncated: false });
   });
 });
-

--- a/main/src/services/pullRequestManager.test.ts
+++ b/main/src/services/pullRequestManager.test.ts
@@ -1,0 +1,784 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  PullRequestManager,
+  ghCandidatePaths,
+  normalizeBaseBranch,
+  parseBranchNames,
+  parseTrackingBranches,
+  buildCreateArgs,
+  deriveDraftText,
+  normalizeCheckState,
+  normalizeReviewDecision,
+  parsePullRequestStatus,
+  parseChecks,
+  parseCommitSummaries,
+  parseCreatedPullRequest,
+  parseGitHubRemote,
+  resolvePushRemote,
+  resolveTargets,
+  sortBaseBranches,
+  summarizeChecks,
+  summarizeFileChanges,
+} from './pullRequestManager';
+import type { GitCommitFileChange } from '../../../shared/types/git';
+import type { CommandRunner } from '../utils/commandRunner';
+
+describe('deriveDraftText', () => {
+  it('takes the title from the first commit and the body from the rest', () => {
+    const { title, body } = deriveDraftText([
+      { subject: 'Add the thing', body: 'Because the other thing needed it.' },
+      { subject: 'Fix a typo in the thing', body: '' },
+    ], null);
+
+    expect(title).toBe('Add the thing');
+    expect(body).toContain('Because the other thing needed it.');
+    expect(body).toContain('- Fix a typo in the thing');
+  });
+
+  it('appends the repository template rather than replacing the commits', () => {
+    const { body } = deriveDraftText(
+      [{ subject: 'Add the thing', body: 'Why.' }],
+      '## Checklist\n- [ ] tests',
+    );
+
+    expect(body).toBe('Why.\n\n## Checklist\n- [ ] tests');
+  });
+
+  it('survives a repository with no commits and no template', () => {
+    expect(deriveDraftText([], null)).toEqual({ title: '', body: '' });
+  });
+});
+
+describe('resolveTargets', () => {
+  /**
+   * The whole point of the target picker: contributions from a fork are meant
+   * for the parent, and picking your own fork by accident is a silent mistake.
+   */
+  it('offers the parent first for a fork', () => {
+    const { targets, defaultTarget } = resolveTargets({
+      nameWithOwner: '0x92/Pane',
+      defaultBranchRef: { name: 'main' },
+      parent: { name: 'Pane', owner: { login: 'dcouple' }, defaultBranchRef: { name: 'main' } },
+    });
+
+    expect(targets.map(t => t.nameWithOwner)).toEqual(['dcouple/Pane', '0x92/Pane']);
+    expect(targets[0].isParent).toBe(true);
+    expect(defaultTarget).toBe('dcouple/Pane');
+  });
+
+  it('offers only the repository itself when it is not a fork', () => {
+    const { targets, defaultTarget } = resolveTargets({
+      nameWithOwner: 'someone/thing',
+      defaultBranchRef: { name: 'trunk' },
+      parent: null,
+    });
+
+    expect(targets).toEqual([
+      { nameWithOwner: 'someone/thing', isParent: false, defaultBranch: 'trunk' },
+    ]);
+    expect(defaultTarget).toBe('someone/thing');
+  });
+});
+
+describe('buildCreateArgs', () => {
+  const request = {
+    sessionId: 's1',
+    title: 'Add the thing',
+    body: 'ignored — the body goes through a file',
+    baseBranch: 'main',
+    targetRepo: 'dcouple/Pane',
+  };
+
+  it('names the fork in the head ref when the pull request crosses repositories', () => {
+    const args = buildCreateArgs(request, {
+      branch: 'feature/x',
+      forkOwner: '0x92',
+      bodyFile: '/tmp/body.md',
+    });
+
+    expect(args).toEqual([
+      'pr', 'create',
+      '--repo', 'dcouple/Pane',
+      '--base', 'main',
+      '--head', '0x92:feature/x',
+      '--title', 'Add the thing',
+      '--body-file', '/tmp/body.md',
+    ]);
+  });
+
+  it('uses the bare branch when staying inside one repository', () => {
+    const args = buildCreateArgs(
+      { ...request, targetRepo: '0x92/Pane' },
+      { branch: 'feature/x', forkOwner: '0x92', bodyFile: '/tmp/body.md' },
+    );
+
+    expect(args).toContain('feature/x');
+    expect(args).not.toContain('0x92:feature/x');
+  });
+
+  it('compares owners case-insensitively — GitHub does', () => {
+    const args = buildCreateArgs(
+      { ...request, targetRepo: '0X92/Pane' },
+      { branch: 'feature/x', forkOwner: '0x92', bodyFile: '/tmp/body.md' },
+    );
+
+    expect(args).toContain('feature/x');
+    expect(args).not.toContain('0x92:feature/x');
+  });
+
+  it('adds --draft only when asked', () => {
+    expect(buildCreateArgs(request, { branch: 'b', forkOwner: null, bodyFile: '/tmp/b.md' }))
+      .not.toContain('--draft');
+    expect(buildCreateArgs({ ...request, draft: true }, { branch: 'b', forkOwner: null, bodyFile: '/tmp/b.md' }))
+      .toContain('--draft');
+  });
+
+  it('never inlines the body — markdown does not survive a shell', () => {
+    const args = buildCreateArgs(
+      { ...request, body: 'contains `backticks` and "quotes"\nand newlines' },
+      { branch: 'b', forkOwner: null, bodyFile: '/tmp/b.md' },
+    );
+
+    expect(args).toContain('--body-file');
+    expect(args.join(' ')).not.toContain('backticks');
+  });
+});
+
+describe('parseCreatedPullRequest', () => {
+  it('reads the number and url gh prints', () => {
+    expect(parseCreatedPullRequest('https://github.com/dcouple/Pane/pull/382\n')).toEqual({
+      url: 'https://github.com/dcouple/Pane/pull/382',
+      number: 382,
+    });
+  });
+
+  it('finds the url among gh chatter', () => {
+    const stdout = 'Warning: 3 uncommitted changes\nhttps://github.com/o/r/pull/7\n';
+    expect(parseCreatedPullRequest(stdout)?.number).toBe(7);
+  });
+
+  it('returns null when gh printed something else entirely', () => {
+    expect(parseCreatedPullRequest('aborted')).toBeNull();
+  });
+});
+
+describe('check states', () => {
+  it('maps gh buckets and raw states onto one vocabulary', () => {
+    expect(normalizeCheckState('pass')).toBe('pass');
+    expect(normalizeCheckState('SUCCESS')).toBe('pass');
+    expect(normalizeCheckState('fail')).toBe('fail');
+    expect(normalizeCheckState('TIMED_OUT')).toBe('fail');
+    expect(normalizeCheckState('skipping')).toBe('skipped');
+    expect(normalizeCheckState('cancel')).toBe('cancelled');
+    expect(normalizeCheckState(undefined)).toBe('pending');
+    expect(normalizeCheckState('something new')).toBe('pending');
+  });
+
+  it('prefers the bucket over the raw state', () => {
+    const checks = parseChecks(JSON.stringify([
+      { name: 'build', state: 'COMPLETED', bucket: 'fail', link: 'https://ci/1' },
+    ]));
+
+    expect(checks).toEqual([{ name: 'build', state: 'fail', url: 'https://ci/1' }]);
+  });
+
+  it('summarises by what needs attention first', () => {
+    const check = (state: string) => ({ name: state, state: normalizeCheckState(state) });
+
+    expect(summarizeChecks([])).toBe('none');
+    expect(summarizeChecks([check('pass'), check('fail'), check('pending')])).toBe('fail');
+    expect(summarizeChecks([check('pass'), check('pending')])).toBe('pending');
+    expect(summarizeChecks([check('pass'), check('skipping')])).toBe('pass');
+    expect(summarizeChecks([check('skipping')])).toBe('skipped');
+  });
+
+  it('ignores rows without a name', () => {
+    expect(parseChecks(JSON.stringify([{ bucket: 'pass' }]))).toEqual([]);
+  });
+});
+
+describe('parsePullRequestStatus', () => {
+  const view = {
+    number: 382,
+    url: 'https://github.com/dcouple/Pane/pull/382',
+    title: 'Add Agent Fleet',
+    state: 'open',
+    isDraft: false,
+    baseRefName: 'main',
+    headRefName: 'feature/agent-fleet',
+    headRepositoryOwner: { login: '0x92' },
+    reviewDecision: 'CHANGES_REQUESTED',
+    mergeable: 'CONFLICTING',
+    reviews: [
+      { author: { login: 'parsa' }, state: 'CHANGES_REQUESTED' },
+      { author: { login: 'parsa' }, state: 'APPROVED' },
+      { author: { login: 'someone' }, state: 'COMMENTED' },
+    ],
+    comments: [{}, {}],
+    additions: 2599,
+    deletions: 65,
+    changedFiles: 23,
+  };
+
+  it('reads the fields the review panel shows', () => {
+    const status = parsePullRequestStatus(JSON.stringify(view));
+
+    expect(status).toMatchObject({
+      number: 382,
+      state: 'OPEN',
+      isDraft: false,
+      baseRefName: 'main',
+      headRefName: 'feature/agent-fleet',
+      headRepositoryOwner: '0x92',
+      reviewDecision: 'changes_requested',
+      mergeable: 'CONFLICTING',
+      commentCount: 2,
+      changedFiles: 23,
+    });
+  });
+
+  it('keeps only the newest review per person', () => {
+    // parsa asked for changes and later approved: one reviewer, approved.
+    expect(parsePullRequestStatus(JSON.stringify(view))?.reviewers).toEqual([
+      { login: 'parsa', state: 'APPROVED' },
+      { login: 'someone', state: 'COMMENTED' },
+    ]);
+  });
+
+  it('fills in what gh left out rather than throwing', () => {
+    const status = parsePullRequestStatus(JSON.stringify({ number: 7 }));
+
+    expect(status).toMatchObject({
+      number: 7,
+      state: 'OPEN',
+      reviewDecision: 'none',
+      mergeable: 'UNKNOWN',
+      reviewers: [],
+      commentCount: 0,
+      additions: 0,
+    });
+  });
+
+  it('is null for an empty answer or one without a number', () => {
+    expect(parsePullRequestStatus('')).toBeNull();
+    expect(parsePullRequestStatus('{}')).toBeNull();
+  });
+});
+
+describe('normalizeReviewDecision', () => {
+  it('maps GitHub spellings and treats anything else as no decision', () => {
+    expect(normalizeReviewDecision('APPROVED')).toBe('approved');
+    expect(normalizeReviewDecision('changes_requested')).toBe('changes_requested');
+    expect(normalizeReviewDecision('REVIEW_REQUIRED')).toBe('review_required');
+    expect(normalizeReviewDecision(null)).toBe('none');
+    expect(normalizeReviewDecision('SOMETHING_NEW')).toBe('none');
+  });
+});
+
+describe('parseCommitSummaries', () => {
+  it('splits subjects from bodies without tripping over blank lines', () => {
+    const raw = 'First\x00Body line one\n\nBody line two\x01Second\x00\x01';
+    expect(parseCommitSummaries(raw)).toEqual([
+      { subject: 'First', body: 'Body line one\n\nBody line two' },
+      { subject: 'Second', body: '' },
+    ]);
+  });
+
+  it('returns nothing for an empty log', () => {
+    expect(parseCommitSummaries('')).toEqual([]);
+  });
+});
+
+describe('normalizeBaseBranch', () => {
+  /**
+   * `gh pr create --base origin/main` looks for a branch called
+   * "origin/main" — which does not exist anywhere.
+   */
+  it('strips the remote prefix from a tracking ref', () => {
+    expect(normalizeBaseBranch('origin/main', ['origin', 'upstream'])).toBe('main');
+    expect(normalizeBaseBranch('upstream/release/2.x', ['origin', 'upstream'])).toBe('release/2.x');
+  });
+
+  it('leaves a plain branch alone', () => {
+    expect(normalizeBaseBranch('main', ['origin'])).toBe('main');
+    expect(normalizeBaseBranch('feature/origin-story', ['origin'])).toBe('feature/origin-story');
+  });
+
+  it('strips refs/heads/ as well', () => {
+    expect(normalizeBaseBranch('refs/heads/main', [])).toBe('main');
+  });
+});
+
+describe('ghCandidatePaths', () => {
+  /**
+   * Pane snapshots PATH at start-up, so a `gh` installed *because* Pane asked
+   * for it is invisible until a restart. These are the places to look instead.
+   */
+  // String.raw throughout: a lone backslash in a normal literal is an escape,
+  // which is exactly the mistake this test exists to catch.
+  it('builds real Windows paths, separators and all', () => {
+    const paths = ghCandidatePaths('win32', {
+      ProgramFiles: String.raw`C:\Program Files`,
+      LOCALAPPDATA: String.raw`C:\Users\me\AppData\Local`,
+    } as NodeJS.ProcessEnv);
+
+    expect(paths[0]).toBe(String.raw`C:\Program Files\GitHub CLI\gh.exe`);
+    expect(paths[1]).toBe(String.raw`C:\Users\me\AppData\Local\Programs\GitHub CLI\gh.exe`);
+    // The bug this replaced produced "C:\Program FilesGitHub CLIgh.exe".
+    for (const candidate of paths) {
+      expect(candidate).not.toMatch(/FilesGitHub|LocalPrograms/);
+    }
+  });
+
+  it('does not double a separator the environment already ends with', () => {
+    // Not String.raw here: a template literal cannot end on a backslash.
+    const paths = ghCandidatePaths('win32', { ProgramFiles: 'C:\\Program Files\\' } as NodeJS.ProcessEnv);
+    expect(paths[0]).toBe(String.raw`C:\Program Files\GitHub CLI\gh.exe`);
+  });
+
+  it('leaves out the user location when the environment has none', () => {
+    const paths = ghCandidatePaths('win32', { ProgramFiles: String.raw`C:\Program Files` } as NodeJS.ProcessEnv);
+    expect(paths).toHaveLength(1);
+  });
+
+  it('covers homebrew and the usual unix prefixes', () => {
+    const paths = ghCandidatePaths('darwin', {} as NodeJS.ProcessEnv);
+    expect(paths).toContain('/opt/homebrew/bin/gh');
+    expect(paths).toContain('/usr/local/bin/gh');
+  });
+});
+
+describe('parseBranchNames', () => {
+  it('reads names from the api response', () => {
+    expect(parseBranchNames('["main","dev"]')).toEqual(['main', 'dev']);
+    expect(parseBranchNames('[{"name":"main"},{"name":"dev"}]')).toEqual(['main', 'dev']);
+  });
+
+  it('is empty rather than throwing on an empty answer', () => {
+    expect(parseBranchNames('')).toEqual([]);
+    expect(parseBranchNames('[]')).toEqual([]);
+  });
+});
+
+describe('parseGitHubRemote', () => {
+  it('reads owner/repo from every url form git accepts', () => {
+    expect(parseGitHubRemote('https://github.com/0x92/Pane.git')).toBe('0x92/Pane');
+    expect(parseGitHubRemote('https://github.com/0x92/Pane')).toBe('0x92/Pane');
+    expect(parseGitHubRemote('git@github.com:0x92/Pane.git')).toBe('0x92/Pane');
+    expect(parseGitHubRemote('ssh://git@github.com/0x92/Pane.git')).toBe('0x92/Pane');
+  });
+
+  it('ignores remotes that are not GitHub', () => {
+    expect(parseGitHubRemote('https://gitlab.com/o/r.git')).toBeNull();
+    expect(parseGitHubRemote('/srv/git/bare.git')).toBeNull();
+    expect(parseGitHubRemote('')).toBeNull();
+  });
+});
+
+describe('resolvePushRemote', () => {
+  it('prefers origin, which is the fork in the usual setup', () => {
+    expect(resolvePushRemote(['upstream', 'origin'])).toBe('origin');
+  });
+
+  it('falls back to the only remote there is', () => {
+    expect(resolvePushRemote(['fork'])).toBe('fork');
+  });
+
+  it('reports none rather than guessing', () => {
+    expect(resolvePushRemote([])).toBeNull();
+  });
+});
+
+/**
+ * A CommandRunner whose answers are chosen by matching the command text.
+ *
+ * Quotes are stripped before matching: arguments are shell-escaped on the way
+ * out, and on Windows that wraps even `pr` and `create` in double quotes.
+ */
+function stubRunner(responses: Array<[match: string, output: string | Error]>): CommandRunner {
+  const pick = (command: string) => {
+    const plain = command.replace(/["']/g, '');
+    for (const [match, output] of responses) {
+      if (plain.includes(match)) return output;
+    }
+    return '';
+  };
+  return {
+    exec: vi.fn((command: string) => {
+      const output = pick(command);
+      if (output instanceof Error) throw output;
+      return output;
+    }),
+    execAsync: vi.fn(async (command: string) => {
+      const output = pick(command);
+      if (output instanceof Error) throw output;
+      return { stdout: output, stderr: '' };
+    }),
+    wslContext: null,
+  } as unknown as CommandRunner;
+}
+
+describe('PullRequestManager.getDraft', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('blocks with a readable reason when there is nothing to propose', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git log', ''],
+      ['git status --porcelain', ''],
+      ['--version', 'gh version 2.97.0'],
+      ['auth status', 'Logged in'],
+      ['repo view', JSON.stringify({ nameWithOwner: '0x92/Pane', parent: null })],
+      ['pr list', '[]'],
+    ]);
+
+    const draft = await new PullRequestManager().getDraft('/wt', '/repo', 'main', runner);
+
+    expect(draft.commitCount).toBe(0);
+    expect(draft.blockers).toContainEqual(expect.stringContaining('No commits on feature/x'));
+  });
+
+  it('says what to do when gh is missing instead of failing obscurely', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git log', 'Add it\x00Why.\x01'],
+      ['--version', new Error('command not found: gh')],
+    ]);
+
+    const draft = await new PullRequestManager().getDraft('/wt', '/repo', 'main', runner);
+
+    expect(draft.blockers.join(' ')).toMatch(/cli\.github\.com/);
+    expect(draft.title).toBe('Add it');
+  });
+
+  it('distinguishes "not installed" from "not signed in"', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git log', 'Add it\x00\x01'],
+      ['--version', 'gh version 2.97.0'],
+      ['auth status', new Error('You are not logged into any GitHub hosts')],
+    ]);
+
+    const draft = await new PullRequestManager().getDraft('/wt', '/repo', 'main', runner);
+
+    expect(draft.blockers.join(' ')).toMatch(/gh auth login/);
+    expect(draft.blockers.join(' ')).not.toMatch(/cli\.github\.com/);
+  });
+
+  it('surfaces an existing pull request instead of offering to open a second', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git log', 'Add it\x00\x01'],
+      ['git status --porcelain', ''],
+      ['--version', 'gh version 2.97.0'],
+      ['auth status', 'Logged in'],
+      ['repo view', JSON.stringify({
+        nameWithOwner: '0x92/Pane',
+        parent: { name: 'Pane', owner: { login: 'dcouple' } },
+      })],
+      ['pr list', JSON.stringify([
+        { number: 382, url: 'https://github.com/dcouple/Pane/pull/382', state: 'OPEN', title: 'Add it' },
+      ])],
+    ]);
+
+    const draft = await new PullRequestManager().getDraft('/wt', '/repo', 'main', runner);
+
+    expect(draft.existing?.number).toBe(382);
+    expect(draft.defaultTarget).toBe('dcouple/Pane');
+  });
+
+  it('reports uncommitted work so the dialog can offer to commit first', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git log', 'Add it\x00\x01'],
+      ['git status --porcelain', ' M src/thing.ts\n'],
+      ['--version', 'gh version 2.97.0'],
+      ['auth status', 'Logged in'],
+      ['repo view', JSON.stringify({ nameWithOwner: '0x92/Pane', parent: null })],
+      ['pr list', '[]'],
+    ]);
+
+    const draft = await new PullRequestManager().getDraft('/wt', '/repo', 'main', runner);
+    expect(draft.hasUncommittedChanges).toBe(true);
+  });
+});
+
+describe('PullRequestManager.create', () => {
+  it('pushes the branch before asking gh to open anything', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git remote', 'origin\nupstream\n'],
+      ['git push', ''],
+      ['repo view', JSON.stringify({ nameWithOwner: '0x92/Pane' })],
+      ['pr create', 'https://github.com/dcouple/Pane/pull/391\n'],
+    ]);
+
+    const result = await new PullRequestManager().create(
+      {
+        sessionId: 's1',
+        title: 'Add it',
+        body: 'Why.',
+        baseBranch: 'main',
+        targetRepo: 'dcouple/Pane',
+      },
+      '/wt', '/repo', runner,
+    );
+
+    expect(result).toEqual({ number: 391, url: 'https://github.com/dcouple/Pane/pull/391' });
+
+    const commands = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+      .map(c => c[0].replace(/["']/g, ''));
+    const pushIndex = commands.findIndex(c => c.includes('git push'));
+    const createIndex = commands.findIndex(c => c.includes('gh pr create'));
+    expect(pushIndex).toBeGreaterThanOrEqual(0);
+    expect(createIndex).toBeGreaterThan(pushIndex);
+    expect(commands[pushIndex]).toContain('-u');
+  });
+
+  it('fails loudly when gh returns no url', async () => {
+    const runner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git remote', 'origin\n'],
+      ['git push', ''],
+      ['repo view', JSON.stringify({ nameWithOwner: '0x92/Pane' })],
+      ['pr create', 'aborted: you have no permission'],
+    ]);
+
+    await expect(new PullRequestManager().create(
+      { sessionId: 's1', title: 't', body: 'b', baseBranch: 'main', targetRepo: 'dcouple/Pane' },
+      '/wt', '/repo', runner,
+    )).rejects.toThrow(/did not return a pull request URL/);
+  });
+});
+
+describe('PullRequestManager.getChecks', () => {
+  it('reads the checks gh reports', async () => {
+    const runner = stubRunner([
+      ['pr checks', JSON.stringify([
+        { name: 'quality', bucket: 'pass', link: 'https://ci/1' },
+        { name: 'smoke', bucket: 'pending' },
+      ])],
+    ]);
+
+    const result = await new PullRequestManager().getChecks('dcouple/Pane', 382, '/repo', runner);
+
+    expect(result.checks).toHaveLength(2);
+    expect(result.summary).toBe('pending');
+  });
+
+  /** gh exits non-zero when a check fails — the data is still in the output. */
+  it('still reports failures, which gh signals with a non-zero exit', async () => {
+    const payload = JSON.stringify([{ name: 'quality', bucket: 'fail' }]);
+    const runner = stubRunner([
+      ['pr checks', new Error(`Command failed: gh pr checks\n${payload}`)],
+    ]);
+
+    const result = await new PullRequestManager().getChecks('dcouple/Pane', 382, '/repo', runner);
+
+    expect(result.summary).toBe('fail');
+    expect(result.checks[0].name).toBe('quality');
+  });
+
+  it('treats "no checks" as a state, not an error', async () => {
+    const runner = stubRunner([
+      ['pr checks', new Error('no checks reported on the "main" branch')],
+    ]);
+
+    const result = await new PullRequestManager().getChecks('dcouple/Pane', 382, '/repo', runner);
+
+    expect(result.summary).toBe('none');
+    expect(result.checks).toEqual([]);
+  });
+});
+
+describe('sortBaseBranches', () => {
+  it('lifts the default branch and the long-lived lines above the alphabet', () => {
+    const sorted = sortBaseBranches(
+      ['zebra', 'develop', 'main', 'alpha', 'release/2.4', 'master'],
+      'main'
+    );
+
+    expect(sorted).toEqual(['main', 'master', 'develop', 'release/2.4', 'alpha', 'zebra']);
+  });
+
+  it('honours a default branch that is not called main', () => {
+    expect(sortBaseBranches(['main', 'trunk', 'alpha'], 'trunk')[0]).toBe('trunk');
+  });
+
+  it('drops duplicates from overlapping pages', () => {
+    expect(sortBaseBranches(['a', 'b', 'a'], null)).toEqual(['a', 'b']);
+  });
+});
+
+describe('summarizeFileChanges', () => {
+  const file = (additions: number | null, deletions: number | null): GitCommitFileChange => ({
+    path: 'x', oldPath: 'x', status: 'modified', additions, deletions, isBinary: additions === null,
+  });
+
+  it('adds up the counts and treats binary files as zero', () => {
+    expect(summarizeFileChanges([file(3, 1), file(null, null), file(10, 0)]))
+      .toEqual({ additions: 13, deletions: 1 });
+  });
+
+  it('is zero for an empty comparison', () => {
+    expect(summarizeFileChanges([])).toEqual({ additions: 0, deletions: 0 });
+  });
+});
+
+describe('PullRequestManager.getChanges', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // numstat keeps the path in the same record as the counts; name-status puts
+  // it in the next NUL-separated token.
+  const NUMSTAT = '3\t1\tsrc/a.ts\x002\t0\tsrc/b.ts\x00';
+  const NAME_STATUS = 'M\x00src/a.ts\x00A\x00src/b.ts\x00';
+
+  it('compares against the tracking ref and reports totals', async () => {
+    const runner = stubRunner([
+      ['rev-parse --verify --quiet origin/main', 'abc123\n'],
+      ['diff --numstat', NUMSTAT],
+      ['diff --name-status', NAME_STATUS],
+    ]);
+
+    const changes = await new PullRequestManager().getChanges('/wt', 'main', runner);
+
+    expect(changes.baseRef).toBe('origin/main');
+    expect(changes.files.map(f => f.path)).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(changes.files[1].status).toBe('added');
+    expect(changes).toMatchObject({ additions: 5, deletions: 1, totalFiles: 2, truncated: false });
+  });
+
+  it('falls back to the local branch when there is no tracking ref', async () => {
+    const runner = stubRunner([
+      ['rev-parse --verify --quiet origin/main', new Error('unknown revision')],
+      ['rev-parse --verify --quiet main', 'abc123\n'],
+      ['diff --numstat', NUMSTAT],
+      ['diff --name-status', NAME_STATUS],
+    ]);
+
+    expect((await new PullRequestManager().getChanges('/wt', 'main', runner)).baseRef).toBe('main');
+  });
+
+  it('says so rather than throwing when the base resolves to nothing', async () => {
+    const runner = stubRunner([['rev-parse', new Error('unknown revision')]]);
+
+    const changes = await new PullRequestManager().getChanges('/wt', 'nope', runner);
+
+    expect(changes).toMatchObject({ baseRef: 'nope', files: [], totalFiles: 0 });
+  });
+});
+
+describe('parseTrackingBranches', () => {
+  it('keeps slashed branch names and drops the remote HEAD', () => {
+    const raw = ['feature/usage-and-limits', 'HEAD', 'main', 'fix/agent-terminal-robustness', ''].join('\n');
+
+    expect(parseTrackingBranches(raw)).toEqual([
+      'feature/usage-and-limits',
+      'main',
+      'fix/agent-terminal-robustness',
+    ]);
+  });
+
+  it('is empty for a remote with no refs', () => {
+    expect(parseTrackingBranches('\n  \n')).toEqual([]);
+  });
+});
+
+describe('PullRequestManager.listBaseBranches', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  /**
+   * The case that surprised the user: their own feature branches sit in the
+   * fork, so they must appear when the fork is the target — and only then, as
+   * GitHub rejects a base the target repository does not have.
+   */
+  it('adds the tracking refs of the remote that is the target repository', async () => {
+    const runner = stubRunner([
+      ['--version', 'gh version 2.97.0'],
+      ['git remote get-url origin', 'https://github.com/0x92/Pane.git\n'],
+      ['git remote', 'origin\nupstream\n'],
+      ['for-each-ref --format=%(refname:lstrip=2) refs/heads', 'main\nfeature/usage-and-limits\n'],
+      ['for-each-ref', 'feature/usage-and-limits\nHEAD\nmain\n'],
+      ['api repos/0x92/Pane/branches', JSON.stringify(['main'])],
+    ]);
+
+    const branches = await new PullRequestManager()
+      .listBaseBranches('0x92/Pane', '/repo', runner, 'main');
+
+    expect(branches.all).toEqual(['main', 'feature/usage-and-limits']);
+    // Everything here is locally known, so the short list is the whole list.
+    expect(branches.local).toEqual(['main', 'feature/usage-and-limits']);
+  });
+
+  it('keeps the short list to branches of this clone, not everything fetched', async () => {
+    const runner = stubRunner([
+      ['--version', 'gh version 2.97.0'],
+      ['git remote get-url upstream', 'https://github.com/dcouple/Pane.git\n'],
+      ['git remote', 'upstream\n'],
+      // A full fetch of a busy upstream leaves hundreds of tracking refs…
+      ['for-each-ref --format=%(refname:lstrip=2) refs/heads', 'main\nmy-feature\n'],
+      ['for-each-ref', 'release\nsomeone-elses-branch\nanother\n'],
+      ['api repos/dcouple/Pane/branches', JSON.stringify(['main', 'release', 'someone-elses-branch', 'another'])],
+    ]);
+
+    const branches = await new PullRequestManager()
+      .listBaseBranches('dcouple/Pane', '/repo', runner, 'main');
+
+    // …but only `main` is a branch of this clone, and `my-feature` is not a
+    // branch of the upstream at all, so it is no candidate either.
+    expect(branches.all).toHaveLength(4);
+    expect(branches.local).toEqual(['main']);
+  });
+
+  it('ignores a remote that points at a different repository', async () => {
+    const runner = stubRunner([
+      ['--version', 'gh version 2.97.0'],
+      ['git remote get-url origin', 'https://github.com/0x92/Pane.git\n'],
+      ['git remote', 'origin\n'],
+      ['for-each-ref', 'feature/usage-and-limits\n'],
+      ['api repos/dcouple/Pane/branches', JSON.stringify(['main', 'release'])],
+    ]);
+
+    const branches = await new PullRequestManager()
+      .listBaseBranches('dcouple/Pane', '/repo', runner, 'main');
+
+    expect(branches.all).toEqual(['main', 'release']);
+  });
+
+  it('still answers from git alone when gh is missing', async () => {
+    const runner = stubRunner([
+      ['--version', new Error('not found')],
+      ['git remote get-url origin', 'https://github.com/0x92/Pane.git\n'],
+      ['git remote', 'origin\n'],
+      ['for-each-ref', 'main\nfeature/x\n'],
+    ]);
+
+    expect(await new PullRequestManager().listBaseBranches('0x92/Pane', '/repo', runner, 'main'))
+      .toEqual({ all: ['main', 'feature/x'], local: ['main', 'feature/x'] });
+  });
+});
+
+describe('PullRequestManager.getDiff', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns the patch for the merge base, not a two-dot range', async () => {
+    const runner = stubRunner([
+      ['rev-parse --verify --quiet origin/main', 'abc123\n'],
+      ['git diff -M', 'diff --git a/x b/x\n'],
+    ]);
+
+    const result = await new PullRequestManager().getDiff('/wt', 'main', runner);
+
+    expect(result).toMatchObject({ baseRef: 'origin/main', truncated: false });
+    expect(result.diff).toContain('diff --git');
+    const commands = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+    expect(commands.some(command => command.includes('...HEAD'))).toBe(true);
+  });
+
+  it('is empty rather than an error when the base does not resolve', async () => {
+    const runner = stubRunner([['rev-parse', new Error('unknown revision')]]);
+    expect(await new PullRequestManager().getDiff('/wt', 'ghost', runner))
+      .toEqual({ baseRef: 'ghost', diff: '', truncated: false });
+  });
+});
+

--- a/main/src/services/pullRequestManager.test.ts
+++ b/main/src/services/pullRequestManager.test.ts
@@ -320,7 +320,7 @@ describe('ghCandidatePaths', () => {
     const paths = ghCandidatePaths('win32', {
       ProgramFiles: String.raw`C:\Program Files`,
       LOCALAPPDATA: String.raw`C:\Users\me\AppData\Local`,
-    } as NodeJS.ProcessEnv);
+    } satisfies NodeJS.ProcessEnv);
 
     expect(paths[0]).toBe(String.raw`C:\Program Files\GitHub CLI\gh.exe`);
     expect(paths[1]).toBe(String.raw`C:\Users\me\AppData\Local\Programs\GitHub CLI\gh.exe`);
@@ -332,17 +332,17 @@ describe('ghCandidatePaths', () => {
 
   it('does not double a separator the environment already ends with', () => {
     // Not String.raw here: a template literal cannot end on a backslash.
-    const paths = ghCandidatePaths('win32', { ProgramFiles: 'C:\\Program Files\\' } as NodeJS.ProcessEnv);
+    const paths = ghCandidatePaths('win32', { ProgramFiles: 'C:\\Program Files\\' } satisfies NodeJS.ProcessEnv);
     expect(paths[0]).toBe(String.raw`C:\Program Files\GitHub CLI\gh.exe`);
   });
 
   it('leaves out the user location when the environment has none', () => {
-    const paths = ghCandidatePaths('win32', { ProgramFiles: String.raw`C:\Program Files` } as NodeJS.ProcessEnv);
+    const paths = ghCandidatePaths('win32', { ProgramFiles: String.raw`C:\Program Files` } satisfies NodeJS.ProcessEnv);
     expect(paths).toHaveLength(1);
   });
 
   it('covers homebrew and the usual unix prefixes', () => {
-    const paths = ghCandidatePaths('darwin', {} as NodeJS.ProcessEnv);
+    const paths = ghCandidatePaths('darwin', {} satisfies NodeJS.ProcessEnv);
     expect(paths).toContain('/opt/homebrew/bin/gh');
     expect(paths).toContain('/usr/local/bin/gh');
   });
@@ -403,6 +403,7 @@ function stubRunner(responses: Array<[match: string, output: string | Error]>): 
     }
     return '';
   };
+  // SAFETY: The service tests exercise only the CommandRunner members supplied by this fixture.
   return {
     exec: vi.fn((command: string) => {
       const output = pick(command);
@@ -415,7 +416,7 @@ function stubRunner(responses: Array<[match: string, output: string | Error]>): 
       return { stdout: output, stderr: '' };
     }),
     wslContext: null,
-  } as unknown as CommandRunner;
+  } as CommandRunner;
 }
 
 describe('PullRequestManager.getDraft', () => {
@@ -485,7 +486,7 @@ describe('PullRequestManager.getDraft', () => {
 
     expect(draft.existing?.number).toBe(382);
     expect(draft.defaultTarget).toBe('dcouple/Pane');
-    const commands = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+    const commands = vi.mocked(runner.execAsync).mock.calls
       .map(call => call[0].replace(/["']/g, ''));
     expect(commands).toContainEqual(expect.stringContaining(
       'pr list --repo dcouple/Pane --head 0x92:feature/x'
@@ -531,7 +532,7 @@ describe('PullRequestManager.create', () => {
 
     expect(result).toEqual({ number: 391, url: 'https://github.com/dcouple/Pane/pull/391' });
 
-    const commands = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+    const commands = vi.mocked(runner.execAsync).mock.calls
       .map(c => c[0].replace(/["']/g, ''));
     const pushIndex = commands.findIndex(c => c.includes('git push'));
     const createIndex = commands.findIndex(c => c.includes('gh pr create'));
@@ -568,7 +569,7 @@ describe('PullRequestManager.create', () => {
       '/wt', '/repo', runner,
     )).rejects.toThrow(/Base branch missing was not found in dcouple\/Pane/);
 
-    const commands = (runner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+    const commands = vi.mocked(runner.execAsync).mock.calls
       .map(call => call[0]);
     expect(commands.some(command => command.includes('git push'))).toBe(false);
   });
@@ -794,7 +795,7 @@ describe('PullRequestManager.getDiff', () => {
 
     expect(result).toMatchObject({ baseRef: 'origin/main', truncated: false });
     expect(result.diff).toContain('diff --git');
-    const commands = (runner.exec as unknown as { mock: { calls: string[][] } }).mock.calls.map(call => call[0]);
+    const commands = vi.mocked(runner.exec).mock.calls.map(call => call[0]);
     expect(commands.some(command => command.includes('...HEAD'))).toBe(true);
   });
 

--- a/main/src/services/pullRequestManager.ts
+++ b/main/src/services/pullRequestManager.ts
@@ -1,0 +1,979 @@
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+import type { CommandRunner } from '../utils/commandRunner';
+import type { Logger } from '../utils/logger';
+import { escapeShellArg } from '../utils/shellEscape';
+import {
+  PR_TEMPLATE_PATHS,
+  type CreatePullRequestRequest,
+  type CreatePullRequestResult,
+  type ExistingPullRequest,
+  type PullRequestCheck,
+  type PullRequestCheckState,
+  type PullRequestChecksResult,
+  type BaseBranchOptions,
+  type PullRequestChanges,
+  type PullRequestDiff,
+  type PullRequestDraft,
+  type PullRequestReviewDecision,
+  type PullRequestReviewer,
+  type PullRequestStatus,
+  type PullRequestTarget,
+} from '../../../shared/types/pullRequest';
+import { MAX_FILES_PER_COMMIT, type GitCommitFileChange } from '../../../shared/types/git';
+import { mergeFileChanges, parseNameStatusZ, parseNumstatZ } from './gitDiffManager';
+
+/**
+ * Opening pull requests through the GitHub CLI.
+ *
+ * Everything that decides *what* to send is a pure function below and tested on
+ * its own; the class is the thin part that runs commands. `gh` is invoked
+ * through the session's `CommandRunner`, so a WSL project uses the `gh` inside
+ * the distro rather than the one on the Windows host.
+ */
+
+const GH_TIMEOUT_MS = 20_000;
+const PUSH_TIMEOUT_MS = 120_000;
+/** Branches per API page, and how many pages are worth waiting for. */
+const BRANCH_PAGE_SIZE = 100;
+const MAX_BRANCH_PAGES = 5;
+/** Patches beyond this are cut: a modal cannot usefully show more. */
+const MAX_DIFF_BYTES = 2_000_000;
+
+export interface CommitSummary {
+  subject: string;
+  body: string;
+}
+
+/**
+ * Title and body for a new pull request.
+ *
+ * The first commit's subject is the title — the same convention `gh pr create`
+ * uses when it fills the form itself. Everything else becomes the body, with
+ * the repository's template appended rather than replaced: the template asks
+ * questions the commits do not answer.
+ */
+export function deriveDraftText(
+  commits: CommitSummary[],
+  template: string | null
+): { title: string; body: string } {
+  const title = commits[0]?.subject.trim() ?? '';
+
+  const sections: string[] = [];
+  const first = commits[0]?.body.trim();
+  if (first) sections.push(first);
+
+  const rest = commits.slice(1).filter(commit => commit.subject.trim().length > 0);
+  if (rest.length > 0) {
+    sections.push(rest.map(commit => `- ${commit.subject.trim()}`).join('\n'));
+  }
+
+  if (template && template.trim()) sections.push(template.trim());
+
+  return { title, body: sections.join('\n\n') };
+}
+
+/**
+ * Which repositories this branch could be sent to.
+ *
+ * A fork has two: itself and the repository it was forked from. Contributions
+ * are meant for the parent, so that is the default — sending them to your own
+ * fork by accident is the mistake this ordering prevents.
+ */
+export function resolveTargets(repoView: {
+  nameWithOwner?: string;
+  defaultBranchRef?: { name?: string } | null;
+  parent?: { name?: string; owner?: { login?: string }; defaultBranchRef?: { name?: string } } | null;
+}): { targets: PullRequestTarget[]; defaultTarget: string } {
+  const targets: PullRequestTarget[] = [];
+
+  const parentOwner = repoView.parent?.owner?.login;
+  const parentName = repoView.parent?.name;
+  if (parentOwner && parentName) {
+    targets.push({
+      nameWithOwner: `${parentOwner}/${parentName}`,
+      isParent: true,
+      ...(repoView.parent?.defaultBranchRef?.name
+        ? { defaultBranch: repoView.parent.defaultBranchRef.name }
+        : {}),
+    });
+  }
+
+  if (repoView.nameWithOwner) {
+    targets.push({
+      nameWithOwner: repoView.nameWithOwner,
+      isParent: false,
+      ...(repoView.defaultBranchRef?.name ? { defaultBranch: repoView.defaultBranchRef.name } : {}),
+    });
+  }
+
+  return { targets, defaultTarget: targets[0]?.nameWithOwner ?? '' };
+}
+
+/**
+ * Arguments for `gh pr create`, as a list.
+ *
+ * Returned unescaped so tests can assert the arguments themselves rather than
+ * one long quoted string; the caller escapes exactly once, on the way out.
+ */
+export function buildCreateArgs(
+  request: CreatePullRequestRequest,
+  context: { branch: string; forkOwner: string | null; bodyFile: string }
+): string[] {
+  // A pull request that crosses repositories has to name the fork the branch
+  // lives in; within one repository the bare branch name is what gh expects.
+  const targetOwner = request.targetRepo.split('/')[0].toLowerCase();
+  const crossRepo = Boolean(context.forkOwner) && targetOwner !== context.forkOwner?.toLowerCase();
+  const head = crossRepo ? `${context.forkOwner}:${context.branch}` : context.branch;
+
+  const args = [
+    'pr', 'create',
+    '--repo', request.targetRepo,
+    '--base', request.baseBranch,
+    '--head', head,
+    '--title', request.title,
+    '--body-file', context.bodyFile,
+  ];
+  if (request.draft) args.push('--draft');
+  return args;
+}
+
+/** `gh pr create` prints the new pull request's URL, and nothing else useful. */
+export function parseCreatedPullRequest(stdout: string): CreatePullRequestResult | null {
+  const match = stdout.match(/https:\/\/[^\s]*\/pull\/(\d+)/);
+  if (!match) return null;
+  return { url: match[0], number: Number(match[1]) };
+}
+
+/** gh reports a check as a bucket (`pass`) or a raw state (`SUCCESS`). */
+export function normalizeCheckState(raw: string | undefined): PullRequestCheckState {
+  const value = (raw ?? '').toLowerCase();
+  if (['pass', 'success', 'completed', 'neutral'].includes(value)) return 'pass';
+  if (['fail', 'failure', 'failing', 'error', 'timed_out', 'action_required', 'startup_failure'].includes(value)) return 'fail';
+  if (['skipping', 'skipped'].includes(value)) return 'skipped';
+  if (['cancel', 'cancelled', 'canceled'].includes(value)) return 'cancelled';
+  return 'pending';
+}
+
+/**
+ * One state for a whole run.
+ *
+ * Ordered by what needs a human: a failure matters even when nine other checks
+ * passed, and something still running matters more than an all-green rollup
+ * that is not final yet.
+ */
+export function summarizeChecks(checks: PullRequestCheck[]): PullRequestChecksResult['summary'] {
+  if (checks.length === 0) return 'none';
+  if (checks.some(check => check.state === 'fail')) return 'fail';
+  if (checks.some(check => check.state === 'pending')) return 'pending';
+  if (checks.some(check => check.state === 'pass')) return 'pass';
+  if (checks.some(check => check.state === 'cancelled')) return 'cancelled';
+  return 'skipped';
+}
+
+/**
+ * Read `gh pr view --json …`.
+ *
+ * Every field is treated as optional: gh omits what GitHub did not compute
+ * (`mergeable` is lazy) and adds fields over time, and a review panel that
+ * throws on an unexpected shape is worse than one missing a badge.
+ */
+export function parsePullRequestStatus(stdout: string): PullRequestStatus | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+
+  const raw = JSON.parse(trimmed) as {
+    number?: number;
+    url?: string;
+    title?: string;
+    state?: string;
+    isDraft?: boolean;
+    baseRefName?: string;
+    headRefName?: string;
+    headRepositoryOwner?: { login?: string } | null;
+    reviewDecision?: string | null;
+    mergeable?: string | null;
+    reviews?: Array<{ author?: { login?: string } | null; state?: string }>;
+    comments?: unknown[];
+    additions?: number;
+    deletions?: number;
+    changedFiles?: number;
+  };
+  if (typeof raw.number !== 'number') return null;
+
+  // Only the newest review per person counts — GitHub shows it that way, and a
+  // "changes requested" someone later approved is not an open objection.
+  const byAuthor = new Map<string, PullRequestReviewer>();
+  for (const review of raw.reviews ?? []) {
+    const login = review?.author?.login;
+    if (!login) continue;
+    byAuthor.set(login, { login, state: review.state ?? 'COMMENTED' });
+  }
+
+  return {
+    number: raw.number,
+    url: raw.url ?? '',
+    title: raw.title ?? '',
+    state: (raw.state ?? 'OPEN').toUpperCase(),
+    isDraft: Boolean(raw.isDraft),
+    baseRefName: raw.baseRefName ?? '',
+    headRefName: raw.headRefName ?? '',
+    ...(raw.headRepositoryOwner?.login ? { headRepositoryOwner: raw.headRepositoryOwner.login } : {}),
+    reviewDecision: normalizeReviewDecision(raw.reviewDecision),
+    mergeable: (raw.mergeable ?? 'UNKNOWN').toUpperCase(),
+    reviewers: Array.from(byAuthor.values()),
+    commentCount: Array.isArray(raw.comments) ? raw.comments.length : 0,
+    additions: raw.additions ?? 0,
+    deletions: raw.deletions ?? 0,
+    changedFiles: raw.changedFiles ?? 0,
+    fetchedAtMs: Date.now(),
+  };
+}
+
+export function normalizeReviewDecision(raw: string | null | undefined): PullRequestReviewDecision {
+  switch ((raw ?? '').toUpperCase()) {
+    case 'APPROVED': return 'approved';
+    case 'CHANGES_REQUESTED': return 'changes_requested';
+    case 'REVIEW_REQUIRED': return 'review_required';
+    default: return 'none';
+  }
+}
+
+export function parseChecks(stdout: string): PullRequestCheck[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+
+  const rows = JSON.parse(trimmed) as Array<{
+    name?: string;
+    state?: string;
+    bucket?: string;
+    link?: string;
+  }>;
+
+  return rows
+    .filter(row => Boolean(row?.name))
+    .map(row => ({
+      name: row.name as string,
+      state: normalizeCheckState(row.bucket ?? row.state),
+      ...(row.link ? { url: row.link } : {}),
+    }));
+}
+
+/** Parse `git log --format=%s%x00%b%x01`. */
+export function parseCommitSummaries(raw: string): CommitSummary[] {
+  return raw
+    .split('\x01')
+    .map(record => record.trim())
+    .filter(record => record.length > 0)
+    .map(record => {
+      const [subject, body] = record.split('\x00');
+      return { subject: (subject ?? '').trim(), body: (body ?? '').trim() };
+    });
+}
+
+/** Pushing goes to `origin` when it exists — the fork, in the usual setup. */
+export function resolvePushRemote(remotes: string[]): string | null {
+  if (remotes.includes('origin')) return 'origin';
+  return remotes[0] ?? null;
+}
+
+/**
+ * Where the GitHub CLI is when it is not on PATH.
+ *
+ * Pane snapshots its PATH at start-up, so a `gh` installed while the app is
+ * running is invisible to it — which is exactly when people install it, having
+ * just been told they need it. Rather than telling the user to restart, look
+ * where the installers put it.
+ */
+export function ghCandidatePaths(platform: NodeJS.Platform, env: NodeJS.ProcessEnv = process.env): string[] {
+  if (platform === 'win32') {
+    // Built with join rather than string templates: a backslash in a template
+    // is an escape, and getting that wrong yields "C:\Program FilesGitHub CLI".
+    const programFiles = env.ProgramFiles ?? 'C:/Program Files';
+    const localAppData = env.LOCALAPPDATA ?? '';
+    return [
+      win32Join(programFiles, 'GitHub CLI', 'gh.exe'),
+      ...(localAppData ? [win32Join(localAppData, 'Programs', 'GitHub CLI', 'gh.exe')] : []),
+    ];
+  }
+  return ['/opt/homebrew/bin/gh', '/usr/local/bin/gh', '/usr/bin/gh', '/snap/bin/gh'];
+}
+
+/** Join Windows path segments regardless of which platform is running. */
+function win32Join(...segments: string[]): string {
+  return segments
+    .map((segment, index) => (index === 0 ? segment.replace(/[\\/]+$/, '') : segment.replace(/^[\\/]+|[\\/]+$/g, '')))
+    .join('\\');
+}
+
+/**
+ * A base branch as GitHub names it.
+ *
+ * The session's comparison branch is a tracking ref like `origin/main`, and
+ * `gh pr create --base origin/main` looks for a branch of that name — which
+ * does not exist. The remote prefix has to come off.
+ */
+export function normalizeBaseBranch(branch: string, remotes: string[]): string {
+  const trimmed = branch.trim().replace(/^refs\/heads\//, '');
+  for (const remote of remotes) {
+    if (trimmed.startsWith(`${remote}/`)) return trimmed.slice(remote.length + 1);
+  }
+  return trimmed;
+}
+
+/** Branch names from `gh api .../branches`, newest API shape or the older one. */
+/**
+ * Order base candidates so the useful ones are reachable without scrolling.
+ *
+ * A repository with hundreds of branches sorted A-Z buries `main` somewhere in
+ * the middle; the branch a pull request targets is almost always the default or
+ * a long-lived line, so those come first and the rest follows alphabetically.
+ * Duplicates — the same name from two pages — are dropped.
+ */
+const LONG_LIVED_BRANCHES = ['main', 'master', 'develop', 'development', 'dev', 'release'];
+
+export function sortBaseBranches(names: string[], defaultBranch?: string | null): string[] {
+  const rank = (name: string): number => {
+    if (defaultBranch && name === defaultBranch) return 0;
+    const index = LONG_LIVED_BRANCHES.indexOf(name);
+    if (index >= 0) return 1 + index;
+    if (name.startsWith('release/') || name.startsWith('releases/')) return 50;
+    return 100;
+  };
+
+  return Array.from(new Set(names)).sort((a, b) => {
+    const byRank = rank(a) - rank(b);
+    return byRank !== 0 ? byRank : a.localeCompare(b);
+  });
+}
+
+/**
+ * Roll per-file counts up into the totals shown above the list. Binary files
+ * report `null` rather than 0 and must not be counted as either.
+ */
+export function summarizeFileChanges(files: GitCommitFileChange[]): { additions: number; deletions: number } {
+  return files.reduce(
+    (totals, file) => ({
+      additions: totals.additions + (file.additions ?? 0),
+      deletions: totals.deletions + (file.deletions ?? 0),
+    }),
+    { additions: 0, deletions: 0 }
+  );
+}
+
+/**
+ * Branch names from `git for-each-ref refs/remotes/<remote>`.
+ *
+ * `HEAD` is in there as the remote's symbolic default and is not a branch
+ * anyone can target; names with a slash survive intact (`feature/x`).
+ */
+export function parseTrackingBranches(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .map(line => line.trim())
+    .filter(name => name.length > 0 && name !== 'HEAD');
+}
+
+export function parseBranchNames(stdout: string): string[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+
+  const parsed = JSON.parse(trimmed) as Array<{ name?: string } | string>;
+  return parsed
+    .map(row => (typeof row === 'string' ? row : row?.name))
+    .filter((name): name is string => Boolean(name));
+}
+
+/**
+ * `owner/repo` from a git remote URL, in any of the forms git accepts.
+ *
+ * Needed because `gh repo view` without an argument answers with the *base*
+ * repository, which for a fork is the upstream one. Taking the fork's identity
+ * from that would put the wrong owner in the head ref and send the pull request
+ * looking for a branch that is not there.
+ */
+export function parseGitHubRemote(url: string): string | null {
+  const trimmed = url.trim().replace(/\.git$/, '');
+  if (!trimmed) return null;
+
+  // https://github.com/owner/repo and ssh://git@github.com/owner/repo
+  const withScheme = /^(?:https?|ssh):\/\/[^/]*github\.com\/([^/]+)\/([^/]+)/.exec(trimmed);
+  if (withScheme) return `${withScheme[1]}/${withScheme[2]}`;
+
+  // git@github.com:owner/repo
+  const scpLike = /^[^@]+@[^:]*github\.com:([^/]+)\/([^/]+)$/.exec(trimmed);
+  if (scpLike) return `${scpLike[1]}/${scpLike[2]}`;
+
+  return null;
+}
+
+export class PullRequestManager {
+  /** Resolved `gh` command per execution context; see `ghCandidatePaths`. */
+  private ghCommand = new Map<string, string | null>();
+
+  constructor(private logger?: Logger) {}
+
+  /**
+   * The command that runs the GitHub CLI here, or null if it is not installed.
+   *
+   * Tries PATH first and falls back to the standard install locations, because
+   * Pane's PATH is a snapshot from start-up and `gh` is usually installed
+   * after Pane has told the user it is missing.
+   */
+  private async resolveGh(cwd: string, commandRunner: CommandRunner): Promise<string | null> {
+    const key = commandRunner.wslContext?.distribution ?? 'host';
+    const cached = this.ghCommand.get(key);
+    if (cached !== undefined) return cached;
+
+    const platform = commandRunner.wslContext ? 'linux' : process.platform;
+    const candidates = ['gh', ...ghCandidatePaths(platform)];
+
+    for (const candidate of candidates) {
+      try {
+        await commandRunner.execAsync(`${escapeShellArg(candidate)} --version`, cwd, {
+          timeout: 5000,
+          silent: true,
+        });
+        if (candidate !== 'gh') {
+          this.logger?.info(`[PullRequest] Using the GitHub CLI at ${candidate} — it is not on Pane's PATH.`);
+        }
+        this.ghCommand.set(key, candidate);
+        return candidate;
+      } catch {
+        // Try the next location.
+      }
+    }
+
+    this.ghCommand.set(key, null);
+    return null;
+  }
+
+  /**
+   * Everything the create dialog opens with.
+   *
+   * Deliberately one call: the branch, its commits, the target repositories, an
+   * existing pull request and the repository's template all have to be on
+   * screen at once, and a form that fills itself in over three round trips
+   * looks broken.
+   */
+  async getDraft(
+    worktreePath: string,
+    projectPath: string,
+    baseBranch: string,
+    commandRunner: CommandRunner
+  ): Promise<PullRequestDraft> {
+    const blockers: string[] = [];
+    let baseBranches: BaseBranchOptions = { all: [], local: [] };
+    // `origin/main` is a tracking ref; a pull request needs the branch name.
+    const base = normalizeBaseBranch(baseBranch, this.remotes(worktreePath, commandRunner));
+
+    const branch = this.currentBranch(worktreePath, commandRunner);
+    if (!branch) blockers.push('This worktree has a detached HEAD, so there is no branch to propose.');
+
+    const commits = branch ? this.commitsAhead(worktreePath, baseBranch, commandRunner) : [];
+    if (branch && commits.length === 0) {
+      blockers.push(`No commits on ${branch} that ${baseBranch} does not already have.`);
+    }
+
+    const hasUncommittedChanges = this.hasUncommittedChanges(worktreePath, commandRunner);
+
+    let targets: PullRequestTarget[] = [];
+    let defaultTarget = '';
+    let existing: ExistingPullRequest | undefined;
+
+    const gh = await this.resolveGh(worktreePath, commandRunner);
+    if (!gh) {
+      blockers.push('The GitHub CLI (gh) was not found. Install it from https://cli.github.com and sign in with `gh auth login`.');
+    } else if (!await this.isGhAuthenticated(gh, worktreePath, commandRunner)) {
+      blockers.push('The GitHub CLI is installed but not signed in. Run `gh auth login` once.');
+    } else {
+      const view = await this.repoView(projectPath, commandRunner, this.originRepo(worktreePath, commandRunner));
+      if (view) {
+        const resolved = resolveTargets(view);
+        targets = resolved.targets;
+        defaultTarget = resolved.defaultTarget;
+      } else {
+        blockers.push('This repository has no GitHub remote that gh recognises.');
+      }
+
+      if (branch) existing = await this.findExisting(projectPath, branch, commandRunner);
+      if (defaultTarget) {
+        const targetDefault = targets.find(target => target.nameWithOwner === defaultTarget)?.defaultBranch;
+        baseBranches = await this.listBaseBranches(defaultTarget, projectPath, commandRunner, targetDefault);
+      }
+    }
+
+    const template = this.readTemplate(projectPath);
+    const { title, body } = deriveDraftText(commits, template);
+
+    return {
+      branch: branch ?? '',
+      baseBranch: base,
+      baseBranches: baseBranches.all,
+      localBaseBranches: baseBranches.local,
+      title,
+      body,
+      commitCount: commits.length,
+      hasUncommittedChanges,
+      targets,
+      defaultTarget,
+      ...(existing ? { existing } : {}),
+      blockers,
+    };
+  }
+
+  /** Push the branch, then open the pull request. */
+  async create(
+    request: CreatePullRequestRequest,
+    worktreePath: string,
+    projectPath: string,
+    commandRunner: CommandRunner
+  ): Promise<CreatePullRequestResult> {
+    const branch = this.currentBranch(worktreePath, commandRunner);
+    if (!branch) throw new Error('This worktree has a detached HEAD, so there is no branch to push.');
+
+    const remote = resolvePushRemote(this.remotes(worktreePath, commandRunner));
+    if (!remote) throw new Error('This repository has no remote to push to.');
+
+    await commandRunner.execAsync(
+      `git push -u ${escapeShellArg(remote)} ${escapeShellArg(branch)}`,
+      worktreePath,
+      { timeout: PUSH_TIMEOUT_MS }
+    );
+
+    const forkOwner = this.originRepo(worktreePath, commandRunner)?.split('/')[0] ?? null;
+
+    // The body goes through a file: it is markdown with newlines, quotes and
+    // backticks, and no amount of shell escaping makes that pleasant.
+    const bodyFile = join(tmpdir(), `pane-pr-${randomUUID()}.md`);
+    writeFileSync(bodyFile, request.body, 'utf8');
+
+    try {
+      const gh = await this.resolveGh(worktreePath, commandRunner);
+      if (!gh) throw new Error('The GitHub CLI (gh) was not found. Install it from https://cli.github.com.');
+
+      const args = buildCreateArgs(request, { branch, forkOwner, bodyFile });
+      const command = `${escapeShellArg(gh)} ${args.map(escapeShellArg).join(' ')}`;
+      const { stdout } = await commandRunner.execAsync(command, worktreePath, { timeout: GH_TIMEOUT_MS });
+
+      const created = parseCreatedPullRequest(stdout);
+      if (!created) {
+        throw new Error(`gh did not return a pull request URL. Output: ${stdout.trim().slice(0, 200)}`);
+      }
+      return created;
+    } finally {
+      try {
+        unlinkSync(bodyFile);
+      } catch {
+        // A leftover temp file is not worth failing a created pull request over.
+      }
+    }
+  }
+
+  /**
+   * The pull request as it stands now: state, reviews, mergeability, size.
+   *
+   * One `gh pr view` rather than several calls — every field here comes from
+   * the same object, and the review panel wants them together or not at all.
+   */
+  async getStatus(
+    repo: string,
+    number: number,
+    projectPath: string,
+    commandRunner: CommandRunner
+  ): Promise<PullRequestStatus | null> {
+    const gh = await this.resolveGh(projectPath, commandRunner);
+    if (!gh) return null;
+
+    const fields = [
+      'number', 'url', 'title', 'state', 'isDraft', 'baseRefName', 'headRefName',
+      'headRepositoryOwner', 'reviewDecision', 'mergeable', 'reviews', 'comments',
+      'additions', 'deletions', 'changedFiles',
+    ].join(',');
+
+    try {
+      const { stdout } = await commandRunner.execAsync(
+        `${escapeShellArg(gh)} pr view ${number} --repo ${escapeShellArg(repo)} --json ${fields}`,
+        projectPath,
+        { timeout: GH_TIMEOUT_MS, silent: true }
+      );
+      return parsePullRequestStatus(stdout);
+    } catch (error) {
+      this.logger?.verbose(
+        `[PullRequest] Could not read ${repo}#${number}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
+  }
+
+  /** CI state for a pull request, normalised. */
+  async getChecks(
+    repo: string,
+    number: number,
+    projectPath: string,
+    commandRunner: CommandRunner
+  ): Promise<PullRequestChecksResult> {
+    const gh = await this.resolveGh(projectPath, commandRunner);
+    if (!gh) return { number, checks: [], summary: 'none', fetchedAtMs: Date.now() };
+
+    const command = `${escapeShellArg(gh)} pr checks ${number} --repo ${escapeShellArg(repo)} --json name,state,bucket,link`;
+
+    try {
+      const { stdout } = await commandRunner.execAsync(command, projectPath, {
+        timeout: GH_TIMEOUT_MS,
+        silent: true,
+      });
+      const checks = parseChecks(stdout);
+      return { number, checks, summary: summarizeChecks(checks), fetchedAtMs: Date.now() };
+    } catch (error) {
+      // `gh pr checks` exits non-zero when checks are failing *or* when there
+      // are none at all — the message tells them apart, the exit code does not.
+      const message = error instanceof Error ? error.message : String(error);
+      if (/no checks/i.test(message)) {
+        return { number, checks: [], summary: 'none', fetchedAtMs: Date.now() };
+      }
+
+      const embedded = message.match(/\[[\s\S]*\]/);
+      if (embedded) {
+        const checks = parseChecks(embedded[0]);
+        return { number, checks, summary: summarizeChecks(checks), fetchedAtMs: Date.now() };
+      }
+
+      this.logger?.verbose(`[PullRequest] Could not read checks for ${repo}#${number}: ${message}`);
+      return { number, checks: [], summary: 'none', fetchedAtMs: Date.now() };
+    }
+  }
+
+  // --- git and gh plumbing ---
+
+  private currentBranch(worktreePath: string, commandRunner: CommandRunner): string | null {
+    try {
+      return commandRunner.exec('git branch --show-current', worktreePath, { silent: true }).trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  private remotes(worktreePath: string, commandRunner: CommandRunner): string[] {
+    try {
+      return commandRunner.exec('git remote', worktreePath, { silent: true })
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
+  private commitsAhead(
+    worktreePath: string,
+    baseBranch: string,
+    commandRunner: CommandRunner
+  ): CommitSummary[] {
+    // Oldest first: the first commit is the one the title comes from.
+    const range = `${escapeShellArg(baseBranch)}..HEAD`;
+    try {
+      const raw = commandRunner.exec(
+        `git log ${range} --reverse --format=%s%x00%b%x01`,
+        worktreePath,
+        { silent: true }
+      );
+      return parseCommitSummaries(raw);
+    } catch {
+      return [];
+    }
+  }
+
+  private hasUncommittedChanges(worktreePath: string, commandRunner: CommandRunner): boolean {
+    try {
+      return commandRunner.exec('git status --porcelain', worktreePath, { silent: true }).trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private readTemplate(projectPath: string): string | null {
+    for (const relative of PR_TEMPLATE_PATHS) {
+      const candidate = join(projectPath, relative);
+      try {
+        if (existsSync(candidate)) return readFileSync(candidate, 'utf8');
+      } catch {
+        // Unreadable template: fall through to the next candidate.
+      }
+    }
+    return null;
+  }
+
+  private async isGhAuthenticated(gh: string, cwd: string, commandRunner: CommandRunner): Promise<boolean> {
+    try {
+      await commandRunner.execAsync(`${escapeShellArg(gh)} auth status`, cwd, { timeout: 10_000, silent: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Branches of the target repository, as candidates for the base.
+   *
+   * Asked of the target rather than taken from the local clone: the base has to
+   * exist *there*, and a fork's branches are not the upstream's. Split in two,
+   * because a busy upstream has hundreds of branches and none of them is the
+   * one you meant — that one is among the handful your clone already tracks.
+   */
+  async listBaseBranches(
+    repo: string,
+    projectPath: string,
+    commandRunner: CommandRunner,
+    defaultBranch?: string | null
+  ): Promise<BaseBranchOptions> {
+    // Local knowledge first: it needs no network, and a branch pushed a minute
+    // ago is in the tracking refs before anyone asks GitHub about it.
+    const local = this.trackingBranchesFor(repo, projectPath, commandRunner);
+
+    const gh = await this.resolveGh(projectPath, commandRunner);
+    if (!gh) {
+      const sorted = sortBaseBranches(local, defaultBranch);
+      return { all: sorted, local: sorted };
+    }
+
+    // Paged by hand rather than with `--paginate`: this repository has hundreds
+    // of branches, and waiting for every last one to fill a picker nobody
+    // scrolls to the end of is not worth the round trips.
+    const names: string[] = [];
+    try {
+      for (let page = 1; page <= MAX_BRANCH_PAGES; page++) {
+        const query = `repos/${repo}/branches?per_page=${BRANCH_PAGE_SIZE}&page=${page}`;
+        const { stdout } = await commandRunner.execAsync(
+          `${escapeShellArg(gh)} api ${escapeShellArg(query)} --jq ${escapeShellArg('[.[].name]')}`,
+          projectPath,
+          { timeout: GH_TIMEOUT_MS, silent: true }
+        );
+        const pageNames = parseBranchNames(stdout);
+        names.push(...pageNames);
+        if (pageNames.length < BRANCH_PAGE_SIZE) break;
+      }
+    } catch (error) {
+      this.logger?.verbose(
+        `[PullRequest] Could not list branches of ${repo}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    const all = sortBaseBranches([...names, ...local], defaultBranch);
+
+    // The short list is the branches you *work on*, not everything you ever
+    // fetched: a full fetch of a busy upstream leaves hundreds of tracking refs
+    // behind, which is exactly the noise this list exists to avoid. The
+    // default branch joins them because nearly every pull request targets it.
+    const own = new Set(this.localHeads(projectPath, commandRunner));
+    if (defaultBranch) own.add(defaultBranch);
+
+    return { all, local: all.filter(name => own.has(name)) };
+  }
+
+  /** Branches that exist as heads in this clone — yours, across all worktrees. */
+  private localHeads(projectPath: string, commandRunner: CommandRunner): string[] {
+    try {
+      return parseTrackingBranches(
+        commandRunner.exec(
+          'git for-each-ref --format=%(refname:lstrip=2) refs/heads',
+          projectPath,
+          { silent: true }
+        )
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Branches this clone already tracks for the remote that *is* the given
+   * repository. A fork and its upstream both have remotes here, and only the
+   * matching one's branches are valid bases for a pull request into it.
+   */
+  private trackingBranchesFor(
+    repo: string,
+    projectPath: string,
+    commandRunner: CommandRunner
+  ): string[] {
+    const remote = this.remotes(projectPath, commandRunner).find(name => {
+      try {
+        const url = commandRunner.exec(`git remote get-url ${escapeShellArg(name)}`, projectPath, { silent: true });
+        return parseGitHubRemote(url)?.toLowerCase() === repo.toLowerCase();
+      } catch {
+        return false;
+      }
+    });
+    if (!remote) return [];
+
+    try {
+      const raw = commandRunner.exec(
+        `git for-each-ref --format=%(refname:lstrip=3) ${escapeShellArg(`refs/remotes/${remote}`)}`,
+        projectPath,
+        { silent: true }
+      );
+      return parseTrackingBranches(raw);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Which files the pull request would carry, and by how much.
+   *
+   * Cheap on purpose — counts only, no patch — so the dialog can show the list
+   * the moment it opens and reload it when the base changes.
+   */
+  async getChanges(
+    worktreePath: string,
+    baseBranch: string,
+    commandRunner: CommandRunner
+  ): Promise<PullRequestChanges> {
+    const baseRef = this.resolveComparisonRef(worktreePath, baseBranch, commandRunner);
+    const empty: PullRequestChanges = {
+      baseRef, files: [], totalFiles: 0, truncated: false, additions: 0, deletions: 0,
+    };
+    if (!baseRef) return { ...empty, baseRef: baseBranch };
+
+    try {
+      const range = `${escapeShellArg(baseRef)}...HEAD`;
+      const numstatRaw = commandRunner.exec(`git diff --numstat -M -z ${range}`, worktreePath, { silent: true });
+      const nameStatusRaw = commandRunner.exec(`git diff --name-status -M -z ${range}`, worktreePath, { silent: true });
+
+      const all = mergeFileChanges(parseNumstatZ(numstatRaw), parseNameStatusZ(nameStatusRaw));
+      const files = all.slice(0, MAX_FILES_PER_COMMIT);
+      const { additions, deletions } = summarizeFileChanges(all);
+
+      return {
+        baseRef,
+        files,
+        totalFiles: all.length,
+        truncated: all.length > files.length,
+        additions,
+        deletions,
+      };
+    } catch (error) {
+      this.logger?.verbose(
+        `[PullRequest] Could not list changed files against ${baseRef}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return empty;
+    }
+  }
+
+  /** The patch behind {@link getChanges}, loaded only when the user asks. */
+  async getDiff(
+    worktreePath: string,
+    baseBranch: string,
+    commandRunner: CommandRunner
+  ): Promise<PullRequestDiff> {
+    const baseRef = this.resolveComparisonRef(worktreePath, baseBranch, commandRunner);
+    if (!baseRef) return { baseRef: baseBranch, diff: '', truncated: false };
+
+    const raw = commandRunner.exec(
+      `git diff -M ${escapeShellArg(baseRef)}...HEAD`,
+      worktreePath,
+      { silent: true, maxBuffer: MAX_DIFF_BYTES * 2 }
+    );
+
+    const truncated = raw.length > MAX_DIFF_BYTES;
+    return { baseRef, diff: truncated ? raw.slice(0, MAX_DIFF_BYTES) : raw, truncated };
+  }
+
+  /**
+   * A ref git can actually compare against.
+   *
+   * The base is a branch name in the *target* repository. Locally it may exist
+   * only as a tracking ref — a fresh worktree often has no local `main` — so the
+   * remote-tracking form is tried first, and only a ref that resolves is used.
+   */
+  private resolveComparisonRef(
+    worktreePath: string,
+    baseBranch: string,
+    commandRunner: CommandRunner
+  ): string {
+    const base = baseBranch.trim();
+    if (!base) return '';
+
+    const candidates = base.includes('/')
+      ? [base, `refs/remotes/${base}`]
+      : [`origin/${base}`, base, `upstream/${base}`];
+
+    for (const candidate of candidates) {
+      try {
+        commandRunner.exec(
+          `git rev-parse --verify --quiet ${escapeShellArg(`${candidate}^{commit}`)}`,
+          worktreePath,
+          { silent: true }
+        );
+        return candidate;
+      } catch {
+        // Not a ref here — try the next spelling.
+      }
+    }
+    return '';
+  }
+
+  /** The fork this clone pushes to, as `owner/repo`. */
+  private originRepo(worktreePath: string, commandRunner: CommandRunner): string | null {
+    const remote = resolvePushRemote(this.remotes(worktreePath, commandRunner));
+    if (!remote) return null;
+    try {
+      const url = commandRunner.exec(`git remote get-url ${escapeShellArg(remote)}`, worktreePath, { silent: true });
+      return parseGitHubRemote(url);
+    } catch {
+      return null;
+    }
+  }
+
+  private async repoView(
+    projectPath: string,
+    commandRunner: CommandRunner,
+    repo?: string | null
+  ): Promise<{
+    nameWithOwner?: string;
+    defaultBranchRef?: { name?: string } | null;
+    parent?: { name?: string; owner?: { login?: string }; defaultBranchRef?: { name?: string } } | null;
+  } | null> {
+    try {
+      // Naming the repository matters: without it gh answers about the *base*
+      // repository, which for a fork is upstream — and then the fork's own
+      // identity, which the head ref needs, is nowhere in the answer.
+      const gh = await this.resolveGh(projectPath, commandRunner);
+      if (!gh) return null;
+      const target = repo ? ` ${escapeShellArg(repo)}` : '';
+      const { stdout } = await commandRunner.execAsync(
+        `${escapeShellArg(gh)} repo view${target} --json nameWithOwner,defaultBranchRef,parent`,
+        projectPath,
+        { timeout: GH_TIMEOUT_MS, silent: true }
+      );
+      return JSON.parse(stdout.trim());
+    } catch (error) {
+      this.logger?.verbose(
+        `[PullRequest] gh repo view failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
+  }
+
+  private async findExisting(
+    projectPath: string,
+    branch: string,
+    commandRunner: CommandRunner
+  ): Promise<ExistingPullRequest | undefined> {
+    try {
+      const gh = await this.resolveGh(projectPath, commandRunner);
+      if (!gh) return undefined;
+      const { stdout } = await commandRunner.execAsync(
+        `${escapeShellArg(gh)} pr list --head ${escapeShellArg(branch)} --state all --json number,url,state,title --limit 1`,
+        projectPath,
+        { timeout: GH_TIMEOUT_MS, silent: true }
+      );
+      const rows = JSON.parse(stdout.trim() || '[]') as ExistingPullRequest[];
+      return rows[0];
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/main/src/services/pullRequestManager.ts
+++ b/main/src/services/pullRequestManager.ts
@@ -522,6 +522,7 @@ export class PullRequestManager {
 
     let targets: PullRequestTarget[] = [];
     let defaultTarget = '';
+    let forkOwner: string | null = null;
     let existing: ExistingPullRequest | undefined;
 
     const gh = await this.resolveGh(worktreePath, commandRunner);
@@ -535,11 +536,14 @@ export class PullRequestManager {
         const resolved = resolveTargets(view);
         targets = resolved.targets;
         defaultTarget = resolved.defaultTarget;
+        forkOwner = view.nameWithOwner?.split('/')[0] ?? null;
       } else {
         blockers.push('This repository has no GitHub remote that gh recognises.');
       }
 
-      if (branch) existing = await this.findExisting(projectPath, branch, commandRunner);
+      if (branch) {
+        existing = await this.findExisting(projectPath, branch, targets, forkOwner, commandRunner);
+      }
       if (defaultTarget) {
         const targetDefault = targets.find(target => target.nameWithOwner === defaultTarget)?.defaultBranch;
         baseBranches = await this.listBaseBranches(defaultTarget, projectPath, commandRunner, targetDefault);
@@ -578,6 +582,10 @@ export class PullRequestManager {
     const remote = resolvePushRemote(this.remotes(worktreePath, commandRunner));
     if (!remote) throw new Error('This repository has no remote to push to.');
 
+    const gh = await this.resolveGh(worktreePath, commandRunner);
+    if (!gh) throw new Error('The GitHub CLI (gh) was not found. Install it from https://cli.github.com.');
+    await this.assertBaseBranchExists(gh, request.targetRepo, request.baseBranch, projectPath, commandRunner);
+
     await commandRunner.execAsync(
       `git push -u ${quoteArg(commandRunner, remote)} ${quoteArg(commandRunner, branch)}`,
       worktreePath,
@@ -596,9 +604,6 @@ export class PullRequestManager {
     writeFileSync(writePath, request.body, 'utf8');
 
     try {
-      const gh = await this.resolveGh(worktreePath, commandRunner);
-      if (!gh) throw new Error('The GitHub CLI (gh) was not found. Install it from https://cli.github.com.');
-
       const args = buildCreateArgs(request, { branch, forkOwner, bodyFile: ghPath });
       const command = `${quoteArg(commandRunner, gh)} ${args.map(arg => quoteArg(commandRunner, arg)).join(' ')}`;
       const { stdout } = await commandRunner.execAsync(command, worktreePath, { timeout: GH_TIMEOUT_MS });
@@ -1005,20 +1010,50 @@ export class PullRequestManager {
   private async findExisting(
     projectPath: string,
     branch: string,
+    targets: PullRequestTarget[],
+    forkOwner: string | null,
     commandRunner: CommandRunner
   ): Promise<ExistingPullRequest | undefined> {
+    const gh = await this.resolveGh(projectPath, commandRunner);
+    if (!gh) return undefined;
+
+    for (const target of targets) {
+      try {
+        const targetOwner = target.nameWithOwner.split('/')[0];
+        const head = forkOwner && targetOwner.toLowerCase() !== forkOwner.toLowerCase()
+          ? `${forkOwner}:${branch}`
+          : branch;
+        const { stdout } = await commandRunner.execAsync(
+          `${quoteArg(commandRunner, gh)} pr list --repo ${quoteArg(commandRunner, target.nameWithOwner)} --head ${quoteArg(commandRunner, head)} --state all --json number,url,state,title --limit 1`,
+          projectPath,
+          { timeout: GH_TIMEOUT_MS, silent: true }
+        );
+        const rows = JSON.parse(stdout.trim() || '[]') as ExistingPullRequest[];
+        if (rows[0]) return rows[0];
+      } catch {
+        // One inaccessible target should not hide a pull request in another.
+      }
+    }
+
+    return undefined;
+  }
+
+  private async assertBaseBranchExists(
+    gh: string,
+    repo: string,
+    branch: string,
+    projectPath: string,
+    commandRunner: CommandRunner
+  ): Promise<void> {
+    const endpoint = `repos/${repo}/branches/${encodeURIComponent(branch)}`;
     try {
-      const gh = await this.resolveGh(projectPath, commandRunner);
-      if (!gh) return undefined;
-      const { stdout } = await commandRunner.execAsync(
-        `${quoteArg(commandRunner, gh)} pr list --head ${quoteArg(commandRunner, branch)} --state all --json number,url,state,title --limit 1`,
+      await commandRunner.execAsync(
+        `${quoteArg(commandRunner, gh)} api ${quoteArg(commandRunner, endpoint)} --silent`,
         projectPath,
         { timeout: GH_TIMEOUT_MS, silent: true }
       );
-      const rows = JSON.parse(stdout.trim() || '[]') as ExistingPullRequest[];
-      return rows[0];
     } catch {
-      return undefined;
+      throw new Error(`Base branch ${branch} was not found in ${repo}. Choose a branch that exists in the target repository.`);
     }
   }
 }

--- a/main/src/services/pullRequestManager.ts
+++ b/main/src/services/pullRequestManager.ts
@@ -25,6 +25,7 @@ import {
 } from '../../../shared/types/pullRequest';
 import { MAX_FILES_PER_COMMIT, type GitCommitFileChange } from '../../../shared/types/git';
 import { mergeFileChanges, parseNameStatusZ, parseNumstatZ } from './gitDiffManager';
+import { boundary, decodeBoundary, decodeOptionalBoundary } from '../../../shared/validation/boundaryDecoder';
 
 /**
  * Opening pull requests through the GitHub CLI.
@@ -47,6 +48,31 @@ export interface CommitSummary {
   subject: string;
   body: string;
 }
+
+interface BodyFilePaths {
+  writePath: string;
+  ghPath: string;
+}
+
+interface DraftText {
+  title: string;
+  body: string;
+}
+
+interface ResolvedTargets {
+  targets: PullRequestTarget[];
+  defaultTarget: string;
+}
+
+export interface PullRequestFileOps {
+  writeFile(path: string, contents: string): void;
+  unlink(path: string): void;
+}
+
+const DEFAULT_FILE_OPS: PullRequestFileOps = {
+  writeFile: (path, contents) => writeFileSync(path, contents, 'utf8'),
+  unlink: path => unlinkSync(path),
+};
 
 /** Just enough of a {@link CommandRunner} to know which shell it targets. */
 type ShellTarget = { wslContext?: { distribution: string } | null };
@@ -78,7 +104,7 @@ export function quoteArg(target: ShellTarget, value: string): string {
 export function resolveBodyFile(
   distribution: string | null | undefined,
   fileName: string
-): { writePath: string; ghPath: string } {
+): BodyFilePaths {
   if (!distribution) {
     const hostPath = join(tmpdir(), fileName);
     return { writePath: hostPath, ghPath: hostPath };
@@ -99,7 +125,7 @@ export function resolveBodyFile(
 export function deriveDraftText(
   commits: CommitSummary[],
   template: string | null
-): { title: string; body: string } {
+): DraftText {
   const title = commits[0]?.subject.trim() ?? '';
 
   const sections: string[] = [];
@@ -127,27 +153,29 @@ export function resolveTargets(repoView: {
   nameWithOwner?: string;
   defaultBranchRef?: { name?: string } | null;
   parent?: { name?: string; owner?: { login?: string }; defaultBranchRef?: { name?: string } } | null;
-}): { targets: PullRequestTarget[]; defaultTarget: string } {
+}): ResolvedTargets {
   const targets: PullRequestTarget[] = [];
 
   const parentOwner = repoView.parent?.owner?.login;
   const parentName = repoView.parent?.name;
   if (parentOwner && parentName) {
-    targets.push({
+    const target: PullRequestTarget = {
       nameWithOwner: `${parentOwner}/${parentName}`,
       isParent: true,
-      ...(repoView.parent?.defaultBranchRef?.name
-        ? { defaultBranch: repoView.parent.defaultBranchRef.name }
-        : {}),
-    });
+    };
+    if (repoView.parent?.defaultBranchRef?.name) {
+      target.defaultBranch = repoView.parent.defaultBranchRef.name;
+    }
+    targets.push(target);
   }
 
   if (repoView.nameWithOwner) {
-    targets.push({
+    const target: PullRequestTarget = {
       nameWithOwner: repoView.nameWithOwner,
       isParent: false,
-      ...(repoView.defaultBranchRef?.name ? { defaultBranch: repoView.defaultBranchRef.name } : {}),
-    });
+    };
+    if (repoView.defaultBranchRef?.name) target.defaultBranch = repoView.defaultBranchRef.name;
+    targets.push(target);
   }
 
   return { targets, defaultTarget: targets[0]?.nameWithOwner ?? '' };
@@ -225,24 +253,31 @@ export function parsePullRequestStatus(stdout: string): PullRequestStatus | null
   const trimmed = stdout.trim();
   if (!trimmed) return null;
 
-  const raw = JSON.parse(trimmed) as {
-    number?: number;
-    url?: string;
-    title?: string;
-    state?: string;
-    isDraft?: boolean;
-    baseRefName?: string;
-    headRefName?: string;
-    headRepositoryOwner?: { login?: string } | null;
-    reviewDecision?: string | null;
-    mergeable?: string | null;
-    reviews?: Array<{ author?: { login?: string } | null; state?: string }>;
-    comments?: unknown[];
-    additions?: number;
-    deletions?: number;
-    changedFiles?: number;
-  };
-  if (typeof raw.number !== 'number') return null;
+  const raw = decodeBoundary(JSON.parse(trimmed), boundary.object({
+    number: boundary.optional(boundary.number),
+    url: boundary.optional(boundary.string),
+    title: boundary.optional(boundary.string),
+    state: boundary.optional(boundary.string),
+    isDraft: boundary.optional(boundary.boolean),
+    baseRefName: boundary.optional(boundary.string),
+    headRefName: boundary.optional(boundary.string),
+    headRepositoryOwner: boundary.optional(boundary.nullable(boundary.object({
+      login: boundary.optional(boundary.string),
+    }))),
+    reviewDecision: boundary.optional(boundary.nullable(boundary.string)),
+    mergeable: boundary.optional(boundary.nullable(boundary.string)),
+    reviews: boundary.optional(boundary.array(boundary.object({
+      author: boundary.optional(boundary.nullable(boundary.object({
+        login: boundary.optional(boundary.string),
+      }))),
+      state: boundary.optional(boundary.string),
+    }))),
+    comments: boundary.optional(boundary.array(boundary.json)),
+    additions: boundary.optional(boundary.number),
+    deletions: boundary.optional(boundary.number),
+    changedFiles: boundary.optional(boundary.number),
+  }));
+  if (raw.number === undefined) return null;
 
   // Only the newest review per person counts — GitHub shows it that way, and a
   // "changes requested" someone later approved is not an open objection.
@@ -253,7 +288,7 @@ export function parsePullRequestStatus(stdout: string): PullRequestStatus | null
     byAuthor.set(login, { login, state: review.state ?? 'COMMENTED' });
   }
 
-  return {
+  const status: PullRequestStatus = {
     number: raw.number,
     url: raw.url ?? '',
     title: raw.title ?? '',
@@ -261,7 +296,6 @@ export function parsePullRequestStatus(stdout: string): PullRequestStatus | null
     isDraft: Boolean(raw.isDraft),
     baseRefName: raw.baseRefName ?? '',
     headRefName: raw.headRefName ?? '',
-    ...(raw.headRepositoryOwner?.login ? { headRepositoryOwner: raw.headRepositoryOwner.login } : {}),
     reviewDecision: normalizeReviewDecision(raw.reviewDecision),
     mergeable: (raw.mergeable ?? 'UNKNOWN').toUpperCase(),
     reviewers: Array.from(byAuthor.values()),
@@ -271,6 +305,8 @@ export function parsePullRequestStatus(stdout: string): PullRequestStatus | null
     changedFiles: raw.changedFiles ?? 0,
     fetchedAtMs: Date.now(),
   };
+  if (raw.headRepositoryOwner?.login) status.headRepositoryOwner = raw.headRepositoryOwner.login;
+  return status;
 }
 
 export function normalizeReviewDecision(raw: string | null | undefined): PullRequestReviewDecision {
@@ -286,20 +322,23 @@ export function parseChecks(stdout: string): PullRequestCheck[] {
   const trimmed = stdout.trim();
   if (!trimmed) return [];
 
-  const rows = JSON.parse(trimmed) as Array<{
-    name?: string;
-    state?: string;
-    bucket?: string;
-    link?: string;
-  }>;
+  const rows = decodeBoundary(JSON.parse(trimmed), boundary.array(boundary.object({
+    name: boundary.optional(boundary.string),
+    state: boundary.optional(boundary.string),
+    bucket: boundary.optional(boundary.string),
+    link: boundary.optional(boundary.string),
+  })));
 
   return rows
     .filter(row => Boolean(row?.name))
-    .map(row => ({
-      name: row.name as string,
-      state: normalizeCheckState(row.bucket ?? row.state),
-      ...(row.link ? { url: row.link } : {}),
-    }));
+    .map(row => {
+      const check: PullRequestCheck = {
+        name: row.name ?? '',
+        state: normalizeCheckState(row.bucket ?? row.state),
+      };
+      if (row.link) check.url = row.link;
+      return check;
+    });
 }
 
 /** Parse `git log --format=%s%x00%b%x01`. */
@@ -421,9 +460,14 @@ export function parseBranchNames(stdout: string): string[] {
   const trimmed = stdout.trim();
   if (!trimmed) return [];
 
-  const parsed = JSON.parse(trimmed) as Array<{ name?: string } | string>;
-  return parsed
-    .map(row => (typeof row === 'string' ? row : row?.name))
+  const parsed = JSON.parse(trimmed);
+  const stringRows = decodeOptionalBoundary(parsed, boundary.array(boundary.string));
+  if (stringRows) return stringRows;
+
+  return decodeBoundary(parsed, boundary.array(boundary.object({
+    name: boundary.optional(boundary.string),
+  })))
+    .map(row => row.name)
     .filter((name): name is string => Boolean(name));
 }
 
@@ -454,7 +498,10 @@ export class PullRequestManager {
   /** Resolved `gh` command per execution context; see `ghCandidatePaths`. */
   private ghCommand = new Map<string, string | null>();
 
-  constructor(private logger?: Logger) {}
+  constructor(
+    private logger?: Logger,
+    private fileOps: PullRequestFileOps = DEFAULT_FILE_OPS,
+  ) {}
 
   /**
    * The command that runs the GitHub CLI here, or null if it is not installed.
@@ -553,7 +600,7 @@ export class PullRequestManager {
     const template = this.readTemplate(projectPath);
     const { title, body } = deriveDraftText(commits, template);
 
-    return {
+    const draft: PullRequestDraft = {
       branch: branch ?? '',
       baseBranch: base,
       baseBranches: baseBranches.all,
@@ -564,9 +611,10 @@ export class PullRequestManager {
       hasUncommittedChanges,
       targets,
       defaultTarget,
-      ...(existing ? { existing } : {}),
       blockers,
     };
+    if (existing) draft.existing = existing;
+    return draft;
   }
 
   /** Push the branch, then open the pull request. */
@@ -601,7 +649,7 @@ export class PullRequestManager {
       commandRunner.wslContext?.distribution,
       `pane-pr-${randomUUID()}.md`
     );
-    writeFileSync(writePath, request.body, 'utf8');
+    this.fileOps.writeFile(writePath, request.body);
 
     try {
       const args = buildCreateArgs(request, { branch, forkOwner, bodyFile: ghPath });
@@ -615,7 +663,7 @@ export class PullRequestManager {
       return created;
     } finally {
       try {
-        unlinkSync(writePath);
+        this.fileOps.unlink(writePath);
       } catch {
         // A leftover temp file is not worth failing a created pull request over.
       }
@@ -1028,7 +1076,12 @@ export class PullRequestManager {
           projectPath,
           { timeout: GH_TIMEOUT_MS, silent: true }
         );
-        const rows = JSON.parse(stdout.trim() || '[]') as ExistingPullRequest[];
+        const rows = decodeBoundary(JSON.parse(stdout.trim() || '[]'), boundary.array(boundary.object({
+          number: boundary.number,
+          url: boundary.string,
+          state: boundary.string,
+          title: boundary.string,
+        })));
         if (rows[0]) return rows[0];
       } catch {
         // One inaccessible target should not hide a pull request in another.

--- a/main/src/services/pullRequestManager.ts
+++ b/main/src/services/pullRequestManager.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import type { CommandRunner } from '../utils/commandRunner';
 import type { Logger } from '../utils/logger';
 import { escapeShellArg } from '../utils/shellEscape';
+import { escapeForBash, linuxToUNCPath, posixJoin } from '../utils/wslUtils';
 import {
   PR_TEMPLATE_PATHS,
   type CreatePullRequestRequest,
@@ -45,6 +46,46 @@ const MAX_DIFF_BYTES = 2_000_000;
 export interface CommitSummary {
   subject: string;
   body: string;
+}
+
+/** Just enough of a {@link CommandRunner} to know which shell it targets. */
+type ShellTarget = { wslContext?: { distribution: string } | null };
+
+/**
+ * Quote one argument for the shell that will actually run the command.
+ *
+ * `escapeShellArg` decides by `process.platform`, which is the wrong question
+ * here. A WSL project's commands are handed to `bash -c` inside the distro even
+ * though the host is Windows, and Windows-style double quotes leave `$`,
+ * backticks and `\` live in bash. Git only forbids space, `~^:?*[\` and control
+ * characters in a ref, so a branch named ``fix-`whoami` `` is legal — and would
+ * otherwise run as a command. `wslUtils` has `escapeForBash` for exactly this,
+ * with a comment saying so.
+ */
+export function quoteArg(target: ShellTarget, value: string): string {
+  return target.wslContext ? escapeForBash(value) : escapeShellArg(value);
+}
+
+/**
+ * Where the pull request body is written, and the path `gh` is given for it.
+ *
+ * For a WSL project `gh` runs inside the distro, so the host's `tmpdir()` — a
+ * `C:\…` path on Windows — is one it cannot open, and `--body-file` fails
+ * before the pull request is ever created. The file therefore goes to the
+ * distro's `/tmp`, written through the UNC view Windows has of it and named to
+ * `gh` as the Linux path it sees.
+ */
+export function resolveBodyFile(
+  distribution: string | null | undefined,
+  fileName: string
+): { writePath: string; ghPath: string } {
+  if (!distribution) {
+    const hostPath = join(tmpdir(), fileName);
+    return { writePath: hostPath, ghPath: hostPath };
+  }
+
+  const linuxPath = posixJoin('/tmp', fileName);
+  return { writePath: linuxToUNCPath(linuxPath, distribution), ghPath: linuxPath };
 }
 
 /**
@@ -432,7 +473,7 @@ export class PullRequestManager {
 
     for (const candidate of candidates) {
       try {
-        await commandRunner.execAsync(`${escapeShellArg(candidate)} --version`, cwd, {
+        await commandRunner.execAsync(`${quoteArg(commandRunner, candidate)} --version`, cwd, {
           timeout: 5000,
           silent: true,
         });
@@ -538,7 +579,7 @@ export class PullRequestManager {
     if (!remote) throw new Error('This repository has no remote to push to.');
 
     await commandRunner.execAsync(
-      `git push -u ${escapeShellArg(remote)} ${escapeShellArg(branch)}`,
+      `git push -u ${quoteArg(commandRunner, remote)} ${quoteArg(commandRunner, branch)}`,
       worktreePath,
       { timeout: PUSH_TIMEOUT_MS }
     );
@@ -546,16 +587,20 @@ export class PullRequestManager {
     const forkOwner = this.originRepo(worktreePath, commandRunner)?.split('/')[0] ?? null;
 
     // The body goes through a file: it is markdown with newlines, quotes and
-    // backticks, and no amount of shell escaping makes that pleasant.
-    const bodyFile = join(tmpdir(), `pane-pr-${randomUUID()}.md`);
-    writeFileSync(bodyFile, request.body, 'utf8');
+    // backticks, and no amount of shell escaping makes that pleasant. Where the
+    // file goes depends on which side of the WSL boundary gh runs on.
+    const { writePath, ghPath } = resolveBodyFile(
+      commandRunner.wslContext?.distribution,
+      `pane-pr-${randomUUID()}.md`
+    );
+    writeFileSync(writePath, request.body, 'utf8');
 
     try {
       const gh = await this.resolveGh(worktreePath, commandRunner);
       if (!gh) throw new Error('The GitHub CLI (gh) was not found. Install it from https://cli.github.com.');
 
-      const args = buildCreateArgs(request, { branch, forkOwner, bodyFile });
-      const command = `${escapeShellArg(gh)} ${args.map(escapeShellArg).join(' ')}`;
+      const args = buildCreateArgs(request, { branch, forkOwner, bodyFile: ghPath });
+      const command = `${quoteArg(commandRunner, gh)} ${args.map(arg => quoteArg(commandRunner, arg)).join(' ')}`;
       const { stdout } = await commandRunner.execAsync(command, worktreePath, { timeout: GH_TIMEOUT_MS });
 
       const created = parseCreatedPullRequest(stdout);
@@ -565,7 +610,7 @@ export class PullRequestManager {
       return created;
     } finally {
       try {
-        unlinkSync(bodyFile);
+        unlinkSync(writePath);
       } catch {
         // A leftover temp file is not worth failing a created pull request over.
       }
@@ -595,7 +640,7 @@ export class PullRequestManager {
 
     try {
       const { stdout } = await commandRunner.execAsync(
-        `${escapeShellArg(gh)} pr view ${number} --repo ${escapeShellArg(repo)} --json ${fields}`,
+        `${quoteArg(commandRunner, gh)} pr view ${number} --repo ${quoteArg(commandRunner, repo)} --json ${fields}`,
         projectPath,
         { timeout: GH_TIMEOUT_MS, silent: true }
       );
@@ -618,7 +663,7 @@ export class PullRequestManager {
     const gh = await this.resolveGh(projectPath, commandRunner);
     if (!gh) return { number, checks: [], summary: 'none', fetchedAtMs: Date.now() };
 
-    const command = `${escapeShellArg(gh)} pr checks ${number} --repo ${escapeShellArg(repo)} --json name,state,bucket,link`;
+    const command = `${quoteArg(commandRunner, gh)} pr checks ${number} --repo ${quoteArg(commandRunner, repo)} --json name,state,bucket,link`;
 
     try {
       const { stdout } = await commandRunner.execAsync(command, projectPath, {
@@ -673,7 +718,7 @@ export class PullRequestManager {
     commandRunner: CommandRunner
   ): CommitSummary[] {
     // Oldest first: the first commit is the one the title comes from.
-    const range = `${escapeShellArg(baseBranch)}..HEAD`;
+    const range = `${quoteArg(commandRunner, baseBranch)}..HEAD`;
     try {
       const raw = commandRunner.exec(
         `git log ${range} --reverse --format=%s%x00%b%x01`,
@@ -708,7 +753,7 @@ export class PullRequestManager {
 
   private async isGhAuthenticated(gh: string, cwd: string, commandRunner: CommandRunner): Promise<boolean> {
     try {
-      await commandRunner.execAsync(`${escapeShellArg(gh)} auth status`, cwd, { timeout: 10_000, silent: true });
+      await commandRunner.execAsync(`${quoteArg(commandRunner, gh)} auth status`, cwd, { timeout: 10_000, silent: true });
       return true;
     } catch {
       return false;
@@ -747,7 +792,7 @@ export class PullRequestManager {
       for (let page = 1; page <= MAX_BRANCH_PAGES; page++) {
         const query = `repos/${repo}/branches?per_page=${BRANCH_PAGE_SIZE}&page=${page}`;
         const { stdout } = await commandRunner.execAsync(
-          `${escapeShellArg(gh)} api ${escapeShellArg(query)} --jq ${escapeShellArg('[.[].name]')}`,
+          `${quoteArg(commandRunner, gh)} api ${quoteArg(commandRunner, query)} --jq ${quoteArg(commandRunner, '[.[].name]')}`,
           projectPath,
           { timeout: GH_TIMEOUT_MS, silent: true }
         );
@@ -800,7 +845,7 @@ export class PullRequestManager {
   ): string[] {
     const remote = this.remotes(projectPath, commandRunner).find(name => {
       try {
-        const url = commandRunner.exec(`git remote get-url ${escapeShellArg(name)}`, projectPath, { silent: true });
+        const url = commandRunner.exec(`git remote get-url ${quoteArg(commandRunner, name)}`, projectPath, { silent: true });
         return parseGitHubRemote(url)?.toLowerCase() === repo.toLowerCase();
       } catch {
         return false;
@@ -810,7 +855,7 @@ export class PullRequestManager {
 
     try {
       const raw = commandRunner.exec(
-        `git for-each-ref --format=%(refname:lstrip=3) ${escapeShellArg(`refs/remotes/${remote}`)}`,
+        `git for-each-ref --format=%(refname:lstrip=3) ${quoteArg(commandRunner, `refs/remotes/${remote}`)}`,
         projectPath,
         { silent: true }
       );
@@ -838,7 +883,7 @@ export class PullRequestManager {
     if (!baseRef) return { ...empty, baseRef: baseBranch };
 
     try {
-      const range = `${escapeShellArg(baseRef)}...HEAD`;
+      const range = `${quoteArg(commandRunner, baseRef)}...HEAD`;
       const numstatRaw = commandRunner.exec(`git diff --numstat -M -z ${range}`, worktreePath, { silent: true });
       const nameStatusRaw = commandRunner.exec(`git diff --name-status -M -z ${range}`, worktreePath, { silent: true });
 
@@ -872,7 +917,7 @@ export class PullRequestManager {
     if (!baseRef) return { baseRef: baseBranch, diff: '', truncated: false };
 
     const raw = commandRunner.exec(
-      `git diff -M ${escapeShellArg(baseRef)}...HEAD`,
+      `git diff -M ${quoteArg(commandRunner, baseRef)}...HEAD`,
       worktreePath,
       { silent: true, maxBuffer: MAX_DIFF_BYTES * 2 }
     );
@@ -903,7 +948,7 @@ export class PullRequestManager {
     for (const candidate of candidates) {
       try {
         commandRunner.exec(
-          `git rev-parse --verify --quiet ${escapeShellArg(`${candidate}^{commit}`)}`,
+          `git rev-parse --verify --quiet ${quoteArg(commandRunner, `${candidate}^{commit}`)}`,
           worktreePath,
           { silent: true }
         );
@@ -920,7 +965,7 @@ export class PullRequestManager {
     const remote = resolvePushRemote(this.remotes(worktreePath, commandRunner));
     if (!remote) return null;
     try {
-      const url = commandRunner.exec(`git remote get-url ${escapeShellArg(remote)}`, worktreePath, { silent: true });
+      const url = commandRunner.exec(`git remote get-url ${quoteArg(commandRunner, remote)}`, worktreePath, { silent: true });
       return parseGitHubRemote(url);
     } catch {
       return null;
@@ -942,9 +987,9 @@ export class PullRequestManager {
       // identity, which the head ref needs, is nowhere in the answer.
       const gh = await this.resolveGh(projectPath, commandRunner);
       if (!gh) return null;
-      const target = repo ? ` ${escapeShellArg(repo)}` : '';
+      const target = repo ? ` ${quoteArg(commandRunner, repo)}` : '';
       const { stdout } = await commandRunner.execAsync(
-        `${escapeShellArg(gh)} repo view${target} --json nameWithOwner,defaultBranchRef,parent`,
+        `${quoteArg(commandRunner, gh)} repo view${target} --json nameWithOwner,defaultBranchRef,parent`,
         projectPath,
         { timeout: GH_TIMEOUT_MS, silent: true }
       );
@@ -966,7 +1011,7 @@ export class PullRequestManager {
       const gh = await this.resolveGh(projectPath, commandRunner);
       if (!gh) return undefined;
       const { stdout } = await commandRunner.execAsync(
-        `${escapeShellArg(gh)} pr list --head ${escapeShellArg(branch)} --state all --json number,url,state,title --limit 1`,
+        `${quoteArg(commandRunner, gh)} pr list --head ${quoteArg(commandRunner, branch)} --state all --json number,url,state,title --limit 1`,
         projectPath,
         { timeout: GH_TIMEOUT_MS, silent: true }
       );

--- a/main/src/services/pullRequestManager.ts
+++ b/main/src/services/pullRequestManager.ts
@@ -24,7 +24,7 @@ import {
   type PullRequestTarget,
 } from '../../../shared/types/pullRequest';
 import { MAX_FILES_PER_COMMIT, type GitCommitFileChange } from '../../../shared/types/git';
-import { mergeFileChanges, parseNameStatusZ, parseNumstatZ } from './gitDiffManager';
+import { mergeFileChanges, parseNameStatusZ, parseNumstatZ } from './gitDiffParsers';
 import { boundary, decodeBoundary, decodeOptionalBoundary } from '../../../shared/validation/boundaryDecoder';
 
 /**
@@ -271,6 +271,7 @@ export function parsePullRequestStatus(stdout: string): PullRequestStatus | null
         login: boundary.optional(boundary.string),
       }))),
       state: boundary.optional(boundary.string),
+      submittedAt: boundary.optional(boundary.string),
     }))),
     comments: boundary.optional(boundary.array(boundary.json)),
     additions: boundary.optional(boundary.number),
@@ -281,11 +282,19 @@ export function parsePullRequestStatus(stdout: string): PullRequestStatus | null
 
   // Only the newest review per person counts — GitHub shows it that way, and a
   // "changes requested" someone later approved is not an open objection.
-  const byAuthor = new Map<string, PullRequestReviewer>();
+  const byAuthor = new Map<string, { reviewer: PullRequestReviewer; submittedAt: number }>();
   for (const review of raw.reviews ?? []) {
     const login = review?.author?.login;
     if (!login) continue;
-    byAuthor.set(login, { login, state: review.state ?? 'COMMENTED' });
+    const parsedSubmittedAt = review.submittedAt ? Date.parse(review.submittedAt) : 0;
+    const submittedAt = Number.isNaN(parsedSubmittedAt) ? 0 : parsedSubmittedAt;
+    const previous = byAuthor.get(login);
+    if (!previous || submittedAt >= previous.submittedAt) {
+      byAuthor.set(login, {
+        reviewer: { login, state: review.state ?? 'COMMENTED' },
+        submittedAt,
+      });
+    }
   }
 
   const status: PullRequestStatus = {
@@ -298,7 +307,7 @@ export function parsePullRequestStatus(stdout: string): PullRequestStatus | null
     headRefName: raw.headRefName ?? '',
     reviewDecision: normalizeReviewDecision(raw.reviewDecision),
     mergeable: (raw.mergeable ?? 'UNKNOWN').toUpperCase(),
-    reviewers: Array.from(byAuthor.values()),
+    reviewers: Array.from(byAuthor.values(), entry => entry.reviewer),
     commentCount: Array.isArray(raw.comments) ? raw.comments.length : 0,
     additions: raw.additions ?? 0,
     deletions: raw.deletions ?? 0,

--- a/main/src/services/pullRequestManager.wsl.test.ts
+++ b/main/src/services/pullRequestManager.wsl.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { writeFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { PullRequestManager, quoteArg, resolveBodyFile } from './pullRequestManager';
+import { escapeShellArg } from '../utils/shellEscape';
+import type { CommandRunner } from '../utils/commandRunner';
+
+/**
+ * A WSL project runs its commands as `wsl.exe -d <distro> -- bash -c <command>`,
+ * so the target shell is bash even when the host is Windows. Two things went
+ * wrong there and both are guarded here:
+ *
+ * 1. Arguments were quoted by `escapeShellArg`, which picks its style from
+ *    `process.platform` and hands bash double quotes on a Windows host —
+ *    leaving `$`, backticks and `\` live inside them.
+ * 2. The pull request body was written to the *host's* temp directory and its
+ *    Windows path passed to a `gh` running inside the distro, which cannot open
+ *    it.
+ */
+
+vi.mock('fs', async importOriginal => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return { ...actual, writeFileSync: vi.fn(), unlinkSync: vi.fn() };
+});
+
+/** A branch name git accepts and bash would otherwise execute. */
+const HOSTILE_BRANCH = 'fix-`whoami`-$(id)';
+
+function stubRunner(
+  responses: Array<[match: string, output: string | Error]>,
+  distribution: string | null,
+): CommandRunner {
+  const pick = (command: string) => {
+    const plain = command.replace(/["']/g, '');
+    for (const [match, output] of responses) {
+      if (plain.includes(match)) return output;
+    }
+    return '';
+  };
+  return {
+    exec: vi.fn((command: string) => {
+      const output = pick(command);
+      if (output instanceof Error) throw output;
+      return output;
+    }),
+    execAsync: vi.fn(async (command: string) => {
+      const output = pick(command);
+      if (output instanceof Error) throw output;
+      return { stdout: output, stderr: '' };
+    }),
+    wslContext: distribution ? { enabled: true, distribution, linuxPath: '/home/dev/p' } : null,
+  } as unknown as CommandRunner;
+}
+
+describe('quoteArg', () => {
+  it('quotes for bash when the command is bound for a WSL distro', () => {
+    const wsl = { wslContext: { distribution: 'Ubuntu' } };
+
+    // Single quotes are the only form bash expands nothing inside.
+    expect(quoteArg(wsl, HOSTILE_BRANCH)).toBe("'fix-`whoami`-$(id)'");
+    expect(quoteArg(wsl, "it's")).toBe("'it'\\''s'");
+    expect(quoteArg(wsl, '')).toBe("''");
+  });
+
+  it('leaves nothing outside the quotes for bash to interpret', () => {
+    const quoted = quoteArg({ wslContext: { distribution: 'Ubuntu' } }, HOSTILE_BRANCH);
+
+    expect(quoted.startsWith("'")).toBe(true);
+    expect(quoted.endsWith("'")).toBe(true);
+    // The dangerous characters survive as literals, not as syntax: the only
+    // quote characters in the result are the two that wrap it.
+    expect(quoted.slice(1, -1)).toBe(HOSTILE_BRANCH);
+    expect(quoted.slice(1, -1)).not.toContain("'");
+  });
+
+  /**
+   * The regression, stated so it holds on any test host: the old code asked
+   * `process.platform`, and on a Windows host that answered with double quotes
+   * for a command bash was about to run.
+   */
+  it('ignores the host platform — the distro decides the shell', () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    try {
+      expect(escapeShellArg(HOSTILE_BRANCH)).toContain('"');
+      expect(quoteArg({ wslContext: { distribution: 'Ubuntu' } }, HOSTILE_BRANCH))
+        .toBe("'fix-`whoami`-$(id)'");
+    } finally {
+      Object.defineProperty(process, 'platform', platform);
+    }
+  });
+
+  it('defers to the platform-aware escape when there is no distro', () => {
+    const host = { wslContext: null };
+    const quoted = quoteArg(host, HOSTILE_BRANCH);
+
+    // Whichever style the host uses, the value has to come back out whole.
+    expect(quoted).toContain(HOSTILE_BRANCH.replace(/\\/g, '\\\\'));
+    expect(quoted).not.toBe(HOSTILE_BRANCH);
+  });
+});
+
+describe('resolveBodyFile', () => {
+  it('puts the body where gh inside the distro can read it', () => {
+    const { writePath, ghPath } = resolveBodyFile('Ubuntu', 'pane-pr-1.md');
+
+    expect(ghPath).toBe('/tmp/pane-pr-1.md');
+    expect(writePath).toBe('\\\\wsl.localhost\\Ubuntu\\tmp\\pane-pr-1.md');
+    // The regression: a Windows temp path is meaningless inside the distro.
+    expect(ghPath).not.toMatch(/^[A-Za-z]:/);
+  });
+
+  it('uses the host temp directory when nothing crosses a boundary', () => {
+    const { writePath, ghPath } = resolveBodyFile(null, 'pane-pr-2.md');
+
+    expect(writePath).toBe(ghPath);
+    expect(ghPath.startsWith(tmpdir())).toBe(true);
+  });
+});
+
+/**
+ * The `gh pr create` command as it was actually issued. Every argument is
+ * quoted separately, so `pr create` never appears as those two words in a row —
+ * matching has to happen on the unquoted text and read the original back.
+ */
+function ghCreateCommand(commandRunner: CommandRunner): string {
+  const commands = (commandRunner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+    .map(call => call[0]);
+  const index = commands.findIndex(text => text.replace(/['"]/g, '').includes('pr create'));
+  expect(index).toBeGreaterThanOrEqual(0);
+  return commands[index];
+}
+
+describe('PullRequestManager.create on a WSL project', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const runner = () => stubRunner([
+    ['branch --show-current', `${HOSTILE_BRANCH}\n`],
+    ['git remote get-url', 'https://github.com/0x92/Pane.git\n'],
+    ['git remote', 'origin\n'],
+    ['git push', ''],
+    ['--version', 'gh version 2.97.0'],
+    ['pr create', 'https://github.com/dcouple/Pane/pull/391\n'],
+  ], 'Ubuntu');
+
+  const create = (commandRunner: CommandRunner) => new PullRequestManager().create(
+    {
+      sessionId: 's1',
+      title: 'Add `date` support for $HOME',
+      body: '# Body\n\n`code` and $vars stay markdown.\n',
+      baseBranch: 'main',
+      targetRepo: 'dcouple/Pane',
+    },
+    '/home/dev/p/wt', '/home/dev/p', commandRunner,
+  );
+
+  it('never lets a branch name become bash syntax', async () => {
+    const commandRunner = runner();
+    await create(commandRunner);
+
+    const commands = (commandRunner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+      .map(call => call[0]);
+
+    const push = commands.find(command => command.includes('git push'))!;
+    expect(push).toContain(`'${HOSTILE_BRANCH}'`);
+    // Double quotes would leave the backtick and $( ) live for bash.
+    expect(push).not.toContain('"');
+  });
+
+  it('quotes the title the same way, wherever the user put a backtick', async () => {
+    const commandRunner = runner();
+    await create(commandRunner);
+
+    const command = ghCreateCommand(commandRunner);
+
+    expect(command).toContain("'Add `date` support for $HOME'");
+    expect(command).not.toContain('"');
+  });
+
+  it('gives gh a path that exists inside the distro, and writes the file there', async () => {
+    const commandRunner = runner();
+    await create(commandRunner);
+
+    const command = ghCreateCommand(commandRunner);
+
+    const bodyFile = /--body-file' '([^']+)'/.exec(command)?.[1];
+    expect(bodyFile).toMatch(/^\/tmp\/pane-pr-[0-9a-f-]+\.md$/);
+
+    const written = vi.mocked(writeFileSync).mock.calls[0];
+    expect(written[0]).toBe(`\\\\wsl.localhost\\Ubuntu\\tmp\\${bodyFile!.slice('/tmp/'.length)}`);
+    expect(written[1]).toContain('`code` and $vars stay markdown.');
+  });
+
+  it('removes the temp file it wrote, not some host path', async () => {
+    const commandRunner = runner();
+    await create(commandRunner);
+
+    expect(vi.mocked(unlinkSync).mock.calls[0][0]).toBe(vi.mocked(writeFileSync).mock.calls[0][0]);
+  });
+
+  it('cleans up even when gh fails', async () => {
+    const commandRunner = stubRunner([
+      ['branch --show-current', `${HOSTILE_BRANCH}\n`],
+      ['git remote', 'origin\n'],
+      ['git push', ''],
+      ['--version', 'gh version 2.97.0'],
+      ['pr create', new Error('gh: pull request already exists')],
+    ], 'Ubuntu');
+
+    await expect(create(commandRunner)).rejects.toThrow();
+    expect(vi.mocked(unlinkSync)).toHaveBeenCalledWith(vi.mocked(writeFileSync).mock.calls[0][0]);
+  });
+});
+
+describe('PullRequestManager.create on a host project', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('still writes to the host temp directory', async () => {
+    const commandRunner = stubRunner([
+      ['branch --show-current', 'feature/x\n'],
+      ['git remote', 'origin\n'],
+      ['git push', ''],
+      ['--version', 'gh version 2.97.0'],
+      ['pr create', 'https://github.com/dcouple/Pane/pull/392\n'],
+    ], null);
+
+    await new PullRequestManager().create(
+      { sessionId: 's1', title: 't', body: 'b', baseBranch: 'main', targetRepo: 'dcouple/Pane' },
+      '/wt', '/repo', commandRunner,
+    );
+
+    const written = String(vi.mocked(writeFileSync).mock.calls[0][0]);
+    expect(written.startsWith(tmpdir())).toBe(true);
+  });
+});

--- a/main/src/services/pullRequestManager.wsl.test.ts
+++ b/main/src/services/pullRequestManager.wsl.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { PullRequestManager, quoteArg, resolveBodyFile } from './pullRequestManager';
 import { escapeShellArg } from '../utils/shellEscape';
@@ -18,13 +17,14 @@ import type { CommandRunner } from '../utils/commandRunner';
  *    it.
  */
 
-vi.mock('fs', async importOriginal => {
-  const actual = await importOriginal<typeof import('fs')>();
-  return { ...actual, writeFileSync: vi.fn(), unlinkSync: vi.fn() };
-});
-
 /** A branch name git accepts and bash would otherwise execute. */
 const HOSTILE_BRANCH = 'fix-`whoami`-$(id)';
+const writeBodyFile = vi.fn();
+const unlinkBodyFile = vi.fn();
+const manager = () => new PullRequestManager(undefined, {
+  writeFile: writeBodyFile,
+  unlink: unlinkBodyFile,
+});
 
 function stubRunner(
   responses: Array<[match: string, output: string | Error]>,
@@ -37,6 +37,7 @@ function stubRunner(
     }
     return '';
   };
+  // SAFETY: These tests exercise only the CommandRunner members supplied by this fixture.
   return {
     exec: vi.fn((command: string) => {
       const output = pick(command);
@@ -49,7 +50,7 @@ function stubRunner(
       return { stdout: output, stderr: '' };
     }),
     wslContext: distribution ? { enabled: true, distribution, linuxPath: '/home/dev/p' } : null,
-  } as unknown as CommandRunner;
+  } as CommandRunner;
 }
 
 describe('quoteArg', () => {
@@ -125,7 +126,7 @@ describe('resolveBodyFile', () => {
  * matching has to happen on the unquoted text and read the original back.
  */
 function ghCreateCommand(commandRunner: CommandRunner): string {
-  const commands = (commandRunner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+  const commands = vi.mocked(commandRunner.execAsync).mock.calls
     .map(call => call[0]);
   const index = commands.findIndex(text => text.replace(/['"]/g, '').includes('pr create'));
   expect(index).toBeGreaterThanOrEqual(0);
@@ -144,7 +145,7 @@ describe('PullRequestManager.create on a WSL project', () => {
     ['pr create', 'https://github.com/dcouple/Pane/pull/391\n'],
   ], 'Ubuntu');
 
-  const create = (commandRunner: CommandRunner) => new PullRequestManager().create(
+  const create = (commandRunner: CommandRunner) => manager().create(
     {
       sessionId: 's1',
       title: 'Add `date` support for $HOME',
@@ -159,7 +160,7 @@ describe('PullRequestManager.create on a WSL project', () => {
     const commandRunner = runner();
     await create(commandRunner);
 
-    const commands = (commandRunner.execAsync as unknown as { mock: { calls: string[][] } }).mock.calls
+    const commands = vi.mocked(commandRunner.execAsync).mock.calls
       .map(call => call[0]);
 
     const push = commands.find(command => command.includes('git push'))!;
@@ -187,7 +188,7 @@ describe('PullRequestManager.create on a WSL project', () => {
     const bodyFile = /--body-file' '([^']+)'/.exec(command)?.[1];
     expect(bodyFile).toMatch(/^\/tmp\/pane-pr-[0-9a-f-]+\.md$/);
 
-    const written = vi.mocked(writeFileSync).mock.calls[0];
+    const written = writeBodyFile.mock.calls[0];
     expect(written[0]).toBe(`\\\\wsl.localhost\\Ubuntu\\tmp\\${bodyFile!.slice('/tmp/'.length)}`);
     expect(written[1]).toContain('`code` and $vars stay markdown.');
   });
@@ -196,7 +197,7 @@ describe('PullRequestManager.create on a WSL project', () => {
     const commandRunner = runner();
     await create(commandRunner);
 
-    expect(vi.mocked(unlinkSync).mock.calls[0][0]).toBe(vi.mocked(writeFileSync).mock.calls[0][0]);
+    expect(unlinkBodyFile.mock.calls[0][0]).toBe(writeBodyFile.mock.calls[0][0]);
   });
 
   it('cleans up even when gh fails', async () => {
@@ -209,7 +210,7 @@ describe('PullRequestManager.create on a WSL project', () => {
     ], 'Ubuntu');
 
     await expect(create(commandRunner)).rejects.toThrow();
-    expect(vi.mocked(unlinkSync)).toHaveBeenCalledWith(vi.mocked(writeFileSync).mock.calls[0][0]);
+    expect(unlinkBodyFile).toHaveBeenCalledWith(writeBodyFile.mock.calls[0][0]);
   });
 });
 
@@ -225,12 +226,12 @@ describe('PullRequestManager.create on a host project', () => {
       ['pr create', 'https://github.com/dcouple/Pane/pull/392\n'],
     ], null);
 
-    await new PullRequestManager().create(
+    await manager().create(
       { sessionId: 's1', title: 't', body: 'b', baseBranch: 'main', targetRepo: 'dcouple/Pane' },
       '/wt', '/repo', commandRunner,
     );
 
-    const written = String(vi.mocked(writeFileSync).mock.calls[0][0]);
+    const written = String(writeBodyFile.mock.calls[0][0]);
     expect(written.startsWith(tmpdir())).toBe(true);
   });
 });

--- a/shared/types/daemon.ts
+++ b/shared/types/daemon.ts
@@ -91,6 +91,7 @@ export const DAEMON_OWNED_CHANNEL_PREFIXES = [
   'projects:',
   'prompts:',
   'resource-monitor:',
+  'pr:',
   'runpane:',
   'sessions:',
   'terminal:',

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -1,0 +1,49 @@
+/**
+ * Wire types for per-file git change details.
+ *
+ * These describe *which* files a commit (or the working tree) touched and by
+ * how much, without carrying the patch text. The diff panel loads them lazily
+ * per commit so expanding one commit never costs a full `git show`.
+ */
+
+export type GitFileChangeStatus =
+  | 'added'
+  | 'modified'
+  | 'deleted'
+  | 'renamed'
+  | 'copied'
+  | 'typechange'
+  | 'unmerged'
+  | 'unknown';
+
+export interface GitCommitFileChange {
+  /** Post-change path (the new path for renames/copies). */
+  path: string;
+  /** Pre-change path; equals `path` unless renamed or copied. */
+  oldPath: string;
+  status: GitFileChangeStatus;
+  /** null for binary files — git numstat prints `-` for those. */
+  additions: number | null;
+  deletions: number | null;
+  isBinary: boolean;
+  /** Rename/copy similarity 0-100, when git reports it. */
+  similarity?: number;
+}
+
+export interface GitCommitFilesResult {
+  /** Commit hash, or `index` for uncommitted working-tree changes. */
+  ref: string;
+  files: GitCommitFileChange[];
+  /** Total files touched before truncation. */
+  totalFiles: number;
+  /** True when the commit exceeded the per-commit cap and `files` was clipped. */
+  truncated: boolean;
+  /**
+   * True when `ref` is a merge commit and the listing is the diff against the
+   * first parent only. Surfaced in the UI so the numbers are not misread.
+   */
+  isMergeAgainstFirstParent: boolean;
+}
+
+/** Hard cap on files returned for a single commit. */
+export const MAX_FILES_PER_COMMIT = 500;

--- a/shared/types/pullRequest.ts
+++ b/shared/types/pullRequest.ts
@@ -1,0 +1,172 @@
+/**
+ * Opening a pull request from inside Pane.
+ *
+ * A session already *is* a branch in a worktree, so everything a pull request
+ * needs is on hand — the only missing pieces were the target repository (a fork
+ * has two candidates) and the text. Both are decided in the dialog and sent
+ * here; the main process does the pushing and calls `gh`.
+ */
+
+import type { GitCommitFileChange } from './git';
+
+/** A repository a pull request could be opened against. */
+export interface PullRequestTarget {
+  /** `owner/repo`, as GitHub names it. */
+  nameWithOwner: string;
+  /** True for the repository this clone was forked from. */
+  isParent: boolean;
+  /** Default branch of that repository, when known. */
+  defaultBranch?: string;
+}
+
+/** Base candidates for one repository, split by how likely you are to want them. */
+export interface BaseBranchOptions {
+  /** Every branch the target repository has, as far as we could see. */
+  all: string[];
+  /** Those this clone tracks locally — fetched or pushed by you. */
+  local: string[];
+}
+
+/** An existing pull request for the session's branch. */
+export interface ExistingPullRequest {
+  number: number;
+  url: string;
+  /** `OPEN`, `MERGED`, `CLOSED` — as reported by the provider. */
+  state: string;
+  title: string;
+}
+
+/**
+ * Everything the dialog needs to open with sensible values, gathered in one
+ * round trip: a second one would leave the form visibly filling itself in.
+ */
+export interface PullRequestDraft {
+  branch: string;
+  /** Base as GitHub names it — never a tracking ref like `origin/main`. */
+  baseBranch: string;
+  /** Branches of the default target, as candidates for the base. */
+  baseBranches: string[];
+  /**
+   * The subset this clone already knows — the branches you fetched or pushed
+   * yourself. A busy upstream has hundreds; those are what you actually pick.
+   */
+  localBaseBranches: string[];
+  /** Suggested title — the first commit's subject. */
+  title: string;
+  /** Suggested body: remaining commit messages, plus the repo's PR template. */
+  body: string;
+  /** Commits this branch has that the base does not. */
+  commitCount: number;
+  hasUncommittedChanges: boolean;
+  targets: PullRequestTarget[];
+  defaultTarget: string;
+  existing?: ExistingPullRequest;
+  /**
+   * Reasons the button must stay disabled, in plain language. Empty means the
+   * pull request can be created.
+   */
+  blockers: string[];
+}
+
+/**
+ * What the pull request would actually contain.
+ *
+ * Computed against the merge base, the way GitHub does it: commits the base has
+ * gained since the branch started are not this pull request's changes, and
+ * showing them would misstate its size.
+ */
+export interface PullRequestChanges {
+  /** Ref the comparison ran against, as git resolved it (e.g. `origin/main`). */
+  baseRef: string;
+  files: GitCommitFileChange[];
+  /** Files touched before truncation. */
+  totalFiles: number;
+  truncated: boolean;
+  additions: number;
+  deletions: number;
+}
+
+/** The patch behind {@link PullRequestChanges}, fetched only when asked for. */
+export interface PullRequestDiff {
+  baseRef: string;
+  diff: string;
+  /** True when the patch was cut at the size limit. */
+  truncated: boolean;
+}
+
+export interface CreatePullRequestRequest {
+  sessionId: string;
+  title: string;
+  body: string;
+  baseBranch: string;
+  /** `owner/repo` of the repository that receives the pull request. */
+  targetRepo: string;
+  draft?: boolean;
+}
+
+export interface CreatePullRequestResult {
+  number: number;
+  url: string;
+}
+
+/** Normalised CI state; providers spell these several ways. */
+export type PullRequestCheckState = 'pass' | 'fail' | 'pending' | 'skipped' | 'cancelled';
+
+export interface PullRequestCheck {
+  name: string;
+  state: PullRequestCheckState;
+  url?: string;
+}
+
+export interface PullRequestChecksResult {
+  number: number;
+  checks: PullRequestCheck[];
+  /** Rollup: fail beats pending beats pass, because that is what needs action. */
+  summary: PullRequestCheckState | 'none';
+  fetchedAtMs: number;
+}
+
+/** GitHub's verdict on a pull request's reviews. */
+export type PullRequestReviewDecision = 'approved' | 'changes_requested' | 'review_required' | 'none';
+
+export interface PullRequestReviewer {
+  login: string;
+  /** `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, … as GitHub spells it. */
+  state: string;
+}
+
+/**
+ * What happened to a pull request after it was opened.
+ *
+ * The questions this answers are the ones you would otherwise switch to the
+ * browser for: did anyone review it, does it still merge, how big did it get.
+ */
+export interface PullRequestStatus {
+  number: number;
+  url: string;
+  title: string;
+  /** `OPEN`, `MERGED`, `CLOSED`. */
+  state: string;
+  isDraft: boolean;
+  baseRefName: string;
+  headRefName: string;
+  /** Owner of the repository the head branch lives in, for a fork's pull request. */
+  headRepositoryOwner?: string;
+  reviewDecision: PullRequestReviewDecision;
+  /** `MERGEABLE`, `CONFLICTING`, `UNKNOWN` — GitHub computes this lazily. */
+  mergeable: string;
+  reviewers: PullRequestReviewer[];
+  commentCount: number;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  fetchedAtMs: number;
+}
+
+/** Files a repository may keep its pull request template in, in search order. */
+export const PR_TEMPLATE_PATHS = [
+  '.github/pull_request_template.md',
+  '.github/PULL_REQUEST_TEMPLATE.md',
+  'docs/pull_request_template.md',
+  'PULL_REQUEST_TEMPLATE.md',
+] as const;

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -45,6 +45,7 @@ type ElectronApiMockOptions = {
   }>;
   initialExecutions?: JsonObject[];
   initialCombinedDiff?: JsonObject | null;
+  initialCommitFiles?: JsonObject[];
   initialTerminalStates?: Record<string, JsonObject>;
   initialAgentUsage?: JsonObject;
   forcedAgentUsageError?: string;
@@ -589,6 +590,13 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         getResumable: () => success([]),
         getExecutions: () => success(clone(mockOptions.initialExecutions ?? [])),
         getCombinedDiff: () => success(clone(mockOptions.initialCombinedDiff ?? null)),
+        getCommitFiles: (_sessionId: string, ref: string) => success({
+          ref,
+          files: clone(mockOptions.initialCommitFiles ?? []),
+          totalFiles: (mockOptions.initialCommitFiles ?? []).length,
+          truncated: false,
+          isMergeAgainstFirstParent: false,
+        }),
       }),
       remoteDaemon: namespace({
         getConfig: () => success(clone(remoteDaemonConfig)),

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -3,6 +3,13 @@ import type { CloudVmState } from '../shared/types/cloud';
 import type { PaneChatAgent } from '../shared/types/paneChat';
 import type { PanePermissionRequest, PanePermissionResponse } from '../shared/types/permissions';
 import type {
+  BaseBranchOptions,
+  PullRequestChanges,
+  PullRequestDiff,
+  PullRequestDraft,
+  PullRequestStatus,
+} from '../shared/types/pullRequest';
+import type {
   RemoteDaemonClientRecord,
   RemoteDaemonConfig,
   RemoteDaemonHostConfig,
@@ -46,6 +53,11 @@ type ElectronApiMockOptions = {
   initialExecutions?: JsonObject[];
   initialCombinedDiff?: JsonObject | null;
   initialCommitFiles?: JsonObject[];
+  pullRequestDraft?: PullRequestDraft;
+  pullRequestBranches?: BaseBranchOptions;
+  pullRequestChanges?: PullRequestChanges;
+  pullRequestDiff?: PullRequestDiff;
+  pullRequestStatus?: PullRequestStatus | null;
   initialTerminalStates?: Record<string, JsonObject>;
   initialAgentUsage?: JsonObject;
   forcedAgentUsageError?: string;
@@ -504,6 +516,13 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           configState.defaultOrchestratorAgent = agent === 'codex' || agent === 'cursor' ? agent : 'claude';
           return success(createPaneChatState());
         },
+      }),
+      pullRequests: namespace({
+        getDraft: () => success(clone(mockOptions.pullRequestDraft ?? null)),
+        listBaseBranches: () => success(clone(mockOptions.pullRequestBranches ?? { all: [], local: [] })),
+        getChanges: () => success(clone(mockOptions.pullRequestChanges ?? null)),
+        getDiff: () => success(clone(mockOptions.pullRequestDiff ?? null)),
+        getStatus: () => success(clone(mockOptions.pullRequestStatus ?? null)),
       }),
       panels: namespace({
         getSessionPanels: (sessionId: string) => success(

--- a/tests/review-availability.spec.ts
+++ b/tests/review-availability.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page, type TestInfo } from '@playwright/test';
 import type { JsonObject } from '../shared/validation/boundaryDecoder';
+import type { PullRequestDraft, PullRequestStatus } from '../shared/types/pullRequest';
 import { installElectronApiMock } from './electronApiMock';
 
 const project = {
@@ -113,6 +114,45 @@ const localCombinedDiff = {
   changedFiles: ['src/review.ts'],
 };
 
+const pullRequestDraft: PullRequestDraft = {
+  branch: 'feature/pull-request-workflow',
+  baseBranch: 'main',
+  baseBranches: ['main', 'release'],
+  localBaseBranches: ['main'],
+  title: 'Open pull requests from Pane',
+  body: '## Summary\n\nOpen and follow pull requests without leaving Pane.',
+  commitCount: 4,
+  hasUncommittedChanges: true,
+  targets: [
+    { nameWithOwner: 'dcouple/Pane', isParent: true, defaultBranch: 'main' },
+    { nameWithOwner: 'contributor/Pane', isParent: false, defaultBranch: 'main' },
+  ],
+  defaultTarget: 'dcouple/Pane',
+  blockers: [],
+};
+
+const pullRequestStatus: PullRequestStatus = {
+  number: 387,
+  url: 'https://github.com/dcouple/Pane/pull/387',
+  title: 'Open pull requests from Pane',
+  state: 'OPEN',
+  isDraft: false,
+  baseRefName: 'main',
+  headRefName: 'feature/pull-request-workflow',
+  headRepositoryOwner: 'contributor',
+  reviewDecision: 'changes_requested',
+  mergeable: 'CONFLICTING',
+  reviewers: [
+    { login: 'reviewer-one', state: 'APPROVED' },
+    { login: 'reviewer-two', state: 'CHANGES_REQUESTED' },
+  ],
+  commentCount: 3,
+  additions: 418,
+  deletions: 72,
+  changedFiles: 15,
+  fetchedAtMs: Date.parse('2026-08-23T12:00:00.000Z'),
+};
+
 async function openSession(
   page: Page,
   gitStatus: ReviewGitStatus = baseGitStatus,
@@ -148,6 +188,72 @@ async function capture(page: Page, testInfo: TestInfo, filename: string): Promis
   await page.screenshot({ path });
   await testInfo.attach(filename, { path, contentType: 'image/png' });
 }
+
+test('Create Pull Request validates the selected target branch', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [createSession()],
+    initialPanels: panels,
+    activeProjectId: project.id,
+    pullRequestDraft,
+    pullRequestBranches: { all: ['main', 'release'], local: ['main'] },
+    pullRequestChanges: {
+      baseRef: 'origin/main',
+      files: [{ path: 'frontend/src/components/git/CreatePullRequestDialog.tsx', status: 'modified', additions: 32, deletions: 4 }],
+      totalFiles: 1,
+      truncated: false,
+      additions: 32,
+      deletions: 4,
+    },
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Review fixture$/ }).click();
+  await page.getByRole('button', { name: 'Review changes before PR', exact: true }).click();
+
+  await page.getByRole('button', { name: 'Create Pull Request', exact: true }).evaluate(button => button.click());
+  const dialog = page.getByRole('dialog', { name: 'Create pull request' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('input').first()).toHaveValue('Open pull requests from Pane');
+  await expect(dialog.locator('select')).toHaveValue('dcouple/Pane');
+  await expect(dialog.locator('option').first()).toHaveText('dcouple/Pane (upstream)');
+  await expect(dialog.getByText('1 file', { exact: true })).toBeVisible();
+  await capture(page, testInfo, 'pr-387-01-create-dialog.png');
+
+  await dialog.getByRole('combobox', { name: 'Base branch' }).fill('missing-branch');
+  await expect(dialog.getByText(/missing-branch is not a branch in dcouple\/Pane/)).toBeVisible();
+  await expect(dialog.getByRole('button', { name: 'Create pull request', exact: true })).toBeDisabled();
+  await capture(page, testInfo, 'pr-387-02-invalid-base.png');
+});
+
+test('Review displays and expands current pull request status', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [createSession({
+      ...baseGitStatus,
+      prNumber: 387,
+      prTitle: pullRequestStatus.title,
+      prUrl: pullRequestStatus.url,
+    })],
+    initialPanels: panels,
+    initialExecutions: localExecutions,
+    initialCombinedDiff: localCombinedDiff,
+    activeProjectId: project.id,
+    pullRequestStatus,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Review fixture$/ }).click();
+  await page.getByRole('button', { name: pullRequestStatus.title, exact: true }).click();
+  await page.getByRole('tab', { name: 'Review', exact: true }).click();
+
+  const status = page.getByRole('button', { name: /Open #387 Open pull requests from Pane/ });
+  await expect(status).toBeVisible();
+  await expect(page.getByText('Changes requested', { exact: true })).toBeVisible();
+  await expect(page.getByText('Conflicts', { exact: true })).toBeVisible();
+  await status.click();
+  await expect(page.getByText('contributor:feature/pull-request-workflow → dcouple/Pane:main', { exact: true })).toBeVisible();
+  await expect(page.getByText(/Reviewed by reviewer-one \(approved\), reviewer-two \(changes requested\)/)).toBeVisible();
+  await capture(page, testInfo, 'pr-387-03-review-status.png');
+});
 
 test('Pinned panes use the short repository and pane name', async ({ page }, testInfo) => {
   const pinnedProject = {


### PR DESCRIPTION
## Description

Open a pull request for a session's branch without leaving Pane, and follow it from the review panel afterwards.

A session already *is* a branch in a worktree, so everything a pull request needs is on hand. Today the flow leaves the app: switch to a browser, find the fork, remember which repository the contribution is meant for. This adds a **Create Pull Request** entry to the session's git menu that gathers the branch, its commits, the repository's PR template and the possible targets in one round trip, pushes the branch and calls `gh pr create`.

Once the pull request exists, the same session's **Review** panel gains a status strip: state, review decision, mergeability, size and reviewers — the questions that otherwise send you back to the browser.

<img width="785" height="775" alt="image" src="https://github.com/user-attachments/assets/e19a9c52-ba57-4188-88e3-052fdb7c5770" />


### What it does

**Creating**
- Title and body are proposed from the commits ahead of the base: the first commit's subject becomes the title, the rest become a list, and the repository's `pull_request_template.md` is appended rather than replacing them.
- Fork-aware target picker. A fork has two candidates, and picking your own by accident is a silent mistake, so the parent is offered first and the head ref is spelled `owner:branch` when the pull request crosses repositories.
- Searchable base-branch picker. The short list is the branches this clone actually works on that also exist in the target; everything else is one click away. (A busy upstream has ~200 branches — a plain list is unusable, and a native `<datalist>` hides everything that does not match what is already typed.)
- **Changes** section: which files the pull request would carry, with per-file `+/-` and totals, compared against the **merge base** the way GitHub counts it. "Show diff" loads the patch on demand and renders it in the existing `DiffViewer`.
- Says what is wrong instead of failing obscurely: no commits ahead, detached HEAD, `gh` missing or signed out, an existing pull request for this branch (shown as a link — there is nothing to create), a base branch the target repository does not have.
- Uncommitted changes are called out explicitly, because they stay behind.

**Following**
- A strip under the review header: `Open / Draft / Merged / Closed`, number and title, review decision, comment count, and a conflict warning when GitHub reports `CONFLICTING`.
- Expanded: `owner:head → repo:base`, size, and each reviewer with their *newest* verdict — a "changes requested" that the same person later approved is not an open objection.
- Refreshes itself every 90s while the panel is on screen, and on demand.
- CI checks continue to be shown by the existing checks chip.

### How it works

- `PullRequestManager` (main process) is the only place that runs commands; everything that decides *what* to send is a pure function next to it, tested on its own: `deriveDraftText`, `resolveTargets`, `buildCreateArgs`, `normalizeBaseBranch`, `sortBaseBranches`, `parsePullRequestStatus`, `parseChecks`, …
- `gh` is invoked through the session's `CommandRunner`, so a WSL project uses the `gh` inside the distro rather than the one on the Windows host. When `gh` is not on the snapshotted PATH — for instance because it was installed while Pane was running — the usual install locations are tried before giving up.
- The body never goes through a shell: it is written to a temp file and passed with `--body-file`, so backticks, quotes and newlines in markdown survive.
- All channels are daemon-owned (`pr:*`): the branch, its remote and the `gh` binary live on the machine that runs the agents, so a remote runtime answers these itself instead of having the laptop push a branch it does not have.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
- [x] State management/IPC events

## Additional Notes

Builds on the per-file commit details PR — it reuses `shared/types/git.ts`, the `numstat`/`name-status` parsers in `gitDiffManager` and `parseUnifiedDiff`. Please merge that one first.

Tested against the real GitHub CLI and this repository: draft generation, the target list for a fork, base-branch listing across several API pages, the file comparison cross-checked against `git diff --name-only <base>...HEAD`, and status for open pull requests. One real pull request was created end to end and closed again.

<!-- pr-test-automation-summary:start -->
## PR test automation

Status: PASS on `2ab27e158ae6cbe230373bb4c8dd0b2d17158250`

- Create Pull Request dialog: PASS for draft values, upstream target, base branch, file totals, and uncommitted-change warning.
- Invalid target base: PASS for clear warning and disabled submit.
- Review status strip: PASS for current state, latest review verdict, conflicts, fork/base coordinates, size, comments, and reviewers.
- Safety: mocked IPC only. No live pull request, push, or other production GitHub object was created by QA.

![Create Pull Request dialog](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-387-2ab27e15-4f2184e993b8-01-create-dialog.png)

![Invalid base branch](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-387-2ab27e15-76424a28b227-02-invalid-base.png)

![Review status strip](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-387-2ab27e15-f84944b20ed4-03-review-status.png)
<!-- pr-test-automation-summary:end -->
