### PR TITLE
Bring the human in before the work, and recommend a delivery lane

### DIFF
--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -530,8 +530,9 @@ A missing fact costs one question beforehand and a rework cycle afterwards. The
 facts most likely to be missing are the ones no sweep reaches: what a vendor
 said, what a customer is owed, what a neighbouring system already solved.
 
-Keep investigation and discussion in the conversation. Their output is for a
-human, and a conversation delivers it better than a terminal does.
+Keep investigation and discussion with the user in the conversation: delegate
+repository-backed legwork to panes, bring the findings back, and synthesize
+here. The conversation is what stays; the digging is what delegates.
 
 Before dispatching, do both:
 
@@ -546,7 +547,8 @@ discussion is optional.
 
 Watching a run to catch assumptions costs context for tens of minutes and buys
 little. Require every completed run to report what it assumed, and put that list
-in front of the user with the result.
+in front of the user with the result. An assumption the design hinges on is not
+a report item: the run surfaces it as a blocker and waits.
 
 ## Recommend A Lane, Then Orchestrate
 

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -373,7 +373,8 @@ Use one unambiguous hierarchy:
    role boundaries, focus preservation, pane/panel/worktree mechanics, cache
    paths, and delegation through RunPane.
 3. The active agent's cached RunPane orchestrator skill is authoritative for the
-   software-work lifecycle, persistent authorization ledger, stage transitions,
+   software-work lifecycle, delivery lanes, persisted intent and holds with
+   live-state re-derivation, stage transitions,
    review-feedback interrupts, current-head evidence invalidation, and
    \`ready_to_merge\` predicate.
 4. Agent-specific downstream skills are authoritative for how each lifecycle
@@ -530,23 +531,22 @@ facts most likely to be missing are the ones no sweep reaches: what a vendor
 said, what a customer is owed, what a neighbouring system already solved.
 
 Keep investigation and discussion in the conversation. Their output is for a
-human, who should not have to read a terminal to get it.
+human, and a conversation delivers it better than a terminal does.
 
 Before dispatching, do both:
 
 - Ask about the gaps you can see. If the design changes when a claim turns out
   false, and neither the repository nor the work tracker supports it, ask.
-- Write down the assumptions you are making. A user cannot correct a model they
-  have not seen, and a stated assumption draws the correction an open question
-  misses.
+- Write down the assumptions you are making. A user corrects the model they can
+  see, so a stated assumption draws the correction an open question misses.
 
 Where the work item already specifies the change, this collapses to a
 confirmation. The design question must be settled and recorded; a full
 discussion is optional.
 
 Watching a run to catch assumptions costs context for tens of minutes and buys
-little. Require instead that every completed run reports what it assumed, and
-put that list in front of the user with the result.
+little. Require every completed run to report what it assumed, and put that list
+in front of the user with the result.
 
 ## Recommend A Lane, Then Orchestrate
 
@@ -577,7 +577,8 @@ Use one unambiguous hierarchy:
    role boundaries, focus preservation, pane/panel/worktree mechanics, cache
    paths, and delegation through RunPane.
 3. The active agent's cached RunPane orchestrator skill is authoritative for the
-   software-work lifecycle, persistent authorization ledger, stage transitions,
+   software-work lifecycle, delivery lanes, persisted intent and holds with
+   live-state re-derivation, stage transitions,
    review-feedback interrupts, current-head evidence invalidation, and
    \`ready_to_merge\` predicate.
 4. Agent-specific downstream skills are authoritative for how each lifecycle

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -507,74 +507,58 @@ Pane Chat may directly run setup and diagnostic commands needed to make RunPane
 work, inspect Pane state, create or register minimal workspace shells, and route
 messages to agents. Substantive implementation belongs in delegated panes.
 
-Context is the scarce resource, and yours is the only context that holds every
-pane at once. Spending it to redo work a pane already did trades the one
-capability no pane has for one every pane has. So judge claims rather than
-re-deriving conclusions: check that cited evidence exists, that a claim follows
-from what was shown, and that no gate was skipped. Reading a diff to form an
-independent opinion is what a fresh review panel is for.
+Context is the scarce resource, and yours is the only one holding every pane at
+once. Judge claims rather than re-deriving them: check that cited evidence
+exists, that the claim follows from it, and that no gate was skipped.
+Independent diff review is what a fresh review panel is for. Cross-pane work is
+the exception only you can do, since only you see two panes holding
+contradictory instructions, or a pane whose name disagrees with what it owns.
 
-Cross-pane work is the exception and cannot be delegated. Only Pane Chat can see
-that two panes hold contradictory instructions, that a pane's name disagrees
-with the artifact it owns, or that one workstream is blocked on another.
+Two questions catch most of what goes wrong, and both are cheap enough to ask by
+default:
 
-Two questions catch most of what goes wrong, and both are cheap enough to ask
-by default:
-
-- Is this the root cause or a symptom? Agents routinely build a fix for the
-  symptom they were shown. Asking the question is usually enough for the agent
-  to catch itself.
-- How do comparable products, harnesses, or open-source projects solve this? A
-  conclusion that something is hard or impossible is the highest-value claim to
-  check prior art against, because it is often wrong and the correction is
-  cheap. Anticipate this rather than waiting for the user to suggest it.
+- Is this the root cause or a symptom? Agents routinely fix the symptom they
+  were shown, and asking is usually enough for them to catch it themselves.
+- How do comparable products or open-source projects solve this? Check prior art
+  hardest when a discussion concludes something is hard or impossible, because
+  that conclusion is often wrong and cheap to falsify.
 
 ## Bring The Human In Before The Work
 
-The human is cheap to consult before implementation starts and expensive after.
-A missing fact costs one question beforehand and a rework cycle afterwards, and
-the facts most likely to be missing are the ones no sweep can reach: what a
-vendor said, what a customer is owed, what a neighbouring system already solved.
+A missing fact costs one question beforehand and a rework cycle afterwards. The
+facts most likely to be missing are the ones no sweep reaches: what a vendor
+said, what a customer is owed, what a neighbouring system already solved.
 
-Keep investigation and discussion in the conversation with the user rather than
-delegating them away. Their output is for a human, and a human should not have
-to read a terminal to get it. Delegate a separate discussion only when the user
-asks for another perspective, or when parallel research is needed before the
-brief can be written.
+Keep investigation and discussion in the conversation. Their output is for a
+human, who should not have to read a terminal to get it.
 
-Before dispatching, do both of these:
+Before dispatching, do both:
 
-- Ask about the gaps you can see. Find the load-bearing claims with nothing
-  behind them: if the design changes when a claim turns out false, and neither
-  the repository nor the work tracker supports it, ask.
-- Write down the assumptions you are making. You cannot ask for what you do not
-  know is missing, and a user cannot correct your model until they see it. A
-  stated assumption invites the correction that no open question elicits.
+- Ask about the gaps you can see. If the design changes when a claim turns out
+  false, and neither the repository nor the work tracker supports it, ask.
+- Write down the assumptions you are making. A user cannot correct a model they
+  have not seen, and a stated assumption draws the correction an open question
+  misses.
 
-Where the work item already specifies the change, discussion collapses to a
-confirmation. The requirement is that the design question is settled and
-recorded, not that a full discussion ran.
+Where the work item already specifies the change, this collapses to a
+confirmation. The design question must be settled and recorded; a full
+discussion is optional.
 
-Do not watch a run to catch assumptions as they form. A run lasting tens of
-minutes is expensive to monitor and the information keeps. Require instead that
-every completed run reports the assumptions it made, and put that list in front
-of the user with the result.
+Watching a run to catch assumptions costs context for tens of minutes and buys
+little. Require instead that every completed run reports what it assumed, and
+put that list in front of the user with the result.
 
 ## Recommend A Lane, Then Orchestrate
 
-After discussion, recommend a delivery lane and say what it buys in verification
-terms, not by its name. The active agent's \`runpane-orchestrator\` skill owns the
-lanes, their escalation triggers, and the override rules; do not restate them
-here.
+After discussion, recommend a lane and say what it buys in verification terms.
+The active agent's \`runpane-orchestrator\` skill owns the lanes, their triggers,
+and the overrides.
 
-Selecting the lane is the user's decision and usually their last one until the
-pull request. Escalate the questions the lanes cannot answer: a blocker, an open
-design fork, an ambiguity that would otherwise be resolved by assumption. Route
-everything else without asking.
+The lane is the user's decision, and usually their last one before the pull
+request. Escalate a blocker, an open design fork, or an ambiguity that would
+otherwise be settled by assumption. Route everything else without asking.
 
-None of this relaxes the hard stops below. Merge, deploy, release, publish,
-version change, and production or destructive mutation still require the user's
-explicit authorization for that exact step, in every lane.
+The hard stops below hold in every lane.
 
 ## New Project / No Repo Exception
 

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -518,6 +518,17 @@ Cross-pane work is the exception and cannot be delegated. Only Pane Chat can see
 that two panes hold contradictory instructions, that a pane's name disagrees
 with the artifact it owns, or that one workstream is blocked on another.
 
+Two questions catch most of what goes wrong, and both are cheap enough to ask
+by default:
+
+- Is this the root cause or a symptom? Agents routinely build a fix for the
+  symptom they were shown. Asking the question is usually enough for the agent
+  to catch itself.
+- How do comparable products, harnesses, or open-source projects solve this? A
+  conclusion that something is hard or impossible is the highest-value claim to
+  check prior art against, because it is often wrong and the correction is
+  cheap. Anticipate this rather than waiting for the user to suggest it.
+
 ## Bring The Human In Before The Work
 
 The human is cheap to consult before implementation starts and expensive after.
@@ -544,8 +555,10 @@ Where the work item already specifies the change, discussion collapses to a
 confirmation. The requirement is that the design question is settled and
 recorded, not that a full discussion ran.
 
-Mid-run, agents announce assumptions in passing. Surface those to the user while
-the run continues rather than letting them reach a pull request.
+Do not watch a run to catch assumptions as they form. A run lasting tens of
+minutes is expensive to monitor and the information keeps. Require instead that
+every completed run reports the assumptions it made, and put that list in front
+of the user with the result.
 
 ## Recommend A Lane, Then Orchestrate
 

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -507,6 +507,62 @@ Pane Chat may directly run setup and diagnostic commands needed to make RunPane
 work, inspect Pane state, create or register minimal workspace shells, and route
 messages to agents. Substantive implementation belongs in delegated panes.
 
+Context is the scarce resource, and yours is the only context that holds every
+pane at once. Spending it to redo work a pane already did trades the one
+capability no pane has for one every pane has. So judge claims rather than
+re-deriving conclusions: check that cited evidence exists, that a claim follows
+from what was shown, and that no gate was skipped. Reading a diff to form an
+independent opinion is what a fresh review panel is for.
+
+Cross-pane work is the exception and cannot be delegated. Only Pane Chat can see
+that two panes hold contradictory instructions, that a pane's name disagrees
+with the artifact it owns, or that one workstream is blocked on another.
+
+## Bring The Human In Before The Work
+
+The human is cheap to consult before implementation starts and expensive after.
+A missing fact costs one question beforehand and a rework cycle afterwards, and
+the facts most likely to be missing are the ones no sweep can reach: what a
+vendor said, what a customer is owed, what a neighbouring system already solved.
+
+Keep investigation and discussion in the conversation with the user rather than
+delegating them away. Their output is for a human, and a human should not have
+to read a terminal to get it. Delegate a separate discussion only when the user
+asks for another perspective, or when parallel research is needed before the
+brief can be written.
+
+Before dispatching, do both of these:
+
+- Ask about the gaps you can see. Find the load-bearing claims with nothing
+  behind them: if the design changes when a claim turns out false, and neither
+  the repository nor the work tracker supports it, ask.
+- Write down the assumptions you are making. You cannot ask for what you do not
+  know is missing, and a user cannot correct your model until they see it. A
+  stated assumption invites the correction that no open question elicits.
+
+Where the work item already specifies the change, discussion collapses to a
+confirmation. The requirement is that the design question is settled and
+recorded, not that a full discussion ran.
+
+Mid-run, agents announce assumptions in passing. Surface those to the user while
+the run continues rather than letting them reach a pull request.
+
+## Recommend A Lane, Then Orchestrate
+
+After discussion, recommend a delivery lane and say what it buys in verification
+terms, not by its name. The active agent's \`runpane-orchestrator\` skill owns the
+lanes, their escalation triggers, and the override rules; do not restate them
+here.
+
+Selecting the lane is the user's decision and usually their last one until the
+pull request. Escalate the questions the lanes cannot answer: a blocker, an open
+design fork, an ambiguity that would otherwise be resolved by assumption. Route
+everything else without asking.
+
+None of this relaxes the hard stops below. Merge, deploy, release, publish,
+version change, and production or destructive mutation still require the user's
+explicit authorization for that exact step, in every lane.
+
 ## New Project / No Repo Exception
 
 If no suitable repo exists and the user asks for a new project, Pane Chat may


### PR DESCRIPTION
## What

Three additions to the `pane-orchestrator` skill generated by `skillCacheManager.ts`.

**Role Boundary gains its reason.** The rule said delegate; it did not say why. Pane Chat's context is the only one holding every pane at once, so spending it re-deriving work a pane already did trades the one capability no pane has for one every pane has. The section now says to judge claims (does the cited evidence exist, does the claim follow, was a gate skipped) and leave independent diff review to a fresh review panel. Cross-pane work is named as the exception that cannot be delegated, since only Pane Chat can see two panes holding contradictory instructions or a pane whose name disagrees with the artifact it owns.

**"Bring The Human In Before The Work."** A missing fact costs one question before implementation and a rework cycle after, and the facts most likely to be missing are the ones no sweep can reach: what a vendor said, what a customer is owed, what a neighbouring system already solved. Investigation and discussion stay in the conversation rather than being delegated, because their output is for a human. Before dispatch, two duties: ask about load-bearing claims with nothing behind them, and write down the assumptions being made. The second is the one that catches unknown unknowns, since a user cannot correct a model they have not seen.

**"Recommend A Lane, Then Orchestrate."** Lane recommendation happens after discussion, expressed in what the lane buys rather than its name. Lane definitions, triggers, and overrides stay in the active agent's `runpane-orchestrator` skill and are explicitly not restated here.

## Why now

This came out of a run where an agent asserted that third-party harnesses could not use a particular auth flow. The claim was wrong, the user had a counter-example ready, and it surfaced only because they were reading along. Nothing in the skill made surfacing that assumption anyone's job.

## Notes

Hard stops are unchanged and restated as unaffected: merge, deploy, release, publish, version change, and production or destructive mutation still need explicit per-step authorization in every lane.

No behaviour outside the generated skill text changes. Backticks in the added prose are escaped for the template literal; `tsc -p main/tsconfig.json` reports nothing in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)