### PR TITLE
Expand main checkout sidebar actions

### DIFF
--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -16,11 +16,6 @@ interface DetailPanelProps {
   height?: number;
   onResize: (e: React.MouseEvent) => void;
   mergeError?: string | null;
-  projectGitActions?: {
-    onPull?: () => void;
-    onPush?: () => void;
-    isMerging?: boolean;
-  };
   orientation?: 'vertical' | 'horizontal';
   isCollapsed?: boolean;
   onToggleCollapse?: () => void;
@@ -75,7 +70,7 @@ function actionTooltip(action: { description?: string; disabled?: boolean; disab
   );
 }
 
-export function DetailPanel({ isVisible, width, height, onResize, mergeError, projectGitActions, orientation, isCollapsed, onToggleCollapse, onSwapLayout, terminalShortcuts, onCommitClick }: DetailPanelProps) {
+export function DetailPanel({ isVisible, width, height, onResize, mergeError, orientation, isCollapsed, onToggleCollapse, onSwapLayout, terminalShortcuts, onCommitClick }: DetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(s => s.immersiveMode);
   const remoteIdeTooltip = 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.';
@@ -297,8 +292,8 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
           )}
         </div>
 
-        {/* Changes — worktree sessions only */}
-        {!isProject && gitStatus && (
+        {/* Changes for the checkout represented by this session */}
+        {gitStatus && (
           <DetailSection title="Changes">
             <div className="space-y-1 text-sm px-1">
               {gitStatus.ahead != null && gitStatus.ahead > 0 && (
@@ -329,7 +324,7 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
         )}
 
         {/* Branch actions */}
-        {((!isProject && (onSetTracking || onOpenIDEWithCommand)) || (isProject && onOpenIDEWithCommand)) && (
+        {(onSetTracking || onOpenIDEWithCommand) && (
           <DetailSection title="Branch">
             <div className="space-y-0.5">
               {!gitUnavailable && onSetTracking && (
@@ -366,13 +361,13 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
                       </Button>
                     }
                     items={ideItems}
-                    footer={
+                    footer={onConfigureIDE ? (
                       <DropdownMenuItem
                         icon={Settings}
                         label="Configure..."
                         onClick={onConfigureIDE}
                       />
-                    }
+                    ) : undefined}
                     position="auto"
                     width="sm"
                   />
@@ -404,8 +399,8 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
         ) : (
         <DetailSection title="Actions">
           <div className="space-y-0.5">
-            {/* Worktree actions — ordered by workflow */}
-            {!isProject && (() => {
+            {/* Checkout actions — callers provide only actions valid for this checkout */}
+            {(() => {
               const byId = (id: string) => gitBranchActions?.find(a => a.id === id);
               const behindCount = gitStatus?.behind ?? 0;
               const aheadCount = gitStatus?.ahead ?? 0;
@@ -544,21 +539,6 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, pr
               });
             })()}
 
-            {/* Project: Pull/Push */}
-            {isProject && projectGitActions && (
-              <>
-                {projectGitActions.onPull && (
-                  <Button variant="ghost" size="sm" className={sidebarBtn} onClick={projectGitActions.onPull} disabled={projectGitActions.isMerging}>
-                    Pull
-                  </Button>
-                )}
-                {projectGitActions.onPush && (
-                  <Button variant="ghost" size="sm" className={sidebarBtn} onClick={projectGitActions.onPush} disabled={projectGitActions.isMerging}>
-                    Push
-                  </Button>
-                )}
-              </>
-            )}
           </div>
         </DetailSection>
         )}

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -1,20 +1,20 @@
 import React, { useMemo } from 'react';
+import { AlertTriangle, ArrowLeftRight, Code2, GitBranch, Link, Settings, TerminalSquare } from 'lucide-react';
 import { useSession } from '../contexts/SessionContext';
 import { useNavigationStore } from '../stores/navigationStore';
-import { GitBranch, AlertTriangle, Code2, Settings, Link, TerminalSquare, ChevronUp, ChevronDown, ArrowLeftRight } from 'lucide-react';
-import { Button } from './ui/Button';
-import { Tooltip } from './ui/Tooltip';
-import { Dropdown, DropdownMenuItem } from './ui/Dropdown';
+import { DetailPanelGitActions } from './DetailPanelGitActions';
 import { GitHistoryGraph } from './GitHistoryGraph';
-import { Kbd } from './ui/Kbd';
-import { formatKeyDisplay } from '../utils/hotkeyUtils';
+import { HorizontalDetailPanel } from './HorizontalDetailPanel';
+import { Button } from './ui/Button';
+import { Dropdown, DropdownMenuItem } from './ui/Dropdown';
+import { Tooltip } from './ui/Tooltip';
 
 interface DetailPanelProps {
   isVisible: boolean;
   onToggle: () => void;
   width: number;
   height?: number;
-  onResize: (e: React.MouseEvent) => void;
+  onResize: (event: React.MouseEvent) => void;
   mergeError?: string | null;
   orientation?: 'vertical' | 'horizontal';
   isCollapsed?: boolean;
@@ -24,24 +24,11 @@ interface DetailPanelProps {
   onCommitClick?: (hash: string) => void;
 }
 
-/** Consistent compact button class for sidebar actions */
-const sidebarBtn = 'w-full justify-start text-sm !px-2';
-
-function formatTimeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
+const sidebarButtonClass = 'w-full justify-start text-sm !px-2';
+const remoteIdeTooltip = 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.';
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <h3 className="text-xs uppercase text-text-tertiary font-medium mb-2 px-1">{children}</h3>
-  );
+  return <h3 className="text-xs uppercase text-text-tertiary font-medium mb-2 px-1">{children}</h3>;
 }
 
 function DetailSection({ title, children }: { title: string; children: React.ReactNode }) {
@@ -53,300 +40,149 @@ function DetailSection({ title, children }: { title: string; children: React.Rea
   );
 }
 
-function actionTooltip(action: { description?: string; disabled?: boolean; disabledReason?: string; shortcut?: string }, disabled = action.disabled): React.ReactNode {
-  const message = disabled ? action.disabledReason ?? action.description : action.description;
-  return (
-    <div className="space-y-1">
-      {message && (
-        <div>{disabled ? `Unavailable: ${message}` : message}</div>
-      )}
-      {action.shortcut && (
-        <div className="flex items-center gap-2 text-text-tertiary">
-          <span>Shortcut</span>
-          <Kbd size="xs" variant="muted">{formatKeyDisplay(action.shortcut)}</Kbd>
-        </div>
-      )}
-    </div>
-  );
-}
-
-export function DetailPanel({ isVisible, width, height, onResize, mergeError, orientation, isCollapsed, onToggleCollapse, onSwapLayout, terminalShortcuts, onCommitClick }: DetailPanelProps) {
+export function DetailPanel({
+  isVisible,
+  width,
+  height,
+  onResize,
+  mergeError,
+  orientation,
+  isCollapsed,
+  onToggleCollapse,
+  onSwapLayout,
+  terminalShortcuts,
+  onCommitClick,
+}: DetailPanelProps) {
   const sessionContext = useSession();
-  const immersiveMode = useNavigationStore(s => s.immersiveMode);
-  const remoteIdeTooltip = 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.';
-
-  // Build IDE dropdown items, sending safe IDE keys (resolved to commands server-side)
+  const immersiveMode = useNavigationStore(state => state.immersiveMode);
   const ideItems = useMemo(() => {
     if (!sessionContext?.onOpenIDEWithCommand) return [];
     const handler = sessionContext.onOpenIDEWithCommand;
     const configured = sessionContext.configuredIDECommand?.trim();
-    const knownCommands = ['code .', 'cursor .'];
-    const isCustom = configured && !knownCommands.includes(configured);
-    const items = isCustom
-      ? [{ id: 'configured', label: configured, description: 'Project default', icon: TerminalSquare, onClick: () => handler() }]
-      : [];
+    const isCustom = configured && !['code .', 'cursor .'].includes(configured);
     return [
-      ...items,
+      ...(isCustom
+        ? [{ id: 'configured', label: configured, description: 'Project default', icon: TerminalSquare, onClick: () => handler() }]
+        : []),
       { id: 'vscode', label: 'VS Code', description: 'code .', icon: Code2, onClick: () => handler('vscode') },
       { id: 'cursor', label: 'Cursor', description: 'cursor .', icon: Code2, onClick: () => handler('cursor') },
     ];
-  }, [sessionContext?.onOpenIDEWithCommand, sessionContext?.configuredIDECommand]);
+  }, [sessionContext?.configuredIDECommand, sessionContext?.onOpenIDEWithCommand]);
 
   if (!sessionContext) return null;
-
-  const { session, gitBranchActions, isMerging, gitCommands, onOpenIDEWithCommand, onConfigureIDE, onSetTracking, trackingBranch, isRemoteMode } = sessionContext;
-  const gitStatus = session.gitStatus;
-  const isProject = !!session.isMainRepo;
-  // Treat git as unavailable only when status has loaded but indicates failure.
-  // gitStatus is undefined while still loading — don't hide UI in that window.
-  // state === 'unknown' means the git status fetch completed but git commands failed;
-  // if it's a transient failure, the next poll cycle will recover and update the state.
-  const gitUnavailable = isProject && gitStatus?.state === 'unknown';
-
-  // Horizontal bottom-bar rendering mode
   if (orientation === 'horizontal') {
     return (
-      <div
-        className={`pane-detail-panel pane-detail-panel-horizontal flex-shrink-0 bg-surface-primary flex flex-col overflow-hidden relative transition-[height] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${immersiveMode ? '' : 'border-t border-border-primary'}`}
-        style={{ height: immersiveMode ? '0px' : isCollapsed ? 'auto' : `${height ?? 200}px` }}
-      >
-        {/* Resize handle at top edge */}
-        {!isCollapsed && (
-          <div
-            className="absolute top-0 left-0 right-0 h-1 cursor-row-resize group z-10"
-            onMouseDown={onResize}
-          >
-            <div className="absolute -top-2 bottom-0 left-0 right-0" />
-          </div>
-        )}
-
-        <div className="pane-detail-panel-inner flex flex-col h-full min-h-0">
-          {/* Header row: wrapping content + pinned swap button */}
-          <div className="flex items-start flex-shrink-0">
-          <div className="flex items-center flex-wrap flex-1 min-w-0 min-h-[32px] px-3 gap-x-2 gap-y-1 py-1">
-          {/* Collapse toggle */}
-          <button
-            onClick={onToggleCollapse}
-            className="p-0.5 hover:bg-surface-hover rounded transition-colors"
-            title={isCollapsed ? 'Expand detail panel' : 'Collapse detail panel'}
-          >
-            {isCollapsed ? (
-              <ChevronUp className="w-3.5 h-3.5 text-text-tertiary" />
-            ) : (
-              <ChevronDown className="w-3.5 h-3.5 text-text-tertiary" />
-            )}
-          </button>
-
-          {/* Branch icon + name */}
-          <GitBranch className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
-          <span className="text-sm text-text-primary font-medium truncate max-w-[150px]">
-            {(gitCommands?.currentBranch?.trim()) || session.baseBranch?.replace(/^origin\//, '') || 'unknown'}
-          </span>
-
-          {/* Inline change badges */}
-          {!isProject && gitStatus && (
-            <div className="flex items-center gap-2 flex-shrink-0">
-              {gitStatus.ahead != null && gitStatus.ahead > 0 && (
-                <span className="text-[10px] text-status-success font-medium">&uarr;{gitStatus.ahead}</span>
-              )}
-              {gitStatus.behind != null && gitStatus.behind > 0 && (
-                <span className="text-[10px] text-status-warning font-medium">&darr;{gitStatus.behind}</span>
-              )}
-              {gitStatus.hasUncommittedChanges && gitStatus.filesChanged != null && gitStatus.filesChanged > 0 && (
-                <span className="text-[10px] text-status-info font-medium">{gitStatus.filesChanged} files</span>
-              )}
-            </div>
-          )}
-
-          {/* Merge error indicator */}
-          {mergeError && (
-            <Tooltip content={mergeError} side="top">
-              <AlertTriangle className="w-3.5 h-3.5 text-status-error flex-shrink-0" />
-            </Tooltip>
-          )}
-
-          {/* Action buttons — icon-only, labels in tooltips */}
-          {!gitUnavailable && !isProject && gitBranchActions?.map(action => (
-            <Tooltip key={action.id} content={action.label + (action.description ? ` — ${action.description}` : '')} side="top">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0"
-                onClick={action.onClick}
-                disabled={action.disabled || isMerging}
-              >
-                <action.icon className="w-3 h-3" />
-              </Button>
-            </Tooltip>
-          ))}
-
-          {/* IDE button */}
-          {onOpenIDEWithCommand && (
-            isRemoteMode ? (
-              <Tooltip content={remoteIdeTooltip} side="top">
-                <span>
-                  <Button variant="ghost" size="sm" className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0" disabled>
-                    <Code2 className="w-3 h-3" />
-                  </Button>
-                </span>
-              </Tooltip>
-            ) : (
-              <Dropdown
-                trigger={
-                  <Tooltip content="Open in IDE" side="top">
-                    <Button variant="ghost" size="sm" className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0">
-                      <Code2 className="w-3 h-3" />
-                    </Button>
-                  </Tooltip>
-                }
-                items={ideItems}
-                footer={
-                  <DropdownMenuItem
-                    icon={Settings}
-                    label="Configure..."
-                    onClick={onConfigureIDE}
-                  />
-                }
-                position="auto"
-                width="sm"
-              />
-            )
-          )}
-
-          {/* Terminal shortcut pills — inline with git actions */}
-          {terminalShortcuts}
-          </div>
-
-          {/* Swap button — pinned right */}
-          {onSwapLayout && (
-            <Tooltip content="Swap terminal and detail panel positions" side="top">
-              <button
-                type="button"
-                aria-label="Swap terminal and detail panel positions"
-                onClick={onSwapLayout}
-                className="p-1 hover:bg-surface-hover rounded transition-colors flex-shrink-0 mr-2 mt-1"
-              >
-                <ArrowLeftRight aria-hidden="true" className="w-3.5 h-3.5 text-text-tertiary" />
-              </button>
-            </Tooltip>
-          )}
-          </div>
-
-          {/* Expandable content: history */}
-          {!isCollapsed && !gitUnavailable && session.worktreePath && (
-            <div className="flex-1 min-h-0 overflow-y-auto px-2 py-2">
-              <GitHistoryGraph
-                sessionId={session.id}
-                baseBranch={session.baseBranch || 'main'}
-                layout="wide"
-                onCommitClick={onCommitClick}
-              />
-            </div>
-          )}
-        </div>
-      </div>
+      <HorizontalDetailPanel
+        height={height}
+        onResize={onResize}
+        mergeError={mergeError}
+        isCollapsed={isCollapsed}
+        onToggleCollapse={onToggleCollapse}
+        onSwapLayout={onSwapLayout}
+        terminalShortcuts={terminalShortcuts}
+        onCommitClick={onCommitClick}
+      />
     );
   }
+
+  const {
+    session,
+    gitBranchActions,
+    isMerging,
+    gitCommands,
+    onOpenIDEWithCommand,
+    onConfigureIDE,
+    onSetTracking,
+    trackingBranch,
+    isRemoteMode,
+  } = sessionContext;
+  const gitStatus = session.gitStatus;
+  const gitUnavailable = !!session.isMainRepo && gitStatus?.state === 'unknown';
 
   return (
     <div
       className={`pane-detail-panel pane-detail-panel-vertical flex-shrink-0 min-w-0 bg-surface-primary flex flex-col overflow-hidden relative transition-[width] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${isVisible && !immersiveMode ? 'border-l border-border-primary' : ''}`}
       style={{ width: isVisible && !immersiveMode ? `${width}px` : '0px' }}
     >
-      {/* Resize handle */}
-      <div
-        className="absolute top-0 left-0 w-1 h-full cursor-col-resize group z-10"
-        onMouseDown={onResize}
-      >
+      <div className="absolute top-0 left-0 w-1 h-full cursor-col-resize group z-10" onMouseDown={onResize}>
         <div className="absolute -left-2 right-0 top-0 bottom-0" />
       </div>
 
       <div className="pane-detail-panel-inner flex flex-col h-full min-h-0">
-        {/* Fixed top sections — never scroll */}
         <div className="flex-shrink-0 overflow-hidden">
-        {/* Branch name — standalone header */}
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-border-primary min-w-0">
-          <GitBranch className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
-          <span className="flex flex-col leading-tight min-w-0 flex-1">
-            <span className="text-sm text-text-primary font-medium truncate">
-              {(gitCommands?.currentBranch?.trim()) || session.baseBranch?.replace(/^origin\//, '') || 'unknown'}
-            </span>
-            {session.baseBranch && gitCommands?.currentBranch &&
-             gitCommands.currentBranch !== session.baseBranch.replace(/^origin\//, '') && (
-              <span className="text-xs text-text-tertiary truncate">
-                from {session.baseBranch.replace(/^origin\//, '')}
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-border-primary min-w-0">
+            <GitBranch className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
+            <span className="flex flex-col leading-tight min-w-0 flex-1">
+              <span className="text-sm text-text-primary font-medium truncate">
+                {gitCommands?.currentBranch?.trim() || session.baseBranch?.replace(/^origin\//, '') || 'unknown'}
               </span>
+              {session.baseBranch && gitCommands?.currentBranch
+                && gitCommands.currentBranch !== session.baseBranch.replace(/^origin\//, '') && (
+                <span className="text-xs text-text-tertiary truncate">
+                  from {session.baseBranch.replace(/^origin\//, '')}
+                </span>
+              )}
+            </span>
+            {onSwapLayout && (
+              <Tooltip content="Swap terminal and detail panel positions" side="left">
+                <button
+                  type="button"
+                  aria-label="Swap terminal and detail panel positions"
+                  onClick={onSwapLayout}
+                  className="p-1 hover:bg-surface-hover rounded transition-colors flex-shrink-0"
+                >
+                  <ArrowLeftRight aria-hidden="true" className="w-3.5 h-3.5 text-text-tertiary" />
+                </button>
+              </Tooltip>
             )}
-          </span>
-          {onSwapLayout && (
-            <Tooltip content="Swap terminal and detail panel positions" side="left">
-              <button
-                type="button"
-                aria-label="Swap terminal and detail panel positions"
-                onClick={onSwapLayout}
-                className="p-1 hover:bg-surface-hover rounded transition-colors flex-shrink-0"
-              >
-                <ArrowLeftRight aria-hidden="true" className="w-3.5 h-3.5 text-text-tertiary" />
-              </button>
-            </Tooltip>
+          </div>
+
+          {gitStatus && (
+            <DetailSection title="Changes">
+              <div className="space-y-1 text-sm px-1">
+                {!!gitStatus.ahead && (
+                  <div className="flex justify-between text-text-secondary">
+                    <span>Commits ahead</span>
+                    <span className="text-status-success font-medium">{gitStatus.ahead}</span>
+                  </div>
+                )}
+                {!!gitStatus.behind && (
+                  <div className="flex justify-between text-text-secondary">
+                    <span>Commits behind</span>
+                    <span className="text-status-warning font-medium">{gitStatus.behind}</span>
+                  </div>
+                )}
+                {gitStatus.hasUncommittedChanges && !!gitStatus.filesChanged && (
+                  <div className="flex justify-between text-text-secondary">
+                    <span>Uncommitted files</span>
+                    <span className="text-status-info font-medium">{gitStatus.filesChanged}</span>
+                  </div>
+                )}
+                {!gitStatus.ahead && !gitStatus.behind && !gitStatus.hasUncommittedChanges && (
+                  <div className="text-text-tertiary text-xs">No changes detected</div>
+                )}
+              </div>
+            </DetailSection>
           )}
-        </div>
 
-        {/* Changes for the checkout represented by this session */}
-        {gitStatus && (
-          <DetailSection title="Changes">
-            <div className="space-y-1 text-sm px-1">
-              {gitStatus.ahead != null && gitStatus.ahead > 0 && (
-                <div className="flex justify-between text-text-secondary">
-                  <span>Commits ahead</span>
-                  <span className="text-status-success font-medium">{gitStatus.ahead}</span>
-                </div>
-              )}
-              {gitStatus.behind != null && gitStatus.behind > 0 && (
-                <div className="flex justify-between text-text-secondary">
-                  <span>Commits behind</span>
-                  <span className="text-status-warning font-medium">{gitStatus.behind}</span>
-                </div>
-              )}
-              {gitStatus.hasUncommittedChanges && gitStatus.filesChanged != null && gitStatus.filesChanged > 0 && (
-                <div className="flex justify-between text-text-secondary">
-                  <span>Uncommitted files</span>
-                  <span className="text-status-info font-medium">{gitStatus.filesChanged}</span>
-                </div>
-              )}
-              {(!gitStatus.ahead || gitStatus.ahead === 0) &&
-               (!gitStatus.behind || gitStatus.behind === 0) &&
-               !gitStatus.hasUncommittedChanges && (
-                <div className="text-text-tertiary text-xs">No changes detected</div>
-              )}
-            </div>
-          </DetailSection>
-        )}
-
-        {/* Branch actions */}
-        {(onSetTracking || onOpenIDEWithCommand) && (
-          <DetailSection title="Branch">
-            <div className="space-y-0.5">
-              {!gitUnavailable && onSetTracking && (
-                <Tooltip content="Set upstream tracking branch for git pull/push" side="left">
-                  <Button variant="ghost" size="sm" className={sidebarBtn} onClick={onSetTracking} disabled={isMerging}>
-                    <Link className="w-4 h-4 mr-2 flex-shrink-0" />
-                    <span className="flex flex-col items-start leading-tight min-w-0">
-                      <span>Set Tracking</span>
-                      {trackingBranch && (
-                        <span className="text-xs text-text-tertiary truncate max-w-full">
-                          {trackingBranch}
-                        </span>
-                      )}
-                    </span>
-                  </Button>
-                </Tooltip>
-              )}
-              {onOpenIDEWithCommand && (
-                isRemoteMode ? (
+          {(onSetTracking || onOpenIDEWithCommand) && (
+            <DetailSection title="Branch">
+              <div className="space-y-0.5">
+                {!gitUnavailable && onSetTracking && (
+                  <Tooltip content="Set upstream tracking branch for git pull/push" side="left">
+                    <Button variant="ghost" size="sm" className={sidebarButtonClass} onClick={onSetTracking} disabled={isMerging}>
+                      <Link className="w-4 h-4 mr-2 flex-shrink-0" />
+                      <span className="flex flex-col items-start leading-tight min-w-0">
+                        <span>Set Tracking</span>
+                        {trackingBranch && <span className="text-xs text-text-tertiary truncate max-w-full">{trackingBranch}</span>}
+                      </span>
+                    </Button>
+                  </Tooltip>
+                )}
+                {onOpenIDEWithCommand && (isRemoteMode ? (
                   <Tooltip content={remoteIdeTooltip} side="left">
                     <span>
-                      <Button variant="ghost" size="sm" className={sidebarBtn} disabled>
+                      <Button variant="ghost" size="sm" className={sidebarButtonClass} disabled>
                         <Code2 className="w-4 h-4 mr-2 flex-shrink-0" />
                         <span className="truncate">Open in IDE</span>
                       </Button>
@@ -354,208 +190,53 @@ export function DetailPanel({ isVisible, width, height, onResize, mergeError, or
                   </Tooltip>
                 ) : (
                   <Dropdown
-                    trigger={
-                      <Button variant="ghost" size="sm" className={sidebarBtn}>
+                    trigger={(
+                      <Button variant="ghost" size="sm" className={sidebarButtonClass}>
                         <Code2 className="w-4 h-4 mr-2 flex-shrink-0" />
                         <span className="truncate">Open in IDE</span>
                       </Button>
-                    }
+                    )}
                     items={ideItems}
-                    footer={onConfigureIDE ? (
-                      <DropdownMenuItem
-                        icon={Settings}
-                        label="Configure..."
-                        onClick={onConfigureIDE}
-                      />
-                    ) : undefined}
+                    footer={onConfigureIDE ? <DropdownMenuItem icon={Settings} label="Configure..." onClick={onConfigureIDE} /> : undefined}
                     position="auto"
                     width="sm"
                   />
-                )
-              )}
-            </div>
-          </DetailSection>
-        )}
+                ))}
+              </div>
+            </DetailSection>
+          )}
 
-        {/* Merge error */}
-        {mergeError && (
-          <div className="px-2 py-2 border-b border-border-primary">
-            <div className="p-2 bg-status-error/10 border border-status-error/30 rounded-md">
-              <div className="flex items-start gap-2">
-                <AlertTriangle className="w-4 h-4 text-status-error flex-shrink-0 mt-0.5" />
-                <p className="text-xs text-status-error">{mergeError}</p>
+          {mergeError && (
+            <div className="px-2 py-2 border-b border-border-primary">
+              <div className="p-2 bg-status-error/10 border border-status-error/30 rounded-md">
+                <div className="flex items-start gap-2">
+                  <AlertTriangle className="w-4 h-4 text-status-error flex-shrink-0 mt-0.5" />
+                  <p className="text-xs text-status-error">{mergeError}</p>
+                </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Git actions */}
-        {gitUnavailable ? (
-          <div className="px-3 py-4 border-b border-border-primary">
-            <p className="text-xs text-text-tertiary">
-              Git features unavailable. Initialize a git repository to enable history, branches, and sync.
-            </p>
-          </div>
-        ) : (
-        <DetailSection title="Actions">
-          <div className="space-y-0.5">
-            {/* Checkout actions — callers provide only actions valid for this checkout */}
-            {(() => {
-              const byId = (id: string) => gitBranchActions?.find(a => a.id === id);
-              const behindCount = gitStatus?.behind ?? 0;
-              const aheadCount = gitStatus?.ahead ?? 0;
-              const fetchedAgo = gitStatus?.lastChecked ? formatTimeAgo(gitStatus.lastChecked) : null;
-
-              // Paired buttons rendered side-by-side
-              const pairedIds = new Set(['pull', 'push', 'stash', 'stash-pop', 'rebase-from-main', 'rebase-to-main', 'fetch', 'commit']);
-
-              // Layout: each entry is either a single action or a paired row
-              type Row = { type: 'single'; action: NonNullable<typeof gitBranchActions>[number] }
-                       | { type: 'pair'; left: NonNullable<typeof gitBranchActions>[number]; right: NonNullable<typeof gitBranchActions>[number] };
-              const rows: Row[] = [];
-
-              if (gitBranchActions) {
-                for (let i = 0; i < gitBranchActions.length; i++) {
-                  const action = gitBranchActions[i];
-                  if (pairedIds.has(action.id)) {
-                    // Fetch + Commit pair
-                    if (action.id === 'fetch') {
-                      const commit = byId('commit');
-                      if (commit) { rows.push({ type: 'pair', left: action, right: commit }); continue; }
-                    }
-                    // Stash + Pop pair
-                    if (action.id === 'stash') {
-                      const pop = byId('stash-pop');
-                      if (pop) { rows.push({ type: 'pair', left: action, right: pop }); continue; }
-                    }
-                    // Pull + Push pair
-                    if (action.id === 'pull') {
-                      const push = byId('push');
-                      if (push) { rows.push({ type: 'pair', left: action, right: push }); continue; }
-                    }
-                    // Rebase + Merge pair
-                    if (action.id === 'rebase-from-main') {
-                      const merge = byId('rebase-to-main');
-                      if (merge) { rows.push({ type: 'pair', left: action, right: merge }); continue; }
-                    }
-                    // Skip partners (they were already included in the pair above)
-                    if (action.id === 'commit' || action.id === 'stash-pop' || action.id === 'push' || action.id === 'rebase-to-main') continue;
-                  }
-                  rows.push({ type: 'single', action });
-                }
-              }
-
-              return rows.map(row => {
-                if (row.type === 'pair') {
-                  const { left, right } = row;
-                  // Badge for pull/push
-                  const leftBadge = left.id === 'pull' && behindCount > 0
-                    ? <span className="text-[10px] text-status-warning font-medium ml-1">&darr;{behindCount}</span> : null;
-                  const rightBadge = right.id === 'push' && aheadCount > 0
-                    ? <span className="text-[10px] text-status-success font-medium ml-1">&uarr;{aheadCount}</span> : null;
-
-                  const isRebaseMerge = left.id === 'rebase-from-main';
-                  const mainBranchRaw = gitCommands?.comparisonBaseBranch || 'main';
-                  const mainBranchLastSegment = mainBranchRaw.includes('/') ? mainBranchRaw.split('/').pop()! : mainBranchRaw;
-                  const mainBranch = mainBranchLastSegment.length > 12 ? mainBranchLastSegment.slice(0, 12) + '…' : mainBranchLastSegment;
-
-                  const pairBtnClass = isRebaseMerge
-                    ? 'flex-1 justify-start text-xs !px-2'
-                    : 'flex-1 justify-start text-sm !px-2';
-                  const pairIconClass = isRebaseMerge
-                    ? 'w-3.5 h-3.5 mr-1 flex-shrink-0'
-                    : 'w-4 h-4 mr-2 flex-shrink-0';
-
-                  return (
-                    <div key={`${left.id}-${right.id}`} className="flex gap-0.5 [&>*]:min-w-[90px]">
-                      <Tooltip content={actionTooltip(left, left.disabled || isMerging)} side="left">
-                        <Button variant="ghost" size="sm" className={pairBtnClass} onClick={left.onClick} disabled={left.disabled || isMerging}>
-                          <left.icon className={pairIconClass} />
-                          {isRebaseMerge ? (
-                            <span className="flex flex-col items-start leading-tight">
-                              <span>Rebase</span>
-                              <span className="text-[10px] text-text-tertiary">from {mainBranch}</span>
-                            </span>
-                          ) : left.id === 'fetch' && fetchedAgo ? (
-                            <span className="flex flex-col items-start leading-tight min-w-0">
-                              <span>{left.label}</span>
-                              <span className="text-[10px] text-text-tertiary">{fetchedAgo}</span>
-                            </span>
-                          ) : (
-                            <>
-                              <span>{left.label}</span>
-                              {leftBadge}
-                            </>
-                          )}
-                        </Button>
-                      </Tooltip>
-                      <Tooltip content={actionTooltip(right, right.disabled || isMerging)} side="left">
-                        <Button variant="ghost" size="sm" className={pairBtnClass} onClick={right.onClick} disabled={right.disabled || isMerging}>
-                          <right.icon className={pairIconClass} />
-                          {isRebaseMerge ? (
-                            <span className="flex flex-col items-start leading-tight">
-                              <span>Merge</span>
-                              <span className="text-[10px] text-text-tertiary">to {mainBranch}</span>
-                            </span>
-                          ) : right.id === 'commit' ? (
-                            <span className="flex flex-col items-start leading-tight min-w-0">
-                              <span>{right.label}</span>
-                              <span className="text-[10px] text-text-tertiary truncate max-w-full">
-                                {gitStatus?.filesChanged && gitStatus.filesChanged > 0
-                                  ? `${gitStatus.filesChanged} ${gitStatus.filesChanged === 1 ? 'file' : 'files'}`
-                                  : `to ${(() => { const b = gitCommands?.currentBranch?.trim() || 'branch'; return b.length > 6 ? b.slice(0, 6) + '…' : b; })()}`}
-                              </span>
-                            </span>
-                          ) : (
-                            <>
-                              <span>{right.label}</span>
-                              {rightBadge}
-                            </>
-                          )}
-                        </Button>
-                      </Tooltip>
-                    </div>
-                  );
-                }
-
-                const { action } = row;
-                const isFetch = action.id === 'fetch';
-
-                return (
-                  <Tooltip key={action.id} content={actionTooltip(action, action.disabled || isMerging)} side="left">
-                    <Button variant="ghost" size="sm" className={sidebarBtn} onClick={action.onClick} disabled={action.disabled || isMerging}>
-                      <action.icon className="w-4 h-4 mr-2 flex-shrink-0" />
-                      {isFetch && fetchedAgo ? (
-                        <span className="flex flex-col items-start leading-tight min-w-0">
-                          <span>{action.label}</span>
-                          <span className="text-xs text-text-tertiary">{fetchedAgo}</span>
-                        </span>
-                      ) : (
-                        <span className="truncate">{action.label}</span>
-                      )}
-                    </Button>
-                  </Tooltip>
-                );
-              });
-            })()}
-
-          </div>
-        </DetailSection>
-        )}
+          {gitUnavailable ? (
+            <div className="px-3 py-4 border-b border-border-primary">
+              <p className="text-xs text-text-tertiary">
+                Git features unavailable. Initialize a git repository to enable history, branches, and sync.
+              </p>
+            </div>
+          ) : (
+            <DetailPanelGitActions
+              actions={gitBranchActions}
+              isMerging={isMerging}
+              gitCommands={gitCommands}
+              gitStatus={gitStatus}
+            />
+          )}
         </div>
 
-        {/* History — fills remaining space, only this section scrolls */}
         {!gitUnavailable && session.worktreePath && (
           <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-            <div className="px-2 pt-2 flex-shrink-0">
-              <SectionHeader>History</SectionHeader>
-            </div>
-            <div
-              role="region"
-              tabIndex={0}
-              aria-label="Commit history"
-              className="flex-1 min-h-0 overflow-y-auto px-2 pb-2"
-            >
+            <div className="px-2 pt-2 flex-shrink-0"><SectionHeader>History</SectionHeader></div>
+            <div role="region" tabIndex={0} aria-label="Commit history" className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
               <GitHistoryGraph
                 sessionId={session.id}
                 baseBranch={session.baseBranch || 'main'}

--- a/frontend/src/components/DetailPanelGitActions.tsx
+++ b/frontend/src/components/DetailPanelGitActions.tsx
@@ -1,0 +1,198 @@
+import type { LucideIcon } from 'lucide-react';
+import type { GitCommands, GitStatus } from '../types/session';
+import { formatKeyDisplay } from '../utils/hotkeyUtils';
+import { Button } from './ui/Button';
+import { Kbd } from './ui/Kbd';
+import { Tooltip } from './ui/Tooltip';
+
+interface GitBranchAction {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  onClick: () => void;
+  disabled: boolean;
+  variant: 'default' | 'success' | 'danger';
+  description: string;
+  shortcut?: string;
+  disabledReason?: string;
+}
+
+interface DetailPanelGitActionsProps {
+  actions?: GitBranchAction[];
+  isMerging?: boolean;
+  gitCommands?: GitCommands;
+  gitStatus?: GitStatus;
+}
+
+type ActionRow =
+  | { type: 'single'; action: GitBranchAction }
+  | { type: 'pair'; left: GitBranchAction; right: GitBranchAction };
+
+const sidebarButtonClass = 'w-full justify-start text-sm !px-2';
+
+function formatTimeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function actionTooltip(action: GitBranchAction, disabled: boolean) {
+  const message = disabled ? action.disabledReason ?? action.description : action.description;
+  return (
+    <div className="space-y-1">
+      {message && <div>{disabled ? `Unavailable: ${message}` : message}</div>}
+      {action.shortcut && (
+        <div className="flex items-center gap-2 text-text-tertiary">
+          <span>Shortcut</span>
+          <Kbd size="xs" variant="muted">{formatKeyDisplay(action.shortcut)}</Kbd>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildRows(actions: GitBranchAction[]): ActionRow[] {
+  const byId = (id: string) => actions.find(action => action.id === id);
+  const partners: Record<string, string> = {
+    fetch: 'commit',
+    stash: 'stash-pop',
+    pull: 'push',
+    'rebase-from-main': 'rebase-to-main',
+  };
+  const partnerIds = new Set(Object.values(partners));
+  const rows: ActionRow[] = [];
+
+  for (const action of actions) {
+    const partnerId = partners[action.id];
+    const partner = partnerId ? byId(partnerId) : undefined;
+    if (partner) {
+      rows.push({ type: 'pair', left: action, right: partner });
+    } else if (!partnerIds.has(action.id)) {
+      rows.push({ type: 'single', action });
+    }
+  }
+  return rows;
+}
+
+function ActionPair({
+  left,
+  right,
+  isMerging,
+  gitCommands,
+  gitStatus,
+  fetchedAgo,
+}: {
+  left: GitBranchAction;
+  right: GitBranchAction;
+  isMerging?: boolean;
+  gitCommands?: GitCommands;
+  gitStatus?: GitStatus;
+  fetchedAgo: string | null;
+}) {
+  const isRebaseMerge = left.id === 'rebase-from-main';
+  const mainBranchName = (gitCommands?.comparisonBaseBranch || 'main').split('/').pop() || 'main';
+  const mainBranch = mainBranchName.length > 12 ? `${mainBranchName.slice(0, 12)}…` : mainBranchName;
+  const pairButtonClass = isRebaseMerge ? 'flex-1 justify-start text-xs !px-2' : 'flex-1 justify-start text-sm !px-2';
+  const pairIconClass = isRebaseMerge ? 'w-3.5 h-3.5 mr-1 flex-shrink-0' : 'w-4 h-4 mr-2 flex-shrink-0';
+  const branchName = gitCommands?.currentBranch?.trim() || 'branch';
+  const shortBranch = branchName.length > 6 ? `${branchName.slice(0, 6)}…` : branchName;
+
+  return (
+    <div className="flex gap-0.5 [&>*]:min-w-[90px]">
+      <Tooltip content={actionTooltip(left, left.disabled || !!isMerging)} side="left">
+        <Button variant="ghost" size="sm" className={pairButtonClass} onClick={left.onClick} disabled={left.disabled || isMerging}>
+          <left.icon className={pairIconClass} />
+          {isRebaseMerge ? (
+            <span className="flex flex-col items-start leading-tight">
+              <span>Rebase</span>
+              <span className="text-[10px] text-text-tertiary">from {mainBranch}</span>
+            </span>
+          ) : left.id === 'fetch' && fetchedAgo ? (
+            <span className="flex flex-col items-start leading-tight min-w-0">
+              <span>{left.label}</span>
+              <span className="text-[10px] text-text-tertiary">{fetchedAgo}</span>
+            </span>
+          ) : (
+            <>
+              <span>{left.label}</span>
+              {left.id === 'pull' && !!gitStatus?.behind && (
+                <span className="text-[10px] text-status-warning font-medium ml-1">&darr;{gitStatus.behind}</span>
+              )}
+            </>
+          )}
+        </Button>
+      </Tooltip>
+      <Tooltip content={actionTooltip(right, right.disabled || !!isMerging)} side="left">
+        <Button variant="ghost" size="sm" className={pairButtonClass} onClick={right.onClick} disabled={right.disabled || isMerging}>
+          <right.icon className={pairIconClass} />
+          {isRebaseMerge ? (
+            <span className="flex flex-col items-start leading-tight">
+              <span>Merge</span>
+              <span className="text-[10px] text-text-tertiary">to {mainBranch}</span>
+            </span>
+          ) : right.id === 'commit' ? (
+            <span className="flex flex-col items-start leading-tight min-w-0">
+              <span>{right.label}</span>
+              <span className="text-[10px] text-text-tertiary truncate max-w-full">
+                {gitStatus?.filesChanged
+                  ? `${gitStatus.filesChanged} ${gitStatus.filesChanged === 1 ? 'file' : 'files'}`
+                  : `to ${shortBranch}`}
+              </span>
+            </span>
+          ) : (
+            <>
+              <span>{right.label}</span>
+              {right.id === 'push' && !!gitStatus?.ahead && (
+                <span className="text-[10px] text-status-success font-medium ml-1">&uarr;{gitStatus.ahead}</span>
+              )}
+            </>
+          )}
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+export function DetailPanelGitActions({ actions = [], isMerging, gitCommands, gitStatus }: DetailPanelGitActionsProps) {
+  const fetchedAgo = gitStatus?.lastChecked ? formatTimeAgo(gitStatus.lastChecked) : null;
+  return (
+    <div className="px-2 py-2 border-b border-border-primary">
+      <h3 className="text-xs uppercase text-text-tertiary font-medium mb-2 px-1">Actions</h3>
+      <div className="space-y-0.5">
+        {buildRows(actions).map(row => row.type === 'pair' ? (
+          <ActionPair
+            key={`${row.left.id}-${row.right.id}`}
+            left={row.left}
+            right={row.right}
+            isMerging={isMerging}
+            gitCommands={gitCommands}
+            gitStatus={gitStatus}
+            fetchedAgo={fetchedAgo}
+          />
+        ) : (
+          <Tooltip key={row.action.id} content={actionTooltip(row.action, row.action.disabled || !!isMerging)} side="left">
+            <Button
+              variant="ghost"
+              size="sm"
+              className={sidebarButtonClass}
+              onClick={row.action.onClick}
+              disabled={row.action.disabled || isMerging}
+            >
+              <row.action.icon className="w-4 h-4 mr-2 flex-shrink-0" />
+              {row.action.id === 'fetch' && fetchedAgo ? (
+                <span className="flex flex-col items-start leading-tight min-w-0">
+                  <span>{row.action.label}</span>
+                  <span className="text-xs text-text-tertiary">{fetchedAgo}</span>
+                </span>
+              ) : <span className="truncate">{row.action.label}</span>}
+            </Button>
+          </Tooltip>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/HorizontalDetailPanel.tsx
+++ b/frontend/src/components/HorizontalDetailPanel.tsx
@@ -1,0 +1,184 @@
+import React, { useMemo } from 'react';
+import { AlertTriangle, ArrowLeftRight, ChevronDown, ChevronUp, Code2, GitBranch, Settings, TerminalSquare } from 'lucide-react';
+import { useSession } from '../contexts/SessionContext';
+import { useNavigationStore } from '../stores/navigationStore';
+import { Button } from './ui/Button';
+import { Dropdown, DropdownMenuItem } from './ui/Dropdown';
+import { Tooltip } from './ui/Tooltip';
+import { GitHistoryGraph } from './GitHistoryGraph';
+
+interface HorizontalDetailPanelProps {
+  height?: number;
+  onResize: (event: React.MouseEvent) => void;
+  mergeError?: string | null;
+  isCollapsed?: boolean;
+  onToggleCollapse?: () => void;
+  onSwapLayout?: () => void;
+  terminalShortcuts?: React.ReactNode;
+  onCommitClick?: (hash: string) => void;
+}
+
+export function HorizontalDetailPanel({
+  height,
+  onResize,
+  mergeError,
+  isCollapsed,
+  onToggleCollapse,
+  onSwapLayout,
+  terminalShortcuts,
+  onCommitClick,
+}: HorizontalDetailPanelProps) {
+  const sessionContext = useSession();
+  const immersiveMode = useNavigationStore(state => state.immersiveMode);
+  const remoteIdeTooltip = 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.';
+  const ideItems = useMemo(() => {
+    if (!sessionContext?.onOpenIDEWithCommand) return [];
+    const handler = sessionContext.onOpenIDEWithCommand;
+    const configured = sessionContext.configuredIDECommand?.trim();
+    const isCustom = configured && !['code .', 'cursor .'].includes(configured);
+    return [
+      ...(isCustom
+        ? [{ id: 'configured', label: configured, description: 'Project default', icon: TerminalSquare, onClick: () => handler() }]
+        : []),
+      { id: 'vscode', label: 'VS Code', description: 'code .', icon: Code2, onClick: () => handler('vscode') },
+      { id: 'cursor', label: 'Cursor', description: 'cursor .', icon: Code2, onClick: () => handler('cursor') },
+    ];
+  }, [sessionContext?.configuredIDECommand, sessionContext?.onOpenIDEWithCommand]);
+
+  if (!sessionContext) return null;
+
+  const {
+    session,
+    gitBranchActions,
+    isMerging,
+    gitCommands,
+    onOpenIDEWithCommand,
+    onConfigureIDE,
+    isRemoteMode,
+  } = sessionContext;
+  const gitStatus = session.gitStatus;
+  const isProject = !!session.isMainRepo;
+  const gitUnavailable = isProject && gitStatus?.state === 'unknown';
+
+  return (
+    <div
+      className={`pane-detail-panel pane-detail-panel-horizontal flex-shrink-0 bg-surface-primary flex flex-col overflow-hidden relative transition-[height] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${immersiveMode ? '' : 'border-t border-border-primary'}`}
+      style={{ height: immersiveMode ? '0px' : isCollapsed ? 'auto' : `${height ?? 200}px` }}
+    >
+      {!isCollapsed && (
+        <div
+          role="separator"
+          aria-label="Resize detail panel"
+          aria-orientation="horizontal"
+          tabIndex={-1}
+          className="absolute top-0 left-0 right-0 h-1 cursor-row-resize group z-10"
+          onMouseDown={onResize}
+        >
+          <div className="absolute -top-2 bottom-0 left-0 right-0" />
+        </div>
+      )}
+
+      <div className="pane-detail-panel-inner flex flex-col h-full min-h-0">
+        <div className="flex items-start flex-shrink-0">
+          <div className="flex items-center flex-wrap flex-1 min-w-0 min-h-[32px] px-3 gap-x-2 gap-y-1 py-1">
+            <button
+              type="button"
+              onClick={onToggleCollapse}
+              className="p-0.5 hover:bg-surface-hover rounded transition-colors"
+              title={isCollapsed ? 'Expand detail panel' : 'Collapse detail panel'}
+            >
+              {isCollapsed
+                ? <ChevronUp className="w-3.5 h-3.5 text-text-tertiary" />
+                : <ChevronDown className="w-3.5 h-3.5 text-text-tertiary" />}
+            </button>
+
+            <GitBranch className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
+            <span className="text-sm text-text-primary font-medium truncate max-w-[150px]">
+              {gitCommands?.currentBranch?.trim() || session.baseBranch?.replace(/^origin\//, '') || 'unknown'}
+            </span>
+
+            {!isProject && gitStatus && (
+              <div className="flex items-center gap-2 flex-shrink-0">
+                {!!gitStatus.ahead && <span className="text-[10px] text-status-success font-medium">&uarr;{gitStatus.ahead}</span>}
+                {!!gitStatus.behind && <span className="text-[10px] text-status-warning font-medium">&darr;{gitStatus.behind}</span>}
+                {gitStatus.hasUncommittedChanges && !!gitStatus.filesChanged && (
+                  <span className="text-[10px] text-status-info font-medium">{gitStatus.filesChanged} files</span>
+                )}
+              </div>
+            )}
+
+            {mergeError && (
+              <Tooltip content={mergeError} side="top">
+                <AlertTriangle className="w-3.5 h-3.5 text-status-error flex-shrink-0" />
+              </Tooltip>
+            )}
+
+            {!gitUnavailable && !isProject && gitBranchActions?.map(action => (
+              <Tooltip key={action.id} content={action.label + (action.description ? ` — ${action.description}` : '')} side="top">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0"
+                  onClick={action.onClick}
+                  disabled={action.disabled || isMerging}
+                >
+                  <action.icon className="w-3 h-3" />
+                </Button>
+              </Tooltip>
+            ))}
+
+            {onOpenIDEWithCommand && (isRemoteMode ? (
+              <Tooltip content={remoteIdeTooltip} side="top">
+                <span>
+                  <Button variant="ghost" size="sm" className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0" disabled>
+                    <Code2 className="w-3 h-3" />
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : (
+              <Dropdown
+                trigger={(
+                  <Tooltip content="Open in IDE" side="top">
+                    <Button variant="ghost" size="sm" className="!px-1.5 !py-0.5 text-xs h-6 flex-shrink-0">
+                      <Code2 className="w-3 h-3" />
+                    </Button>
+                  </Tooltip>
+                )}
+                items={ideItems}
+                footer={onConfigureIDE ? <DropdownMenuItem icon={Settings} label="Configure..." onClick={onConfigureIDE} /> : undefined}
+                position="auto"
+                width="sm"
+              />
+            ))}
+
+            {terminalShortcuts}
+          </div>
+
+          {onSwapLayout && (
+            <Tooltip content="Swap terminal and detail panel positions" side="top">
+              <button
+                type="button"
+                aria-label="Swap terminal and detail panel positions"
+                onClick={onSwapLayout}
+                className="p-1 hover:bg-surface-hover rounded transition-colors flex-shrink-0 mr-2 mt-1"
+              >
+                <ArrowLeftRight aria-hidden="true" className="w-3.5 h-3.5 text-text-tertiary" />
+              </button>
+            </Tooltip>
+          )}
+        </div>
+
+        {!isCollapsed && !gitUnavailable && session.worktreePath && (
+          <div className="flex-1 min-h-0 overflow-y-auto px-2 py-2">
+            <GitHistoryGraph
+              sessionId={session.id}
+              baseBranch={session.baseBranch || 'main'}
+              layout="wide"
+              onCommitClick={onCommitClick}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -12,16 +12,21 @@ import { SessionProvider } from '../contexts/SessionContext';
 import { DetailPanel } from './DetailPanel';
 import { useResizable } from '../hooks/useResizable';
 import { CommitMessageDialog } from './session/CommitMessageDialog';
+import { SetTrackingBranchDialog } from './session/SetTrackingBranchDialog';
 import { useMainRepoGitActions } from '../hooks/useMainRepoGitActions';
 
 interface ProjectViewProps {
   projectId: number;
   projectName: string;
+  configuredIDECommand?: string | null;
+  onConfigureIDE: () => void;
 }
 
 export const ProjectView: React.FC<ProjectViewProps> = ({ 
   projectId, 
   projectName,
+  configuredIDECommand,
+  onConfigureIDE,
 }) => {
   const [mainRepoSessionId, setMainRepoSessionId] = useState<string | null>(null);
   const [mainRepoSession, setMainRepoSession] = useState<Session | null>(null);
@@ -309,8 +314,10 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
           isMerging={mainRepoGit.actionsBusy}
           gitCommands={mainRepoGit.gitCommands}
           onOpenIDEWithCommand={mainRepoGit.handleOpenIDE}
+          onConfigureIDE={onConfigureIDE}
           onSetTracking={mainRepoGit.handleOpenSetTracking}
           trackingBranch={mainRepoGit.currentUpstream}
+          configuredIDECommand={configuredIDECommand}
           isRemoteMode={mainRepoGit.isRemoteMode}
         >
           {/* Tab bar at top */}
@@ -436,43 +443,14 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
         isMerging={mainRepoGit.isRunning}
       />
 
-      {mainRepoGit.showSetTrackingDialog && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-labelledby="main-tracking-title">
-          <div className="bg-bg-primary border border-border-primary rounded-lg shadow-lg p-4 w-80 max-h-96 overflow-hidden flex flex-col">
-            <h3 id="main-tracking-title" className="text-lg font-medium text-text-primary mb-2">Set Tracking Branch</h3>
-            {mainRepoGit.currentUpstream && (
-              <p className="text-sm text-text-secondary mb-3">
-                Currently tracking: <span className="text-text-primary font-mono">{mainRepoGit.currentUpstream}</span>
-              </p>
-            )}
-            <p className="text-sm text-text-secondary mb-3">Select a remote branch for the primary checkout to track:</p>
-            <div className="flex-1 overflow-y-auto space-y-1 mb-4">
-              {mainRepoGit.remoteBranches.length === 0 ? (
-                <p className="text-sm text-text-tertiary italic">No remote branches found</p>
-              ) : mainRepoGit.remoteBranches.map((branch) => (
-                <button
-                  key={branch}
-                  type="button"
-                  onClick={() => mainRepoGit.handleSelectUpstream(branch)}
-                  className={`w-full text-left px-3 py-2 rounded text-sm font-mono hover:bg-bg-secondary transition-colors ${
-                    branch === mainRepoGit.currentUpstream ? 'bg-bg-secondary text-accent-primary' : 'text-text-primary'
-                  }`}
-                >
-                  {branch}
-                  {branch === mainRepoGit.currentUpstream && <span className="ml-2 text-xs">(current)</span>}
-                </button>
-              ))}
-            </div>
-            <button
-              type="button"
-              onClick={() => mainRepoGit.setShowSetTrackingDialog(false)}
-              className="w-full px-4 py-2 text-sm text-text-secondary hover:text-text-primary border border-border-primary rounded hover:bg-bg-secondary transition-colors"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
+      <SetTrackingBranchDialog
+        isOpen={mainRepoGit.showSetTrackingDialog}
+        currentUpstream={mainRepoGit.currentUpstream}
+        remoteBranches={mainRepoGit.remoteBranches}
+        checkoutLabel="the primary checkout"
+        onSelect={mainRepoGit.handleSelectUpstream}
+        onClose={() => mainRepoGit.setShowSetTrackingDialog(false)}
+      />
     </div>
   );
 };

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -1,31 +1,27 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { API } from '../utils/api';
 import { useSessionStore } from '../stores/sessionStore';
-import { Session } from '../types/session';
+import type { Session } from '../types/session';
 import { PanelTabBar } from './panels/PanelTabBar';
 import { PanelContainer } from './panels/PanelContainer';
 import { usePanelStore } from '../stores/panelStore';
 import { panelApi } from '../services/panelApi';
-import { ToolPanel, ToolPanelType } from '../../../shared/types/panels';
-import { PanelCreateOptions } from '../types/panelComponents';
+import type { ToolPanel, ToolPanelType } from '../../../shared/types/panels';
+import type { PanelCreateOptions } from '../types/panelComponents';
 import { SessionProvider } from '../contexts/SessionContext';
 import { DetailPanel } from './DetailPanel';
 import { useResizable } from '../hooks/useResizable';
+import { CommitMessageDialog } from './session/CommitMessageDialog';
+import { useMainRepoGitActions } from '../hooks/useMainRepoGitActions';
 
 interface ProjectViewProps {
   projectId: number;
   projectName: string;
-  onGitPull: () => void;
-  onGitPush: () => void;
-  isMerging: boolean;
 }
 
 export const ProjectView: React.FC<ProjectViewProps> = ({ 
   projectId, 
-  projectName, 
-  onGitPull, 
-  onGitPush, 
-  isMerging
+  projectName,
 }) => {
   const [mainRepoSessionId, setMainRepoSessionId] = useState<string | null>(null);
   const [mainRepoSession, setMainRepoSession] = useState<Session | null>(null);
@@ -204,17 +200,6 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
     [mainRepoSessionId, addPanel, setActivePanelInStore]
   );
   
-  // Wrapped git operations - just call the handlers directly without navigating to a panel
-  const handleGitPull = useCallback(() => {
-    onGitPull();
-  }, [onGitPull]);
-
-  const handleGitPush = useCallback(() => {
-    onGitPush();
-  }, [onGitPush]);
-  
-  // We don't need terminal handling or the hook for now, as panels handle their own terminals
-  
   // Debug logging
   useEffect(() => {
     console.log('[ProjectView] Session state:', { 
@@ -268,10 +253,15 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
   // Subscribe to session updates - optimized to check for actual changes
   useEffect(() => {
     if (!mainRepoSessionId) return;
-    
-    let previousSession = useSessionStore.getState().sessions.find(s => s.id === mainRepoSessionId);
+
+    const selectMainSession = (state: ReturnType<typeof useSessionStore.getState>) => (
+      state.activeMainRepoSession?.id === mainRepoSessionId
+        ? state.activeMainRepoSession
+        : state.sessions.find(s => s.id === mainRepoSessionId)
+    );
+    let previousSession = selectMainSession(useSessionStore.getState());
     const unsubscribe = useSessionStore.subscribe((state) => {
-      const session = state.sessions.find(s => s.id === mainRepoSessionId);
+      const session = selectMainSession(state);
       // Only update if session actually changed
       if (session && session !== previousSession) {
         previousSession = session;
@@ -281,6 +271,8 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
     
     return unsubscribe;
   }, [mainRepoSessionId]);
+
+  const mainRepoGit = useMainRepoGitActions(mainRepoSessionId, mainRepoSession);
 
   // Listen for panel updates from the backend
   useEffect(() => {
@@ -310,7 +302,17 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
     <div className="flex-1 flex flex-col overflow-hidden bg-bg-primary">
       {/* SINGLE SessionProvider wraps everything */}
       {activeMainRepoSession && (
-        <SessionProvider session={detailSession} projectName={projectName}>
+        <SessionProvider
+          session={detailSession}
+          projectName={projectName}
+          gitBranchActions={mainRepoGit.actions}
+          isMerging={mainRepoGit.actionsBusy}
+          gitCommands={mainRepoGit.gitCommands}
+          onOpenIDEWithCommand={mainRepoGit.handleOpenIDE}
+          onSetTracking={mainRepoGit.handleOpenSetTracking}
+          trackingBranch={mainRepoGit.currentUpstream}
+          isRemoteMode={mainRepoGit.isRemoteMode}
+        >
           {/* Tab bar at top */}
           <PanelTabBar
             panels={sessionPanels}
@@ -385,11 +387,7 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
               onToggle={() => setDetailVisible(v => !v)}
               width={detailWidth}
               onResize={startDetailResize}
-              projectGitActions={{
-                onPull: handleGitPull,
-                onPush: handleGitPush,
-                isMerging
-              }}
+              mergeError={mainRepoGit.error}
             />
           </div>
         </SessionProvider>
@@ -422,6 +420,57 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
       {!activeMainRepoSession && !isLoadingSession && (
         <div className="flex-1 flex items-center justify-center text-text-secondary">
           No session selected
+        </div>
+      )}
+
+      <CommitMessageDialog
+        isOpen={mainRepoGit.showCommitDialog}
+        onClose={() => mainRepoGit.setShowCommitDialog(false)}
+        dialogType="commit"
+        gitCommands={mainRepoGit.gitCommands}
+        commitMessage={mainRepoGit.commitMessage}
+        setCommitMessage={mainRepoGit.setCommitMessage}
+        shouldSquash={false}
+        setShouldSquash={() => {}}
+        onConfirm={mainRepoGit.handleCommit}
+        isMerging={mainRepoGit.isRunning}
+      />
+
+      {mainRepoGit.showSetTrackingDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true" aria-labelledby="main-tracking-title">
+          <div className="bg-bg-primary border border-border-primary rounded-lg shadow-lg p-4 w-80 max-h-96 overflow-hidden flex flex-col">
+            <h3 id="main-tracking-title" className="text-lg font-medium text-text-primary mb-2">Set Tracking Branch</h3>
+            {mainRepoGit.currentUpstream && (
+              <p className="text-sm text-text-secondary mb-3">
+                Currently tracking: <span className="text-text-primary font-mono">{mainRepoGit.currentUpstream}</span>
+              </p>
+            )}
+            <p className="text-sm text-text-secondary mb-3">Select a remote branch for the primary checkout to track:</p>
+            <div className="flex-1 overflow-y-auto space-y-1 mb-4">
+              {mainRepoGit.remoteBranches.length === 0 ? (
+                <p className="text-sm text-text-tertiary italic">No remote branches found</p>
+              ) : mainRepoGit.remoteBranches.map((branch) => (
+                <button
+                  key={branch}
+                  type="button"
+                  onClick={() => mainRepoGit.handleSelectUpstream(branch)}
+                  className={`w-full text-left px-3 py-2 rounded text-sm font-mono hover:bg-bg-secondary transition-colors ${
+                    branch === mainRepoGit.currentUpstream ? 'bg-bg-secondary text-accent-primary' : 'text-text-primary'
+                  }`}
+                >
+                  {branch}
+                  {branch === mainRepoGit.currentUpstream && <span className="ml-2 text-xs">(current)</span>}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => mainRepoGit.setShowSetTrackingDialog(false)}
+              className="w-full px-4 py-2 text-sm text-text-secondary hover:text-text-primary border border-border-primary rounded hover:bg-bg-secondary transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1627,10 +1627,28 @@ export const SessionView = memo(() => {
     }
 
     return (
-      <ProjectView
-        projectId={activeProjectId}
-        projectName={projectData.name || 'Project'}
-      />
+      <>
+        <ProjectView
+          projectId={activeProjectId}
+          projectName={projectData.name || 'Project'}
+          configuredIDECommand={projectData.open_ide_command}
+          onConfigureIDE={() => setShowProjectSettings(true)}
+        />
+        <ProjectSettings
+          project={projectData}
+          isOpen={showProjectSettings}
+          onClose={() => setShowProjectSettings(false)}
+          onUpdate={() => {
+            API.projects.getAll().then(response => {
+              if (response.success && response.data) {
+                const project = response.data.find((candidate: Project) => candidate.id === activeProjectId);
+                if (project) setProjectData(project);
+              }
+            });
+          }}
+          onDelete={() => setShowProjectSettings(false)}
+        />
+      </>
     );
   }
 

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -72,7 +72,6 @@ export const SessionView = memo(() => {
   const { activeView, activeProjectId } = useNavigationStore();
   const [projectData, setProjectData] = useState<Project | null>(null);
   const [isProjectLoading, setIsProjectLoading] = useState(false);
-  const [isMergingProject, setIsMergingProject] = useState(false);
   const [sessionProject, setSessionProject] = useState<Project | null>(null);
   const [showSetTrackingDialog, setShowSetTrackingDialog] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
@@ -1241,44 +1240,6 @@ export const SessionView = memo(() => {
     }
   }, [activeView, activeProjectId]);
 
-  const handleProjectGitPull = async () => {
-    if (!activeProjectId || !projectData) return;
-    setIsMergingProject(true);
-    try {
-      // Get or create main repo session for this project
-      const sessionResponse = await API.sessions.getOrCreateMainRepoSession(activeProjectId);
-      if (sessionResponse.success && sessionResponse.data) {
-        const response = await API.sessions.gitPull(sessionResponse.data.id);
-        if (!response.success) {
-          console.error('Git pull failed:', response.error);
-        }
-      }
-    } catch (error) {
-      console.error('Failed to perform git pull:', error);
-    } finally {
-      setIsMergingProject(false);
-    }
-  };
-
-  const handleProjectGitPush = async () => {
-    if (!activeProjectId || !projectData) return;
-    setIsMergingProject(true);
-    try {
-      // Get or create main repo session for this project
-      const sessionResponse = await API.sessions.getOrCreateMainRepoSession(activeProjectId);
-      if (sessionResponse.success && sessionResponse.data) {
-        const response = await API.sessions.gitPush(sessionResponse.data.id);
-        if (!response.success) {
-          console.error('Git push failed:', response.error);
-        }
-      }
-    } catch (error) {
-      console.error('Failed to perform git push:', error);
-    } finally {
-      setIsMergingProject(false);
-    }
-  };
-
   const hook = useSessionView(activeSession);
 
   // Handler to open set tracking dialog
@@ -1669,9 +1630,6 @@ export const SessionView = memo(() => {
       <ProjectView
         projectId={activeProjectId}
         projectName={projectData.name || 'Project'}
-        onGitPull={handleProjectGitPull}
-        onGitPush={handleProjectGitPush}
-        isMerging={isMergingProject}
       />
     );
   }

--- a/frontend/src/components/session/SetTrackingBranchDialog.tsx
+++ b/frontend/src/components/session/SetTrackingBranchDialog.tsx
@@ -1,0 +1,62 @@
+import { Button } from '../ui/Button';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from '../ui/Modal';
+
+interface SetTrackingBranchDialogProps {
+  isOpen: boolean;
+  currentUpstream: string | null;
+  remoteBranches: string[];
+  checkoutLabel?: string;
+  onSelect: (branch: string) => void;
+  onClose: () => void;
+}
+
+export function SetTrackingBranchDialog({
+  isOpen,
+  currentUpstream,
+  remoteBranches,
+  checkoutLabel = 'this checkout',
+  onSelect,
+  onClose,
+}: SetTrackingBranchDialogProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="sm"
+      showCloseButton={false}
+      ariaLabel="Set Tracking Branch"
+    >
+      <ModalHeader title="Set Tracking Branch" />
+      <ModalBody className="space-y-3">
+        {currentUpstream && (
+          <p className="text-sm text-text-secondary">
+            Currently tracking: <span className="text-text-primary font-mono">{currentUpstream}</span>
+          </p>
+        )}
+        <p className="text-sm text-text-secondary">
+          Select a remote branch for {checkoutLabel} to track:
+        </p>
+        <div className="space-y-1">
+          {remoteBranches.length === 0 ? (
+            <p className="text-sm text-text-tertiary italic">No remote branches found</p>
+          ) : remoteBranches.map(branch => (
+            <button
+              key={branch}
+              type="button"
+              onClick={() => onSelect(branch)}
+              className={`w-full text-left px-3 py-2 rounded text-sm font-mono hover:bg-bg-secondary transition-colors ${
+                branch === currentUpstream ? 'bg-bg-secondary text-accent-primary' : 'text-text-primary'
+              }`}
+            >
+              {branch}
+              {branch === currentUpstream && <span className="ml-2 text-xs">(current)</span>}
+            </button>
+          ))}
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="secondary" className="w-full" onClick={onClose}>Cancel</Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/frontend/src/hooks/useMainRepoGitActions.ts
+++ b/frontend/src/hooks/useMainRepoGitActions.ts
@@ -16,6 +16,7 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
   const [gitCommands, setGitCommands] = useState<GitCommands | null>(null);
   const [hasStash, setHasStash] = useState(false);
   const [currentUpstream, setCurrentUpstream] = useState<string | null>(null);
+  const [isUpstreamLoaded, setIsUpstreamLoaded] = useState(false);
   const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
   const [showSetTrackingDialog, setShowSetTrackingDialog] = useState(false);
   const [showCommitDialog, setShowCommitDialog] = useState(false);
@@ -33,9 +34,11 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
       setGitCommands(null);
       setHasStash(false);
       setCurrentUpstream(null);
+      setIsUpstreamLoaded(false);
       return;
     }
 
+    setIsUpstreamLoaded(false);
     let cancelled = false;
     Promise.all([
       API.sessions.getGitCommands(sessionId),
@@ -45,7 +48,10 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
       if (cancelled) return;
       if (commandsResponse.success) setGitCommands(commandsResponse.data);
       if (stashResponse.success) setHasStash(stashResponse.data);
-      if (upstreamResponse.success) setCurrentUpstream(upstreamResponse.data);
+      if (upstreamResponse.success) {
+        setCurrentUpstream(upstreamResponse.data);
+        setIsUpstreamLoaded(true);
+      }
     }).catch((loadError) => {
       if (!cancelled) console.error('Failed to load main checkout Git data:', loadError);
     });
@@ -207,13 +213,19 @@ export function useMainRepoGitActions(sessionId: string | null, session: Session
     },
     {
       id: 'push', label: 'Push', icon: Upload, onClick: handlePush,
-      disabled: actionsBusy || !gitStatus?.ahead, variant: 'default' as const,
-      description: gitStatus?.ahead
-        ? `Push ${gitStatus.ahead} commit(s) from ${gitCommands?.currentBranch || 'the current branch'}`
-        : 'No commits to push',
-      disabledReason: busyReason ?? (gitStatus?.ahead ? undefined : 'No commits to push'),
+      disabled: actionsBusy || !isUpstreamLoaded || (!!currentUpstream && !gitStatus?.ahead), variant: 'default' as const,
+      description: !isUpstreamLoaded
+        ? 'Checking remote tracking branch'
+        : !currentUpstream
+          ? `Publish ${gitCommands?.currentBranch || 'the current branch'} to origin and set its upstream`
+          : gitStatus?.ahead
+            ? `Push ${gitStatus.ahead} commit(s) from ${gitCommands?.currentBranch || 'the current branch'}`
+            : 'No commits to push',
+      disabledReason: busyReason ?? (!isUpstreamLoaded
+        ? 'Checking remote tracking branch'
+        : currentUpstream && !gitStatus?.ahead ? 'No commits to push' : undefined),
     },
-  ], [actionsBusy, busyReason, gitCommands?.currentBranch, gitStatus, handleFetch, handlePull, handlePush, handleSoftReset, handleStash, handleStashPop, hasStash]);
+  ], [actionsBusy, busyReason, currentUpstream, gitCommands?.currentBranch, gitStatus, handleFetch, handlePull, handlePush, handleSoftReset, handleStash, handleStashPop, hasStash, isUpstreamLoaded]);
 
   return {
     actions,

--- a/frontend/src/hooks/useMainRepoGitActions.ts
+++ b/frontend/src/hooks/useMainRepoGitActions.ts
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Archive, ArchiveRestore, Download, GitCommitHorizontal, RefreshCw, Undo2, Upload } from 'lucide-react';
+import { API } from '../utils/api';
+import type { GitCommands, Session } from '../types/session';
+import { useConfigStore } from '../stores/configStore';
+import { useErrorStore } from '../stores/errorStore';
+
+interface GitOperationResponse {
+  success: boolean;
+  error?: string;
+}
+
+export function useMainRepoGitActions(sessionId: string | null, session: Session | null) {
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [gitCommands, setGitCommands] = useState<GitCommands | null>(null);
+  const [hasStash, setHasStash] = useState(false);
+  const [currentUpstream, setCurrentUpstream] = useState<string | null>(null);
+  const [remoteBranches, setRemoteBranches] = useState<string[]>([]);
+  const [showSetTrackingDialog, setShowSetTrackingDialog] = useState(false);
+  const [showCommitDialog, setShowCommitDialog] = useState(false);
+  const [commitMessage, setCommitMessage] = useState('');
+  const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
+
+  const refreshStashState = useCallback(async () => {
+    if (!sessionId) return;
+    const response = await API.sessions.hasStash(sessionId);
+    if (response.success) setHasStash(response.data);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) {
+      setGitCommands(null);
+      setHasStash(false);
+      setCurrentUpstream(null);
+      return;
+    }
+
+    let cancelled = false;
+    Promise.all([
+      API.sessions.getGitCommands(sessionId),
+      API.sessions.hasStash(sessionId),
+      API.sessions.getUpstream(sessionId),
+    ]).then(([commandsResponse, stashResponse, upstreamResponse]) => {
+      if (cancelled) return;
+      if (commandsResponse.success) setGitCommands(commandsResponse.data);
+      if (stashResponse.success) setHasStash(stashResponse.data);
+      if (upstreamResponse.success) setCurrentUpstream(upstreamResponse.data);
+    }).catch((loadError) => {
+      if (!cancelled) console.error('Failed to load main checkout Git data:', loadError);
+    });
+
+    return () => { cancelled = true; };
+  }, [sessionId]);
+
+  const runOperation = useCallback(async (
+    operation: (activeSessionId: string) => Promise<GitOperationResponse>,
+    failureMessage: string,
+  ): Promise<boolean> => {
+    if (!sessionId) return false;
+    setIsRunning(true);
+    setError(null);
+    try {
+      const response = await operation(sessionId);
+      if (!response.success) {
+        setError(response.error || failureMessage);
+        return false;
+      }
+      return true;
+    } catch (operationError) {
+      setError(operationError instanceof Error ? operationError.message : failureMessage);
+      return false;
+    } finally {
+      setIsRunning(false);
+    }
+  }, [sessionId]);
+
+  const handleFetch = useCallback(() => {
+    void runOperation(API.sessions.gitFetch, 'Failed to fetch from remote');
+  }, [runOperation]);
+  const handlePull = useCallback(() => {
+    void runOperation(API.sessions.gitPull, 'Failed to pull from remote');
+  }, [runOperation]);
+  const handlePush = useCallback(() => {
+    void runOperation(API.sessions.gitPush, 'Failed to push to remote');
+  }, [runOperation]);
+  const handleStash = useCallback(() => {
+    void runOperation(API.sessions.gitStash, 'Failed to stash changes').then((success) => {
+      if (success) void refreshStashState();
+    });
+  }, [refreshStashState, runOperation]);
+  const handleStashPop = useCallback(() => {
+    void runOperation(API.sessions.gitStashPop, 'Failed to pop stash').then((success) => {
+      if (success) void refreshStashState();
+    });
+  }, [refreshStashState, runOperation]);
+  const handleSoftReset = useCallback(() => {
+    void runOperation(API.sessions.gitSoftReset, 'Failed to undo commit');
+  }, [runOperation]);
+  const handleCommit = useCallback((message: string) => {
+    setShowCommitDialog(false);
+    void runOperation(
+      (activeSessionId) => API.sessions.gitStageAndCommit(activeSessionId, message),
+      'Failed to commit changes',
+    ).then((success) => {
+      if (success) setCommitMessage('');
+    });
+  }, [runOperation]);
+
+  const handleOpenSetTracking = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      const [branchesResponse, upstreamResponse] = await Promise.all([
+        API.sessions.getRemoteBranches(sessionId),
+        API.sessions.getUpstream(sessionId),
+      ]);
+      if (branchesResponse.success) setRemoteBranches(branchesResponse.data || []);
+      if (upstreamResponse.success) setCurrentUpstream(upstreamResponse.data);
+      setShowSetTrackingDialog(true);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load remote branches');
+    }
+  }, [sessionId]);
+
+  const handleSelectUpstream = useCallback((branch: string) => {
+    setShowSetTrackingDialog(false);
+    void runOperation(
+      (activeSessionId) => API.sessions.setUpstream(activeSessionId, branch),
+      'Failed to set tracking branch',
+    ).then((success) => {
+      if (success) setCurrentUpstream(branch);
+    });
+  }, [runOperation]);
+
+  const handleOpenIDE = useCallback(async (ideKey?: string) => {
+    if (!sessionId || isRemoteMode) return;
+    try {
+      const response = await API.sessions.openIDE(sessionId, ideKey);
+      if (!response.success) {
+        useErrorStore.getState().showError({
+          title: 'Failed to open IDE',
+          error: response.error || 'Unknown error occurred',
+        });
+      }
+    } catch (openError) {
+      useErrorStore.getState().showError({
+        title: 'Failed to open IDE',
+        error: openError instanceof Error ? openError.message : 'Unknown error occurred',
+      });
+    }
+  }, [isRemoteMode, sessionId]);
+
+  const sessionBusy = session?.status === 'running' || session?.status === 'initializing';
+  const actionsBusy = isRunning || sessionBusy;
+  const busyReason = isRunning
+    ? 'Git operation already in progress'
+    : sessionBusy
+      ? 'Session is currently running'
+      : undefined;
+  const gitStatus = session?.gitStatus;
+  const actions = useMemo(() => [
+    {
+      id: 'fetch', label: 'Fetch', icon: RefreshCw, onClick: handleFetch,
+      disabled: actionsBusy, variant: 'default' as const,
+      description: `Fetch remote updates for ${gitCommands?.currentBranch || 'the current branch'} without merging`,
+      disabledReason: busyReason,
+    },
+    {
+      id: 'stash', label: 'Stash', icon: Archive, onClick: handleStash,
+      disabled: actionsBusy || !gitStatus?.hasUncommittedChanges, variant: 'default' as const,
+      description: gitStatus?.hasUncommittedChanges
+        ? 'Stash changes from the main checkout in the repository-wide stash stack'
+        : 'No changes to stash',
+      disabledReason: busyReason ?? (gitStatus?.hasUncommittedChanges ? undefined : 'No changes to stash'),
+    },
+    {
+      id: 'stash-pop', label: 'Pop', icon: ArchiveRestore, onClick: handleStashPop,
+      disabled: actionsBusy || !hasStash, variant: 'default' as const,
+      description: hasStash
+        ? 'Apply and remove the newest repository stash (shared by all worktrees)'
+        : 'No stash to pop',
+      disabledReason: busyReason ?? (hasStash ? undefined : 'No stash to pop'),
+    },
+    {
+      id: 'commit', label: 'Commit', icon: GitCommitHorizontal,
+      onClick: () => setShowCommitDialog(true),
+      disabled: actionsBusy || (!gitStatus?.hasUncommittedChanges && !gitStatus?.hasUntrackedFiles),
+      variant: 'default' as const,
+      description: (gitStatus?.hasUncommittedChanges || gitStatus?.hasUntrackedFiles)
+        ? `Stage all changes and commit on ${gitCommands?.currentBranch || 'the current branch'}`
+        : 'No changes to commit',
+      disabledReason: busyReason ?? ((gitStatus?.hasUncommittedChanges || gitStatus?.hasUntrackedFiles) ? undefined : 'No changes to commit'),
+    },
+    {
+      id: 'undo-commit', label: 'Undo Commit', icon: Undo2, onClick: handleSoftReset,
+      disabled: actionsBusy || !gitStatus?.ahead, variant: 'default' as const,
+      description: gitStatus?.ahead
+        ? 'Undo the latest unpushed commit on the main checkout, keeping changes staged'
+        : 'No unpushed commits to undo',
+      disabledReason: busyReason ?? (gitStatus?.ahead ? undefined : 'No unpushed commits to undo'),
+    },
+    {
+      id: 'pull', label: 'Pull', icon: Download, onClick: handlePull,
+      disabled: actionsBusy, variant: 'default' as const,
+      description: `Pull remote changes into ${gitCommands?.currentBranch || 'the current branch'}`,
+      disabledReason: busyReason,
+    },
+    {
+      id: 'push', label: 'Push', icon: Upload, onClick: handlePush,
+      disabled: actionsBusy || !gitStatus?.ahead, variant: 'default' as const,
+      description: gitStatus?.ahead
+        ? `Push ${gitStatus.ahead} commit(s) from ${gitCommands?.currentBranch || 'the current branch'}`
+        : 'No commits to push',
+      disabledReason: busyReason ?? (gitStatus?.ahead ? undefined : 'No commits to push'),
+    },
+  ], [actionsBusy, busyReason, gitCommands?.currentBranch, gitStatus, handleFetch, handlePull, handlePush, handleSoftReset, handleStash, handleStashPop, hasStash]);
+
+  return {
+    actions,
+    actionsBusy,
+    commitMessage,
+    currentUpstream,
+    error,
+    gitCommands,
+    handleCommit,
+    handleOpenIDE,
+    handleOpenSetTracking,
+    handleSelectUpstream,
+    isRemoteMode,
+    isRunning,
+    remoteBranches,
+    setCommitMessage,
+    setShowCommitDialog,
+    setShowSetTrackingDialog,
+    showCommitDialog,
+    showSetTrackingDialog,
+  };
+}


### PR DESCRIPTION
## Summary

- show Changes, Branch controls, and the applicable worktree-style action grid in the main checkout sidebar
- add Fetch, Commit, Stash, Pop, Undo Commit, Pull, and Push while keeping Rebase/Merge worktree-only
- wire current branch, upstream tracking, Open in IDE, disabled states, and shared-stash risk copy through a dedicated main-checkout controller
- leave the swap-layout control absent because the main project view has no swapped layout model
- keep the Codex usage widget work from #398 out of this branch

Closes #405.

Marker: `SB405A`

## Review fixes

- enable the first Push when a branch has no upstream, even when its ahead count is zero
- carry the project's configured IDE command into the main-checkout sidebar and make Configure open Project Settings
- replace the tracking popup with the repository's accessible Radix modal
- split the oversized detail panel into focused horizontal-layout and action-grid components

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter frontend test -- --reporter=dot` (139 tests)
- `pnpm --filter frontend build`
- `pnpm dlx react-doctor@0.9.2 frontend --scope changed --base origin/main --include-untracked --no-score --json` (0 new findings, 3 fixed)
- isolated Playwright QA against mocked main-checkout Git data (1/1 passed, no page errors)

## Automated UI QA

Verified on head `8068c50` at 1600×900:

- main sidebar renders the current branch and checkout-valid controls
- Push is enabled for a branch with no upstream and zero ahead commits
- the configured `zed .` IDE entry is present and Configure opens Project Settings
- Rebase from main, Merge to main, and the swap-layout control remain absent on main
- Set Tracking uses a keyboard-dismissable dialog and describes the primary checkout
- no Git action handler was invoked; the scenario used isolated mocked data because Stash, Pop, and Undo Commit can mutate the shared repository or primary checkout

![Main checkout Set Tracking dialog after review fixes](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-407-8068c50-90d8e89c52b2-main-sidebar-review-fixes.png)

## Manual review

- confirm worktree sidebar behavior and paired action layout are unchanged
- confirm disabled states for clean, no-stash, tracked/no-ahead, and busy sessions
- use a disposable repository before manually invoking Stash, Pop, or Undo Commit; the stash stack is shared across worktrees, and Undo Commit rewrites the primary checkout's current branch
