### PR TITLE
Commit window got Title and Description boxes + keyboard shortcut.

### DIFF
--- a/frontend/src/components/CommitDialog.tsx
+++ b/frontend/src/components/CommitDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { GitCommit } from 'lucide-react';
+import { composeCommitMessage, isCommitSubmitShortcut } from '../../../shared/utils/commitMessage';
 import { formatKeyDisplay } from '../utils/hotkeyUtils';
-import { composeCommitMessage } from '../utils/commitMessage';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import { Input } from './ui/Input';
@@ -66,13 +66,13 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
   }, [description, onCommit, onClose, title]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (keyboardShortcutsEnabled && e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    if (isCommitSubmitShortcut(e, keyboardShortcutsEnabled, !isCommitting && !!title.trim())) {
       e.preventDefault();
-      handleCommit();
+      void handleCommit();
     } else if (e.key === 'Escape') {
       onClose();
     }
-  }, [handleCommit, keyboardShortcutsEnabled, onClose]);
+  }, [handleCommit, isCommitting, keyboardShortcutsEnabled, onClose, title]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="md">

--- a/frontend/src/components/CommitDialog.tsx
+++ b/frontend/src/components/CommitDialog.tsx
@@ -1,8 +1,10 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { GitCommit } from 'lucide-react';
 import { formatKeyDisplay } from '../utils/hotkeyUtils';
+import { composeCommitMessage } from '../utils/commitMessage';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
+import { Input } from './ui/Input';
 import { Textarea } from './ui/Textarea';
 import { areKeyboardShortcutsEnabled, useConfigStore } from '../stores/configStore';
 
@@ -19,23 +21,24 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
   onCommit,
   fileCount
 }) => {
-  const [commitMessage, setCommitMessage] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
   const [isCommitting, setIsCommitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const titleRef = useRef<HTMLInputElement>(null);
   const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
 
   // Set default message
   useEffect(() => {
     if (isOpen) {
-      const defaultMessage = `Update ${fileCount} file${fileCount > 1 ? 's' : ''}`;
-      setCommitMessage(defaultMessage);
+      setTitle(`Update ${fileCount} file${fileCount > 1 ? 's' : ''}`);
+      setDescription('');
       setError(null);
       // Focus and select all text after a short delay
       const focusTimer = window.setTimeout(() => {
-        if (textareaRef.current) {
-          textareaRef.current.focus();
-          textareaRef.current.select();
+        if (titleRef.current) {
+          titleRef.current.focus();
+          titleRef.current.select();
         }
       }, 100);
 
@@ -44,8 +47,8 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
   }, [isOpen, fileCount]);
 
   const handleCommit = useCallback(async () => {
-    if (!commitMessage.trim()) {
-      setError('Please enter a commit message');
+    if (!title.trim()) {
+      setError('Please enter a title');
       return;
     }
 
@@ -53,14 +56,14 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
     setError(null);
 
     try {
-      await onCommit(commitMessage);
+      await onCommit(composeCommitMessage(title, description));
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to commit changes');
     } finally {
       setIsCommitting(false);
     }
-  }, [commitMessage, onCommit, onClose]);
+  }, [description, onCommit, onClose, title]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (keyboardShortcutsEnabled && e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
@@ -84,15 +87,30 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
           Committing {fileCount} file{fileCount > 1 ? 's' : ''} with changes
         </p>
         
-        <Textarea
-          ref={textareaRef}
-          value={commitMessage}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCommitMessage(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Enter commit message..."
-          rows={4}
-          error={error}
-        />
+        <div className="space-y-4">
+          <Input
+            ref={titleRef}
+            label="Title"
+            value={title}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setTitle(e.target.value);
+              if (error) setError(null);
+            }}
+            onKeyDown={handleKeyDown}
+            placeholder="Enter commit title..."
+            error={error ?? undefined}
+            fullWidth
+          />
+          <Textarea
+            label="Description (optional)"
+            value={description}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDescription(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Add more details..."
+            rows={4}
+            fullWidth
+          />
+        </div>
         
         <p className="mt-2 text-xs text-text-tertiary">
           Press {formatKeyDisplay('mod+enter')} to commit
@@ -109,7 +127,7 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
         </Button>
         <Button
           onClick={handleCommit}
-          disabled={isCommitting || !commitMessage.trim()}
+          disabled={isCommitting || !title.trim()}
           variant="primary"
           loading={isCommitting}
           loadingText="Committing..."

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -425,7 +425,6 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
         dialogType="commit"
         gitCommands={mainRepoGit.gitCommands}
         commitMessage={mainRepoGit.commitMessage}
-        setCommitMessage={mainRepoGit.setCommitMessage}
         shouldSquash={false}
         setShouldSquash={() => {}}
         onConfirm={mainRepoGit.handleCommit}

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -424,7 +424,6 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
         onClose={() => mainRepoGit.setShowCommitDialog(false)}
         dialogType="commit"
         gitCommands={mainRepoGit.gitCommands}
-        commitMessage={mainRepoGit.commitMessage}
         shouldSquash={false}
         setShouldSquash={() => {}}
         onConfirm={mainRepoGit.handleCommit}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1949,7 +1949,6 @@ export const SessionView = memo(() => {
         dialogType={hook.dialogType}
         gitCommands={hook.gitCommands}
         commitMessage={hook.commitMessage}
-        setCommitMessage={hook.setCommitMessage}
         shouldSquash={hook.shouldSquash}
         setShouldSquash={hook.setShouldSquash}
         onConfirm={(message) => {

--- a/frontend/src/components/session/CommitMessageDialog.tsx
+++ b/frontend/src/components/session/CommitMessageDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { composeCommitMessage, isCommitSubmitShortcut, splitCommitMessage } from '../../../../shared/utils/commitMessage';
 import type { GitCommands } from '../../types/session';
 import { areKeyboardShortcutsEnabled, useConfigStore } from '../../stores/configStore';
-import { composeCommitMessage, splitCommitMessage } from '../../utils/commitMessage';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../ui/Modal';
 import { Button } from '../ui/Button';
 import { Checkbox, Input, Textarea } from '../ui/Input';
@@ -12,7 +12,7 @@ interface CommitMessageDialogProps {
   onClose: () => void;
   dialogType: 'squash' | 'rebase' | 'commit';
   gitCommands: GitCommands | null;
-  commitMessage: string;
+  commitMessage?: string;
   shouldSquash: boolean;
   setShouldSquash: (should: boolean) => void;
   onConfirm: (message: string) => void;
@@ -26,7 +26,7 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
   onClose,
   dialogType,
   gitCommands,
-  commitMessage,
+  commitMessage = '',
   shouldSquash,
   setShouldSquash,
   onConfirm,
@@ -44,13 +44,7 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
   const canConfirm = !isProcessing && (!isMessageRequired || !!title.trim());
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (
-      keyboardShortcutsEnabled
-      && !event.repeat
-      && event.key === 'Enter'
-      && (event.ctrlKey || event.metaKey)
-      && canConfirm
-    ) {
+    if (isCommitSubmitShortcut(event, keyboardShortcutsEnabled, canConfirm)) {
       event.preventDefault();
       onConfirm(composedMessage);
     }

--- a/frontend/src/components/session/CommitMessageDialog.tsx
+++ b/frontend/src/components/session/CommitMessageDialog.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
-import { GitCommands } from '../../types/session';
+import React, { useCallback, useEffect, useState } from 'react';
+import type { GitCommands } from '../../types/session';
+import { areKeyboardShortcutsEnabled, useConfigStore } from '../../stores/configStore';
+import { composeCommitMessage, splitCommitMessage } from '../../utils/commitMessage';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from '../ui/Modal';
 import { Button } from '../ui/Button';
-import { Checkbox, Textarea } from '../ui/Input';
+import { Checkbox, Input, Textarea } from '../ui/Input';
 import { Card } from '../ui/Card';
 
 interface CommitMessageDialogProps {
@@ -11,7 +13,6 @@ interface CommitMessageDialogProps {
   dialogType: 'squash' | 'rebase' | 'commit';
   gitCommands: GitCommands | null;
   commitMessage: string;
-  setCommitMessage: (message: string) => void;
   shouldSquash: boolean;
   setShouldSquash: (should: boolean) => void;
   onConfirm: (message: string) => void;
@@ -26,7 +27,6 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
   dialogType,
   gitCommands,
   commitMessage,
-  setCommitMessage,
   shouldSquash,
   setShouldSquash,
   onConfirm,
@@ -34,7 +34,36 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
   isMerging,
   isMergingAndArchiving,
 }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
   const isProcessing = isMerging || isMergingAndArchiving;
+  const isMessageDisabled = dialogType === 'squash' && !shouldSquash;
+  const isMessageRequired = dialogType === 'commit' || shouldSquash;
+  const composedMessage = composeCommitMessage(title, description);
+  const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
+  const canConfirm = !isProcessing && (!isMessageRequired || !!title.trim());
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      keyboardShortcutsEnabled
+      && !event.repeat
+      && event.key === 'Enter'
+      && (event.ctrlKey || event.metaKey)
+      && canConfirm
+    ) {
+      event.preventDefault();
+      onConfirm(composedMessage);
+    }
+  }, [canConfirm, composedMessage, keyboardShortcutsEnabled, onConfirm]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const parts = splitCommitMessage(commitMessage);
+    setTitle(parts.title);
+    setDescription(parts.description);
+  }, [commitMessage, isOpen]);
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl">
       <ModalHeader
@@ -46,7 +75,7 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
       />
       
       <ModalBody>
-          <div className="space-y-4">
+          <div className="space-y-4" onKeyDown={handleKeyDown}>
             {dialogType === 'squash' && (
               <Card variant="bordered" padding="md" className="bg-surface-secondary">
                 <div className="flex items-center space-x-3">
@@ -64,22 +93,25 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
               </Card>
             )}
             
+            <Input
+              label="Title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              disabled={isMessageDisabled}
+              placeholder={isMessageDisabled ? "Not needed when preserving commits" : "Enter commit title..."}
+              fullWidth
+            />
+
             <Textarea
-              label="Commit Message"
-              value={commitMessage}
-              onChange={(e) => setCommitMessage(e.target.value)}
-              rows={8}
-              disabled={dialogType === 'squash' && !shouldSquash}
-              placeholder={
-                dialogType === 'commit'
-                  ? "Enter commit message..."
-                  : dialogType === 'squash'
-                    ? (shouldSquash ? "Enter commit message..." : "Not needed when preserving commits")
-                    : "Enter commit message..."
-              }
+              label="Description (optional)"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={6}
+              disabled={isMessageDisabled}
+              placeholder={isMessageDisabled ? "Not needed when preserving commits" : "Add more details..."}
               helperText={
                 dialogType === 'commit'
-                  ? 'All changes will be staged and committed with this message.'
+                  ? 'All changes will be staged and committed.'
                   : dialogType === 'squash'
                     ? (shouldSquash
                         ? `This message will be used for the merge commit.`
@@ -119,8 +151,8 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
         </Button>
         {dialogType === 'squash' && onMergeAndArchive && (
           <Button
-            onClick={() => onMergeAndArchive(commitMessage)}
-            disabled={(shouldSquash && !commitMessage.trim()) || isProcessing}
+            onClick={() => onMergeAndArchive(composedMessage)}
+            disabled={(shouldSquash && !title.trim()) || isProcessing}
             loading={isMergingAndArchiving}
             variant="secondary"
           >
@@ -128,8 +160,8 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
           </Button>
         )}
         <Button
-          onClick={() => onConfirm(commitMessage)}
-          disabled={(!commitMessage.trim() && (dialogType === 'commit' || shouldSquash)) || isProcessing}
+          onClick={() => onConfirm(composedMessage)}
+          disabled={(isMessageRequired && !title.trim()) || isProcessing}
           loading={isMerging}
         >
           {isMerging

--- a/frontend/src/components/session/CommitMessageDialog.tsx
+++ b/frontend/src/components/session/CommitMessageDialog.tsx
@@ -152,7 +152,7 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
         {dialogType === 'squash' && onMergeAndArchive && (
           <Button
             onClick={() => onMergeAndArchive(composedMessage)}
-            disabled={(shouldSquash && !title.trim()) || isProcessing}
+            disabled={!canConfirm}
             loading={isMergingAndArchiving}
             variant="secondary"
           >
@@ -161,7 +161,7 @@ export const CommitMessageDialog: React.FC<CommitMessageDialogProps> = ({
         )}
         <Button
           onClick={() => onConfirm(composedMessage)}
-          disabled={(isMessageRequired && !title.trim()) || isProcessing}
+          disabled={!canConfirm}
           loading={isMerging}
         >
           {isMerging

--- a/frontend/src/hooks/useMainRepoGitActions.ts
+++ b/frontend/src/hooks/useMainRepoGitActions.ts
@@ -20,7 +20,6 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
   const [showSetTrackingDialog, setShowSetTrackingDialog] = useState(false);
   const [showCommitDialog, setShowCommitDialog] = useState(false);
-  const [commitMessage, setCommitMessage] = useState('');
   const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
 
   const refreshStashState = useCallback(async () => {
@@ -108,9 +107,7 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
     void runOperation(
       (activeSessionId) => API.sessions.gitStageAndCommit(activeSessionId, message),
       'Failed to commit changes',
-    ).then((success) => {
-      if (success) setCommitMessage('');
-    });
+    );
   }, [runOperation]);
 
   const handleOpenSetTracking = useCallback(async () => {
@@ -230,7 +227,6 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
   return {
     actions,
     actionsBusy,
-    commitMessage,
     currentUpstream,
     error,
     gitCommands,
@@ -241,7 +237,6 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
     isRemoteMode,
     isRunning,
     remoteBranches,
-    setCommitMessage,
     setShowCommitDialog,
     setShowSetTrackingDialog,
     showCommitDialog,

--- a/frontend/src/utils/commitMessage.test.ts
+++ b/frontend/src/utils/commitMessage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { composeCommitMessage, splitCommitMessage } from './commitMessage';
+
+describe('commitMessage', () => {
+  it('composes a title and description using the conventional blank line separator', () => {
+    expect(composeCommitMessage('Add commit title field', 'Explain the change clearly.')).toBe(
+      'Add commit title field\n\nExplain the change clearly.',
+    );
+  });
+
+  it('omits the separator when the optional description is empty', () => {
+    expect(composeCommitMessage('Add commit title field', '  ')).toBe('Add commit title field');
+  });
+
+  it('splits an existing multiline commit message into title and description', () => {
+    expect(splitCommitMessage('Add commit title field\r\n\r\nExplain the change.\r\nKeep existing behavior.')).toEqual({
+      title: 'Add commit title field',
+      description: 'Explain the change.\nKeep existing behavior.',
+    });
+  });
+
+  it('supports existing messages without a blank separator', () => {
+    expect(splitCommitMessage('Add commit title field\nExplain the change.')).toEqual({
+      title: 'Add commit title field',
+      description: 'Explain the change.',
+    });
+  });
+});

--- a/frontend/src/utils/commitMessage.test.ts
+++ b/frontend/src/utils/commitMessage.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { composeCommitMessage, splitCommitMessage } from './commitMessage';
+import {
+  composeCommitMessage,
+  hasCommitMessageTitle,
+  isCommitSubmitShortcut,
+  splitCommitMessage,
+} from '../../../shared/utils/commitMessage';
 
 describe('commitMessage', () => {
   it('composes a title and description using the conventional blank line separator', () => {
@@ -24,5 +29,19 @@ describe('commitMessage', () => {
       title: 'Add commit title field',
       description: 'Explain the change.',
     });
+  });
+
+  it('requires a non-empty first-line title at process boundaries', () => {
+    expect(hasCommitMessageTitle('Commit title\n\nDescription')).toBe(true);
+    expect(hasCommitMessageTitle('  \n\nDescription only')).toBe(false);
+  });
+
+  it('recognizes enabled, non-repeating modifier-enter submissions', () => {
+    const event = { key: 'Enter', ctrlKey: true, metaKey: false, repeat: false };
+
+    expect(isCommitSubmitShortcut(event, true, true)).toBe(true);
+    expect(isCommitSubmitShortcut({ ...event, repeat: true }, true, true)).toBe(false);
+    expect(isCommitSubmitShortcut(event, false, true)).toBe(false);
+    expect(isCommitSubmitShortcut(event, true, false)).toBe(false);
   });
 });

--- a/frontend/src/utils/commitMessage.ts
+++ b/frontend/src/utils/commitMessage.ts
@@ -6,10 +6,6 @@ export interface CommitMessageParts {
 export function splitCommitMessage(message: string): CommitMessageParts {
   const [title = '', ...descriptionLines] = message.replace(/\r\n?/g, '\n').split('\n');
 
-  while (descriptionLines[0]?.trim() === '') {
-    descriptionLines.shift();
-  }
-
   return {
     title: title.trim(),
     description: descriptionLines.join('\n').trim(),

--- a/frontend/src/utils/commitMessage.ts
+++ b/frontend/src/utils/commitMessage.ts
@@ -1,0 +1,26 @@
+export interface CommitMessageParts {
+  title: string;
+  description: string;
+}
+
+export function splitCommitMessage(message: string): CommitMessageParts {
+  const [title = '', ...descriptionLines] = message.replace(/\r\n?/g, '\n').split('\n');
+
+  while (descriptionLines[0]?.trim() === '') {
+    descriptionLines.shift();
+  }
+
+  return {
+    title: title.trim(),
+    description: descriptionLines.join('\n').trim(),
+  };
+}
+
+export function composeCommitMessage(title: string, description: string): string {
+  const normalizedTitle = title.trim();
+  const normalizedDescription = description.trim();
+
+  return normalizedDescription
+    ? `${normalizedTitle}\n\n${normalizedDescription}`
+    : normalizedTitle;
+}

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -468,4 +468,23 @@ describe('daemon registry IPC bindings', () => {
     expect(ipcMain.boundChannels.sort()).toEqual([...GIT_CHANNELS].sort());
     expect(registry.has('git:clone-repo')).toBe(true);
   });
+
+  it('rejects commit messages without a title at the git IPC boundary', async () => {
+    const registry = new PaneCommandRegistry();
+    registerGitHandlers(createIpcMainStub(), createServicesStub(), registry);
+    registerFileHandlers(createIpcMainStub(), createServicesStub(), registry);
+
+    await expect(registry.invoke(
+      'sessions:git-stage-and-commit',
+      ['session-1', '  \n\nDescription only'],
+    )).resolves.toEqual({ success: false, error: 'Commit title is required' });
+    await expect(registry.invoke(
+      'sessions:squash-and-rebase-to-main',
+      ['session-1', ''],
+    )).resolves.toEqual({ success: false, error: 'Commit title is required' });
+    await expect(registry.invoke(
+      'git:commit',
+      [{ sessionId: 'session-1', message: '\n\nDescription only' }],
+    )).resolves.toEqual({ success: false, error: 'Commit title is required' });
+  });
 });

--- a/main/src/ipc/file.ts
+++ b/main/src/ipc/file.ts
@@ -3,6 +3,7 @@ import { shell } from 'electron';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { glob } from 'glob';
+import { hasCommitMessageTitle } from '../../../shared/utils/commitMessage';
 import type { PaneCommandRegistry } from '../daemon/commandRegistry';
 import type { AppServices } from './types';
 import type { Session } from '../types/session';
@@ -445,13 +446,13 @@ export function registerFileHandlers(
   // Commit changes in a session's worktree
   commandRegistry.register('git:commit', async (request: { sessionId: string; message: string }) => {
     try {
+      if (!hasCommitMessageTitle(request.message)) {
+        throw new Error('Commit title is required');
+      }
+
       const session = sessionManager.getSession(request.sessionId);
       if (!session) {
         throw new Error(`Session not found: ${request.sessionId}`);
-      }
-
-      if (!request.message || !request.message.trim()) {
-        throw new Error('Commit message is required');
       }
 
       const ctx = sessionManager.getProjectContext(request.sessionId);

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -1,4 +1,5 @@
 import type { IpcMain } from 'electron';
+import { hasCommitMessageTitle } from '../../../shared/utils/commitMessage';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import type { AppServices } from './types';
@@ -1105,6 +1106,10 @@ export function registerGitHandlers(
 
   commandRegistry.register('sessions:squash-and-rebase-to-main', async (sessionId: string, commitMessage: string) => {
     try {
+      if (!hasCommitMessageTitle(commitMessage)) {
+        return { success: false, error: 'Commit title is required' };
+      }
+
       const session = await sessionManager.getSession(sessionId);
       if (!session) {
         return { success: false, error: 'Session not found' };
@@ -1802,6 +1807,10 @@ export function registerGitHandlers(
 
   commandRegistry.register('sessions:git-stage-and-commit', async (sessionId: string, message: string) => {
     try {
+      if (!hasCommitMessageTitle(message)) {
+        return { success: false, error: 'Commit title is required' };
+      }
+
       const session = await sessionManager.getSession(sessionId);
       if (!session) {
         return { success: false, error: 'Session not found' };

--- a/shared/utils/commitMessage.ts
+++ b/shared/utils/commitMessage.ts
@@ -3,6 +3,13 @@ export interface CommitMessageParts {
   description: string;
 }
 
+interface CommitShortcutEvent {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  repeat: boolean;
+}
+
 export function splitCommitMessage(message: string): CommitMessageParts {
   const [title = '', ...descriptionLines] = message.replace(/\r\n?/g, '\n').split('\n');
 
@@ -19,4 +26,20 @@ export function composeCommitMessage(title: string, description: string): string
   return normalizedDescription
     ? `${normalizedTitle}\n\n${normalizedDescription}`
     : normalizedTitle;
+}
+
+export function hasCommitMessageTitle(message: string): boolean {
+  return splitCommitMessage(message).title.length > 0;
+}
+
+export function isCommitSubmitShortcut(
+  event: CommitShortcutEvent,
+  keyboardShortcutsEnabled: boolean,
+  canSubmit: boolean,
+): boolean {
+  return keyboardShortcutsEnabled
+    && canSubmit
+    && !event.repeat
+    && event.key === 'Enter'
+    && (event.ctrlKey || event.metaKey);
 }

--- a/tests/commit-dialog.spec.ts
+++ b/tests/commit-dialog.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+const project = {
+  id: 391,
+  name: 'Commit dialog fixture',
+  path: '/tmp/commit-dialog-fixture',
+  active: true,
+  created_at: new Date(0).toISOString(),
+  updated_at: new Date(0).toISOString(),
+};
+
+const gitStatus = {
+  state: 'clean',
+  ahead: 0,
+  behind: 0,
+  hasUncommittedChanges: true,
+  hasUntrackedFiles: false,
+  filesChanged: 1,
+  additions: 3,
+  deletions: 1,
+  totalCommits: 0,
+};
+
+const baseSession = {
+  id: 'commit-dialog-session',
+  name: 'Commit dialog changes',
+  worktreePath: '/tmp/commit-dialog-fixture/commit-dialog-session',
+  prompt: 'Verify commit message fields',
+  status: 'stopped',
+  createdAt: new Date(0).toISOString(),
+  lastActivity: new Date(0).toISOString(),
+  output: [],
+  jsonMessages: [],
+  isRunning: false,
+  permissionMode: 'ignore',
+  projectId: project.id,
+  displayOrder: 0,
+  isFavorite: false,
+  toolType: 'none',
+  archived: false,
+  baseBranch: 'main',
+  gitStatus,
+};
+
+function createSession(overrides: Partial<typeof baseSession> & { isMainRepo?: boolean } = {}) {
+  return { ...baseSession, ...overrides };
+}
+
+const combinedDiff = {
+  diff: [
+    'diff --git a/src/example.ts b/src/example.ts',
+    'index 1111111..2222222 100644',
+    '--- a/src/example.ts',
+    '+++ b/src/example.ts',
+    '@@ -1 +1 @@',
+    '-export const value = 1;',
+    '+export const value = 2;',
+  ].join('\n'),
+  stats: { additions: 1, deletions: 1, filesChanged: 1 },
+  changedFiles: ['src/example.ts'],
+};
+
+async function capture(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const path = testInfo.outputPath(name);
+  await page.screenshot({ path });
+  await testInfo.attach(name, { path, contentType: 'image/png' });
+}
+
+test('main repository commit dialog submits title and description with Ctrl+Enter', async ({ page }, testInfo) => {
+  const mainSession = createSession({
+    id: 'commit-dialog-main',
+    name: 'Commit dialog fixture (Main)',
+    worktreePath: project.path,
+    isMainRepo: true,
+  });
+
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [mainSession],
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: `Repository actions for ${project.name}`, exact: true }).click();
+  await page.getByText('Open session on main', { exact: true }).click();
+  await page.getByRole('button', { name: 'Show details', exact: true }).click();
+  await page.locator('.pane-detail-panel-vertical').getByRole('button', { name: 'Commit 1 file', exact: true }).click();
+
+  const dialog = page.getByRole('dialog');
+  const title = dialog.getByLabel('Title');
+  const description = dialog.getByLabel('Description (optional)');
+  await expect(title).toBeVisible();
+  await expect(description).toBeVisible();
+  await expect(dialog.getByRole('button', { name: 'Commit', exact: true })).toBeDisabled();
+
+  await title.fill('Refine commit workflow');
+  await description.fill('Keep title and description separate in the UI.');
+  await capture(page, testInfo, '01-main-repository-commit-dialog-filled.png');
+  await description.press('Control+Enter');
+
+  await expect(dialog).toHaveCount(0);
+  // SAFETY: installElectronApiMock creates this test-only bridge and owns the returned call shape.
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & {
+      __paneTestElectronMock: {
+        getGitStageAndCommitCalls: () => Array<{ sessionId: string; message: string }>;
+      };
+    }
+  ).__paneTestElectronMock.getGitStageAndCommitCalls())).toEqual([{
+    sessionId: mainSession.id,
+    message: 'Refine commit workflow\n\nKeep title and description separate in the UI.',
+  }]);
+});
+
+test('review commit dialog keeps its default title and submits the composed message', async ({ page }, testInfo) => {
+  const session = createSession();
+  const panels = [{
+    id: 'commit-dialog-diff',
+    sessionId: session.id,
+    type: 'diff',
+    title: 'Review',
+    state: { isActive: true, hasBeenViewed: true },
+    metadata: { createdAt: new Date(0).toISOString(), lastActiveAt: new Date(0).toISOString(), position: 0, permanent: true },
+  }];
+  const executions = [{
+    id: 0,
+    session_id: session.id,
+    execution_sequence: 0,
+    after_commit_hash: 'UNCOMMITTED',
+    commit_message: 'Uncommitted changes',
+    timestamp: new Date(0).toISOString(),
+    stats_additions: 1,
+    stats_deletions: 1,
+    stats_files_changed: 1,
+    author: 'Pane QA',
+    comparison_branch: 'main',
+    history_source: 'branch',
+  }];
+
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    initialSessions: [session],
+    initialPanels: panels,
+    initialExecutions: executions,
+    initialCombinedDiff: combinedDiff,
+    initialUiState: { expandedProjects: [project.id] },
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: session.name, exact: true }).click();
+  await page.getByRole('tab', { name: 'Review', exact: true }).click();
+  await page.getByRole('button', { name: 'Commit', exact: true }).click();
+
+  const dialog = page.getByRole('dialog');
+  const title = dialog.getByLabel('Title');
+  const description = dialog.getByLabel('Description (optional)');
+  await expect(title).toHaveValue('Update 1 file');
+  await description.fill('Explain the reviewed changes.');
+  await capture(page, testInfo, '02-review-commit-dialog-filled.png');
+  await description.press('Control+Enter');
+
+  await expect(dialog).toHaveCount(0);
+});

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -232,6 +232,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     const preferenceWrites: Array<{ key: string; value: string }> = [];
     const sessionDeleteCalls: string[] = [];
     const sessionFavoriteToggleCalls: string[] = [];
+    const gitStageAndCommitCalls: Array<{ sessionId: string; message: string }> = [];
     let sessionsGetCount = 0;
 
     const subscribe = (channel: string, callback: MockEventCallback) => {
@@ -589,6 +590,10 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         getResumable: () => success([]),
         getExecutions: () => success(clone(mockOptions.initialExecutions ?? [])),
         getCombinedDiff: () => success(clone(mockOptions.initialCombinedDiff ?? null)),
+        gitStageAndCommit: (sessionId: string, message: string) => {
+          gitStageAndCommitCalls.push({ sessionId, message });
+          return success();
+        },
       }),
       remoteDaemon: namespace({
         getConfig: () => success(clone(remoteDaemonConfig)),
@@ -882,6 +887,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         getSessionFavoriteToggleCalls() {
           return clone(sessionFavoriteToggleCalls);
+        },
+        getGitStageAndCommitCalls() {
+          return clone(gitStageAndCommitCalls);
         },
       },
     });


### PR DESCRIPTION
## Description
                                                                           
  Adds dedicated Title and optional Description fields to commit dialogs,  
  matching how GitHub displays commit messages. Also adds Ctrl+Enter /     
  Cmd+Enter as a keyboard shortcut for submitting commits.                 
                                                                           
  ## Type of Change                                                        
                                                                           
  - [x] Bug fix (non-breaking change which fixes an issue)                 
  - [x] New feature (non-breaking change which adds functionality)         
                                                                           
  ## Checklist                                                             
                                                                           
  - [x] My code follows the code style of this project                     
  - [x] I have performed a self-review of my own code                      
  - [x] My changes generate no new warnings                                
  - [x] I have added tests that prove my fix is effective or that my       
    feature works                                                          
                                                                           
  - [x] New and existing unit tests pass locally with my changes           
  - [x] I have run pnpm typecheck and pnpm lint locally                    
  - [x] I have tested the Electron app locally with pnpm electron-dev      
                                                                           
  ## Critical Areas Modified                                               
                                                                           
  None.                                                                    
                                                                           
  ## Screenshots                                                           
                                                                           
  Screenshot of the updated commit dialog with separate Title and          
  Description fields.

<img width="1070" height="519" alt="Pane-commit-box" src="https://github.com/user-attachments/assets/69b60cb3-9f97-40f1-838d-9c5f81b0c54e" />                                                      
                                                                           
  ## Additional Notes                                                      
                                                                           
  Commit messages are still sent through the existing IPC contract. Pane   
  combines the title and description using Git’s conventional blank-line   
  separator.

<!-- pr-test-automation-summary:start -->
## Automated QA

Status: Passed at `3b391ee6`.

- Main repository commit dialog: verified empty-title disablement, separate Title and optional Description fields, exact composed message, and Ctrl+Enter submission.
- Review-panel commit dialog: verified the generated `Update 1 file` title, optional description, composed message, and Ctrl+Enter submission.
- Automated checks: Playwright 2/2, frontend Vitest 272/272, focused main IPC Vitest 12/12, repository typecheck and lint.

| Surface | Evidence |
| --- | --- |
| Main repository | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-391-3b391ee6-362efba014b3-01-main-repository-commit-dialog-filled.png" width="420" alt="Main repository commit dialog with title and description"> |
| Review panel | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-391-3b391ee6-fa9b36e425ea-02-review-commit-dialog-filled.png" width="420" alt="Review commit dialog with title and description"> |

Remaining for human review: final platform-specific Cmd+Enter sanity check on macOS.
<!-- pr-test-automation-summary:end -->
