### PR TITLE
Celebrate Pane contributors in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@
 
 <br />
 
+**Made possible by our amazing contributors**
+
+<a href="https://github.com/dcouple/Pane/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=dcouple/Pane" alt="Pane contributors">
+</a>
+
+<sub><a href="./CONTRIBUTING.md">Join them</a> and help make Pane better.</sub>
+
+<br />
+<br />
+
 **Quick install (recommended)**
 
 <sub>Mac / Linux</sub><br />


### PR DESCRIPTION
## Summary

- add an auto-updating contributor avatar roster above Quick Install
- link the roster to the full GitHub contributors graph
- invite new contributors through the existing contributing guide

## Why

Pane has been getting thoughtful contributions from the community. The README should celebrate those people prominently and keep the roster current automatically.

## Validation

- pnpm typecheck
- pnpm lint (passes with 164 existing warnings)
- git diff --check
- verified the contrib.rocks endpoint returns an SVG