### PR TITLE
Fix daemon transport boundary semantics

### DIFF
--- a/main/src/daemon/httpApiServer.test.ts
+++ b/main/src/daemon/httpApiServer.test.ts
@@ -541,13 +541,20 @@ describe('PaneRemoteHttpApiServer', () => {
       lastSeenAt: expect.any(String),
     }]);
 
-    server.getEventSink().send('session:created', { id: 'session-1' });
+    server.getEventSink().send('session:created', {
+      id: 'session-1',
+      omitted: undefined,
+      timestamp: new Date('2026-08-17T00:00:00.000Z'),
+    });
 
     const daemonEvent = await stream.nextEvent();
     expect(daemonEvent.event).toBe('daemon-event');
     expect(JSON.parse(daemonEvent.data.join('\n'))).toEqual({
       channel: 'session:created',
-      args: [{ id: 'session-1' }],
+      args: [{
+        id: 'session-1',
+        timestamp: '2026-08-17T00:00:00.000Z',
+      }],
       timestamp: expect.any(String),
     });
 

--- a/main/src/daemon/httpApiServer.ts
+++ b/main/src/daemon/httpApiServer.ts
@@ -25,6 +25,7 @@ import { remoteHostRuntimeStateStore } from './remoteHostRuntimeState';
 import { getRemotePwaAssetResponse } from './pwaStaticAssets';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 import type { BoundarySchema, JsonValue } from '../../../shared/validation/boundaryDecoder';
+import { serializeJsonTransport } from './jsonTransport';
 
 interface RemoteHttpAddress {
   host: string;
@@ -206,7 +207,7 @@ export class PaneRemoteHttpApiServer {
 
           const payload: RemoteDaemonEventEnvelope = {
             channel,
-            args: decodeBoundary(args, boundary.array(boundary.json)),
+            args: serializeJsonTransport(args, boundary.array(boundary.json)),
             timestamp: new Date().toISOString(),
           };
 

--- a/main/src/daemon/jsonTransport.test.ts
+++ b/main/src/daemon/jsonTransport.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { boundary } from '../../../shared/validation/boundaryDecoder';
+import { serializeJsonTransport } from './jsonTransport';
+
+describe('serializeJsonTransport', () => {
+  it('matches JSON semantics for dates and omitted object properties', () => {
+    const value = serializeJsonTransport({
+      omitted: undefined,
+      timestamp: new Date('2026-08-17T00:00:00.000Z'),
+    }, boundary.jsonObject);
+
+    expect(value).toEqual({
+      timestamp: '2026-08-17T00:00:00.000Z',
+    });
+  });
+
+  it('matches JSON semantics for undefined array entries', () => {
+    expect(serializeJsonTransport(['value', undefined], boundary.array(boundary.json)))
+      .toEqual(['value', null]);
+  });
+});

--- a/main/src/daemon/jsonTransport.ts
+++ b/main/src/daemon/jsonTransport.ts
@@ -1,0 +1,16 @@
+import {
+  decodeBoundary,
+  type BoundarySchema,
+} from '../../../shared/validation/boundaryDecoder';
+
+export function serializeJsonTransport<Value, Decoded>(
+  value: Value,
+  schema: BoundarySchema<Decoded>,
+): Decoded {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new Error('JSON transport value is not serializable');
+  }
+
+  return decodeBoundary(JSON.parse(serialized), schema);
+}

--- a/main/src/daemon/server.test.ts
+++ b/main/src/daemon/server.test.ts
@@ -107,7 +107,11 @@ async function waitForSubscriberCount(server: PaneDaemonServer, expectedCount: n
 describe('PaneDaemonServer', () => {
   it('serves registered daemon commands over the local endpoint', async () => {
     const registry = new PaneCommandRegistry();
-    registry.register('sessions:get-all', async () => [{ id: 'session-1' }]);
+    registry.register('sessions:get-all', async () => [{
+      id: 'session-1',
+      omitted: undefined,
+      timestamp: new Date('2026-08-17T00:00:00.000Z'),
+    }]);
 
     const server = new PaneDaemonServer(registry, createTempAppDirectory());
     activeServers.push(server);
@@ -125,7 +129,10 @@ describe('PaneDaemonServer', () => {
       type: 'response',
       id: 1,
       ok: true,
-      result: [{ id: 'session-1' }],
+      result: [{
+        id: 'session-1',
+        timestamp: '2026-08-17T00:00:00.000Z',
+      }],
     });
   });
 

--- a/main/src/daemon/server.ts
+++ b/main/src/daemon/server.ts
@@ -10,7 +10,8 @@ import type {
   PaneDaemonRequestFrame,
   PaneDaemonSuccessResponseFrame,
 } from '../../../shared/types/daemon';
-import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+import { boundary } from '../../../shared/validation/boundaryDecoder';
+import { serializeJsonTransport } from './jsonTransport';
 
 const DAEMON_EVENT_PREFIXES = [
   'archive:',
@@ -75,7 +76,7 @@ export class PaneDaemonServer {
       const encodedFrame = encodePaneDaemonFrame({
         type: 'event',
         channel,
-        args: decodeBoundary(args, boundary.array(boundary.json)),
+        args: serializeJsonTransport(args, boundary.array(boundary.json)),
       });
 
       for (const [clientId] of this.clients) {
@@ -319,7 +320,7 @@ export class PaneDaemonServer {
         type: 'response',
         id: frame.id,
         ok: true,
-        result: decodeBoundary(result, boundary.optional(boundary.json)),
+        result: result === undefined ? undefined : serializeJsonTransport(result, boundary.json),
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/main/src/ipc/daemon.test.ts
+++ b/main/src/ipc/daemon.test.ts
@@ -42,6 +42,25 @@ describe('daemon IPC bridge', () => {
     expect(handler).toHaveBeenCalledWith('session-1');
   });
 
+  it('preserves structured-clone arguments and results for local handlers', async () => {
+    const registry = new PaneCommandRegistry();
+    const ipcMain = createIpcMainStub();
+    const timestamp = new Date('2026-08-17T00:00:00.000Z');
+    const handler = vi.fn(async (_sessionId: string, optionalValue?: string) => ({
+      optionalValue,
+      timestamp,
+    }));
+
+    registry.register('sessions:get-output', handler);
+    registerDaemonBridgeHandlers(ipcMain, createDaemonBridgeRouter(registry));
+
+    const bridge = ipcMain.handlers.get('daemon:invoke');
+    const result = await bridge?.({}, 'sessions:get-output', 'session-1', undefined);
+
+    expect(handler).toHaveBeenCalledWith('session-1', undefined);
+    expect(result).toEqual({ optionalValue: undefined, timestamp });
+  });
+
   it('rejects adapter-only channels at the bridge boundary', async () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();

--- a/main/src/ipc/daemon.ts
+++ b/main/src/ipc/daemon.ts
@@ -1,23 +1,25 @@
 import { isDaemonOwnedChannel } from '../daemon/daemonChannels';
-import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import type { PaneCommandRegistry, PaneCommandValue } from '../daemon/commandRegistry';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
-import { boundary, decodeBoundary, type JsonValue } from '../../../shared/validation/boundaryDecoder';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 interface IpcMainHandleLike {
-  handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
+  // Keep the daemon boundary independent from Electron while retaining the
+  // structural portion of IpcMainInvokeEvent needed for handler compatibility.
+  handle(
+    channel: string,
+    listener: (_event: { readonly sender: object }, channel: PaneCommandValue, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>,
+  ): void;
 }
 
 interface PaneDaemonBridgeRouter {
-  invoke(channel: string, args: JsonValue[]): Promise<JsonValue | undefined>;
+  invoke(channel: string, args: PaneCommandValue[]): Promise<PaneCommandValue>;
 }
 
 export function createDaemonBridgeRouter(commandRegistry: PaneCommandRegistry): PaneDaemonBridgeRouter {
   return {
-    async invoke(channel: string, args: JsonValue[]): Promise<JsonValue | undefined> {
-      return remotePaneClientController.invoke(channel, args, async () => {
-        const result = await commandRegistry.invoke(channel, args);
-        return result === undefined ? undefined : decodeBoundary(result, boundary.json);
-      });
+    async invoke(channel: string, args: PaneCommandValue[]): Promise<PaneCommandValue> {
+      return remotePaneClientController.invoke(channel, args, () => commandRegistry.invoke(channel, args));
     },
   };
 }
@@ -26,16 +28,18 @@ export function registerDaemonBridgeHandlers(
   ipcMain: IpcMainHandleLike,
   bridgeRouter: PaneDaemonBridgeRouter,
 ): void {
-  ipcMain.handle('daemon:invoke', async (_event, channel: unknown, ...args: unknown[]) => {
-    const decodedArgs = decodeBoundary(args, boundary.array(boundary.json));
-    if (typeof channel !== 'string') {
+  ipcMain.handle('daemon:invoke', async (_event, channel, ...args) => {
+    let decodedChannel: string;
+    try {
+      decodedChannel = decodeBoundary(channel, boundary.string);
+    } catch {
       throw new Error('Pane daemon bridge requires a string channel');
     }
 
-    if (!isDaemonOwnedChannel(channel)) {
-      throw new Error(`Channel "${channel}" is not daemon-owned`);
+    if (!isDaemonOwnedChannel(decodedChannel)) {
+      throw new Error(`Channel "${decodedChannel}" is not daemon-owned`);
     }
 
-    return bridgeRouter.invoke(channel, decodedArgs);
+    return bridgeRouter.invoke(decodedChannel, args);
   });
 }

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -105,6 +105,17 @@ describe('normalizeCloudVmConfig', () => {
       tunnelPort: '9000',
     }).tunnelPort).toBe(9000);
   });
+
+  it('preserves normalized configuration across repeated normalization', () => {
+    const normalized = normalizeCloudVmConfig({
+      provider: 'gcp',
+      apiToken: 'secret-token',
+      serverId: 'pane-user123',
+      projectId: 'pane-cloud-user123',
+    });
+
+    expect(normalizeCloudVmConfig(normalized)).toEqual(normalized);
+  });
 });
 
 describe('CloudVmManager', () => {

--- a/packages/runpane/src/localControl.ts
+++ b/packages/runpane/src/localControl.ts
@@ -69,22 +69,30 @@ type PaneToolSpec =
   | { agent: RunpaneAgent; title?: string; initialInput?: string }
   | { command: string; title?: string; initialInput?: string };
 
+interface PaneCreateSuccessItem {
+  ok: true;
+  index: number;
+  name?: string;
+  pinned: boolean;
+  sessionId?: string;
+  panelId?: string;
+  worktreePath?: string;
+  nextCommand?: string;
+  readiness?: PanelReadiness;
+  initialInput?: InitialInputDeliveryResult;
+}
+
+interface PaneCreateFailureItem {
+  ok: false;
+  index: number;
+  name?: string;
+  error: { message: string; code?: string };
+}
+
 interface PaneCreateResult {
   ok: boolean;
   repo: RepoSummary;
-  items: Array<{
-    ok: boolean;
-    index: number;
-    name?: string;
-    pinned: boolean;
-    sessionId?: string;
-    panelId?: string;
-    worktreePath?: string;
-    nextCommand?: string;
-    readiness?: PanelReadiness;
-    initialInput?: InitialInputDeliveryResult;
-    error?: { message: string; code?: string };
-  }>;
+  items: Array<PaneCreateSuccessItem | PaneCreateFailureItem>;
 }
 
 interface InitialInputDeliveryResult {
@@ -497,22 +505,29 @@ const paneListResultSchema: BoundarySchema<PaneListResult> = boundary.object({
 const paneCreateResultSchema: BoundarySchema<PaneCreateResult> = boundary.object({
   ok: boundary.boolean,
   repo: repoSummarySchema,
-  items: boundary.array(boundary.object({
-    ok: boundary.boolean,
-    index: boundary.number,
-    name: boundary.optional(boundary.string),
-    pinned: boundary.boolean,
-    sessionId: boundary.optional(boundary.string),
-    panelId: boundary.optional(boundary.string),
-    worktreePath: boundary.optional(boundary.string),
-    nextCommand: boundary.optional(boundary.string),
-    readiness: boundary.optional(panelReadinessSchema),
-    initialInput: boundary.optional(initialInputSchema),
-    error: boundary.optional(boundary.object({
+  items: boundary.array(boundary.union(
+    boundary.object({
+      ok: boundary.literal(true),
+      index: boundary.number,
+      name: boundary.optional(boundary.string),
+      pinned: boundary.boolean,
+      sessionId: boundary.optional(boundary.string),
+      panelId: boundary.optional(boundary.string),
+      worktreePath: boundary.optional(boundary.string),
+      nextCommand: boundary.optional(boundary.string),
+      readiness: boundary.optional(panelReadinessSchema),
+      initialInput: boundary.optional(initialInputSchema),
+    }),
+    boundary.object({
+      ok: boundary.literal(false),
+      index: boundary.number,
+      name: boundary.optional(boundary.string),
+      error: boundary.object({
       message: boundary.string,
       code: boundary.optional(boundary.string),
-    })),
-  })),
+      }),
+    }),
+  )),
 });
 const paneArchiveResultSchema: BoundarySchema<PaneArchiveResult> = boundary.union(
   boundary.object({
@@ -1467,10 +1482,9 @@ function printPaneListResult(result: PaneListResult): void {
 
 function printPaneCreateResult(result: PaneCreateResult): void {
   for (const item of result.items) {
-    if (item.sessionId || item.panelId) {
+    if (item.ok) {
       const worktree = item.worktreePath ? ` at ${item.worktreePath}` : '';
-      const status = item.ok ? 'Created' : 'Created with follow-up needed';
-      console.log(`${status} ${item.name ?? `pane ${item.index}`}: session ${item.sessionId ?? 'unknown'} panel ${item.panelId ?? 'unknown'}${worktree}`);
+      console.log(`Created ${item.name ?? `pane ${item.index}`}: session ${item.sessionId ?? 'unknown'} panel ${item.panelId ?? 'unknown'}${worktree}`);
       if (item.readiness) {
         console.log(`  Ready: ${item.readiness.ok ? 'yes' : item.readiness.timedOut ? 'timed out' : 'blocked'} after ${item.readiness.elapsedMs}ms`);
         if (item.readiness.blocked) {
@@ -1483,7 +1497,7 @@ function printPaneCreateResult(result: PaneCreateResult): void {
       }
       continue;
     }
-    console.error(`Failed ${item.name ?? `pane ${item.index}`}: ${item.error?.message ?? 'unknown error'}`);
+    console.error(`Failed ${item.name ?? `pane ${item.index}`}: ${item.error.message}`);
   }
 }
 

--- a/shared/types/cloud.ts
+++ b/shared/types/cloud.ts
@@ -84,7 +84,11 @@ export function normalizeCloudVmConfig<Value>(value: Value): CloudVmConfig {
   const defaults = createDefaultCloudVmConfig();
   let config: JsonObject;
   try {
-    config = decodeBoundary(value, boundary.jsonObject);
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+      return defaults;
+    }
+    config = decodeBoundary(JSON.parse(serialized), boundary.jsonObject);
   } catch {
     return defaults;
   }


### PR DESCRIPTION
## Summary
- preserve omitted optional arguments and structured-clone values across local Electron IPC
- apply JSON serialization semantics to socket, SSE, and cloud configuration boundaries
- model RunPane pane-create success and failure payloads as a discriminated union

Addresses review feedback left on #413 and #414.

## Testing
- `pnpm --filter main exec vitest run` (572 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter runpane build`
- `node scripts/test-runpane-contract.js`
- Phase 2a targeted advisory inventory: zero findings