### PR TITLE
Fix terminal selection popover initialization

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -215,6 +215,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   // All hooks must be called at the top level, before any conditional returns
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
+  // Async initialization must publish the instance reactively so terminal hooks subscribe immediately.
+  const [terminalInstance, setTerminalInstance] = useState<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const webglAddonRef = useRef<WebglAddon | null>(null);
   const webLinksAddonRef = useRef<WebLinksAddon | null>(null);
@@ -564,7 +566,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     handleShowInExplorer,
     closeFilePopover,
     closeSelectionPopover,
-  } = useTerminalLinks(xtermRef.current, {
+  } = useTerminalLinks(terminalInstance, {
     workingDirectory: workingDirectory || '',
     sessionId: sessionId || panel.sessionId,
   });
@@ -1114,6 +1116,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           }
 
           xtermRef.current = terminal;
+          setTerminalInstance(terminal);
           fitAddonRef.current = fitAddon;
 
           // Track scroll position with direction-based sticky behaviour.
@@ -1728,13 +1731,15 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
       // Dispose XTerm instance only on final unmount
       if (xtermRef.current) {
+        const terminalToDispose = xtermRef.current;
         try {
           console.log('[TerminalPanel] Disposing terminal for panel:', panel.id);
-          xtermRef.current.dispose();
+          terminalToDispose.dispose();
         } catch (e) {
           console.warn('Error disposing terminal:', e);
         }
         xtermRef.current = null;
+        setTerminalInstance((current) => current === terminalToDispose ? null : current);
       }
       
       if (fitAddonRef.current) {

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -28,6 +28,7 @@ type ElectronApiMockOptions = {
   }>;
   initialExecutions?: Array<Record<string, unknown>>;
   initialCombinedDiff?: Record<string, unknown> | null;
+  initialTerminalStates?: Record<string, Record<string, unknown>>;
   activeProjectId?: number | null;
   paneChatAgentChangeDelayMs?: number;
 };
@@ -259,6 +260,12 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     });
 
     const invoke = (channel: string, key?: string, value?: string) => {
+      if (channel === 'panels:checkInitialized') {
+        return Promise.resolve(Boolean(key && mockOptions.initialTerminalStates?.[key]));
+      }
+      if (channel === 'terminal:getState') {
+        return Promise.resolve(key ? clone(mockOptions.initialTerminalStates?.[key] ?? null) : null);
+      }
       if (channel === 'preferences:get') {
         return success(key ? preferences[key] ?? 'true' : 'true');
       }

--- a/tests/terminal-selection-popover.spec.ts
+++ b/tests/terminal-selection-popover.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+const project = {
+  id: 380,
+  name: 'Terminal selection fixture',
+  path: '/tmp/terminal-selection-fixture',
+  active: true,
+  created_at: new Date(0).toISOString(),
+  updated_at: new Date(0).toISOString(),
+};
+
+const session = {
+  id: 'terminal-selection-session',
+  name: 'Terminal selection pane',
+  worktreePath: project.path,
+  prompt: 'Verify terminal selection popovers',
+  status: 'stopped',
+  createdAt: new Date(0).toISOString(),
+  lastActivity: new Date(0).toISOString(),
+  output: [],
+  jsonMessages: [],
+  isRunning: false,
+  permissionMode: 'ignore',
+  projectId: project.id,
+  displayOrder: 0,
+  isFavorite: false,
+  toolType: 'none',
+  archived: false,
+};
+
+const panels = ['Bottom Terminal', 'First Terminal', 'Second Terminal'].map((title, index) => ({
+  id: `terminal-${index}`,
+  sessionId: session.id,
+  type: 'terminal',
+  title,
+  state: { isActive: index === 1, hasBeenViewed: true, customState: { isInitialized: true } },
+  metadata: {
+    createdAt: new Date(index).toISOString(),
+    lastActiveAt: new Date(index).toISOString(),
+    position: index,
+    permanent: index === 0,
+  },
+}));
+
+async function selectFirstLine(page: Page, terminal: Locator): Promise<void> {
+  const viewport = terminal.locator('.xterm-screen');
+  await expect(viewport).toBeVisible();
+  const box = await viewport.boundingBox();
+  if (!box) throw new Error('Terminal viewport has no bounding box');
+
+  await page.mouse.move(box.x + 100, box.y + 8);
+  await expect.poll(() => terminal.evaluate((element) => {
+    interface HookNode {
+      memoizedState?: unknown;
+      next?: HookNode | null;
+    }
+    interface FiberNode {
+      memoizedState?: HookNode | null;
+      return?: FiberNode | null;
+    }
+
+    // xterm renders outside React, so walk to TerminalPanel's fiber and use its
+    // existing terminal ref to drive the public selection API deterministically.
+    let reactElement: HTMLElement | null = element.parentElement;
+    while (reactElement) {
+      const fiberKey = Object.keys(reactElement).find((key) => key.startsWith('__reactFiber$'));
+      if (fiberKey) {
+        let fiber = Reflect.get(reactElement, fiberKey) as FiberNode | null;
+        while (fiber) {
+          let hook = fiber.memoizedState;
+          while (hook) {
+            const ref = hook.memoizedState;
+            if (ref && typeof ref === 'object') {
+              const candidate = Reflect.get(ref, 'current') as unknown;
+              if (candidate && typeof candidate === 'object') {
+                const select = Reflect.get(candidate, 'select') as unknown;
+                if (typeof select === 'function') {
+                  select.call(candidate, 0, 0, 11);
+                  return true;
+                }
+              }
+            }
+            hook = hook.next;
+          }
+          fiber = fiber.return ?? null;
+        }
+      }
+      reactElement = reactElement.parentElement;
+    }
+    return false;
+  })).toBe(true);
+}
+
+test('selection popover works in restored bottom and tab terminals', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [session],
+    initialPanels: panels,
+    initialTerminalStates: Object.fromEntries(panels.map((panel, index) => [
+      panel.id,
+      { scrollbackBuffer: `selection-${index}\r\n` },
+    ])),
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Terminal selection fixture$/ }).click();
+  await page.getByRole('button', { name: session.name, exact: true }).click();
+
+  await page.getByRole('button', { name: 'Expand terminal', exact: true }).click();
+  await expect(page.locator('.xterm-screen')).toHaveCount(3, { timeout: 15_000 });
+  await expect(page.getByRole('status', { name: 'Loading terminal' })).toHaveCount(0);
+
+  const assertions = [
+    page.locator('.pane-terminal-shell-body .xterm').first(),
+    page.getByRole('tabpanel').locator('.xterm').first(),
+  ];
+
+  for (const terminal of assertions) {
+    await selectFirstLine(page, terminal);
+    await expect(page.getByRole('button', { name: 'Copy', exact: true }).first()).toBeVisible();
+    await page.mouse.click(20, 20);
+    await expect(page.getByRole('button', { name: 'Copy', exact: true })).toHaveCount(0);
+  }
+
+  await page.getByRole('tab', { name: panels[2].title, exact: true }).click();
+  await expect(page.getByRole('tabpanel').getByRole('status', { name: 'Loading terminal' })).toHaveCount(0);
+  await selectFirstLine(page, page.getByRole('tabpanel').locator('.xterm').first());
+  await expect(page.getByRole('button', { name: 'Copy', exact: true }).first()).toBeVisible();
+
+  const screenshotPath = testInfo.outputPath('terminal-selection-popover.png');
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach('terminal-selection-popover', { path: screenshotPath, contentType: 'image/png' });
+});


### PR DESCRIPTION
## Summary
- publish each asynchronously-created xterm instance through React state so selection and link hooks subscribe immediately
- clear the published instance with identity-aware cleanup to avoid stale StrictMode teardown clearing a replacement terminal
- cover restored bottom, first-tab, and second-tab terminals with a Playwright regression

## Relationship to #381
PR #381 adds keyboard and copy-on-select behavior. This PR fixes the independent selection-popover subscription lifecycle, so the changes are complementary rather than duplicates.

## Testing
- `pnpm test -- tests/terminal-selection-popover.spec.ts --workers=1`
- `pnpm --filter frontend test` (136 tests)
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm build:frontend`

## Automated QA
- verified the pinned bottom terminal, restored first tab, and restored second tab after loading/refresh overlays settled
- confirmed each selected terminal displays the selection popover and outside-click cleanup works before moving to the next terminal
- lifecycle diagnostic logs showed all three xterm instances publishing and all three selection subscriptions registering; temporary diagnostics were removed before commit
- no test or build errors; only the existing `NO_COLOR` and stale Browserslist/chunk-size warnings

![Selection popover in the settled second terminal](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-389-terminal-selection-popover.png)

Fixes #380