### PR TITLE
Preserve optional values across config normalization

### DIFF
--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -324,7 +324,7 @@ export class ConfigManager extends EventEmitter {
         ? normalizePaneChatAgent(updates.defaultOrchestratorAgent)
         : this.config.defaultOrchestratorAgent,
       cloud: 'cloud' in updates
-        ? updates.cloud
+        ? (updates.cloud === undefined ? undefined : normalizeCloudVmConfig(updates.cloud))
         : this.config.cloud,
       remoteDaemon: 'remoteDaemon' in updates
         ? normalizeRemoteDaemonConfig(updates.remoteDaemon)

--- a/packages/runpane/src/boundaryDecoder.ts
+++ b/packages/runpane/src/boundaryDecoder.ts
@@ -60,7 +60,7 @@ function materializeObject<Fields extends ObjectFields>(
   entries: Array<[string, unknown]>,
 ): InferObject<Fields>;
 function materializeObject(entries: Array<[string, unknown]>): ObjectValue {
-  return Object.fromEntries(entries);
+  return Object.fromEntries(entries.filter(([, value]) => value !== undefined));
 }
 
 function decodeUnion<Schemas extends readonly BoundarySchema<unknown>[]>(

--- a/shared/types/cloud.ts
+++ b/shared/types/cloud.ts
@@ -80,7 +80,7 @@ export function createDefaultCloudVmState(): CloudVmState {
   };
 }
 
-export function normalizeCloudVmConfig(value: JsonValue | undefined): CloudVmConfig {
+export function normalizeCloudVmConfig<Value>(value: Value): CloudVmConfig {
   const defaults = createDefaultCloudVmConfig();
   let config: JsonObject;
   try {

--- a/shared/validation/boundaryDecoder.ts
+++ b/shared/validation/boundaryDecoder.ts
@@ -60,7 +60,7 @@ function materializeObject<Fields extends ObjectFields>(
   entries: Array<[string, unknown]>,
 ): InferObject<Fields>;
 function materializeObject(entries: Array<[string, unknown]>): ObjectValue {
-  return Object.fromEntries(entries);
+  return Object.fromEntries(entries.filter(([, value]) => value !== undefined));
 }
 
 function decodeUnion<Schemas extends readonly BoundarySchema<unknown>[]>(


### PR DESCRIPTION
## Summary
- omit absent optional decoder fields instead of materializing explicit `undefined` values
- keep cloud VM configuration normalization active during config updates
- preserve remote connection profiles across repeated normalization passes

Follow-up to #413.

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter main exec vitest run src/ipc/remoteDaemon.test.ts src/services/cloudVmManager.test.ts` (43/43)
- full main suite: 564 functional tests passed; four local DB tests unavailable only because Electron packaging rebuilt the native SQLite module for the Electron ABI