### PR TITLE
Pane Chat sends the root-cause probe at convergence and dispatches fresh-eyes on human deliverables

### DIFF
--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -519,10 +519,21 @@ Two questions catch most of what goes wrong, and both are cheap enough to ask by
 default:
 
 - Is this the root cause or a symptom? Agents routinely fix the symptom they
-  were shown, and asking is usually enough for them to catch it themselves.
+  were shown, and asking is usually enough for them to catch it themselves. Do
+  not just hold this question: when a delegated discussion or investigation
+  converges, send it to that agent verbatim — "is this addressing the root
+  cause or a symptom? dig deep" — before accepting the design or recommending
+  a lane. A premise-changing answer reopens the discussion.
 - How do comparable products or open-source projects solve this? Check prior art
   hardest when a discussion concludes something is hard or impossible, because
   that conclusion is often wrong and cheap to falsify.
+
+Deliverables addressed to a person get a third standing move. When a pane
+completes something a human will read — a pull request body, a brief, a docs
+page, a report — have it run the cached \`fresh-eyes\` skill before handoff: a
+zero-context recipient review, repeated by a fresh-context agent until a pass
+changes nothing. The producing agent cannot review its own work with fresh
+eyes, which is also why the repeat is delegated, never skipped.
 
 ## Bring The Human In Before The Work
 


### PR DESCRIPTION
## Summary

Codifies two of parsa's standing manual moves into the generated pane-orchestrator skill (`skillCacheManager.ts`), so Pane Chat performs them autonomously:

1. **Root-cause probe becomes an action.** The skill already listed "is this the root cause or a symptom?" as a standing question the orchestrator asks itself. Now, when a delegated discussion or investigation converges, Pane Chat sends the probe to that agent **verbatim** — "is this addressing the root cause or a symptom? dig deep" — before accepting the design or recommending a lane. A premise-changing answer reopens the discussion. The open-ended phrasing is deliberate: it invites the agent to overturn the premise, not annotate it.
2. **Fresh-eyes dispatch on human-facing deliverables.** When a pane completes something a person will read (PR body, brief, docs page, report), Pane Chat has it run the cached `fresh-eyes` skill before handoff: a zero-context, groggy-Monday-morning recipient review, repeated by a fresh-context agent until a pass changes nothing. The producing agent cannot review its own work with fresh eyes — which is also why the repeat is delegated, never skipped.

## Companion

The `fresh-eyes` skill itself lands in dcouple/skills#70 (both variants), alongside pointer lines in `prepare-pr` and the `runpane-orchestrator` lane doctrine. This PR is safe to merge in either order — the reference is to the cached skill by name.

## Notes

- Text-only change inside the generated-skill template literal; backtick escaping verified balanced against main.
- One paragraph and one expanded bullet; no structural changes to the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
