### PR TITLE
Add PR creation action to pane git controls

### DIFF
--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1471,6 +1471,25 @@ export const SessionView = memo(() => {
       : activeSession.status === 'running' || activeSession.status === 'initializing'
         ? 'Session is currently running'
         : undefined;
+    const createPrState = activeSession.gitStatus?.prUrl
+      ? {
+          description: `Pull request already exists: ${activeSession.gitStatus.prUrl}`,
+          disabledReason: 'Pull request already exists',
+        }
+      : activeSession.gitStatus?.ahead
+        ? {
+            description: 'Push this branch before creating a pull request',
+            disabledReason: 'Push branch first',
+          }
+        : activeSession.gitStatus?.totalCommits
+          ? {
+              description: `Create a pull request from ${hook.gitCommands?.currentBranch || 'current branch'}`,
+              disabledReason: undefined,
+            }
+          : {
+              description: 'No commits for a pull request',
+              disabledReason: 'No commits for a pull request',
+            };
     
     return activeSession.isMainRepo ? [
       {
@@ -1587,26 +1606,10 @@ export const SessionView = memo(() => {
         label: 'PR',
         icon: GitPullRequestArrow,
         onClick: hook.handleCreatePr,
-        disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing' ||
-                  Boolean(activeSession.gitStatus?.prUrl) ||
-                  Boolean(activeSession.gitStatus?.ahead && activeSession.gitStatus.ahead > 0) ||
-                  !activeSession.gitStatus?.totalCommits,
+        disabled: Boolean(busyReason ?? createPrState.disabledReason),
         variant: 'default' as const,
-        description: activeSession.gitStatus?.prUrl
-          ? `Pull request already exists: ${activeSession.gitStatus.prUrl}`
-          : activeSession.gitStatus?.ahead && activeSession.gitStatus.ahead > 0
-            ? 'Push this branch before creating a pull request'
-            : activeSession.gitStatus?.totalCommits
-              ? `Create a pull request from ${hook.gitCommands?.currentBranch || 'current branch'}`
-              : 'No commits for a pull request',
-        disabledReason: busyReason ??
-          (activeSession.gitStatus?.prUrl
-            ? 'Pull request already exists'
-            : activeSession.gitStatus?.ahead && activeSession.gitStatus.ahead > 0
-              ? 'Push branch first'
-              : activeSession.gitStatus?.totalCommits
-                ? undefined
-                : 'No commits for a pull request'),
+        description: createPrState.description,
+        disabledReason: busyReason ?? createPrState.disabledReason,
       },
       // --- Main branch operations (last) ---
       {

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1582,6 +1582,32 @@ export const SessionView = memo(() => {
           : 'No commits to push',
         disabledReason: busyReason ?? (activeSession.gitStatus?.ahead ? undefined : 'No commits to push'),
       },
+      {
+        id: 'create-pr',
+        label: 'PR',
+        icon: GitPullRequestArrow,
+        onClick: hook.handleCreatePr,
+        disabled: hook.isMerging || activeSession.status === 'running' || activeSession.status === 'initializing' ||
+                  Boolean(activeSession.gitStatus?.prUrl) ||
+                  Boolean(activeSession.gitStatus?.ahead && activeSession.gitStatus.ahead > 0) ||
+                  !activeSession.gitStatus?.totalCommits,
+        variant: 'default' as const,
+        description: activeSession.gitStatus?.prUrl
+          ? `Pull request already exists: ${activeSession.gitStatus.prUrl}`
+          : activeSession.gitStatus?.ahead && activeSession.gitStatus.ahead > 0
+            ? 'Push this branch before creating a pull request'
+            : activeSession.gitStatus?.totalCommits
+              ? `Create a pull request from ${hook.gitCommands?.currentBranch || 'current branch'}`
+              : 'No commits for a pull request',
+        disabledReason: busyReason ??
+          (activeSession.gitStatus?.prUrl
+            ? 'Pull request already exists'
+            : activeSession.gitStatus?.ahead && activeSession.gitStatus.ahead > 0
+              ? 'Push branch first'
+              : activeSession.gitStatus?.totalCommits
+                ? undefined
+                : 'No commits for a pull request'),
+      },
       // --- Main branch operations (last) ---
       {
         id: 'rebase-from-main',

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -22,6 +22,15 @@ interface PromptMarker {
   completion_timestamp?: string;
 }
 
+interface CreatePrResponseData {
+  url?: string;
+}
+
+function isCreatePrResponseData(value: unknown): value is CreatePrResponseData {
+  return typeof value === 'object' &&
+    value !== null &&
+    (!('url' in value) || typeof value.url === 'string');
+}
 
 export const useSessionView = (
   activeSession: Session | undefined,
@@ -994,6 +1003,27 @@ export const useSessionView = (
     }
   };
 
+  const handleCreatePr = async () => {
+    if (!activeSession) return;
+    setIsMerging(true);
+    setMergeError(null);
+    try {
+      const response = await API.sessions.createPr(activeSession.id);
+      if (!response.success) {
+        setMergeError(response.error || 'Failed to create pull request');
+        return;
+      }
+
+      if (isCreatePrResponseData(response.data) && response.data.url) {
+        await window.electronAPI?.openExternal(response.data.url);
+      }
+    } catch (error) {
+      setMergeError(error instanceof Error ? error.message : 'Failed to create pull request');
+    } finally {
+      setIsMerging(false);
+    }
+  };
+
   const handleGitSoftReset = async () => {
     if (!activeSession) return;
     setIsMerging(true);
@@ -1585,6 +1615,7 @@ export const useSessionView = (
     handleStopSession,
     handleGitPull,
     handleGitPush,
+    handleCreatePr,
     handleGitSoftReset,
     handleGitFetch,
     handleGitStash,

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -22,16 +22,6 @@ interface PromptMarker {
   completion_timestamp?: string;
 }
 
-interface CreatePrResponseData {
-  url?: string;
-}
-
-function isCreatePrResponseData(value: unknown): value is CreatePrResponseData {
-  return typeof value === 'object' &&
-    value !== null &&
-    (!('url' in value) || typeof value.url === 'string');
-}
-
 export const useSessionView = (
   activeSession: Session | undefined,
 ) => {
@@ -1014,7 +1004,7 @@ export const useSessionView = (
         return;
       }
 
-      if (isCreatePrResponseData(response.data) && response.data.url) {
+      if (response.data?.url) {
         await window.electronAPI?.openExternal(response.data.url);
       }
     } catch (error) {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -189,7 +189,7 @@ interface ElectronAPI {
     // Git pull/push operations
     gitPull: (sessionId: string) => Promise<IPCResponse>;
     gitPush: (sessionId: string) => Promise<IPCResponse>;
-    createPr: (sessionId: string) => Promise<IPCResponse>;
+    createPr: (sessionId: string) => Promise<IPCResponse<{ output: string; url?: string }>>;
     gitFetch: (sessionId: string) => Promise<IPCResponse>;
     gitStash: (sessionId: string, message?: string) => Promise<IPCResponse>;
     gitStashPop: (sessionId: string) => Promise<IPCResponse>;

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -33,6 +33,7 @@ import type {
 } from '../../../shared/types/panels';
 import type { JsonValue } from '../../../shared/validation/boundaryDecoder';
 import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
+import type { CreatePullRequestResult } from '../../../shared/types/git';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
 import type { CreateSessionRequest } from './session';
@@ -189,7 +190,7 @@ interface ElectronAPI {
     // Git pull/push operations
     gitPull: (sessionId: string) => Promise<IPCResponse>;
     gitPush: (sessionId: string) => Promise<IPCResponse>;
-    createPr: (sessionId: string) => Promise<IPCResponse<{ output: string; url?: string }>>;
+    createPr: (sessionId: string) => Promise<IPCResponse<CreatePullRequestResult>>;
     gitFetch: (sessionId: string) => Promise<IPCResponse>;
     gitStash: (sessionId: string, message?: string) => Promise<IPCResponse>;
     gitStashPop: (sessionId: string) => Promise<IPCResponse>;

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -189,6 +189,7 @@ interface ElectronAPI {
     // Git pull/push operations
     gitPull: (sessionId: string) => Promise<IPCResponse>;
     gitPush: (sessionId: string) => Promise<IPCResponse>;
+    createPr: (sessionId: string) => Promise<IPCResponse>;
     gitFetch: (sessionId: string) => Promise<IPCResponse>;
     gitStash: (sessionId: string, message?: string) => Promise<IPCResponse>;
     gitStashPop: (sessionId: string) => Promise<IPCResponse>;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -301,6 +301,11 @@ export class API {
       return window.electronAPI.sessions.gitPush(sessionId);
     },
 
+    async createPr(sessionId: string) {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.sessions.createPr(sessionId);
+    },
+
     async gitFetch(sessionId: string) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.sessions.gitFetch(sessionId);

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -194,6 +194,7 @@ const GIT_MUTATION_CHANNELS = [
   'sessions:rebase-to-main',
   'sessions:git-pull',
   'sessions:git-push',
+  'sessions:create-pr',
   'sessions:git-soft-reset',
   'sessions:git-fetch',
   'sessions:git-stash',

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -1461,29 +1461,29 @@ export function registerGitHandlers(
         return { success: false, error: 'Cannot create a pull request from a detached HEAD' };
       }
 
-      const comparisonBranch = await worktreeManager.getSessionComparisonBranch(session, ctx);
+      const baseBranch = await worktreeManager.getSessionLocalBaseBranch(session, ctx);
 
-      const startMessage = `ðŸ”„ GIT OPERATION\nCreating pull request...`;
+      const startMessage = `🔄 GIT OPERATION\nCreating pull request...`;
       emitGitOperationToProject(sessionId, 'git:operation_started', startMessage, {
         operation: 'create-pr',
         branch: currentBranch,
-        base: comparisonBranch,
+        base: baseBranch,
       });
 
       const result = await worktreeManager.createPullRequest(
         session.worktreePath,
-        comparisonBranch,
+        baseBranch,
         currentBranch,
         ctx.commandRunner,
       );
 
-      const successMessage = `âœ“ Successfully created pull request` +
+      const successMessage = `✓ Successfully created pull request` +
                             (result.url ? `\n\n${result.url}` : '') +
                             (result.output ? `\n\nGitHub CLI output:\n${result.output}` : '');
       emitGitOperationToProject(sessionId, 'git:operation_completed', successMessage, {
         operation: 'create-pr',
         output: result.output,
-        url: result.url,
+        url: result.url ?? null,
       });
       sessionManager.addSessionOutput(sessionId, {
         type: 'stdout',
@@ -1501,13 +1501,13 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to create pull request:', error);
 
-      const gitError = error as GitError;
-      const errorMessage = `âœ— Create PR failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
+      const gitError = decodeGitError(error);
+      const errorMessage = `✗ Create PR failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
                           (gitError.gitOutput ? `\n\nGitHub CLI output:\n${gitError.gitOutput}` : '');
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'create-pr',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       return {

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -92,6 +92,7 @@ const DAEMON_GIT_MUTATION_CHANNELS = [
   'sessions:rebase-to-main',
   'sessions:git-pull',
   'sessions:git-push',
+  'sessions:create-pr',
   'sessions:git-soft-reset',
   'sessions:git-fetch',
   'sessions:git-stash',
@@ -1433,6 +1434,85 @@ export function registerGitHandlers(
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to push to remote',
+        gitError: {
+          output: gitError.gitOutput || (error instanceof Error ? error.message : String(error)),
+          workingDirectory: gitError.workingDirectory || ''
+        }
+      };
+    }
+  });
+
+  commandRegistry.register('sessions:create-pr', async (sessionId: string) => {
+    try {
+      const session = await sessionManager.getSession(sessionId);
+      if (!session) {
+        return { success: false, error: 'Session not found' };
+      }
+
+      if (!session.worktreePath) {
+        return { success: false, error: 'Session has no worktree path' };
+      }
+
+      const ctx = sessionManager.getProjectContext(sessionId);
+      if (!ctx) throw new Error('Project context not found for session');
+
+      const currentBranch = ctx.commandRunner.exec('git branch --show-current', session.worktreePath).trim();
+      if (!currentBranch) {
+        return { success: false, error: 'Cannot create a pull request from a detached HEAD' };
+      }
+
+      const comparisonBranch = await worktreeManager.getSessionComparisonBranch(session, ctx);
+
+      const startMessage = `ðŸ”„ GIT OPERATION\nCreating pull request...`;
+      emitGitOperationToProject(sessionId, 'git:operation_started', startMessage, {
+        operation: 'create-pr',
+        branch: currentBranch,
+        base: comparisonBranch,
+      });
+
+      const result = await worktreeManager.createPullRequest(
+        session.worktreePath,
+        comparisonBranch,
+        currentBranch,
+        ctx.commandRunner,
+      );
+
+      const successMessage = `âœ“ Successfully created pull request` +
+                            (result.url ? `\n\n${result.url}` : '') +
+                            (result.output ? `\n\nGitHub CLI output:\n${result.output}` : '');
+      emitGitOperationToProject(sessionId, 'git:operation_completed', successMessage, {
+        operation: 'create-pr',
+        output: result.output,
+        url: result.url,
+      });
+      sessionManager.addSessionOutput(sessionId, {
+        type: 'stdout',
+        data: successMessage,
+        timestamp: new Date()
+      });
+
+      const project = sessionManager.getProjectForSession(sessionId);
+      if (project?.path) {
+        gitStatusManager.invalidatePrCache(project.path);
+      }
+      await refreshGitStatusForSession(sessionId);
+
+      return { success: true, data: result };
+    } catch (error: unknown) {
+      console.error('Failed to create pull request:', error);
+
+      const gitError = error as GitError;
+      const errorMessage = `âœ— Create PR failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
+                          (gitError.gitOutput ? `\n\nGitHub CLI output:\n${gitError.gitOutput}` : '');
+      emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
+        operation: 'create-pr',
+        error: error instanceof Error ? error.message : String(error),
+        gitOutput: gitError.gitOutput
+      });
+
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to create pull request',
         gitError: {
           output: gitError.gitOutput || (error instanceof Error ? error.message : String(error)),
           workingDirectory: gitError.workingDirectory || ''

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -27,6 +27,7 @@ import type { AgentUsageSnapshot } from '../../shared/types/agentUsage';
 import type { CloudVmState } from '../../shared/types/cloud';
 import type { ResourceSnapshot } from '../../shared/types/resourceMonitor';
 import type { SubmitFeedbackRequest } from '../../shared/types/feedback';
+import type { CreatePullRequestResult } from '../../shared/types/git';
 import type {
   PanePermissionRequest as PermissionRequest,
   PanePermissionResponse as PermissionResponse,
@@ -528,7 +529,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Git pull/push operations
     gitPull: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-pull', sessionId),
     gitPush: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-push', sessionId),
-    createPr: (sessionId: string): Promise<IPCResponse<{ output: string; url?: string }>> =>
+    createPr: (sessionId: string): Promise<IPCResponse<CreatePullRequestResult>> =>
       invokeIpc('sessions:create-pr', sessionId),
     gitFetch: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-fetch', sessionId),
     gitStash: (sessionId: string, message?: string): Promise<IPCResponse> => invokeIpc('sessions:git-stash', sessionId, message),

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -173,7 +173,6 @@ const DAEMON_OWNED_EXACT_CHANNEL_SET = new Set<string>(DAEMON_OWNED_EXACT_CHANNE
 const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
   'file:showInFolder',
   'sessions:open-ide',
-  'sessions:set-active-session',
   'terminal:clipboard-paste-image',
 ]);
 
@@ -529,6 +528,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Git pull/push operations
     gitPull: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-pull', sessionId),
     gitPush: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-push', sessionId),
+    createPr: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:create-pr', sessionId),
     gitFetch: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-fetch', sessionId),
     gitStash: (sessionId: string, message?: string): Promise<IPCResponse> => invokeIpc('sessions:git-stash', sessionId, message),
     gitStashPop: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-stash-pop', sessionId),

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -528,7 +528,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Git pull/push operations
     gitPull: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-pull', sessionId),
     gitPush: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-push', sessionId),
-    createPr: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:create-pr', sessionId),
+    createPr: (sessionId: string): Promise<IPCResponse<{ output: string; url?: string }>> =>
+      invokeIpc('sessions:create-pr', sessionId),
     gitFetch: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-fetch', sessionId),
     gitStash: (sessionId: string, message?: string): Promise<IPCResponse> => invokeIpc('sessions:git-stash', sessionId, message),
     gitStashPop: (sessionId: string): Promise<IPCResponse> => invokeIpc('sessions:git-stash-pop', sessionId),

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -401,6 +401,7 @@ describe('WorktreeManager.getSessionLocalBaseBranch', () => {
 
 describe('WorktreeManager.createPullRequest', () => {
   it('creates a pull request against the normalized base and returns its URL', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
     const runner = commandRunner(async () => ({
       stdout: 'https://github.com/dcouple/Pane/pull/392\n',
       stderr: '',

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -12,8 +12,9 @@ import { worktreePoolManager } from '../worktreePoolManager';
 
 function commandRunner(
   execAsync: (command: string, cwd: string) => Promise<{ stdout: string; stderr: string }>,
+  wslContext: CommandRunner['wslContext'] = null,
 ): CommandRunner {
-  return partialMock<CommandRunner>({ execAsync: vi.fn(execAsync) });
+  return partialMock<CommandRunner>({ execAsync: vi.fn(execAsync), wslContext });
 }
 
 afterEach(() => {
@@ -395,5 +396,65 @@ describe('WorktreeManager.getSessionLocalBaseBranch', () => {
     );
 
     expect(localBaseBranch).toBe('release');
+  });
+});
+
+describe('WorktreeManager.createPullRequest', () => {
+  it('creates a pull request against the normalized base and returns its URL', async () => {
+    const runner = commandRunner(async () => ({
+      stdout: 'https://github.com/dcouple/Pane/pull/392\n',
+      stderr: '',
+    }));
+    const manager = new WorktreeManager();
+
+    await expect(manager.createPullRequest(
+      '/repo/worktrees/pane',
+      'origin/main',
+      'feature/create-pr',
+      runner,
+    )).resolves.toEqual({
+      output: 'https://github.com/dcouple/Pane/pull/392\n',
+      url: 'https://github.com/dcouple/Pane/pull/392',
+    });
+    expect(runner.execAsync).toHaveBeenCalledWith(
+      "gh pr create --fill --base 'main' --head 'feature/create-pr'",
+      '/repo/worktrees/pane',
+      { timeout: 120000 },
+    );
+  });
+
+  it('uses Bash escaping for WSL-backed repositories on Windows', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    const runner = commandRunner(
+      async () => ({ stdout: '', stderr: '' }),
+      { enabled: true, distribution: 'Ubuntu', linuxPath: '/repo' },
+    );
+    const manager = new WorktreeManager();
+
+    await manager.createPullRequest(
+      '/repo/worktrees/pane',
+      'origin/$(touch-base)',
+      '`touch-head`',
+      runner,
+    );
+
+    expect(runner.execAsync).toHaveBeenCalledWith(
+      "gh pr create --fill --base '$(touch-base)' --head '`touch-head`'",
+      '/repo/worktrees/pane',
+      { timeout: 120000 },
+    );
+  });
+
+  it('preserves CLI output and the working directory when creation fails', async () => {
+    const runner = commandRunner(async () => {
+      throw Object.assign(new Error('gh failed'), { stderr: 'authentication required' });
+    });
+    const manager = new WorktreeManager();
+
+    await expect(manager.createPullRequest('/repo', 'main', 'feature', runner)).rejects.toMatchObject({
+      message: 'gh failed',
+      gitOutput: 'authentication required',
+      workingDirectory: '/repo',
+    });
   });
 });

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -1284,6 +1284,38 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
     }
   }
 
+  async createPullRequest(
+    worktreePath: string,
+    baseBranch: string,
+    currentBranch: string,
+    commandRunner: CommandRunner,
+  ): Promise<{ output: string; url?: string }> {
+    try {
+      const normalizedBaseBranch = baseBranch.replace(/^origin\//, '');
+      const command = [
+        'gh pr create',
+        '--fill',
+        `--base ${escapeShellArg(normalizedBaseBranch)}`,
+        `--head ${escapeShellArg(currentBranch)}`,
+      ].join(' ');
+
+      const { stdout, stderr } = await commandRunner.execAsync(command, worktreePath, { timeout: 120000 });
+      const output = stdout || stderr || 'Pull request created successfully';
+      const url = output.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)?.[0];
+
+      return { output, url };
+    } catch (error: unknown) {
+      const err = error as Error & { stderr?: string; stdout?: string };
+      const gitError = new Error(err.message || 'Failed to create pull request') as Error & {
+        gitOutput?: string;
+        workingDirectory?: string;
+      };
+      gitError.gitOutput = err.stderr || err.stdout || err.message || '';
+      gitError.workingDirectory = worktreePath;
+      throw gitError;
+    }
+  }
+
   async gitFetch(worktreePath: string, commandRunner: CommandRunner): Promise<{ output: string }> {
     try {
       const { stdout, stderr } = await commandRunner.execAsync('git fetch --all', worktreePath, { timeout: 30000 });

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -9,6 +9,7 @@ import { CommandRunner } from '../utils/commandRunner';
 import { getGitAttributionEnv } from '../utils/attribution';
 import { worktreePoolManager } from './worktreePoolManager';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+import type { CreatePullRequestResult } from '../../../shared/types/git';
 
 type WorktreeAuditSource = 'session-delete' | 'project-delete' | 'create-cleanup';
 
@@ -1294,7 +1295,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
     baseBranch: string,
     currentBranch: string,
     commandRunner: CommandRunner,
-  ): Promise<{ output: string; url?: string }> {
+  ): Promise<CreatePullRequestResult> {
     try {
       const normalizedBaseBranch = baseBranch.replace(/^origin\//, '');
       const command = [

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -1310,11 +1310,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return { output, url };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Failed to create pull request') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Failed to create pull request');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -1,6 +1,7 @@
 import { mkdir } from 'fs/promises';
 import { withLock } from '../utils/mutex';
 import { escapeShellArg } from '../utils/shellEscape';
+import { escapeForBash } from '../utils/wslUtils';
 import type { ConfigManager } from './configManager';
 import type { AnalyticsManager } from './analyticsManager';
 import { PathResolver } from '../utils/pathResolver';
@@ -56,6 +57,10 @@ class GitOperationError extends Error {
   workingDirectory?: string;
   projectPath?: string;
   originalError?: { message?: string; stderr?: string; stdout?: string };
+}
+
+function escapeCommandArg(arg: string, commandRunner: CommandRunner): string {
+  return commandRunner.wslContext ? escapeForBash(arg) : escapeShellArg(arg);
 }
 
 // Interface for raw commit data
@@ -1295,8 +1300,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
       const command = [
         'gh pr create',
         '--fill',
-        `--base ${escapeShellArg(normalizedBaseBranch)}`,
-        `--head ${escapeShellArg(currentBranch)}`,
+        `--base ${escapeCommandArg(normalizedBaseBranch, commandRunner)}`,
+        `--head ${escapeCommandArg(currentBranch, commandRunner)}`,
       ].join(' ');
 
       const { stdout, stderr } = await commandRunner.execAsync(command, worktreePath, { timeout: 120000 });

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -1,0 +1,4 @@
+export interface CreatePullRequestResult {
+  output: string;
+  url?: string;
+}

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -232,6 +232,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     const preferenceWrites: Array<{ key: string; value: string }> = [];
     const sessionDeleteCalls: string[] = [];
     const sessionFavoriteToggleCalls: string[] = [];
+    const sessionCreatePrCalls: string[] = [];
     let sessionsGetCount = 0;
 
     const subscribe = (channel: string, callback: MockEventCallback) => {
@@ -561,6 +562,13 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         stopActive: () => success(),
       }),
       sessions: namespace({
+        createPr: (sessionId: string) => {
+          sessionCreatePrCalls.push(sessionId);
+          return success({
+            output: 'https://github.com/dcouple/Pane/pull/392\n',
+            url: 'https://github.com/dcouple/Pane/pull/392',
+          });
+        },
         getOrCreateMainRepoSession: async (projectId: number) => {
           const delayMs = mockOptions.mainRepoSessionDelayByProjectId?.[projectId] ?? 0;
           if (delayMs > 0) await new Promise(resolve => setTimeout(resolve, delayMs));
@@ -882,6 +890,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         getSessionFavoriteToggleCalls() {
           return clone(sessionFavoriteToggleCalls);
+        },
+        getSessionCreatePrCalls() {
+          return clone(sessionCreatePrCalls);
         },
       },
     });

--- a/tests/review-availability.spec.ts
+++ b/tests/review-availability.spec.ts
@@ -316,6 +316,69 @@ test('Review stays local until a newly discovered pull request is explicitly ope
   await expect(splitMode).toHaveClass(/bg-interactive/);
 });
 
+test('PR action requires pushed commits and opens the created pull request', async ({ page }, testInfo) => {
+  await openSession(page, baseGitStatus, {
+    initialPanels: [
+      ...panels,
+      {
+        id: 'review-logs-pr-action',
+        sessionId: 'review-session',
+        type: 'logs',
+        title: 'Logs',
+        state: { isActive: false, hasBeenViewed: true, customState: { isRunning: false } },
+        metadata: { createdAt: new Date(0).toISOString(), lastActiveAt: new Date(0).toISOString(), position: 3 },
+      },
+    ],
+  });
+
+  await page.getByRole('tab', { name: 'Logs', exact: true }).click();
+  await page.getByRole('button', { name: 'Show details', exact: true }).click();
+  const createPrButton = page.getByRole('button', { name: 'PR', exact: true });
+  await expect(createPrButton).toBeVisible();
+  await expect(createPrButton).toBeDisabled();
+  const detailPanel = page.locator('.pane-detail-panel-vertical');
+  const disabledPath = testInfo.outputPath('04-create-pr-unpushed-disabled.png');
+  await detailPanel.screenshot({ path: disabledPath });
+  await testInfo.attach('04-create-pr-unpushed-disabled.png', { path: disabledPath, contentType: 'image/png' });
+
+  await page.evaluate((gitStatus) => {
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+    const mock = (window as typeof window & {
+      __paneTestElectronMock: {
+        emitGitStatusUpdated: (sessionId: string, status: JsonObject) => void;
+      };
+    }).__paneTestElectronMock;
+    mock.emitGitStatusUpdated('review-session', gitStatus);
+  }, {
+    ...baseGitStatus,
+    ahead: 0,
+  });
+
+  await expect(createPrButton).toBeEnabled();
+  await createPrButton.hover();
+  await expect(page.getByRole('tooltip')).toContainText('Create a pull request from');
+  await createPrButton.click();
+
+  const result = await page.evaluate(() => {
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+    const mock = (window as typeof window & {
+      __paneTestElectronMock: {
+        getSessionCreatePrCalls: () => string[];
+        getOpenedExternalUrls: () => string[];
+      };
+    }).__paneTestElectronMock;
+    return {
+      calls: mock.getSessionCreatePrCalls(),
+      openedUrls: mock.getOpenedExternalUrls(),
+    };
+  });
+  expect(result.calls).toEqual(['review-session']);
+  expect(result.openedUrls).toEqual(['https://github.com/dcouple/Pane/pull/392']);
+  const readyPath = testInfo.outputPath('05-create-pr-ready.png');
+  await detailPanel.screenshot({ path: readyPath });
+  await testInfo.attach('05-create-pr-ready.png', { path: readyPath, contentType: 'image/png' });
+});
+
 test('Review shows a clean local empty state before a pull request exists', async ({ page }) => {
   await openSession(page, baseGitStatus, { withLocalChanges: false });
 


### PR DESCRIPTION
## Description

Adds a PR action to worktree pane git controls. The action creates a GitHub pull request with `gh pr create --fill`, refreshes PR status, and opens the created PR URL. Also fixes a daemon IPC channel ownership mismatch for `sessions:set-active-session`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified

- [x] State management/IPC events

<!-- pr-test-automation-summary:start -->
## Automated QA

Status: Passed at `8bed17ba`.

- PR action is disabled while the branch has an unpushed commit.
- After a git-status refresh reports no unpushed commits, PR becomes enabled.
- Clicking PR invokes the active session's create-PR IPC and opens the returned GitHub URL.
- Full lint and typecheck pass; focused main tests pass 29/29; focused Playwright UI test passes 1/1.

Real GitHub PR creation was intentionally not executed against an external repository. Parsa may optionally verify that mutation with a disposable branch before merge.
<!-- pr-test-automation-summary:end -->

