### PR TITLE
Show pane titles and compact sidebar actions

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -726,7 +726,7 @@ function SessionRow({
       {/* Always-present left accent bar reflecting the agent status. */}
       <StatusAccentBar status={agentDisplayStatus} isActive={isActive} />
       <Tooltip
-        content={<SessionDetailTooltip session={session} gitStatus={localGitStatus} showName={false} showDiffStats={false} globalIndex={globalIndex} />}
+        content={<SessionDetailTooltip session={session} gitStatus={localGitStatus} showName showDiffStats={false} globalIndex={globalIndex} />}
         side="right"
         interactive
       >

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { ProjectSessionList, ArchivedSessions } from './ProjectSessionList';
 import { ArchiveProgress } from './ArchiveProgress';
-import { ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare } from 'lucide-react';
+import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { usePaneLogo } from '../hooks/usePaneLogo';
 import { isMac } from '../utils/platformUtils';
@@ -35,6 +35,7 @@ import { getRemoteFooterStatus } from '../utils/remoteRuntimePresentation';
 import { usePanelStore } from '../stores/panelStore';
 import { rollupAgentDisplayStatus, rollupSessionAgentState, toAgentDisplayStatus } from '../utils/agentStatus';
 import { createProjectById, getPinnedSessions, groupSessionsByProject } from '../utils/sessionOrdering';
+import { PopoverButton, TerminalPopover } from './terminal/TerminalPopover';
 
 // --- Collapsed sidebar tooltip content ---
 
@@ -63,7 +64,7 @@ function CompactSessionTooltip({
         {label}
       </p>
       <div className="border-t border-border-primary" />
-      <SessionDetailTooltip session={session} showName />
+      <SessionDetailTooltip session={session} showName={false} />
     </div>
   );
 }
@@ -86,6 +87,11 @@ const RESOURCE_POPOVER_WIDTH = 320;
 const RESOURCE_POPOVER_GAP = 8;
 const RESOURCE_POPOVER_VIEWPORT_MARGIN = 8;
 type SidebarSection = 'pinned' | 'repositories';
+interface CompactSessionMenuState {
+  session: Session;
+  x: number;
+  y: number;
+}
 const COMPACT_RAIL_BUTTON = 'relative flex h-9 min-h-9 w-9 min-w-9 shrink-0 items-center justify-center rounded transition-colors focus:outline-none focus:ring-2 focus:ring-interactive';
 const COMPACT_RAIL_IDLE = 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary';
 const COMPACT_RAIL_ACTIVE = 'bg-surface-hover text-text-primary';
@@ -374,6 +380,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
   // State for collapsed sidebar
   const [projects, setProjects] = useState<Project[]>([]);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [compactSessionMenu, setCompactSessionMenu] = useState<CompactSessionMenuState | null>(null);
   const activeProjectId = useNavigationStore((state) => state.activeProjectId);
   const activeView = useNavigationStore((state) => state.activeView);
   const expandedProjects = useNavigationStore((state) => state.expandedProjects);
@@ -435,10 +442,39 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
   );
 
   const openCompactSession = useCallback((sessionId: string, scope: 'pinned' | 'repositories') => {
+    setCompactSessionMenu(null);
     setSidebarNavigationScope(scope);
     void setActiveSession(sessionId);
     navigateToSessions();
   }, [navigateToSessions, setActiveSession, setSidebarNavigationScope]);
+
+  const openCompactSessionMenu = useCallback((event: React.MouseEvent, session: Session) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setCompactSessionMenu({ session, x: event.clientX, y: event.clientY });
+  }, []);
+
+  const archiveCompactSession = useCallback(async () => {
+    if (!compactSessionMenu) return;
+    const { id } = compactSessionMenu.session;
+    setCompactSessionMenu(null);
+    try {
+      await API.sessions.delete(id);
+    } catch (error) {
+      console.error('Failed to archive session:', error);
+    }
+  }, [compactSessionMenu]);
+
+  const toggleCompactSessionPinned = useCallback(async () => {
+    if (!compactSessionMenu) return;
+    const { id } = compactSessionMenu.session;
+    setCompactSessionMenu(null);
+    try {
+      await API.sessions.toggleFavorite(id);
+    } catch (error) {
+      console.error('Failed to toggle pinned session:', error);
+    }
+  }, [compactSessionMenu]);
 
   // Collapsed sidebar view
   if (collapsed) {
@@ -542,6 +578,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                       data-testid={`compact-pinned-pane-${session.id}`}
                       data-compact-rail-item
                       onClick={() => openCompactSession(session.id, 'pinned')}
+                      onContextMenu={(event) => openCompactSessionMenu(event, session)}
                       aria-label={`Open pinned pane ${label}`}
                       className={`${COMPACT_RAIL_BUTTON} ${session.id === activeSessionId && activeView === 'sessions' ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
                     >
@@ -613,6 +650,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                           data-testid={`compact-repository-pane-${session.id}`}
                           data-compact-rail-item
                           onClick={() => openCompactSession(session.id, 'repositories')}
+                          onContextMenu={(event) => openCompactSessionMenu(event, session)}
                           aria-label={`Open pane ${project.name}/${session.name || 'Untitled'}`}
                           className={`${COMPACT_RAIL_BUTTON} ${session.id === activeSessionId && activeView === 'sessions' ? COMPACT_RAIL_ACTIVE : COMPACT_RAIL_IDLE}`}
                         >
@@ -689,6 +727,29 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
             projectId={activeProject.id}
           />
         )}
+
+        <TerminalPopover
+          visible={compactSessionMenu !== null}
+          x={compactSessionMenu?.x ?? 0}
+          y={compactSessionMenu?.y ?? 0}
+          onClose={() => setCompactSessionMenu(null)}
+        >
+          <div role="menu" aria-label={`Pane actions for ${compactSessionMenu?.session.name || 'Untitled'}`}>
+            <PopoverButton role="menuitem" variant="danger" onClick={() => void archiveCompactSession()}>
+              <span className="flex items-center gap-2">
+                <Archive className="h-4 w-4" />
+                Archive
+              </span>
+            </PopoverButton>
+            <div className="my-1 border-t border-border-primary" />
+            <PopoverButton role="menuitem" onClick={() => void toggleCompactSessionPinned()}>
+              <span className="flex items-center gap-2">
+                <Pin className="h-4 w-4 rotate-45" />
+                {compactSessionMenu?.session.isFavorite ? 'Unpin' : 'Pin'}
+              </span>
+            </PopoverButton>
+          </div>
+        </TerminalPopover>
       </>
     );
   }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -63,7 +63,7 @@ function CompactSessionTooltip({
         {label}
       </p>
       <div className="border-t border-border-primary" />
-      <SessionDetailTooltip session={session} showName={false} />
+      <SessionDetailTooltip session={session} showName />
     </div>
   );
 }

--- a/tests/sidebar-compact.spec.ts
+++ b/tests/sidebar-compact.spec.ts
@@ -54,6 +54,29 @@ async function collapseSidebar(page: Page) {
 }
 
 test.describe('compact sidebar', () => {
+  test('shows the full pane title when hovering a long sidebar label', async ({ page }) => {
+    const longPaneTitle = 'TIP416A · Show the complete descriptive pane title in the sidebar hover popover';
+
+    await installElectronApiMock(page, {
+      initialConfig: { theme: 'night-owl' },
+      initialProjects: projects,
+      initialSessions: [session('pane416--show-full-pane-title-in-sidebar-hover', longPaneTitle, 1)],
+      initialUiState: {
+        expandedProjects: [1],
+        pinnedSectionExpanded: true,
+        repositoriesSectionExpanded: true,
+      },
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    await page.getByRole('button', { name: longPaneTitle, exact: true }).hover();
+    const tooltip = page.getByRole('tooltip');
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip.getByText(longPaneTitle, { exact: true })).toBeVisible();
+    await expect(tooltip).toContainText('pane416--show-full-pane-title-in-sidebar-hover');
+  });
+
   test('keeps the hover background on the active pane in both sidebar modes', async ({ page }) => {
     await installElectronApiMock(page, {
       initialConfig: { theme: 'night-owl' },

--- a/tests/sidebar-compact.spec.ts
+++ b/tests/sidebar-compact.spec.ts
@@ -75,6 +75,12 @@ test.describe('compact sidebar', () => {
     await expect(tooltip).toBeVisible();
     await expect(tooltip.getByText(longPaneTitle, { exact: true })).toBeVisible();
     await expect(tooltip).toContainText('pane416--show-full-pane-title-in-sidebar-hover');
+
+    await collapseSidebar(page);
+    await page.getByTestId('compact-repository-pane-pane416--show-full-pane-title-in-sidebar-hover').hover();
+    const compactTooltip = page.getByRole('tooltip');
+    await expect(compactTooltip.getByText(longPaneTitle, { exact: true })).toHaveCount(1);
+    await expect(compactTooltip).toContainText('pane416--show-full-pane-title-in-sidebar-hover');
   });
 
   test('keeps the hover background on the active pane in both sidebar modes', async ({ page }) => {
@@ -116,6 +122,57 @@ test.describe('compact sidebar', () => {
       path: 'test-results/sidebar-active-pane-compact.png',
       clip: { x: 0, y: 0, width: 180, height: 720 },
     });
+  });
+
+  test('offers archive and pin actions when a compact pane is right-clicked', async ({ page }) => {
+    await installElectronApiMock(page, {
+      initialConfig: { theme: 'night-owl' },
+      initialProjects: projects,
+      initialSessions: [
+        session('pinned', 'Pinned work', 1, {
+          isFavorite: true,
+          favoritePinnedAt: '2026-01-03T00:00:00.000Z',
+        }),
+        session('regular', 'Regular work', 1),
+      ],
+      initialUiState: {
+        expandedProjects: [1],
+        pinnedSectionExpanded: true,
+        repositoriesSectionExpanded: true,
+      },
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await collapseSidebar(page);
+
+    const regularPane = page.getByTestId('compact-repository-pane-regular');
+    await regularPane.click({ button: 'right' });
+    let menu = page.getByRole('menu', { name: 'Pane actions for Regular work' });
+    await expect(menu.getByRole('menuitem').nth(0)).toHaveText('Archive');
+    await expect(menu.getByRole('menuitem').nth(1)).toHaveText('Pin');
+    await menu.getByRole('menuitem', { name: 'Archive' }).click();
+
+    await expect.poll(() => page.evaluate(() => (
+      window as typeof window & {
+        __paneTestElectronMock: { getSessionDeleteCalls: () => string[] };
+      }
+    ).__paneTestElectronMock.getSessionDeleteCalls())).toEqual(['regular']);
+
+    await regularPane.click({ button: 'right' });
+    menu = page.getByRole('menu', { name: 'Pane actions for Regular work' });
+    await menu.getByRole('menuitem', { name: 'Pin', exact: true }).click();
+
+    const pinnedPane = page.getByTestId('compact-pinned-pane-pinned');
+    await pinnedPane.click({ button: 'right' });
+    menu = page.getByRole('menu', { name: 'Pane actions for Pinned work' });
+    await expect(menu.getByRole('menuitem').nth(0)).toHaveText('Archive');
+    await menu.getByRole('menuitem', { name: 'Unpin', exact: true }).click();
+
+    await expect.poll(() => page.evaluate(() => (
+      window as typeof window & {
+        __paneTestElectronMock: { getSessionFavoriteToggleCalls: () => string[] };
+      }
+    ).__paneTestElectronMock.getSessionFavoriteToggleCalls())).toEqual(['regular', 'pinned']);
   });
 
   test('mirrors an expanded pinned section and collapsed repositories section', async ({ page }) => {


### PR DESCRIPTION
## Summary

- show the full pane title in expanded-sidebar hover details while keeping the compact tooltip's existing single-title layout
- add a right-click action menu to compact-sidebar panes, with Archive first and Pin/Unpin second
- cover long-title consistency and compact archive/pin/unpin actions in Playwright

Closes #416

## User experience

- Expanded sidebar: hover a pane to read its complete title above the branch slug.
- Compact sidebar: right-click a pane in either Pinned or Repositories to archive, pin, or unpin it.

## Testing

- `pnpm exec playwright test tests/sidebar-compact.spec.ts` (5 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build:frontend`

<!-- pr-test-automation-summary:start -->
## Automated manual QA

Status: **Passed** on `77ca8f8` with marker `TIP416A`.

- Full compact-sidebar suite: 5/5 Playwright tests passed.
- Verified expanded hover shows the complete title once above the branch slug.
- Verified compact hover keeps its existing single-title layout.
- Verified right-click menus in compact Pinned and Repositories expose Archive first and the correct Pin/Unpin action; mocked API readback confirmed all three actions.
- Downloaded screenshot evidence matched the source PNG hashes and sizes.

| Expanded title hover | Compact pane actions |
| --- | --- |
| Full title appears above the branch slug even when the row truncates it.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-417-77ca8f8-4ed0ace37c91-expanded-long-title-hover.png" width="420" alt="Expanded sidebar hover showing a complete pane title above its branch slug"> | Right-click menu exposes Archive first, followed by Pin.<br><img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-417-77ca8f8-8c48582ced1d-compact-pane-actions.png" width="360" alt="Compact sidebar pane context menu with Archive and Pin actions"> |

Remaining human review: none required before merge; the screenshots use deterministic mocked Pane data.
<!-- pr-test-automation-summary:end -->
