### PR TITLE
Show compact pane placeholder icon

### DIFF
--- a/frontend/src/components/SessionStatusBadge.tsx
+++ b/frontend/src/components/SessionStatusBadge.tsx
@@ -6,18 +6,26 @@ interface SessionStatusBadgeProps {
   sessionId: string;
   size?: 'sm' | 'md';
   unknownClassName?: string;
+  unknownFallback?: React.ReactNode;
 }
 
 /**
  * Session dot for the sidebar / session list: the herd-of-agents status
  * (blocked / working / done / idle) rolled up over the session's terminal
  * panels. `unknown` means no terminal panel has reported yet (or the session
- * has none); an inert placeholder holds the dot's footprint.
+ * has none); callers can supply a more prominent fallback, otherwise an inert
+ * placeholder holds the dot's footprint.
  */
-export const SessionStatusBadge: React.FC<SessionStatusBadgeProps> = ({ sessionId, size = 'md', unknownClassName }) => {
+export const SessionStatusBadge: React.FC<SessionStatusBadgeProps> = ({
+  sessionId,
+  size = 'md',
+  unknownClassName,
+  unknownFallback,
+}) => {
   const displayStatus = useSessionAgentDisplayStatus(sessionId);
 
   if (displayStatus === 'unknown') {
+    if (unknownFallback) return unknownFallback;
     return <AgentActivityDot active={false} size={size} inactiveClassName={unknownClassName} />;
   }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { ProjectSessionList, ArchivedSessions } from './ProjectSessionList';
 import { ArchiveProgress } from './ArchiveProgress';
-import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare } from 'lucide-react';
+import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare, SquareTerminal } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { usePaneLogo } from '../hooks/usePaneLogo';
 import { isMac } from '../utils/platformUtils';
@@ -584,7 +584,13 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                     >
                       <SessionStatusBadge
                         sessionId={session.id}
-                        unknownClassName="bg-text-tertiary/60 opacity-100 duration-150"
+                        unknownFallback={(
+                          <SquareTerminal
+                            data-testid={`compact-pinned-pane-placeholder-${session.id}`}
+                            aria-hidden="true"
+                            className="h-4 w-4 text-text-tertiary"
+                          />
+                        )}
                       />
                     </button>
                   </Tooltip>
@@ -656,7 +662,13 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
                         >
                           <SessionStatusBadge
                             sessionId={session.id}
-                            unknownClassName="bg-text-tertiary/60 opacity-100 duration-150"
+                            unknownFallback={(
+                              <SquareTerminal
+                                data-testid={`compact-repository-pane-placeholder-${session.id}`}
+                                aria-hidden="true"
+                                className="h-4 w-4 text-text-tertiary"
+                              />
+                            )}
                           />
                         </button>
                       </Tooltip>

--- a/tests/sidebar-compact.spec.ts
+++ b/tests/sidebar-compact.spec.ts
@@ -198,6 +198,7 @@ test.describe('compact sidebar', () => {
 
     await expect(page.getByTestId('compact-pinned-toggle')).toHaveAttribute('aria-expanded', 'true');
     await expect(page.getByTestId('compact-pinned-pane-pinned')).toBeVisible();
+    await expect(page.getByTestId('compact-pinned-pane-placeholder-pinned')).toBeVisible();
     await expect(page.getByTestId('compact-repositories-toggle')).toHaveAttribute('aria-expanded', 'false');
     await expect(page.getByTestId('compact-repository-1')).toHaveCount(0);
     await expect(page.getByTestId('compact-repository-pane-regular')).toHaveCount(0);


### PR DESCRIPTION
## Summary

- show a neutral terminal icon when a compact pane has no agent status
- preserve the existing working, blocked, done, and idle indicators
- cover the pinned compact-sidebar placeholder in Playwright

## Testing

- `pnpm typecheck`
- `pnpm lint` (existing warnings only)
- `pnpm exec playwright test tests/sidebar-compact.spec.ts` (5 passed)

## Screenshot

The pinned pane with no agent status now has a visible terminal placeholder:

![Compact pinned pane placeholder](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-419-68d4a57-compact-pane-placeholder.png)