### PR TITLE
Refactor main-process boundary validation (phase 2b)

### DIFF
--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -22,6 +22,11 @@ import type {
   ToolPanelMetadata,
 } from "../../../shared/types/panels";
 import type { GitStatus } from "../types/session";
+import {
+  boundary,
+  decodeBoundary,
+  type JsonObject,
+} from "../../../shared/validation/boundaryDecoder";
 
 // Interface for legacy claude_panel_settings during migration
 interface ClaudePanelSetting {
@@ -71,49 +76,37 @@ interface SessionGitStatusCacheRow {
 }
 
 const DEBUG_DB_PANEL_STATE = process.env.PANE_DEBUG_DB_PANEL_STATE === "1";
-const LARGE_PANEL_STATE_FIELDS = new Set([
-  "scrollbackBuffer",
-  "alternateScreenBuffer",
-  "serializedBuffer",
-  "commandHistory",
-  "lastActiveCommand",
-  "outputBuffer",
-]);
-
-function summarizePanelStateField(value: unknown): string {
-  if (typeof value === "string") {
-    return `[string length=${value.length}]`;
-  }
-
-  if (Array.isArray(value)) {
-    return `[array length=${value.length}]`;
-  }
-
-  if (value && typeof value === "object") {
-    return `[object keys=${Object.keys(value).length}]`;
-  }
-
-  return `[${typeof value}]`;
+interface PanelStateLogSummary {
+  readonly serializedLength: number;
+  readonly isActive?: boolean;
+  readonly isPinned?: boolean;
+  readonly hasBeenViewed?: boolean;
 }
 
-function sanitizePanelStateForLog(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(item => sanitizePanelStateForLog(item));
-  }
-
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value as Record<string, unknown>).map(([key, nestedValue]) => [
-      key,
-      LARGE_PANEL_STATE_FIELDS.has(key)
-        ? summarizePanelStateField(nestedValue)
-        : sanitizePanelStateForLog(nestedValue),
-    ]),
-  );
+function sanitizePanelStateForLog(value: Partial<ToolPanelState>): PanelStateLogSummary {
+  return {
+    serializedLength: JSON.stringify(value).length,
+    isActive: value.isActive,
+    isPinned: value.isPinned,
+    hasBeenViewed: value.hasBeenViewed,
+  };
 }
+
+const toolAnalyticsMessageSchema = boundary.object({
+  type: boundary.optional(boundary.string),
+  message: boundary.optional(boundary.object({
+    content: boundary.optional(boundary.array(boundary.object({
+      type: boundary.optional(boundary.string),
+      name: boundary.optional(boundary.string),
+      id: boundary.optional(boundary.string),
+      tool_use_id: boundary.optional(boundary.string),
+    }))),
+    usage: boundary.optional(boundary.object({
+      input_tokens: boundary.optional(boundary.number),
+      output_tokens: boundary.optional(boundary.number),
+    })),
+  })),
+});
 
 export class DatabaseService {
   private db: Database.Database;
@@ -206,6 +199,7 @@ export class DatabaseService {
       created_at?: string;
       updated_at?: string;
     }
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const tableInfo = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -242,6 +236,7 @@ export class DatabaseService {
     }
 
     // Check for WSL support columns in projects table
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const projectsTableInfoForWsl = this.db
       .prepare("PRAGMA table_info(projects)")
       .all() as SqliteTableInfo[];
@@ -341,6 +336,7 @@ export class DatabaseService {
         .run();
     } else {
       // Check if the table has the correct column name
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const promptMarkersInfo = this.db
         .prepare("PRAGMA table_info(prompt_markers)")
         .all() as SqliteTableInfo[];
@@ -422,6 +418,7 @@ export class DatabaseService {
     }
 
     // Add commit_message column to execution_diffs if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const executionDiffsTableInfo = this.db
       .prepare("PRAGMA table_info(execution_diffs)")
       .all() as SqliteTableInfo[];
@@ -435,6 +432,7 @@ export class DatabaseService {
     }
 
     // Check if claude_session_id column exists
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionTableInfoClaude = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -490,6 +488,7 @@ export class DatabaseService {
           .run();
 
         // Add project_id to sessions table
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const sessionsTableInfoProjects = this.db
           .prepare("PRAGMA table_info(sessions)")
           .all() as SqliteTableInfo[];
@@ -549,6 +548,7 @@ export class DatabaseService {
     }
 
     // Add is_main_repo column to sessions table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionTableInfoForMainRepo = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -570,6 +570,7 @@ export class DatabaseService {
     }
 
     // Add main_branch column to projects table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const projectsTableInfo = this.db
       .prepare("PRAGMA table_info(projects)")
       .all() as SqliteTableInfo[];
@@ -657,6 +658,7 @@ export class DatabaseService {
         .run();
 
       // Migrate existing run_script data to the new table
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const projectsWithRunScripts = this.db
         .prepare(
           "SELECT id, run_script FROM projects WHERE run_script IS NOT NULL",
@@ -677,9 +679,11 @@ export class DatabaseService {
     }
 
     // Check if display_order columns exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const projectsTableInfo2 = this.db
       .prepare("PRAGMA table_info(projects)")
       .all() as SqliteTableInfo[];
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionsTableInfo2 = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -749,6 +753,7 @@ export class DatabaseService {
 
     // Normalize timestamp fields migration
     // Check if last_viewed_at is still TEXT type
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionTableInfoTimestamp = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -878,6 +883,7 @@ export class DatabaseService {
     }
 
     // Add missing completion_timestamp to prompt_markers if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const promptMarkersInfo = this.db
       .prepare("PRAGMA table_info(prompt_markers)")
       .all() as SqliteTableInfo[];
@@ -894,6 +900,7 @@ export class DatabaseService {
     }
 
     // Add is_favorite column to sessions table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionTableInfoFavorite = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -1009,6 +1016,7 @@ export class DatabaseService {
 
       // Check if the old folders table has INTEGER id
       if (foldersExists) {
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const foldersInfo = this.db
           .prepare("PRAGMA table_info(folders)")
           .all() as SqliteTableInfo[];
@@ -1043,6 +1051,7 @@ export class DatabaseService {
         .run();
 
       // Migrate data from project_folders to folders
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const projectFolders = this.db
         .prepare("SELECT * FROM project_folders")
         .all() as LegacyProjectFolder[];
@@ -1085,6 +1094,7 @@ export class DatabaseService {
       console.log("[Database] Dropped legacy project_folders table");
 
       // Update sessions table folder_id column type if needed
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const sessionTableInfo = this.db
         .prepare("PRAGMA table_info(sessions)")
         .all() as SqliteTableInfo[];
@@ -1138,12 +1148,14 @@ export class DatabaseService {
         // fails outright on a column-count mismatch. Skipped columns are
         // re-added by their own PRAGMA-checked ALTERs on the next pass.
         const folderMigTargetCols = (
+          // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
           this.db
             .prepare("PRAGMA table_info(sessions_folders_migration)")
             .all() as SqliteTableInfo[]
         ).map((c) => c.name);
         const folderMigSourceCols = new Set(
           (
+            // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
             this.db
               .prepare("PRAGMA table_info(sessions)")
               .all() as SqliteTableInfo[]
@@ -1259,6 +1271,7 @@ export class DatabaseService {
     }
 
     // Add parent_folder_id column to folders table for nested folders support
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const foldersTableInfo = this.db
       .prepare("PRAGMA table_info(folders)")
       .all() as SqliteTableInfo[];
@@ -1337,6 +1350,7 @@ export class DatabaseService {
     }
 
     // Add app_version column to app_opens table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const appOpensTableInfo = this.db
       .prepare("PRAGMA table_info(app_opens)")
       .all() as SqliteTableInfo[];
@@ -1352,6 +1366,7 @@ export class DatabaseService {
     }
 
     // Remove model column from sessions table if it exists (moved to panel level)
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionTableInfoModel = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -1368,6 +1383,7 @@ export class DatabaseService {
     }
 
     // Add tool_type column to sessions table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionTableInfoToolType = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -1453,6 +1469,7 @@ export class DatabaseService {
     }
 
     // Add worktree_folder column to projects table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const projectsTableInfoWorktree = this.db
       .prepare("PRAGMA table_info(projects)")
       .all() as SqliteTableInfo[];
@@ -1468,6 +1485,7 @@ export class DatabaseService {
     }
 
     // Add lastUsedModel column to projects table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const projectsTableInfoModel = this.db
       .prepare("PRAGMA table_info(projects)")
       .all() as SqliteTableInfo[];
@@ -1485,6 +1503,7 @@ export class DatabaseService {
     }
 
     // Add base_commit and base_branch columns to sessions table if they don't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionsTableInfoBase = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -1517,6 +1536,7 @@ export class DatabaseService {
       .run();
 
     // Add commit mode settings columns to projects table if they don't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const projectsTableInfoCommit = this.db
       .prepare("PRAGMA table_info(projects)")
       .all() as SqliteTableInfo[];
@@ -1564,6 +1584,7 @@ export class DatabaseService {
     }
 
     // Add commit mode settings columns to sessions table if they don't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionsTableInfoCommit = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -1669,6 +1690,7 @@ export class DatabaseService {
     }
 
     // Add active_panel_id column to sessions table if it doesn't exist
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const sessionsTableInfoPanel = this.db
       .prepare("PRAGMA table_info(sessions)")
       .all() as SqliteTableInfo[];
@@ -1709,15 +1731,19 @@ export class DatabaseService {
 
       try {
         // Step 1: Add panel_id columns to Claude tables if they don't exist
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const sessionOutputsInfo = this.db
           .prepare("PRAGMA table_info(session_outputs)")
           .all() as SqliteTableInfo[];
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const conversationMessagesInfo = this.db
           .prepare("PRAGMA table_info(conversation_messages)")
           .all() as SqliteTableInfo[];
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const promptMarkersInfo = this.db
           .prepare("PRAGMA table_info(prompt_markers)")
           .all() as SqliteTableInfo[];
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const executionDiffsInfo = this.db
           .prepare("PRAGMA table_info(execution_diffs)")
           .all() as SqliteTableInfo[];
@@ -1817,6 +1843,7 @@ export class DatabaseService {
           .run();
 
         // Step 4: Data migration - Create Claude panels for existing sessions and migrate data
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const sessionsWithClaude = this.db
           .prepare(
             `
@@ -1940,6 +1967,7 @@ export class DatabaseService {
     }
 
     // Migration 005: Ensure all sessions have diff panels
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const diffPanelsMigrationComplete = this.db
       .prepare(
         "SELECT value FROM user_preferences WHERE key = 'diff_panels_migrated'",
@@ -1953,6 +1981,7 @@ export class DatabaseService {
 
       try {
         // Get all sessions
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const sessions = this.db
           .prepare("SELECT id FROM sessions WHERE archived = 0")
           .all() as { id: string }[];
@@ -2013,6 +2042,7 @@ export class DatabaseService {
     }
 
     // Migration 006: Unified panel settings storage
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const unifiedSettingsMigrationComplete = this.db
       .prepare(
         "SELECT value FROM user_preferences WHERE key = 'unified_panel_settings_migrated'",
@@ -2026,6 +2056,7 @@ export class DatabaseService {
 
       try {
         // Step 1: Add settings column to tool_panels if it doesn't exist
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const toolPanelsInfo = this.db
           .prepare("PRAGMA table_info(tool_panels)")
           .all() as SqliteTableInfo[];
@@ -2051,6 +2082,7 @@ export class DatabaseService {
 
         if (claudePanelSettingsExists) {
           // Migrate data from claude_panel_settings to unified settings
+          // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
           const claudeSettings = this.db
             .prepare("SELECT * FROM claude_panel_settings")
             .all() as ClaudePanelSetting[];
@@ -2120,6 +2152,7 @@ export class DatabaseService {
 
       try {
         // Get all projects
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         const projects = this.db
           .prepare("SELECT id FROM projects")
           .all() as Array<{ id: number }>;
@@ -2129,6 +2162,7 @@ export class DatabaseService {
           // Check if this project has the OLD pattern: folders with low displayOrder (0-10)
           // AND sessions also with low displayOrder (0-10), indicating separate ordering systems
           // Exclude main repo sessions as they have separate handling
+          // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
           const folderStats = this.db
             .prepare(
               `
@@ -2143,6 +2177,7 @@ export class DatabaseService {
             count: number;
           };
 
+          // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
           const sessionStats = this.db
             .prepare(
               `
@@ -2178,6 +2213,7 @@ export class DatabaseService {
             );
 
             // Get all root-level sessions and folders for this project
+            // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
             const rootSessions = this.db
               .prepare(
                 `
@@ -2196,6 +2232,7 @@ export class DatabaseService {
               created_at: string;
             }>;
 
+            // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
             const allFolders = this.db
               .prepare(
                 `
@@ -2294,6 +2331,7 @@ export class DatabaseService {
     wslDistribution?: string | null,
   ): Project {
     // Get the max display_order for projects
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const maxOrderResult = this.db
       .prepare(
         `
@@ -2325,6 +2363,7 @@ export class DatabaseService {
         wslDistribution || null,
       );
 
+    // SAFETY: SQLite row ids for these tables are configured as numeric INTEGER PRIMARY KEY values.
     const project = this.getProject(result.lastInsertRowid as number);
     if (!project) {
       throw new Error("Failed to create project");
@@ -2333,18 +2372,21 @@ export class DatabaseService {
   }
 
   getProject(id: number): Project | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db.prepare("SELECT * FROM projects WHERE id = ?").get(id) as
       | Project
       | undefined;
   }
 
   getProjectByPath(path: string): Project | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare("SELECT * FROM projects WHERE path = ?")
       .get(path) as Project | undefined;
   }
 
   getActiveProject(): Project | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const project = this.db
       .prepare("SELECT * FROM projects WHERE active = 1 LIMIT 1")
       .get() as Project | undefined;
@@ -2360,6 +2402,7 @@ export class DatabaseService {
   }
 
   getAllProjects(): Project[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         "SELECT * FROM projects ORDER BY display_order ASC, created_at ASC",
@@ -2475,10 +2518,10 @@ export class DatabaseService {
     parentFolderId?: string | null,
   ): Folder {
     // Validate inputs
-    if (!name || typeof name !== "string") {
+    if (!name) {
       throw new Error("Folder name must be a non-empty string");
     }
-    if (!projectId || typeof projectId !== "number" || projectId <= 0) {
+    if (!projectId || projectId <= 0) {
       throw new Error("Project ID must be a positive number");
     }
 
@@ -2514,6 +2557,7 @@ export class DatabaseService {
     let displayOrder: number;
     if (!parentFolderId) {
       // Root-level folder: check both folders and sessions
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const maxFolderOrder = this.db
         .prepare(
           `
@@ -2524,6 +2568,7 @@ export class DatabaseService {
         )
         .get(projectId) as { max_order: number | null };
 
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const maxSessionOrder = this.db
         .prepare(
           `
@@ -2542,6 +2587,7 @@ export class DatabaseService {
       displayOrder = maxOrder + 1;
     } else {
       // Nested folder: only check folders at the same level
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const maxOrder = this.db
         .prepare(
           `
@@ -2573,6 +2619,7 @@ export class DatabaseService {
       SELECT * FROM folders WHERE id = ?
     `);
 
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const folder = stmt.get(id) as Folder | undefined;
     console.log(`[Database] Getting folder by id ${id}:`, folder);
     return folder;
@@ -2585,6 +2632,7 @@ export class DatabaseService {
       ORDER BY display_order ASC, name ASC
     `);
 
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const folders = stmt.all(projectId) as Folder[];
     console.log(
       `[Database] Getting folders for project ${projectId}:`,
@@ -2738,6 +2786,7 @@ export class DatabaseService {
       )
       .run(projectId, command, displayName || null, orderIndex || 0);
 
+    // SAFETY: SQLite row ids for these tables are configured as numeric INTEGER PRIMARY KEY values.
     const runCommand = this.getRunCommand(result.lastInsertRowid as number);
     if (!runCommand) {
       throw new Error("Failed to create run command");
@@ -2746,12 +2795,14 @@ export class DatabaseService {
   }
 
   getRunCommand(id: number): ProjectRunCommand | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare("SELECT * FROM project_run_commands WHERE id = ?")
       .get(id) as ProjectRunCommand | undefined;
   }
 
   getProjectRunCommands(projectId: number): ProjectRunCommand[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         "SELECT * FROM project_run_commands WHERE project_id = ? ORDER BY order_index ASC, id ASC",
@@ -2818,6 +2869,7 @@ export class DatabaseService {
       // Get the max display_order for both sessions and folders in this project
       // Sessions and folders share the same display_order space within a project
       // Exclude main repo sessions as they have separate handling
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const maxSessionOrder = this.db
         .prepare(
           `
@@ -2832,6 +2884,7 @@ export class DatabaseService {
         )
         .get(data.project_id ?? null) as { max_order: number | null };
 
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const maxFolderOrder = this.db
         .prepare(
           `
@@ -2887,6 +2940,7 @@ export class DatabaseService {
   }
 
   getSession(id: string): Session | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const session = this.db
       .prepare("SELECT * FROM sessions WHERE id = ?")
       .get(id) as Session | undefined;
@@ -2896,12 +2950,14 @@ export class DatabaseService {
   getAllSessions(projectId?: number, options?: { includeHidden?: boolean }): Session[] {
     const hiddenClause = options?.includeHidden ? "" : " AND (is_hidden = 0 OR is_hidden IS NULL)";
     if (projectId !== undefined) {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       return this.db
         .prepare(
           `SELECT * FROM sessions WHERE project_id = ? AND (archived = 0 OR archived IS NULL) AND (is_main_repo = 0 OR is_main_repo IS NULL)${hiddenClause} ORDER BY display_order ASC, created_at DESC`,
         )
         .all(projectId) as Session[];
     }
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `SELECT * FROM sessions WHERE (archived = 0 OR archived IS NULL) AND (is_main_repo = 0 OR is_main_repo IS NULL)${hiddenClause} ORDER BY display_order ASC, created_at DESC`,
@@ -2910,6 +2966,7 @@ export class DatabaseService {
   }
 
   getAllSessionGitStatusCache(): Array<{ sessionId: string; gitStatus: GitStatus; lastChecked: number }> {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare("SELECT session_id, status_json, last_checked_ms FROM session_git_status_cache")
       .all() as SessionGitStatusCacheRow[];
@@ -2918,6 +2975,7 @@ export class DatabaseService {
       try {
         return [{
           sessionId: row.session_id,
+          // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
           gitStatus: JSON.parse(row.status_json) as GitStatus,
           lastChecked: row.last_checked_ms,
         }];
@@ -2928,6 +2986,7 @@ export class DatabaseService {
   }
 
   getSessionGitStatusCache(sessionId: string): { gitStatus: GitStatus; lastChecked: number } | null {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const row = this.db
       .prepare("SELECT status_json, last_checked_ms FROM session_git_status_cache WHERE session_id = ?")
       .get(sessionId) as Pick<SessionGitStatusCacheRow, "status_json" | "last_checked_ms"> | undefined;
@@ -2936,6 +2995,7 @@ export class DatabaseService {
 
     try {
       return {
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         gitStatus: JSON.parse(row.status_json) as GitStatus,
         lastChecked: row.last_checked_ms,
       };
@@ -2972,6 +3032,7 @@ export class DatabaseService {
 
   getAllSessionsIncludingArchived(options?: { includeHidden?: boolean }): Session[] {
     const hiddenClause = options?.includeHidden ? "" : " AND (is_hidden = 0 OR is_hidden IS NULL)";
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `SELECT * FROM sessions WHERE (is_main_repo = 0 OR is_main_repo IS NULL)${hiddenClause} ORDER BY created_at DESC`,
@@ -2981,6 +3042,7 @@ export class DatabaseService {
 
   getPowerSaveSnapshotSessions(options?: { includeHidden?: boolean }): Session[] {
     const hiddenClause = options?.includeHidden ? "" : "WHERE (is_hidden = 0 OR is_hidden IS NULL)";
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `SELECT * FROM sessions ${hiddenClause} ORDER BY created_at DESC`,
@@ -2991,12 +3053,14 @@ export class DatabaseService {
   getArchivedSessions(projectId?: number, options?: { includeHidden?: boolean }): Session[] {
     const hiddenClause = options?.includeHidden ? "" : " AND (is_hidden = 0 OR is_hidden IS NULL)";
     if (projectId !== undefined) {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       return this.db
         .prepare(
           `SELECT * FROM sessions WHERE project_id = ? AND archived = 1 AND (is_main_repo = 0 OR is_main_repo IS NULL)${hiddenClause} ORDER BY updated_at DESC`,
         )
         .all(projectId) as Session[];
     }
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `SELECT * FROM sessions WHERE archived = 1 AND (is_main_repo = 0 OR is_main_repo IS NULL)${hiddenClause} ORDER BY updated_at DESC`,
@@ -3005,6 +3069,7 @@ export class DatabaseService {
   }
 
   getMainRepoSession(projectId: number): Session | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         "SELECT * FROM sessions WHERE project_id = ? AND is_main_repo = 1 AND (archived = 0 OR archived IS NULL)",
@@ -3183,6 +3248,7 @@ export class DatabaseService {
   }
 
   private deleteSessionOwnedRows(sessionId: string): void {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const panelRows = this.db
       .prepare("SELECT id FROM tool_panels WHERE session_id = ?")
       .all(sessionId) as Array<{ id: string }>;
@@ -3223,6 +3289,7 @@ export class DatabaseService {
 
   deleteArchivedSessionsPermanently(): number {
     return this.transaction(() => {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const rows = this.db
         .prepare(
           `
@@ -3264,8 +3331,9 @@ export class DatabaseService {
   }
 
   getSessionOutputs(sessionId: string, limit?: number): SessionOutput[] {
-    const effectiveLimit = typeof limit === "number" ? limit : Number(limit);
+    const effectiveLimit = limit ?? Number.NaN;
     if (Number.isFinite(effectiveLimit) && effectiveLimit > 0) {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const rows = this.db
         .prepare(
           `
@@ -3279,6 +3347,7 @@ export class DatabaseService {
       return rows.reverse();
     }
 
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `
@@ -3291,8 +3360,9 @@ export class DatabaseService {
   }
 
   getSessionOutputsForPanel(panelId: string, limit?: number): SessionOutput[] {
-    const effectiveLimit = typeof limit === "number" ? limit : Number(limit);
+    const effectiveLimit = limit ?? Number.NaN;
     if (Number.isFinite(effectiveLimit) && effectiveLimit > 0) {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const rows = this.db
         .prepare(
           `
@@ -3306,6 +3376,7 @@ export class DatabaseService {
       return rows.reverse();
     }
 
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `
@@ -3319,6 +3390,7 @@ export class DatabaseService {
 
   getRecentSessionOutputs(sessionId: string, since?: Date): SessionOutput[] {
     if (since) {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       return this.db
         .prepare(
           `
@@ -3362,8 +3434,9 @@ export class DatabaseService {
   }
 
   getPanelOutputs(panelId: string, limit?: number): SessionOutput[] {
-    const effectiveLimit = typeof limit === "number" ? limit : Number(limit);
+    const effectiveLimit = limit ?? Number.NaN;
     if (Number.isFinite(effectiveLimit) && effectiveLimit > 0) {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       const rows = this.db
         .prepare(
           `
@@ -3377,6 +3450,7 @@ export class DatabaseService {
       return rows.reverse();
     }
 
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `
@@ -3390,6 +3464,7 @@ export class DatabaseService {
 
   getRecentPanelOutputs(panelId: string, since?: Date): SessionOutput[] {
     if (since) {
+      // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
       return this.db
         .prepare(
           `
@@ -3427,6 +3502,7 @@ export class DatabaseService {
   }
 
   getConversationMessages(sessionId: string): ConversationMessage[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `
@@ -3467,6 +3543,7 @@ export class DatabaseService {
   }
 
   getPanelConversationMessages(panelId: string): ConversationMessage[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare(
         `
@@ -3486,6 +3563,7 @@ export class DatabaseService {
 
   // Cleanup operations
   getActiveSessions(): Session[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     return this.db
       .prepare("SELECT * FROM sessions WHERE status IN ('running', 'pending')")
       .all() as Session[];
@@ -3535,6 +3613,7 @@ export class DatabaseService {
         "[Database] Prompt marker added successfully, ID:",
         result.lastInsertRowid,
       );
+      // SAFETY: SQLite row ids for these tables are configured as numeric INTEGER PRIMARY KEY values.
       return result.lastInsertRowid as number;
     } catch (error) {
       console.error("[Database] Failed to add prompt marker:", error);
@@ -3543,6 +3622,7 @@ export class DatabaseService {
   }
 
   getPromptMarkers(sessionId: string): PromptMarker[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const markers = this.db
       .prepare(
         `
@@ -3569,6 +3649,7 @@ export class DatabaseService {
   }
 
   getPanelPromptMarkers(panelId: string): PromptMarker[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const markers = this.db
       .prepare(
         `
@@ -3682,6 +3763,7 @@ export class DatabaseService {
         "[Database] Panel prompt marker added successfully, ID:",
         result.lastInsertRowid,
       );
+      // SAFETY: SQLite row ids for these tables are configured as numeric INTEGER PRIMARY KEY values.
       return result.lastInsertRowid as number;
     } catch (error) {
       console.error("[Database] Failed to add panel prompt marker:", error);
@@ -3756,6 +3838,7 @@ export class DatabaseService {
         data.commit_message || null,
       );
 
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const diff = this.db
       .prepare("SELECT * FROM execution_diffs WHERE id = ?")
       .get(result.lastInsertRowid) as ExecutionDiffRow | undefined;
@@ -3766,6 +3849,7 @@ export class DatabaseService {
   }
 
   getExecutionDiffs(sessionId: string): ExecutionDiff[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
         `
@@ -3780,6 +3864,7 @@ export class DatabaseService {
   }
 
   getExecutionDiff(id: number): ExecutionDiff | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const row = this.db
       .prepare("SELECT * FROM execution_diffs WHERE id = ?")
       .get(id) as ExecutionDiffRow | undefined;
@@ -3787,6 +3872,7 @@ export class DatabaseService {
   }
 
   getNextExecutionSequence(sessionId: string): number {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -3845,6 +3931,7 @@ export class DatabaseService {
         data.commit_message || null,
       );
 
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const diff = this.db
       .prepare("SELECT * FROM execution_diffs WHERE id = ?")
       .get(result.lastInsertRowid) as ExecutionDiffRow | undefined;
@@ -3855,6 +3942,7 @@ export class DatabaseService {
   }
 
   getPanelExecutionDiffs(panelId: string): ExecutionDiff[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
         `
@@ -3869,6 +3957,7 @@ export class DatabaseService {
   }
 
   getNextPanelExecutionSequence(panelId: string): number {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -3976,6 +4065,7 @@ export class DatabaseService {
     console.log(`[Database] Getting structure for table: ${tableName}`);
 
     // Get column information
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const columns = this.db
       .prepare(`PRAGMA table_info(${tableName})`)
       .all() as Array<{
@@ -3988,6 +4078,7 @@ export class DatabaseService {
     }>;
 
     // Get foreign key information
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const foreignKeys = this.db
       .prepare(`PRAGMA foreign_key_list(${tableName})`)
       .all() as Array<{
@@ -4002,6 +4093,7 @@ export class DatabaseService {
     }>;
 
     // Get indexes
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const indexes = this.db
       .prepare(
         `
@@ -4028,6 +4120,7 @@ export class DatabaseService {
 
   // UI State operations
   getUIState(key: string): string | undefined {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare("SELECT value FROM ui_state WHERE key = ?")
       .get(key) as { value: string } | undefined;
@@ -4074,6 +4167,7 @@ export class DatabaseService {
     discord_shown: boolean;
     app_version?: string;
   } | null {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -4103,6 +4197,7 @@ export class DatabaseService {
   }
 
   getLastAppVersion(): string | null {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -4132,6 +4227,7 @@ export class DatabaseService {
 
   // User preferences operations
   getUserPreference(key: string): string | null {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -4158,6 +4254,7 @@ export class DatabaseService {
   }
 
   getUserPreferences(): Record<string, string> {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
         `
@@ -4226,49 +4323,27 @@ export class DatabaseService {
 
       if (updates.state !== undefined) {
         // Merge with existing state instead of replacing
-        const existingState = existingPanel?.state || {};
-        const mergedState = {
+        const existingState: ToolPanelState = existingPanel?.state || { isActive: false };
+        const stateUpdates: Partial<ToolPanelState> = updates.state || {};
+        const mergedState: ToolPanelState = {
           ...existingState,
-          ...updates.state,
+          ...stateUpdates,
         };
 
-        // If there's a customState in either, merge that too
-        if (
-          typeof existingState === "object" &&
-          existingState !== null &&
-          "customState" in existingState
-        ) {
-          const existingCustomState = (
-            existingState as { customState?: unknown }
-          ).customState;
-          const updatesCustomState =
-            typeof updates.state === "object" &&
-            updates.state !== null &&
-            "customState" in updates.state
-              ? (updates.state as { customState?: unknown }).customState
-              : undefined;
-
-          if (
-            existingCustomState !== undefined ||
-            updatesCustomState !== undefined
-          ) {
-            (mergedState as { customState: unknown }).customState = {
-              ...(typeof existingCustomState === "object" &&
-              existingCustomState !== null
-                ? existingCustomState
-                : {}),
-              ...(typeof updatesCustomState === "object" &&
-              updatesCustomState !== null
-                ? updatesCustomState
-                : {}),
-            };
-          }
+        // If there's a customState in either, merge that too.
+        const existingCustomState = existingState.customState;
+        const updatesCustomState = stateUpdates.customState;
+        if (existingCustomState !== undefined || updatesCustomState !== undefined) {
+          mergedState.customState = {
+            ...existingCustomState,
+            ...updatesCustomState,
+          };
         }
 
         if (DEBUG_DB_PANEL_STATE) {
           console.log("[DB-DEBUG] updatePanel state merge:", {
             panelId,
-            updates: sanitizePanelStateForLog(updates.state),
+            updates: sanitizePanelStateForLog(stateUpdates),
             existing: sanitizePanelStateForLog(existingState),
             merged: sanitizePanelStateForLog(mergedState),
           });
@@ -4346,6 +4421,7 @@ export class DatabaseService {
   }
 
   getPanel(panelId: string): ToolPanel | null {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const row = this.db
       .prepare("SELECT * FROM tool_panels WHERE id = ?")
       .get(panelId) as ToolPanelRow | undefined;
@@ -4353,24 +4429,30 @@ export class DatabaseService {
     if (!row) return null;
 
     // Check if this panel is the active one for its session
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const activePanel = this.db
       .prepare("SELECT active_panel_id FROM sessions WHERE id = ?")
       .get(row.session_id) as { active_panel_id: string | null } | undefined;
     const isActive = activePanel?.active_panel_id === panelId;
 
+    // SAFETY: Panel state JSON is written from ToolPanelState by createPanel/updatePanel.
     const state = row.state
+      // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
       ? (JSON.parse(row.state) as ToolPanelState)
       : { isActive: false, hasBeenViewed: false, customState: {} };
     // Update isActive based on whether this panel is the active one
     state.isActive = isActive;
 
+    // SAFETY: Panel metadata JSON is written from ToolPanelMetadata by createPanel/updatePanel.
     return {
       id: row.id,
       sessionId: row.session_id,
+      // SAFETY: The panel type column is constrained to values written from ToolPanelType.
       type: row.type as ToolPanelType,
       title: row.title,
       state,
       metadata: row.metadata
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         ? (JSON.parse(row.metadata) as ToolPanelMetadata)
         : {
             createdAt: row.created_at,
@@ -4381,6 +4463,7 @@ export class DatabaseService {
   }
 
   getPanelsForSession(sessionId: string): ToolPanel[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
         "SELECT * FROM tool_panels WHERE session_id = ? ORDER BY created_at",
@@ -4388,25 +4471,31 @@ export class DatabaseService {
       .all(sessionId) as ToolPanelRow[];
 
     // Get the active panel ID for this session
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const activePanel = this.db
       .prepare("SELECT active_panel_id FROM sessions WHERE id = ?")
       .get(sessionId) as { active_panel_id: string | null } | undefined;
     const activePanelId = activePanel?.active_panel_id;
 
     return rows.map((row) => {
+      // SAFETY: Panel state JSON is written from ToolPanelState by createPanel/updatePanel.
       const state = row.state
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         ? (JSON.parse(row.state) as ToolPanelState)
         : { isActive: false, hasBeenViewed: false, customState: {} };
       // Update isActive based on whether this panel is the active one
       state.isActive = row.id === activePanelId;
 
+      // SAFETY: Panel metadata JSON is written from ToolPanelMetadata by createPanel/updatePanel.
       return {
         id: row.id,
         sessionId: row.session_id,
+        // SAFETY: The panel type column is constrained to values written from ToolPanelType.
         type: row.type as ToolPanelType,
         title: row.title,
         state,
         metadata: row.metadata
+          // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
           ? (JSON.parse(row.metadata) as ToolPanelMetadata)
           : {
               createdAt: row.created_at,
@@ -4418,19 +4507,24 @@ export class DatabaseService {
   }
 
   getAllPanels(): ToolPanel[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare("SELECT * FROM tool_panels ORDER BY created_at")
       .all() as ToolPanelRow[];
 
+    // SAFETY: Panel state and metadata JSON are written by the matching typed panel serializers.
     return rows.map((row) => ({
       id: row.id,
       sessionId: row.session_id,
+      // SAFETY: The panel type column is constrained to values written from ToolPanelType.
       type: row.type as ToolPanelType,
       title: row.title,
       state: row.state
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         ? (JSON.parse(row.state) as ToolPanelState)
         : { isActive: false },
       metadata: row.metadata
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         ? (JSON.parse(row.metadata) as ToolPanelMetadata)
         : {
             createdAt: row.created_at,
@@ -4441,6 +4535,7 @@ export class DatabaseService {
   }
 
   getActivePanels(): ToolPanel[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
         `
@@ -4452,15 +4547,19 @@ export class DatabaseService {
       )
       .all() as ToolPanelRow[];
 
+    // SAFETY: Panel state and metadata JSON are written by the matching typed panel serializers.
     return rows.map((row) => ({
       id: row.id,
       sessionId: row.session_id,
+      // SAFETY: The panel type column is constrained to values written from ToolPanelType.
       type: row.type as ToolPanelType,
       title: row.title,
       state: row.state
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         ? (JSON.parse(row.state) as ToolPanelState)
         : { isActive: false },
       metadata: row.metadata
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         ? (JSON.parse(row.metadata) as ToolPanelMetadata)
         : {
             createdAt: row.created_at,
@@ -4478,6 +4577,7 @@ export class DatabaseService {
 
   /** Get the raw JSON layout string for a session's split tab groups. */
   getSessionPanelLayout(sessionId: string): string | null {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const row = this.db
       .prepare("SELECT panel_layout FROM sessions WHERE id = ?")
       .get(sessionId) as { panel_layout: string | null } | undefined;
@@ -4492,6 +4592,7 @@ export class DatabaseService {
   }
 
   getActivePanel(sessionId: string): ToolPanel | null {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const row = this.db
       .prepare(
         `
@@ -4504,19 +4605,24 @@ export class DatabaseService {
 
     if (!row) return null;
 
+    // SAFETY: Panel state JSON is written from ToolPanelState by createPanel/updatePanel.
     const state = row.state
+      // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
       ? (JSON.parse(row.state) as ToolPanelState)
       : { isActive: true, hasBeenViewed: false };
     // This panel is the active one by definition (we joined on active_panel_id)
     state.isActive = true;
 
+    // SAFETY: Panel metadata JSON is written from ToolPanelMetadata by createPanel/updatePanel.
     return {
       id: row.id,
       sessionId: row.session_id,
+      // SAFETY: The panel type column is constrained to values written from ToolPanelType.
       type: row.type as ToolPanelType,
       title: row.title,
       state,
       metadata: row.metadata
+        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
         ? (JSON.parse(row.metadata) as ToolPanelMetadata)
         : {
             createdAt: row.created_at,
@@ -4539,6 +4645,7 @@ export class DatabaseService {
    * Get the list of panel types that have been closed by the user for a session
    */
   getClosedPanelTypes(sessionId: string): string[] {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const row = this.db
       .prepare("SELECT closed_panel_types FROM sessions WHERE id = ?")
       .get(sessionId) as { closed_panel_types: string | null } | undefined;
@@ -4600,7 +4707,8 @@ export class DatabaseService {
    * Get panel settings from the unified JSON storage
    * Returns the parsed settings object or an empty object if none exist
    */
-  getPanelSettings(panelId: string): Record<string, unknown> {
+  getPanelSettings(panelId: string): JsonObject {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const row = this.db
       .prepare(
         `
@@ -4614,7 +4722,7 @@ export class DatabaseService {
     }
 
     try {
-      return JSON.parse(row.settings);
+      return decodeBoundary(JSON.parse(row.settings), boundary.jsonObject);
     } catch (e) {
       console.error(`Failed to parse settings for panel ${panelId}:`, e);
       return {};
@@ -4627,7 +4735,7 @@ export class DatabaseService {
    */
   updatePanelSettings(
     panelId: string,
-    settings: Record<string, unknown>,
+    settings: JsonObject,
   ): void {
     // Get existing settings
     const existingSettings = this.getPanelSettings(panelId);
@@ -4654,7 +4762,7 @@ export class DatabaseService {
   /**
    * Set panel settings (replaces all existing settings)
    */
-  setPanelSettings(panelId: string, settings: Record<string, unknown>): void {
+  setPanelSettings(panelId: string, settings: JsonObject): void {
     const settingsWithTimestamp = {
       ...settings,
       updatedAt: new Date().toISOString(),
@@ -4707,23 +4815,22 @@ export class DatabaseService {
       return null;
     }
 
-    // Convert from new format to old format for compatibility
-    const s = settings as Record<string, unknown>;
+    const decodedSettings = decodeBoundary(settings, boundary.object({
+      model: boundary.optional(boundary.string),
+      systemPrompt: boundary.optional(boundary.string),
+      maxTokens: boundary.optional(boundary.number),
+      temperature: boundary.optional(boundary.number),
+      createdAt: boundary.optional(boundary.string),
+      updatedAt: boundary.optional(boundary.string),
+    }));
     return {
       panel_id: panelId,
-      model: (typeof s.model === "string" ? s.model : null) || "auto",
-      system_prompt:
-        (typeof s.systemPrompt === "string" ? s.systemPrompt : null) || null,
-      max_tokens:
-        (typeof s.maxTokens === "number" ? s.maxTokens : null) || 4096,
-      temperature:
-        (typeof s.temperature === "number" ? s.temperature : null) || 0.7,
-      created_at:
-        (typeof s.createdAt === "string" ? s.createdAt : null) ||
-        new Date().toISOString(),
-      updated_at:
-        (typeof s.updatedAt === "string" ? s.updatedAt : null) ||
-        new Date().toISOString(),
+      model: decodedSettings.model || "auto",
+      system_prompt: decodedSettings.systemPrompt || null,
+      max_tokens: decodedSettings.maxTokens || 4096,
+      temperature: decodedSettings.temperature || 0.7,
+      created_at: decodedSettings.createdAt || new Date().toISOString(),
+      updated_at: decodedSettings.updatedAt || new Date().toISOString(),
     };
   }
 
@@ -4736,7 +4843,7 @@ export class DatabaseService {
       temperature?: number;
     },
   ): void {
-    const updateObj: Record<string, unknown> = {};
+    const updateObj: JsonObject = {};
 
     if (settings.model !== undefined) updateObj.model = settings.model;
     if (settings.system_prompt !== undefined)
@@ -4763,6 +4870,7 @@ export class DatabaseService {
     totalCacheCreationTokens: number;
     messageCount: number;
   } {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
         `
@@ -4815,6 +4923,7 @@ export class DatabaseService {
     stdout: number;
     stderr: number;
   } {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -4836,6 +4945,7 @@ export class DatabaseService {
 
     result.forEach((row: { type: string; count: number }) => {
       if (row.type in counts) {
+        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
         counts[row.type as keyof typeof counts] = row.count;
       }
     });
@@ -4844,6 +4954,7 @@ export class DatabaseService {
   }
 
   getConversationMessageCount(sessionId: string): number {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -4858,6 +4969,7 @@ export class DatabaseService {
   }
 
   getPanelConversationMessageCount(panelId: string): number {
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
         `
@@ -4883,6 +4995,7 @@ export class DatabaseService {
     totalToolCalls: number;
   } {
     // Get all tool_use messages for this session
+    // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const toolUseRows = this.db
       .prepare(
         `
@@ -4912,16 +5025,12 @@ export class DatabaseService {
     toolUseRows.forEach(
       (row: { data: string; timestamp: string }, index: number) => {
         try {
-          const data = JSON.parse(row.data);
+          const data = decodeBoundary(JSON.parse(row.data), toolAnalyticsMessageSchema);
+          const message = data.message;
 
           // Check if this is a tool_use message
-          if (data.type === "assistant" && data.message?.content) {
-            data.message.content.forEach((content: unknown) => {
-              const contentObj = content as {
-                type?: string;
-                name?: string;
-                id?: string;
-              };
+          if (data.type === "assistant" && message?.content) {
+            message.content.forEach((contentObj) => {
               if (contentObj.type === "tool_use" && contentObj.name) {
                 totalToolCalls++;
                 const toolName = contentObj.name!;
@@ -4944,21 +5053,17 @@ export class DatabaseService {
                 }
 
                 // Add token usage if available
-                if (data.message.usage) {
-                  stats.inputTokens += data.message.usage.input_tokens || 0;
-                  stats.outputTokens += data.message.usage.output_tokens || 0;
+                if (message.usage) {
+                  stats.inputTokens += message.usage.input_tokens || 0;
+                  stats.outputTokens += message.usage.output_tokens || 0;
                 }
               }
             });
           }
 
           // Check if this is a tool_result message
-          if (data.type === "user" && data.message?.content) {
-            data.message.content.forEach((content: unknown) => {
-              const contentObj = content as {
-                type?: string;
-                tool_use_id?: string;
-              };
+          if (data.type === "user" && message?.content) {
+            message.content.forEach((contentObj) => {
               if (contentObj.type === "tool_result" && contentObj.tool_use_id) {
                 // Find which tool this result belongs to
                 for (const [toolName, stats] of toolStats.entries()) {

--- a/main/src/ipc/agentUsage.test.ts
+++ b/main/src/ipc/agentUsage.test.ts
@@ -1,6 +1,6 @@
 import * as os from 'os';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { PaneCommandRegistry, type PaneCommandValue } from '../daemon/commandRegistry';
 import { agentUsageService } from '../services/agentUsageService';
 import { registerAgentUsageHandlers, resolveAgentUsageTargets } from './agentUsage';
 import type { AppServices } from './types';
@@ -10,9 +10,10 @@ vi.mock('../services/agentUsageService', () => ({
 }));
 
 describe('registerAgentUsageHandlers', () => {
-  const bound = new Map<string, (_event: unknown, ...args: unknown[]) => unknown>();
+  interface TestIpcEvent { readonly sender?: { readonly id?: number } }
+  const bound = new Map<string, (_event: TestIpcEvent, ...args: PaneCommandValue[]) => PaneCommandValue | Promise<PaneCommandValue>>();
   const ipcMain = {
-    handle: vi.fn((channel: string, listener: (_event: unknown, ...args: unknown[]) => unknown) => {
+    handle: vi.fn((channel: string, listener: (_event: TestIpcEvent, ...args: PaneCommandValue[]) => PaneCommandValue | Promise<PaneCommandValue>) => {
       bound.set(channel, listener);
     }),
   };
@@ -22,6 +23,7 @@ describe('registerAgentUsageHandlers', () => {
     { path: '/home/dev/repo-c', wsl_enabled: true, wsl_distribution: 'Ubuntu' },
     { path: '/home/dev/repo-d', wsl_enabled: true, wsl_distribution: 'Debian' },
   ];
+  // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
   const services = {
     databaseService: { getAllProjects: vi.fn(() => projects) },
   } as unknown as AppServices;
@@ -41,7 +43,9 @@ describe('registerAgentUsageHandlers', () => {
 
   it('probes the daemon host independently of any pane', async () => {
     const registry = new PaneCommandRegistry();
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     vi.mocked(agentUsageService.getSnapshot).mockResolvedValue(available as never);
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerAgentUsageHandlers(ipcMain as never, services, registry, 'darwin');
 
     const result = await registry.invoke('agent-usage:get', [true]);
@@ -59,7 +63,9 @@ describe('registerAgentUsageHandlers', () => {
   it('falls back to known WSL distributions on Windows and returns the first available login', async () => {
     const registry = new PaneCommandRegistry();
     vi.mocked(agentUsageService.getSnapshot).mockImplementation(async target =>
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       (target.cacheKey === 'wsl:Debian' ? available : unavailable) as never);
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerAgentUsageHandlers(ipcMain as never, services, registry, 'win32');
 
     const result = await registry.invoke('agent-usage:get', [false]);
@@ -76,7 +82,9 @@ describe('registerAgentUsageHandlers', () => {
 
   it('returns the host snapshot when no target reports an available login', async () => {
     const registry = new PaneCommandRegistry();
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     vi.mocked(agentUsageService.getSnapshot).mockResolvedValue(unavailable as never);
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerAgentUsageHandlers(ipcMain as never, services, registry, 'win32');
 
     await expect(registry.invoke('agent-usage:get', [false])).resolves.toEqual({ success: true, data: unavailable });
@@ -93,7 +101,9 @@ describe('registerAgentUsageHandlers', () => {
 
   it('defaults to a cached read when no refresh flag is passed', async () => {
     const registry = new PaneCommandRegistry();
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     vi.mocked(agentUsageService.getSnapshot).mockResolvedValue(available as never);
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerAgentUsageHandlers(ipcMain as never, services, registry, 'darwin');
 
     await expect(registry.invoke('agent-usage:get', [])).resolves.toEqual({ success: true, data: available });
@@ -102,6 +112,7 @@ describe('registerAgentUsageHandlers', () => {
 
   it('rejects invalid refresh inputs', async () => {
     const registry = new PaneCommandRegistry();
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerAgentUsageHandlers(ipcMain as never, services, registry, 'darwin');
 
     await expect(registry.invoke('agent-usage:get', ['yes'])).resolves.toMatchObject({ success: false });

--- a/main/src/ipc/agentUsage.ts
+++ b/main/src/ipc/agentUsage.ts
@@ -1,10 +1,11 @@
 import type { IpcMain } from 'electron';
 import * as os from 'os';
-import { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { PaneCommandRegistry, type PaneCommandValue } from '../daemon/commandRegistry';
 import { agentUsageService, type AgentUsageTarget } from '../services/agentUsageService';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import { getWSLContextFromProject } from '../utils/wslUtils';
 import type { AppServices } from './types';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const DAEMON_AGENT_USAGE_CHANNELS = ['agent-usage:get'] as const;
 
@@ -48,8 +49,11 @@ export function registerAgentUsageHandlers(
   commandRegistry: PaneCommandRegistry,
   platform: NodeJS.Platform = process.platform,
 ): void {
-  commandRegistry.register('agent-usage:get', async (force = false) => {
-    if (typeof force !== 'boolean') {
+  commandRegistry.register('agent-usage:get', async (force: PaneCommandValue = false) => {
+    let refreshRequested: boolean;
+    try {
+      refreshRequested = decodeBoundary(force, boundary.boolean);
+    } catch {
       return { success: false, error: 'Invalid agent usage refresh request' };
     }
 
@@ -57,7 +61,7 @@ export function registerAgentUsageHandlers(
       const targets = resolveAgentUsageTargets(platform, services.databaseService.getAllProjects());
       let hostSnapshot: AgentUsageSnapshot | null = null;
       for (const target of targets) {
-        const snapshot = await agentUsageService.getSnapshot(target, force);
+        const snapshot = await agentUsageService.getSnapshot(target, refreshRequested);
         hostSnapshot ??= snapshot;
         if (hasAvailableProvider(snapshot)) return { success: true, data: snapshot };
       }

--- a/main/src/ipc/cloud.test.ts
+++ b/main/src/ipc/cloud.test.ts
@@ -1,18 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CloudVmManager } from '../services/cloudVmManager';
 import { registerCloudHandlers } from './cloud';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
 
 vi.mock('../services/cloudVmManager', () => ({
   CloudVmManager: vi.fn(),
 }));
 
+interface TestIpcEvent { readonly sender?: { readonly id?: number } }
 interface IpcMainStub {
-  handlers: Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>;
-  handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
+  handlers: Map<string, (_event: TestIpcEvent, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>>;
+  handle(channel: string, listener: (_event: TestIpcEvent, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>): void;
 }
 
 function createIpcMainStub(): IpcMainStub {
-  const handlers = new Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>();
+  const handlers = new Map<string, (_event: TestIpcEvent, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>>();
 
   return {
     handlers,
@@ -52,6 +54,7 @@ describe('cloud IPC', () => {
       remoteConnectionStatus: 'available',
     });
 
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     vi.mocked(CloudVmManager).mockImplementation(() => ({
       connectWorkspace,
       disconnectWorkspace,
@@ -63,6 +66,7 @@ describe('cloud IPC', () => {
     const ipcMain = createIpcMainStub();
     const send = vi.fn();
 
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerCloudHandlers(ipcMain, {
       configManager: {
         startWatching: vi.fn(),

--- a/main/src/ipc/config.test.ts
+++ b/main/src/ipc/config.test.ts
@@ -11,8 +11,10 @@ import {
   PANE_AGENT_CONTEXT_START,
 } from '../services/agentContextManager';
 import { registerConfigHandlers } from './config';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
 
-type IpcHandler = (_event: unknown, ...args: unknown[]) => unknown;
+interface TestIpcEvent { readonly sender?: { readonly id?: number } }
+type IpcHandler = (_event: TestIpcEvent, ...args: PaneCommandValue[]) => PaneCommandValue | Promise<PaneCommandValue>;
 
 interface IpcMainStub {
   handlers: Map<string, IpcHandler>;
@@ -45,8 +47,10 @@ async function createTempProject(id: number): Promise<Project> {
 }
 
 function createServicesStub(projects: Project[]): AppServices {
+  // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
   let config = { agentContext: { managedAgentsMd: true } } as AppConfig;
 
+  // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
   return {
     app: {},
     sessionManager: {
@@ -109,6 +113,7 @@ describe('config IPC handlers', () => {
 
     const ipcMain = createIpcMainStub();
     registerConfigHandlers(
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       ipcMain as unknown as IpcMain,
       createServicesStub([activeProject, inactiveProject]),
     );

--- a/main/src/ipc/config.ts
+++ b/main/src/ipc/config.ts
@@ -8,6 +8,7 @@ import type { VoiceTranscriptionMode } from '../../../shared/types/voiceTranscri
 import { ShellDetector } from '../utils/shellDetector';
 import { syncAutoStartOnBoot } from '../utils/autoStart';
 import { ensureProjectAgentContext } from '../services/agentContextManager';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 export function registerConfigHandlers(
   ipcMain: IpcMain,
@@ -209,7 +210,12 @@ export function registerConfigHandlers(
                 return;
               }
               try {
-                const data = JSON.parse(spStdout) as { SPFontsDataType?: Array<{ _name?: string; family?: string }> };
+                const data = decodeBoundary(JSON.parse(spStdout), boundary.object({
+                  SPFontsDataType: boundary.optional(boundary.array(boundary.object({
+                    _name: boundary.optional(boundary.string),
+                    family: boundary.optional(boundary.string),
+                  }))),
+                }));
                 const families = new Set<string>();
                 const monoKeywords = ['mono', 'courier', 'console', 'code', 'fixed', 'menlo', 'terminal'];
                 for (const font of data.SPFontsDataType || []) {
@@ -291,6 +297,6 @@ function hasConfiguredValue(...values: Array<string | undefined>): boolean {
   return values.some(value => Boolean(value?.trim()));
 }
 
-function isVoiceTranscriptionMode(value: unknown): value is VoiceTranscriptionMode {
+function isVoiceTranscriptionMode(value: string | undefined): value is VoiceTranscriptionMode {
   return value === 'recorded' || value === 'streaming';
 }

--- a/main/src/ipc/daemon.test.ts
+++ b/main/src/ipc/daemon.test.ts
@@ -1,15 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { PaneCommandRegistry } from '../daemon/commandRegistry';
+import { PaneCommandRegistry, type PaneCommandValue } from '../daemon/commandRegistry';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import { createDaemonBridgeRouter, registerDaemonBridgeHandlers } from './daemon';
 
+interface TestIpcEvent { readonly sender?: { readonly id?: number } }
 interface IpcMainStub {
-  handlers: Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>;
-  handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
+  handlers: Map<string, (_event: TestIpcEvent, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>>;
+  handle(channel: string, listener: (_event: TestIpcEvent, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>): void;
 }
 
 function createIpcMainStub(): IpcMainStub {
-  const handlers = new Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>();
+  const handlers = new Map<string, (_event: TestIpcEvent, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>>();
 
   return {
     handlers,

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -232,20 +232,23 @@ const GIT_CHANNELS = [
   ...GIT_MUTATION_CHANNELS,
 ] as const;
 
+interface TestIpcEvent { readonly sender?: { readonly id?: number } }
+type TestIpcHandler = (_event: TestIpcEvent, ...args: PaneCommandValue[]) => PaneCommandValue | Promise<PaneCommandValue>;
+
 interface IpcMainStub {
   boundChannels: string[];
-  listeners: Map<string, (_event: unknown, ...args: unknown[]) => unknown>;
-  handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => unknown): void;
+  listeners: Map<string, TestIpcHandler>;
+  handle(channel: string, listener: TestIpcHandler): void;
 }
 
 function createIpcMainStub(): IpcMainStub {
   const boundChannels: string[] = [];
-  const listeners = new Map<string, (_event: unknown, ...args: unknown[]) => unknown>();
+  const listeners = new Map<string, TestIpcHandler>();
 
   return {
     boundChannels,
     listeners,
-    handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => unknown) {
+    handle(channel: string, listener: TestIpcHandler) {
       boundChannels.push(channel);
       listeners.set(channel, listener);
     },
@@ -253,6 +256,7 @@ function createIpcMainStub(): IpcMainStub {
 }
 
 function createServicesStub(overrides: Partial<AppServices> = {}): AppServices {
+  // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
   return {
     sessionManager: {},
     gitStatusManager: {},
@@ -287,6 +291,7 @@ describe('daemon registry IPC bindings', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();
 
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerConfigHandlers(ipcMain, createServicesStub({
       configManager: {
         getConfig: () => ({
@@ -350,6 +355,7 @@ describe('daemon registry IPC bindings', () => {
     const registry = new PaneCommandRegistry();
     const ipcMain = createIpcMainStub();
 
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerVoiceHandlers(ipcMain, createServicesStub({
       configManager: {
         getConfig: () => ({}),
@@ -445,6 +451,7 @@ describe('daemon registry IPC bindings', () => {
 
     registerSessionHandlers(
       ipcMain,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       createServicesStub({ gitStatusManager: { setActiveSession } } as Partial<AppServices>),
       registry,
     );

--- a/main/src/ipc/dashboard.ts
+++ b/main/src/ipc/dashboard.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import type { CommandRunner } from '../utils/commandRunner';
 import type { PathResolver } from '../utils/pathResolver';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 interface MainBranchStatus {
   status: 'up-to-date' | 'behind' | 'ahead' | 'diverged';
@@ -690,13 +691,18 @@ async function getSessionBranchInfoAsync(
       const prOutput = prResult.stdout.trim();
 
       if (prOutput) {
-        const prs = JSON.parse(prOutput);
+        const prs = decodeBoundary(JSON.parse(prOutput), boundary.array(boundary.object({
+          number: boundary.number,
+          title: boundary.string,
+          state: boundary.enumeration('OPEN', 'CLOSED', 'MERGED'),
+          url: boundary.string,
+        })));
         if (prs.length > 0) {
           const pr = prs[0];
           pullRequest = {
             number: pr.number,
             title: pr.title,
-            state: pr.state.toLowerCase() as 'open' | 'closed' | 'merged',
+            state: pr.state === 'OPEN' ? 'open' : pr.state === 'CLOSED' ? 'closed' : 'merged',
             url: pr.url
           };
         }

--- a/main/src/ipc/editorPanel.ts
+++ b/main/src/ipc/editorPanel.ts
@@ -2,6 +2,10 @@ import { IpcMain } from 'electron';
 import * as path from 'path';
 import { panelManager } from '../services/panelManager';
 import type { AppServices } from './types';
+import { boundary, decodeBoundary, type JsonObject } from '../../../shared/validation/boundaryDecoder';
+import type { ToolPanelState } from '../../../shared/types/panels';
+
+type PersistedCustomState = NonNullable<ToolPanelState['customState']>;
 
 interface OpenFileInEditorRequest {
   sessionId: string;
@@ -13,6 +17,16 @@ interface CreateEditorPanelRequest {
   sessionId: string;
   filePath?: string; // Optional: file to open initially
   title?: string; // Optional: custom title
+}
+
+function editorFilePath(customState: PersistedCustomState | undefined): string | undefined {
+  try {
+    return decodeBoundary(customState, boundary.optional(boundary.object({
+      filePath: boundary.optional(boundary.string),
+    })))?.filePath;
+  } catch {
+    return undefined;
+  }
 }
 
 export function registerEditorPanelHandlers(ipcMain: IpcMain, services: AppServices): void {
@@ -71,7 +85,7 @@ export function registerEditorPanelHandlers(ipcMain: IpcMain, services: AppServi
       // If no panel specified, find an existing editor panel or create one
       if (!targetPanelId) {
         const panels = panelManager.getPanelsForSession(sessionId);
-        const editorPanel = panels.find(p => p.type === 'explorer' && !(p.state?.customState as {filePath?: string})?.filePath);
+        const editorPanel = panels.find(p => p.type === 'explorer' && !editorFilePath(p.state?.customState));
         
         if (editorPanel) {
           targetPanelId = editorPanel.id;
@@ -135,7 +149,7 @@ export function registerEditorPanelHandlers(ipcMain: IpcMain, services: AppServi
   });
   
   // Update editor-specific panel state
-  ipcMain.handle('editor:updatePanelState', async (_, panelId: string, state: Record<string, unknown>) => {
+  ipcMain.handle('editor:updatePanelState', async (_, panelId: string, state: JsonObject) => {
     try {
       const panel = panelManager.getPanel(panelId);
       if (!panel) {

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -6,31 +6,13 @@ import type { PaneCommandRegistry } from '../daemon/commandRegistry';
 import { buildGitCommitCommand } from '../utils/shellEscape';
 import { getPaneEventSink } from '../core/runtime';
 import { panelEventBus } from '../services/panelEventBus';
-import { PanelEventType, ToolPanelType, PanelEvent } from '../../../shared/types/panels';
+import { PanelEventType, PanelEvent } from '../../../shared/types/panels';
 import type { Session } from '../types/session';
 import type { GitCommit, GitGraphCommit } from '../services/gitDiffManager';
 import { CommandRunner } from '../utils/commandRunner';
 import { getShellPath } from '../utils/shellPath';
 import { parseWSLPath, validateWSLAvailable } from '../utils/wslUtils';
-
-// Extended type for git system virtual panels
-type SystemPanelType = ToolPanelType | 'git';
-
-// Interface for custom git errors that contain additional context
-interface GitError extends Error {
-  gitCommands?: string[];
-  gitOutput?: string;
-  workingDirectory?: string;
-  projectPath?: string;
-  originalError?: Error;
-}
-
-// Interface for process errors that have stdout/stderr properties
-interface ProcessError {
-  stdout?: string;
-  stderr?: string;
-  message?: string;
-}
+import { boundary, decodeBoundary, type JsonObject } from '../../../shared/validation/boundaryDecoder';
 
 // Interface for generic error objects with git-related properties
 interface ErrorWithGitContext {
@@ -38,8 +20,25 @@ interface ErrorWithGitContext {
   gitCommands?: string[];
   gitOutput?: string;
   workingDirectory?: string;
-  originalError?: Error;
-  [key: string]: unknown;
+  projectPath?: string;
+  originalError?: { message?: string };
+}
+
+function decodeGitError(cause: unknown): ErrorWithGitContext {
+  try {
+    return decodeBoundary(cause, boundary.object({
+      gitCommand: boundary.optional(boundary.string),
+      gitCommands: boundary.optional(boundary.array(boundary.string)),
+      gitOutput: boundary.optional(boundary.string),
+      workingDirectory: boundary.optional(boundary.string),
+      projectPath: boundary.optional(boundary.string),
+      originalError: boundary.optional(boundary.object({
+        message: boundary.optional(boundary.string),
+      })),
+    }));
+  } catch {
+    return {};
+  }
 }
 
 // Interface for raw commit data from worktreeManager
@@ -115,7 +114,7 @@ export function registerGitHandlers(
   const { sessionManager, gitDiffManager, worktreeManager, claudeCodeManager, gitStatusManager, databaseService } = services;
 
   // Helper function to emit git operation events to all sessions in a project
-  const emitGitOperationToProject = (sessionId: string, eventType: PanelEventType, message: string, details?: Record<string, unknown>) => {
+  const emitGitOperationToProject = (sessionId: string, eventType: PanelEventType, message: string, details?: JsonObject) => {
     try {
       const session = sessionManager.getSession(sessionId);
       if (!session) return;
@@ -124,11 +123,11 @@ export function registerGitHandlers(
       if (!project) return;
       
       // Create a virtual event as if it came from the git system
-      const event = {
+      const event: PanelEvent = {
         type: eventType,
         source: {
           panelId: 'git-system', // Special panel ID for git operations
-          panelType: 'git' as SystemPanelType, // Virtual panel type
+          panelType: 'git', // Virtual panel type
           sessionId: sessionId // The session that triggered the operation
         },
         data: {
@@ -143,7 +142,7 @@ export function registerGitHandlers(
       
       // Emit the event once to the panel event bus
       // All Claude panels that have subscribed will receive it
-      panelEventBus.emitPanelEvent(event as PanelEvent);
+      panelEventBus.emitPanelEvent(event);
 
       // Also forward to renderer so UI components listening for window 'panel:event' receive it
       try {
@@ -462,14 +461,24 @@ export function registerGitHandlers(
         return { success: true };
       } catch (commitError: unknown) {
         // Check if it's a pre-commit hook failure
-        if ((commitError && typeof commitError === 'object' && 'stdout' in commitError && (commitError as ProcessError).stdout?.includes('pre-commit')) || (commitError && typeof commitError === 'object' && 'stderr' in commitError && (commitError as ProcessError).stderr?.includes('pre-commit'))) {
+        const processError = decodeBoundary(commitError, boundary.object({
+          stdout: boundary.optional(boundary.string),
+          stderr: boundary.optional(boundary.string),
+        }));
+        if (processError.stdout?.includes('pre-commit') || processError.stderr?.includes('pre-commit')) {
           return { success: false, error: 'Pre-commit hooks failed. Please fix the issues and try again.' };
         }
         throw commitError;
       }
     } catch (error: unknown) {
       console.error('Failed to commit changes:', error);
-      const errorMessage = (error instanceof Error ? error.message : '') || (error && typeof error === 'object' && 'stderr' in error ? (error as ProcessError).stderr : '') || 'Failed to commit changes';
+      let stderr = '';
+      try {
+        stderr = decodeBoundary(error, boundary.object({ stderr: boundary.optional(boundary.string) })).stderr ?? '';
+      } catch {
+        // Preserve the standard error fallback below.
+      }
+      const errorMessage = (error instanceof Error ? error.message : '') || stderr || 'Failed to commit changes';
       return { success: false, error: errorMessage };
     }
   });
@@ -884,8 +893,8 @@ export function registerGitHandlers(
 
       const comparisonBranch = await Promise.race([
         worktreeManager.getSessionComparisonBranch(session, ctx),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('getSessionComparisonBranch timeout')), 30000))
-      ]) as string;
+        new Promise<string>((_, reject) => setTimeout(() => reject(new Error('getSessionComparisonBranch timeout')), 30000))
+      ]);
 
       // Check for conflicts before attempting rebase
       const conflictCheck = await worktreeManager.checkForRebaseConflicts(session.worktreePath, comparisonBranch, ctx.commandRunner);
@@ -932,7 +941,7 @@ export function registerGitHandlers(
           operation: 'rebase_from_main',
           comparisonBranch,
           hasConflicts: true,
-          conflictingFiles: conflictCheck.conflictingFiles
+          conflictingFiles: conflictCheck.conflictingFiles ?? null
         });
 
         // Return detailed conflict information
@@ -978,17 +987,18 @@ export function registerGitHandlers(
       return { success: true, data: { message: `Successfully rebased ${comparisonBranch} into worktree` } };
     } catch (error: unknown) {
       console.error(`[IPC:git] Failed to rebase main into worktree for session ${sessionId}:`, error);
+      const gitError = decodeGitError(error);
 
       // Emit git operation failed event
       const errorMessage = `✗ Rebase failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
-                          (error && typeof error === 'object' && 'gitOutput' in error && (error as GitError).gitOutput ? `\n\nGit output:\n${(error as GitError).gitOutput}` : '');
+                          (gitError.gitOutput ? `\n\nGit output:\n${gitError.gitOutput}` : '');
       
       // Don't let this block the error response either
       try {
         emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
           operation: 'rebase_from_main',
           error: error instanceof Error ? error.message : String(error),
-          gitOutput: error && typeof error === 'object' && 'gitOutput' in error ? (error as GitError).gitOutput : undefined
+          gitOutput: gitError.gitOutput ?? null
         });
       } catch (outputError) {
         console.error(`[IPC:git] Failed to emit git error event for session ${sessionId}:`, outputError);
@@ -999,10 +1009,10 @@ export function registerGitHandlers(
         success: false,
         error: error instanceof Error ? error.message : 'Failed to rebase main into worktree',
         gitError: {
-          command: error && typeof error === 'object' && 'gitCommand' in error ? (error as ErrorWithGitContext).gitCommand : undefined,
-          output: error && typeof error === 'object' && 'gitOutput' in error ? (error as ErrorWithGitContext).gitOutput : (error instanceof Error ? error.message : String(error)),
-          workingDirectory: error && typeof error === 'object' && 'workingDirectory' in error ? (error as ErrorWithGitContext).workingDirectory : undefined,
-          originalError: error && typeof error === 'object' && 'originalError' in error ? (error as ErrorWithGitContext).originalError?.message : undefined
+          command: gitError.gitCommand,
+          output: gitError.gitOutput || (error instanceof Error ? error.message : String(error)),
+          workingDirectory: gitError.workingDirectory,
+          originalError: gitError.originalError?.message
         }
       };
     }
@@ -1119,8 +1129,8 @@ export function registerGitHandlers(
       // and silently fast-forwards detached HEAD instead of the local target.
       const localBaseBranch = await Promise.race([
         worktreeManager.getSessionLocalBaseBranch(session, ctx),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('getSessionLocalBaseBranch timeout')), 30000))
-      ]) as string;
+        new Promise<string>((_, reject) => setTimeout(() => reject(new Error('getSessionLocalBaseBranch timeout')), 30000))
+      ]);
 
       // Emit git operation started event to all sessions in project
       const startMessage = `🔄 GIT OPERATION\nSquashing commits and merging to ${localBaseBranch}...\nCommit message: ${commitMessage.split('\n')[0]}${commitMessage.includes('\n') ? '...' : ''}`;
@@ -1156,24 +1166,24 @@ export function registerGitHandlers(
       return { success: true, data: { message: `Successfully squashed and merged worktree to ${localBaseBranch}` } };
     } catch (error: unknown) {
       console.error(`[IPC:git] Failed to squash and merge worktree to main for session ${sessionId}:`, error);
+      const gitError = decodeGitError(error);
 
       // Emit git operation failed event
       const errorMessage = `✗ Merge failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
-                          (error && typeof error === 'object' && 'gitOutput' in error && (error as GitError).gitOutput ? `\n\nGit output:\n${(error as GitError).gitOutput}` : '');
+                          (gitError.gitOutput ? `\n\nGit output:\n${gitError.gitOutput}` : '');
 
       // Don't let this block the error response either
       try {
         emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
           operation: 'squash_and_merge',
           error: error instanceof Error ? error.message : String(error),
-          gitOutput: error && typeof error === 'object' && 'gitOutput' in error ? (error as GitError).gitOutput : undefined
+          gitOutput: gitError.gitOutput ?? null
         });
       } catch (outputError) {
         console.error(`[IPC:git] Failed to emit git error event for session ${sessionId}:`, outputError);
       }
 
       // Pass detailed git error information to frontend
-      const gitError = error as GitError;
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to squash and merge worktree to main',
@@ -1249,7 +1259,7 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to merge worktree to main:', error);
 
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
 
       // Add error message to session output
       const errorMessage = `✗ Merge failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
@@ -1320,14 +1330,14 @@ export function registerGitHandlers(
       console.error('Failed to pull from remote:', error);
 
       // Emit git operation failed event
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
       
       const errorMessage = `✗ Pull failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
                           (gitError.gitOutput ? `\n\nGit output:\n${gitError.gitOutput}` : '');
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'pull',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       // Check if it's a merge conflict
@@ -1409,7 +1419,7 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to push to remote:', error);
 
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
       
       // Emit git operation failed event
       const errorMessage = `✗ Push failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
@@ -1417,7 +1427,7 @@ export function registerGitHandlers(
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'push',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       return {
@@ -1480,14 +1490,14 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to soft reset:', error);
 
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
 
       const errorMessage = `✗ Undo commit failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
                           (gitError.gitOutput ? `\n\nGit output:\n${gitError.gitOutput}` : '');
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'soft-reset',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       return {
@@ -1539,7 +1549,7 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to fetch from remote:', error);
 
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
 
       // Emit git operation failed event
       const errorMessage = `✗ Fetch failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
@@ -1547,7 +1557,7 @@ export function registerGitHandlers(
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'fetch',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       return {
@@ -1599,7 +1609,7 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to stash changes:', error);
 
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
 
       // Emit git operation failed event
       const errorMessage = `✗ Stash failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
@@ -1607,7 +1617,7 @@ export function registerGitHandlers(
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'stash',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       return {
@@ -1659,7 +1669,7 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to pop stash:', error);
 
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
 
       // Emit git operation failed event
       const errorMessage = `✗ Stash pop failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
@@ -1667,7 +1677,7 @@ export function registerGitHandlers(
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'stash_pop',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       return {
@@ -1728,7 +1738,7 @@ export function registerGitHandlers(
       return { success: true, data: result };
     } catch (error: unknown) {
       console.error('Failed to set upstream:', error);
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Failed to set upstream',
@@ -1829,7 +1839,7 @@ export function registerGitHandlers(
     } catch (error: unknown) {
       console.error('Failed to commit changes:', error);
 
-      const gitError = error as GitError;
+      const gitError = decodeGitError(error);
 
       // Emit git operation failed event
       const errorMessage = `✗ Commit failed: ${error instanceof Error ? error.message : 'Unknown error'}` +
@@ -1837,7 +1847,7 @@ export function registerGitHandlers(
       emitGitOperationToProject(sessionId, 'git:operation_failed', errorMessage, {
         operation: 'commit',
         error: error instanceof Error ? error.message : String(error),
-        gitOutput: gitError.gitOutput
+        gitOutput: gitError.gitOutput ?? null
       });
 
       return {
@@ -2022,7 +2032,7 @@ export function registerGitHandlers(
       }
     } catch (error) {
       console.error('Error getting git status:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -2039,7 +2049,7 @@ export function registerGitHandlers(
       return { success: true };
     } catch (error) {
       console.error('Error cancelling git status:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -2120,7 +2130,7 @@ export function registerGitHandlers(
       await commandRunner.execAsync(
         `git clone "${escapedUrl}" "${escapedPath}"`,
         actualDestDir,
-        { timeout: 300000, env: { ...process.env, PATH: getShellPath() } as Record<string, string> }
+        { timeout: 300000, env: { ...process.env, PATH: getShellPath() } }
       );
 
       // Return the original (non-WSL-translated) path so the frontend can use it directly

--- a/main/src/ipc/onboarding.ts
+++ b/main/src/ipc/onboarding.ts
@@ -2,16 +2,18 @@ import { clipboard, IpcMain, IpcMainInvokeEvent } from 'electron';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { mkdir } from 'fs/promises';
-import { execFile, execSync, spawn } from 'child_process';
+import { execFile, execSync, spawn, type ExecSyncOptionsWithStringEncoding } from 'child_process';
 import { randomUUID } from 'crypto';
 import * as pty from '@lydell/node-pty';
 import type { AppServices } from './types';
 import { getAppDirectory } from '../utils/appDirectory';
 import { CommandRunner } from '../utils/commandRunner';
 import { getShellPath } from '../utils/shellPath';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 /** Returns exec options that include the user's full shell PATH (Homebrew, nvm, etc.). */
-function shellExecOpts(extra?: Record<string, unknown>): Record<string, unknown> {
+function shellExecOpts<Options extends object>(extra: Options): Options & { env: NodeJS.ProcessEnv } {
   return { ...extra, env: { ...process.env, PATH: getShellPath() } };
 }
 
@@ -95,7 +97,7 @@ function detectEnvironment(): EnvironmentInfo {
   try {
     authStatusOutput = execSync(
       `gh auth status -h ${GITHUB_HOST}`,
-      shellExecOpts({ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }) as { encoding: 'utf-8'; stdio: ['pipe', 'pipe', 'pipe']; env: NodeJS.ProcessEnv }
+      shellExecOpts({ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] } satisfies ExecSyncOptionsWithStringEncoding)
     );
     result.ghAuthenticated = true;
   } catch {
@@ -150,7 +152,7 @@ function getGitHubCliScopes(authStatusOutput: string): string[] {
   try {
     const apiOutput = execSync(
       `gh api -i /user --silent --hostname ${GITHUB_HOST}`,
-      shellExecOpts({ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 15000 }) as { encoding: 'utf-8'; stdio: ['pipe', 'pipe', 'pipe']; timeout: number; env: NodeJS.ProcessEnv }
+      shellExecOpts({ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 15000 } satisfies ExecSyncOptionsWithStringEncoding)
     );
     const scopes = parseScopesFromHeaders(apiOutput);
     if (scopes.length > 0) return scopes;
@@ -223,9 +225,17 @@ function buildWindowsInteractiveCommand(command: string): string {
   return `${command} & echo. & echo GitHub setup finished. You can return to Pane. & pause`;
 }
 
-function normalizeTerminalDimensions(cols: unknown, rows: unknown): { cols: number; rows: number } {
-  const parsedCols = typeof cols === 'number' && Number.isFinite(cols) ? Math.floor(cols) : 80;
-  const parsedRows = typeof rows === 'number' && Number.isFinite(rows) ? Math.floor(rows) : 18;
+function normalizeTerminalDimensions(cols: PaneCommandValue, rows: PaneCommandValue): { cols: number; rows: number } {
+  const parseDimension = (value: PaneCommandValue, fallback: number): number => {
+    try {
+      const decoded = decodeBoundary(value, boundary.number);
+      return Number.isFinite(decoded) ? Math.floor(decoded) : fallback;
+    } catch {
+      return fallback;
+    }
+  };
+  const parsedCols = parseDimension(cols, 80);
+  const parsedRows = parseDimension(rows, 18);
 
   return {
     cols: Math.min(Math.max(parsedCols, 20), 240),
@@ -236,7 +246,7 @@ function normalizeTerminalDimensions(cols: unknown, rows: unknown): { cols: numb
 function buildGitHubAuthPtyEnv(): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (typeof value === 'string') {
+    if (value !== undefined) {
       env[key] = value;
     }
   }
@@ -333,7 +343,7 @@ function isPaneRepo(repoPath: string): boolean {
   if (!existsSync(join(repoPath, '.git'))) return false;
   try {
     execSync('git rev-parse --is-inside-work-tree', shellExecOpts({ cwd: repoPath, stdio: 'ignore' }));
-    const execOpts = shellExecOpts({ cwd: repoPath, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] }) as { cwd: string; encoding: 'utf-8' };
+    const execOpts = shellExecOpts({ cwd: repoPath, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] } satisfies ExecSyncOptionsWithStringEncoding);
     const canonicalPattern = /[/:]dcouple-inc\/pane(\.git)?$/i;
     // Fork pattern: any GitHub-hosted repo named exactly "Pane" (gh repo clone sets origin to user's fork)
     const forkPattern = /github\.com[/:][\w.-]+\/pane(\.git)?$/i;
@@ -543,7 +553,7 @@ export function registerOnboardingHandlers(ipcMain: IpcMain, services: AppServic
                 const jqFilter = `.[] | select(.parent.nameWithOwner == \\"${PANE_REPO}\\") | .nameWithOwner`;
                 const forkName = execSync(
                   `gh repo list --fork --limit 1000 --json nameWithOwner,parent --jq "${jqFilter}"`,
-                  shellExecOpts({ encoding: 'utf-8', timeout: 30000 }) as { encoding: 'utf-8'; timeout: number }
+                  shellExecOpts({ encoding: 'utf-8', timeout: 30000 } satisfies ExecSyncOptionsWithStringEncoding)
                 ).trim();
 
                 if (forkName) {

--- a/main/src/ipc/paneChat.ts
+++ b/main/src/ipc/paneChat.ts
@@ -1,5 +1,5 @@
 import type { IpcMain } from 'electron';
-import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import type { PaneCommandRegistry, PaneCommandValue } from '../daemon/commandRegistry';
 import type { AppServices } from './types';
 import { normalizePaneChatAgent } from '../../../shared/types/paneChat';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
@@ -27,7 +27,7 @@ export function registerPaneChatHandlers(
   });
   commandRegistry.bindChannel(ipcMain, 'pane-chat:get-or-create');
 
-  commandRegistry.register('pane-chat:set-agent', async (agent: unknown) => {
+  commandRegistry.register('pane-chat:set-agent', async (agent: PaneCommandValue) => {
     try {
       if (!services.paneChatManager) {
         throw new Error('Pane Chat manager is not initialized');

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -10,13 +10,41 @@ import { getPaneWebviewContextMap } from '../core/runtime';
 import { panelManager } from '../services/panelManager';
 import { terminalPanelManager } from '../services/terminalPanelManager';
 import { databaseService } from '../services/database';
-import { CreatePanelRequest, PanelEventType, SessionPanelLayout, ToolPanel } from '../../../shared/types/panels';
+import { CreatePanelRequest, PanelEventType, SessionPanelLayout, ToolPanel, type PanelLayoutNode, type ToolPanelState } from '../../../shared/types/panels';
 import type { AppServices } from './types';
 import { getAppSubdirectory } from '../utils/appDirectory';
 import { sanitizeTerminalOutput } from '../utils/terminalOutputSanitizer';
 import { getWSLHome, linuxToUNCPath, posixJoin } from '../utils/wslUtils';
+import { boundary, decodeBoundary, type BoundarySchema } from '../../../shared/validation/boundaryDecoder';
 
 const execFileAsync = promisify(execFile);
+
+const panelLayoutNodeSchema: BoundarySchema<PanelLayoutNode> = {
+  decode(cursor) {
+    return boundary.union(
+      boundary.object({
+        type: boundary.literal('group'),
+        id: boundary.string,
+        panelIds: boundary.array(boundary.string),
+        activePanelId: boundary.nullable(boundary.string),
+      }),
+      boundary.object({
+        type: boundary.literal('split'),
+        id: boundary.string,
+        direction: boundary.enumeration('row', 'column'),
+        children: boundary.array(panelLayoutNodeSchema),
+        sizes: boundary.array(boundary.number),
+      }),
+    ).decode(cursor);
+  },
+};
+
+const sessionPanelLayoutSchema: BoundarySchema<SessionPanelLayout> = boundary.object({
+  version: boundary.literal(1),
+  root: panelLayoutNodeSchema,
+  focusedGroupId: boundary.optional(boundary.string),
+  zoomedGroupId: boundary.optional(boundary.nullable(boundary.string)),
+});
 
 /**
  * Convert a Windows path to a WSL mount path.
@@ -72,6 +100,25 @@ function resolveTerminalInitializationCwd(
   }
 
   return requestedCwd;
+}
+
+type PersistedCustomState = NonNullable<ToolPanelState['customState']>;
+
+function readPersistedScrollback(customState: PersistedCustomState | undefined): string | null {
+  try {
+    const state = decodeBoundary(customState, boundary.object({
+      scrollbackBuffer: boundary.optional(boundary.union(
+        boundary.string,
+        boundary.array(boundary.string),
+      )),
+    }));
+    if (state.scrollbackBuffer === undefined) return null;
+    return Array.isArray(state.scrollbackBuffer)
+      ? state.scrollbackBuffer.join('\n')
+      : state.scrollbackBuffer;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -370,7 +417,7 @@ export function registerPanelHandlers(
       return { success: true, data: panel };
     } catch (error) {
       console.error('[IPC] Failed to create panel:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   
@@ -386,7 +433,7 @@ export function registerPanelHandlers(
       return { success: true };
     } catch (error) {
       console.error('[IPC] Failed to delete panel:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   
@@ -406,7 +453,7 @@ export function registerPanelHandlers(
       return { success: true, data: result };
     } catch (error) {
       console.error('[IPC] Failed to update panel:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   
@@ -416,7 +463,7 @@ export function registerPanelHandlers(
       return { success: true, data: panels };
     } catch (error) {
       console.error('[IPC] Failed to list panels:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   
@@ -426,7 +473,7 @@ export function registerPanelHandlers(
       return { success: true };
     } catch (error) {
       console.error('[IPC] Failed to set active panel:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   
@@ -440,7 +487,7 @@ export function registerPanelHandlers(
       const raw = databaseService.getSessionPanelLayout(sessionId);
       if (!raw) return { success: true, data: null };
       try {
-        const parsed = JSON.parse(raw) as SessionPanelLayout;
+        const parsed = decodeBoundary(JSON.parse(raw), sessionPanelLayoutSchema);
         return { success: true, data: parsed };
       } catch {
         // Malformed JSON should never brick a session
@@ -449,7 +496,7 @@ export function registerPanelHandlers(
       }
     } catch (error) {
       console.error('[IPC] Failed to get panel layout:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -503,7 +550,7 @@ export function registerPanelHandlers(
       return { success: true };
     } catch (error) {
       console.error('[IPC] Failed to set panel layout:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -580,7 +627,7 @@ export function registerPanelHandlers(
       return { success: true };
     } catch (error) {
       console.error('[IPC] Failed to resize terminal:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   
@@ -590,7 +637,7 @@ export function registerPanelHandlers(
       return { success: true };
     } catch (error) {
       console.error('[IPC] Failed to send terminal input:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   
@@ -643,9 +690,9 @@ export function registerPanelHandlers(
   // output cadence can drop to OUTPUT_BATCH_INTERVAL_HIDDEN while hidden.
   // No-op when the panel's PTY isn't in the map (pre-init / post-destroy).
   commandRegistry.register('terminal:setVisibility', async (panelId: string, isVisible: boolean, viewerId?: string) => {
-    const scopedViewerId = typeof viewerId === 'string' && viewerId.includes(':')
+    const scopedViewerId = viewerId?.includes(':')
       ? viewerId
-      : typeof viewerId === 'string'
+      : viewerId
         ? `local:${viewerId}`
         : undefined;
     terminalPanelManager.setVisibility(panelId, !!isVisible, scopedViewerId);
@@ -673,15 +720,7 @@ export function registerPanelHandlers(
       // Fall back to persisted scrollback for lazy/inactive terminals
       if (rawScrollback === null) {
         const panel = panelManager.getPanel(panelId);
-        const customState = panel?.state?.customState;
-        if (customState && typeof customState === 'object' && 'scrollbackBuffer' in customState) {
-          const persisted = (customState as { scrollbackBuffer?: string | string[] }).scrollbackBuffer;
-          if (typeof persisted === 'string') {
-            rawScrollback = persisted;
-          } else if (Array.isArray(persisted)) {
-            rawScrollback = persisted.join('\n');
-          }
-        }
+        rawScrollback = readPersistedScrollback(panel?.state?.customState);
       }
 
       if (rawScrollback === null || rawScrollback === '') {
@@ -699,7 +738,7 @@ export function registerPanelHandlers(
       return { success: true, data: { content, lineCount: lastLines.length, panelTitle } };
     } catch (error) {
       console.error('[IPC] Failed to get clean scrollback:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -782,15 +821,7 @@ export function registerPanelHandlers(
 
       if (rawScrollback === null) {
         const panel = panelManager.getPanel(panelId);
-        const customState = panel?.state?.customState;
-        if (customState && typeof customState === 'object' && 'scrollbackBuffer' in customState) {
-          const persisted = (customState as { scrollbackBuffer?: string | string[] }).scrollbackBuffer;
-          if (typeof persisted === 'string') {
-            rawScrollback = persisted;
-          } else if (Array.isArray(persisted)) {
-            rawScrollback = persisted.join('\n');
-          }
-        }
+        rawScrollback = readPersistedScrollback(panel?.state?.customState);
       }
 
       if (rawScrollback === null || rawScrollback === '') {
@@ -815,7 +846,7 @@ export function registerPanelHandlers(
       return { success: true, data: { filePath: resolvedPath, lineCount: lastLines.length, panelTitle } };
     } catch (error) {
       console.error('[IPC] Failed to save scrollback:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 

--- a/main/src/ipc/project.ts
+++ b/main/src/ipc/project.ts
@@ -14,6 +14,7 @@ import { detectProjectConfig } from '../services/projectConfigDetector';
 import { ensureProjectAgentContext } from '../services/agentContextManager';
 import type { ConfigManager } from '../services/configManager';
 import type { Project } from '../database/models';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 // Helper function to stop a running project script
 async function stopProjectScriptInternal(projectId?: number): Promise<{ success: boolean; error?: string }> {
@@ -27,7 +28,7 @@ async function stopProjectScriptInternal(projectId?: number): Promise<{ success:
 
     // If there's a running project script, stop it
     if (runningScript && runningScript.type === 'project' && runningScript.sessionId) {
-      const projectIdToStop = runningScript.id as number;
+      const projectIdToStop = decodeBoundary(runningScript.id, boundary.number);
 
       // Mark as closing
       scriptExecutionTracker.markClosing('project', projectIdToStop);
@@ -239,7 +240,11 @@ export function registerProjectHandlers(
         errorDetails = error.stack || error.toString();
 
         // Check if it's a command error
-        const cmdError = error as Error & { cmd?: string; stderr?: string; stdout?: string };
+        const cmdError = decodeBoundary(error, boundary.object({
+          cmd: boundary.optional(boundary.string),
+          stderr: boundary.optional(boundary.string),
+          stdout: boundary.optional(boundary.string),
+        }));
         if (cmdError.cmd) {
           command = cmdError.cmd;
         }
@@ -708,13 +713,14 @@ export function registerProjectHandlers(
         // Stop the script based on its type
         if (runningScript.type === 'project') {
           // Call internal stop function
-          const stopResult = await stopProjectScriptInternal(runningScript.id as number);
+          const projectScriptId = decodeBoundary(runningScript.id, boundary.number);
+          const stopResult = await stopProjectScriptInternal(projectScriptId);
           if (!stopResult?.success) {
             console.warn('[Main] Failed to stop running project script, continuing anyway');
           }
         } else if (runningScript.type === 'session') {
           // Stop session script through logs panel
-          const sessionIdToStop = runningScript.id as string;
+          const sessionIdToStop = decodeBoundary(runningScript.id, boundary.string);
           const panels = await panelManager.getPanelsForSession(sessionIdToStop);
           const logsPanel = panels?.find((p: { type: string }) => p.type === 'logs');
           if (logsPanel) {

--- a/main/src/ipc/remoteDaemon.test.ts
+++ b/main/src/ipc/remoteDaemon.test.ts
@@ -12,6 +12,7 @@ import { remoteHostRuntimeStateStore } from '../daemon/remoteHostRuntimeState';
 import { disconnectActiveRemoteHostClients } from '../daemon/remoteTransportController';
 import { readConfiguredTailscaleServeAccess, setupRemoteHost } from '../daemon/setupRemoteHost';
 import { registerRemoteDaemonHandlers } from './remoteDaemon';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
 
 vi.mock('../daemon/setupRemoteHost', () => ({
   readConfiguredTailscaleServeAccess: vi.fn(),
@@ -25,8 +26,8 @@ vi.mock('../daemon/remoteTransportController', () => ({
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
 
 interface IpcMainStub {
-  handlers: Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>;
-  handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
+  handlers: Map<string, (_event: { readonly sender: object }, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>>;
+  handle(channel: string, listener: (_event: { readonly sender: object }, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>): void;
 }
 
 interface ConfigManagerStub {
@@ -35,7 +36,7 @@ interface ConfigManagerStub {
 }
 
 function createIpcMainStub(): IpcMainStub {
-  const handlers = new Map<string, (_event: unknown, ...args: unknown[]) => Promise<unknown>>();
+  const handlers = new Map<string, (_event: { readonly sender: object }, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>>();
 
   return {
     handlers,
@@ -158,6 +159,7 @@ describe('remote daemon IPC', () => {
 
     registerRemoteDaemonHandlers(ipcMain, {
       configManager,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       getMainWindow: () => ({ isDestroyed: () => false, webContents: { send } }) as never,
     });
 
@@ -336,6 +338,7 @@ describe('remote daemon IPC', () => {
     registerRemoteDaemonHandlers(ipcMain, { configManager, app: { isPackaged: false } });
 
     const getCommand = ipcMain.handlers.get('remote-daemon:get-interactive-setup-command');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const response = await getCommand?.({}, {
       label: 'Windows WSL Smoke',
       listenPort: 42139,
@@ -366,6 +369,7 @@ describe('remote daemon IPC', () => {
     registerRemoteDaemonHandlers(ipcMain, { configManager });
 
     const getCommand = ipcMain.handlers.get('remote-daemon:get-interactive-client-setup-command');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const response = await getCommand?.({}) as { success?: boolean; data?: { command?: string } };
 
     expect(response).toMatchObject({
@@ -386,6 +390,7 @@ describe('remote daemon IPC', () => {
     registerRemoteDaemonHandlers(ipcMain, { configManager });
 
     const getCommand = ipcMain.handlers.get('remote-daemon:get-interactive-client-setup-command');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const response = await getCommand?.({}) as { success?: boolean; data?: { command?: string } };
 
     expect(response).toMatchObject({
@@ -472,6 +477,7 @@ describe('remote daemon IPC', () => {
 
     registerRemoteDaemonHandlers(ipcMain, {
       configManager,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       getMainWindow: () => ({ isDestroyed: () => false, webContents: { send } }) as never,
     });
 
@@ -523,10 +529,12 @@ describe('remote daemon IPC', () => {
     registerRemoteDaemonHandlers(ipcMain, { configManager });
 
     const importCode = ipcMain.handlers.get('remote-daemon:import-connection-code');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const firstResponse = await importCode?.({}, {
       code: connectionCode,
       connect: false,
     }) as { success?: boolean; data?: { profile?: { id?: string } } };
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const secondResponse = await importCode?.({}, {
       code: connectionCode,
       connect: false,
@@ -637,6 +645,7 @@ describe('remote daemon IPC', () => {
 
     registerRemoteDaemonHandlers(ipcMain, {
       configManager,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       getMainWindow: () => ({ isDestroyed: () => false, webContents: { send } }) as never,
     });
 
@@ -687,6 +696,7 @@ describe('remote daemon IPC', () => {
 
     registerRemoteDaemonHandlers(ipcMain, {
       configManager,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       getMainWindow: () => ({ isDestroyed: () => false, webContents: { send } }) as never,
     });
 
@@ -738,6 +748,7 @@ describe('remote daemon IPC', () => {
 
     registerRemoteDaemonHandlers(ipcMain, {
       configManager,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       getMainWindow: () => ({ isDestroyed: () => false, webContents: { send } }) as never,
     });
 
@@ -806,6 +817,7 @@ describe('remote daemon IPC', () => {
     registerRemoteDaemonHandlers(ipcMain, { configManager });
 
     const createCode = ipcMain.handlers.get('remote-daemon:create-host-connection-code');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const response = await createCode?.({}, { label: 'Office Mac mini' }) as {
       success?: boolean;
       data?: { connectionCode?: string };
@@ -850,6 +862,7 @@ describe('remote daemon IPC', () => {
     registerRemoteDaemonHandlers(ipcMain, { configManager });
 
     const createCode = ipcMain.handlers.get('remote-daemon:create-host-connection-code');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const response = await createCode?.({}, {}) as {
       success?: boolean;
       data?: { connectionCode?: string };
@@ -882,6 +895,7 @@ describe('remote daemon IPC', () => {
     registerRemoteDaemonHandlers(ipcMain, { configManager });
 
     const createCode = ipcMain.handlers.get('remote-daemon:create-host-connection-code');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const firstResponse = await createCode?.({}, { label: 'Office Mac mini' }) as {
       success?: boolean;
       data?: { connectionCode?: string };
@@ -900,6 +914,7 @@ describe('remote daemon IPC', () => {
     });
     expectConnectionCodeForbidden(configManager, firstResponse.data?.connectionCode);
 
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const secondResponse = await createCode?.({}, { label: 'Office Mac mini' }) as {
       success?: boolean;
       data?: { connectionCode?: string };

--- a/main/src/ipc/remoteDaemon.ts
+++ b/main/src/ipc/remoteDaemon.ts
@@ -24,6 +24,8 @@ import {
   type RemoteSetupDataDirectoryMode,
   type RemoteSetupTunnelPreference,
 } from '../../../shared/types/remoteDaemon';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
+import { boundary, decodeBoundary, type JsonObject } from '../../../shared/validation/boundaryDecoder';
 import os from 'os';
 import path from 'path';
 import type { AppServices } from './types';
@@ -47,7 +49,10 @@ import {
 } from '../services/remoteAnalytics';
 
 interface IpcMainHandleLike {
-  handle(channel: string, listener: (_event: unknown, ...args: unknown[]) => Promise<unknown>): void;
+  handle(
+    channel: string,
+    listener: (_event: { readonly sender: object }, ...args: PaneCommandValue[]) => Promise<PaneCommandValue>,
+  ): void;
 }
 
 interface RemoteDaemonHandlerServices {
@@ -121,7 +126,7 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:get-interactive-setup-command', async (_event, input: unknown) => {
+  ipcMain.handle('remote-daemon:get-interactive-setup-command', async (_event, input: PaneCommandValue) => {
     try {
       const request = parseRemoteHostSetupRequest(input);
       const shellName = process.platform === 'win32'
@@ -157,7 +162,7 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:setup-host', async (_event, input: unknown) => {
+  ipcMain.handle('remote-daemon:setup-host', async (_event, input: PaneCommandValue) => {
     let request: RemoteHostSetupRequest | null = null;
     try {
       request = parseRemoteHostSetupRequest(input);
@@ -214,14 +219,14 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:create-connection-pair', async (_event, input: unknown) => {
+  ipcMain.handle('remote-daemon:create-connection-pair', async (_event, input: PaneCommandValue) => {
     try {
-      if (!isRecord(input)) {
-        throw new Error('Remote daemon connection pair request must be an object');
-      }
-
-      const label = typeof input.label === 'string' ? input.label.trim() : '';
-      const baseUrl = typeof input.baseUrl === 'string' ? input.baseUrl.trim() : '';
+      const requestInput = decodeBoundary(input, boundary.object({
+        label: boundary.string,
+        baseUrl: boundary.string,
+      }));
+      const label = requestInput.label.trim();
+      const baseUrl = requestInput.baseUrl.trim();
       if (label.length === 0) {
         throw new Error('Remote daemon connection pair label is required');
       }
@@ -263,7 +268,7 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:create-host-connection-code', async (_event, input: unknown) => {
+  ipcMain.handle('remote-daemon:create-host-connection-code', async (_event, input: PaneCommandValue) => {
     try {
       const current = getRemoteDaemonConfig(configManager.getConfig().remoteDaemon);
       const label = readOptionalConnectionCodeLabel(input) ?? `${os.hostname()} Pane daemon`;
@@ -317,19 +322,19 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:import-connection-code', async (_event, input: unknown) => {
+  ipcMain.handle('remote-daemon:import-connection-code', async (_event, input: PaneCommandValue) => {
     let payload: PaneRemoteConnectionImportPayload | null = null;
     try {
-      if (!isRecord(input)) {
-        throw new Error('Remote daemon import request must be an object');
-      }
-
-      const code = typeof input.code === 'string' ? input.code.trim() : '';
+      const requestInput = decodeBoundary(input, boundary.object({
+        code: boundary.string,
+        connect: boundary.optional(boundary.boolean),
+      }));
+      const code = requestInput.code.trim();
       if (code.length === 0) {
         throw new Error('Remote daemon import code is required');
       }
 
-      const connect = input.connect !== false;
+      const connect = requestInput.connect !== false;
       const importPayload = decodePaneRemoteConnection(code);
       payload = importPayload;
       let profile = remoteImportPayloadToProfile(importPayload);
@@ -394,11 +399,9 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:update-host-config', async (_event, updates: unknown) => {
+  ipcMain.handle('remote-daemon:update-host-config', async (_event, updates: PaneCommandValue) => {
     try {
-      if (!isRecord(updates)) {
-        throw new Error('Remote daemon host config update must be an object');
-      }
+      const decodedUpdates = decodeBoundary(updates, boundary.jsonObject);
 
       const current = getRemoteDaemonConfig(configManager.getConfig().remoteDaemon);
       const next = normalizeRemoteDaemonConfig({
@@ -407,7 +410,7 @@ export function registerRemoteDaemonHandlers(
           ...current.host,
           config: {
             ...current.host.config,
-            ...updates,
+            ...decodedUpdates,
           },
         },
       });
@@ -449,7 +452,7 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:disconnect-host-clients', async (_event, clientIds: unknown) => {
+  ipcMain.handle('remote-daemon:disconnect-host-clients', async (_event, clientIds: PaneCommandValue) => {
     try {
       const parsedClientIds = parseOptionalClientIds(clientIds);
       const disconnectedCount = disconnectActiveRemoteHostClients(parsedClientIds);
@@ -466,7 +469,7 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:upsert-client-record', async (_event, record: unknown) => {
+  ipcMain.handle('remote-daemon:upsert-client-record', async (_event, record: PaneCommandValue) => {
     try {
       if (!isRemoteDaemonClientRecord(record)) {
         throw new Error('Remote daemon client record is invalid');
@@ -489,30 +492,28 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:delete-client-record', async (_event, clientId: unknown) => {
+  ipcMain.handle('remote-daemon:delete-client-record', async (_event, clientId: PaneCommandValue) => {
     try {
-      if (typeof clientId !== 'string' || clientId.length === 0) {
-        throw new Error('Remote daemon client record id must be a non-empty string');
-      }
+      const decodedClientId = decodeBoundary(clientId, boundary.nonEmptyString);
 
       const current = getRemoteDaemonConfig(configManager.getConfig().remoteDaemon);
       const next = normalizeRemoteDaemonConfig({
         ...current,
         host: {
           ...current.host,
-          clients: current.host.clients.filter((client) => client.id !== clientId),
+          clients: current.host.clients.filter((client) => client.id !== decodedClientId),
         },
       });
 
       await configManager.updateConfig({ remoteDaemon: next });
-      disconnectActiveRemoteHostClients([clientId]);
+      disconnectActiveRemoteHostClients([decodedClientId]);
       return { success: true, data: next.host.clients };
     } catch (error) {
       return { success: false, error: getErrorMessage(error, 'Failed to delete remote daemon client record') };
     }
   });
 
-  ipcMain.handle('remote-daemon:upsert-connection-profile', async (_event, profile: unknown) => {
+  ipcMain.handle('remote-daemon:upsert-connection-profile', async (_event, profile: PaneCommandValue) => {
     try {
       if (!isRemotePaneConnectionProfile(profile)) {
         throw new Error('Remote daemon connection profile is invalid');
@@ -535,15 +536,13 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:delete-connection-profile', async (_event, profileId: unknown) => {
+  ipcMain.handle('remote-daemon:delete-connection-profile', async (_event, profileId: PaneCommandValue) => {
     try {
-      if (typeof profileId !== 'string' || profileId.length === 0) {
-        throw new Error('Remote daemon connection profile id must be a non-empty string');
-      }
+      const decodedProfileId = decodeBoundary(profileId, boundary.nonEmptyString);
 
       const next = await applyRemoteClientTransition(async (current) => {
-        const isActiveRemoteProfile = current.client.mode === 'remote' && current.client.activeProfileId === profileId;
-        const activeProfileId = current.client.activeProfileId === profileId
+        const isActiveRemoteProfile = current.client.mode === 'remote' && current.client.activeProfileId === decodedProfileId;
+        const activeProfileId = current.client.activeProfileId === decodedProfileId
           ? null
           : current.client.activeProfileId;
         const mode = activeProfileId ? current.client.mode : 'local';
@@ -557,7 +556,7 @@ export function registerRemoteDaemonHandlers(
             ...current,
             client: {
               ...current.client,
-              profiles: current.client.profiles.filter((profile) => profile.id !== profileId),
+          profiles: current.client.profiles.filter((profile) => profile.id !== decodedProfileId),
               activeProfileId,
               mode,
             },
@@ -577,14 +576,12 @@ export function registerRemoteDaemonHandlers(
     }
   });
 
-  ipcMain.handle('remote-daemon:update-client-state', async (_event, updates: unknown) => {
+  ipcMain.handle('remote-daemon:update-client-state', async (_event, updates: PaneCommandValue) => {
     try {
-      if (!isRecord(updates)) {
-        throw new Error('Remote daemon client state update must be an object');
-      }
+      const decodedUpdates = decodeBoundary(updates, boundary.jsonObject);
 
       const next = await applyRemoteClientTransition(async (current) => {
-        const nextState = buildNextClientState(current.client, updates);
+        const nextState = buildNextClientState(current.client, decodedUpdates);
         const candidate = normalizeRemoteDaemonConfig({
           ...current,
           client: {
@@ -625,45 +622,32 @@ export function registerRemoteDaemonHandlers(
   });
 }
 
-function parseOptionalClientIds(value: unknown): string[] | undefined {
+function parseOptionalClientIds(value: PaneCommandValue): string[] | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
 
-  if (!Array.isArray(value)) {
-    throw new Error('Remote daemon client ids must be an array');
-  }
-
-  const clientIds = value.map((clientId) => {
-    if (typeof clientId !== 'string' || clientId.trim().length === 0) {
-      throw new Error('Remote daemon client id must be a non-empty string');
-    }
-
-    return clientId.trim();
-  });
+  const clientIds = decodeBoundary(value, boundary.array(boundary.nonEmptyString))
+    .map((clientId) => clientId.trim());
 
   return clientIds.length > 0 ? clientIds : undefined;
 }
 
-function getRemoteDaemonConfig(value: unknown): RemoteDaemonConfig {
+function getRemoteDaemonConfig(value: PaneCommandValue): RemoteDaemonConfig {
   return normalizeRemoteDaemonConfig(value);
 }
 
-function readOptionalConnectionCodeLabel(input: unknown): string | undefined {
+function readOptionalConnectionCodeLabel(input: PaneCommandValue): string | undefined {
   if (input === undefined || input === null) {
     return undefined;
   }
-  if (!isRecord(input)) {
-    throw new Error('Remote connection code request must be an object');
-  }
-  if (input.label === undefined || input.label === null) {
+  const requestInput = decodeBoundary(input, boundary.object({
+    label: boundary.optional(boundary.nullable(boundary.string)),
+  }));
+  if (requestInput.label === undefined || requestInput.label === null) {
     return undefined;
   }
-  if (typeof input.label !== 'string') {
-    throw new Error('Remote connection code label must be a string');
-  }
-
-  const label = input.label.trim();
+  const label = requestInput.label.trim();
   return label.length > 0 ? label : undefined;
 }
 
@@ -684,7 +668,7 @@ function resolveCurrentHostAccess(current: RemoteDaemonConfig): RemoteDaemonHost
 
 function buildNextClientState(
   current: RemoteDaemonClientSettings,
-  updates: Record<string, unknown>,
+  updates: JsonObject,
 ): Pick<RemoteDaemonClientSettings, 'activeProfileId' | 'mode'> {
   const nextMode: RemoteDaemonClientMode =
     updates.mode === 'remote' || updates.mode === 'local'
@@ -694,8 +678,12 @@ function buildNextClientState(
   let nextActiveProfileId = current.activeProfileId;
   if (updates.activeProfileId === null) {
     nextActiveProfileId = null;
-  } else if (typeof updates.activeProfileId === 'string') {
-    nextActiveProfileId = updates.activeProfileId;
+  } else {
+    try {
+      nextActiveProfileId = decodeBoundary(updates.activeProfileId, boundary.string);
+    } catch {
+      // Preserve the current profile when the optional update is malformed.
+    }
   }
 
   if (nextMode === 'remote' && !nextActiveProfileId) {
@@ -733,58 +721,54 @@ function attachRemoteHostStateForwarder(getMainWindow?: AppServices['getMainWind
   remoteHostRuntimeStateStore.on('state-changed', remoteHostStateForwarder);
 }
 
-function parseRemoteHostSetupRequest(input: unknown): RemoteHostSetupRequest {
+function parseRemoteHostSetupRequest(input: PaneCommandValue): RemoteHostSetupRequest {
   if (input === undefined || input === null) {
     return {};
   }
-  if (!isRecord(input)) {
-    throw new Error('Remote daemon host setup request must be an object');
-  }
+  const requestInput = decodeBoundary(input, boundary.jsonObject);
 
   const request: RemoteHostSetupRequest = {};
-  const dataDirectoryMode = readOptionalDataDirectoryMode(input.dataDirectoryMode);
+  const dataDirectoryMode = readOptionalDataDirectoryMode(requestInput.dataDirectoryMode);
   if (dataDirectoryMode) {
     request.dataDirectoryMode = dataDirectoryMode;
   }
 
-  const paneDir = readOptionalTrimmedString(input.paneDir);
+  const paneDir = readOptionalTrimmedString(requestInput.paneDir);
   if (paneDir) {
     request.paneDir = paneDir;
   }
 
-  const label = readOptionalTrimmedString(input.label);
+  const label = readOptionalTrimmedString(requestInput.label);
   if (label) {
     request.label = label;
   }
 
-  const listenPort = readOptionalPort(input.listenPort);
+  const listenPort = readOptionalPort(requestInput.listenPort);
   if (listenPort !== undefined) {
     request.listenPort = listenPort;
   }
 
-  const channel = readOptionalChannel(input.channel);
+  const channel = readOptionalChannel(requestInput.channel);
   if (channel) {
     request.channel = channel;
   }
 
-  const repoRef = readOptionalTrimmedString(input.repoRef);
+  const repoRef = readOptionalTrimmedString(requestInput.repoRef);
   if (repoRef) {
     request.repoRef = repoRef;
   }
 
-  if (typeof input.installService === 'boolean') {
-    request.installService = input.installService;
-  }
-  if (typeof input.exposeTailscale === 'boolean') {
-    request.exposeTailscale = input.exposeTailscale;
-  }
+  const installService = decodeOptionalBoolean(requestInput.installService);
+  if (installService !== undefined) request.installService = installService;
+  const exposeTailscale = decodeOptionalBoolean(requestInput.exposeTailscale);
+  if (exposeTailscale !== undefined) request.exposeTailscale = exposeTailscale;
 
-  const preferTunnel = readOptionalTunnelPreference(input.preferTunnel);
+  const preferTunnel = readOptionalTunnelPreference(requestInput.preferTunnel);
   if (preferTunnel) {
     request.preferTunnel = preferTunnel;
   }
 
-  const baseUrl = readOptionalTrimmedString(input.baseUrl);
+  const baseUrl = readOptionalTrimmedString(requestInput.baseUrl);
   if (baseUrl) {
     normalizePaneRemoteConnectionImportPayload({
       v: 1,
@@ -883,14 +867,11 @@ function buildInteractiveClientSetupCommand(shellName?: string): string {
   return 'echo "Install Tailscale from https://tailscale.com/download, sign in, then retry the Pane remote connection."';
 }
 
-function readOptionalTrimmedString(value: unknown): string | undefined {
+function readOptionalTrimmedString(value: PaneCommandValue): string | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
-  if (typeof value !== 'string') {
-    throw new Error('Remote daemon host setup string fields must be strings');
-  }
-  const trimmed = value.trim();
+  const trimmed = decodeBoundary(value, boundary.string).trim();
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
@@ -902,22 +883,19 @@ function quoteTerminalArg(value: string, shellName?: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function readOptionalPort(value: unknown): number | undefined {
+function readOptionalPort(value: PaneCommandValue): number | undefined {
   if (value === undefined || value === null || value === '') {
     return undefined;
   }
-  const port = typeof value === 'number'
-    ? value
-    : typeof value === 'string'
-      ? Number(value)
-      : Number.NaN;
+  const decoded = decodeBoundary(value, boundary.union(boundary.number, boundary.string));
+  const port = Number(decoded);
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     throw new Error('Remote daemon listen port must be between 1 and 65535');
   }
   return port;
 }
 
-function readOptionalDataDirectoryMode(value: unknown): RemoteSetupDataDirectoryMode | undefined {
+function readOptionalDataDirectoryMode(value: PaneCommandValue): RemoteSetupDataDirectoryMode | undefined {
   if (value === undefined || value === null || value === '') {
     return undefined;
   }
@@ -927,7 +905,7 @@ function readOptionalDataDirectoryMode(value: unknown): RemoteSetupDataDirectory
   throw new Error('Remote daemon data directory mode must be "current" or "isolated"');
 }
 
-function readOptionalChannel(value: unknown): RemoteSetupChannel | undefined {
+function readOptionalChannel(value: PaneCommandValue): RemoteSetupChannel | undefined {
   if (value === undefined || value === null || value === '') {
     return undefined;
   }
@@ -937,7 +915,7 @@ function readOptionalChannel(value: unknown): RemoteSetupChannel | undefined {
   throw new Error('Remote daemon setup channel must be "stable" or "nightly"');
 }
 
-function readOptionalTunnelPreference(value: unknown): RemoteSetupTunnelPreference | undefined {
+function readOptionalTunnelPreference(value: PaneCommandValue): RemoteSetupTunnelPreference | undefined {
   if (value === undefined || value === null || value === '') {
     return undefined;
   }
@@ -977,10 +955,11 @@ function findMatchingConnectionProfile(
   ));
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+function decodeOptionalBoolean(value: PaneCommandValue): boolean | undefined {
+  if (value === undefined || value === null) return undefined;
+  return decodeBoundary(value, boundary.boolean);
 }
 
-function getErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error ? error.message : fallback;
+function getErrorMessage(cause: unknown, fallback: string): string {
+  return cause instanceof Error ? cause.message : fallback;
 }

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -101,7 +101,9 @@ function terminalSnapshot(
 }
 
 function createServices(overrides: Partial<AppServices> = {}): AppServices {
+  // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
   return {
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     app: {
       getVersion: vi.fn(() => '2.3.8'),
       isPackaged: false,
@@ -193,6 +195,7 @@ function createTempGitRepo(name = 'repo'): string {
 
 function createRegistry(services = createServices()): PaneCommandRegistry {
   const registry = new PaneCommandRegistry();
+  // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
   registerRunpaneHandlers({} as never, services, registry);
   return registry;
 }
@@ -290,7 +293,9 @@ describe('runpane IPC handlers', () => {
         ]),
       },
     });
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     expect((result as { daemon: { channels: string[] } }).daemon.channels).toContain('runpane:doctor');
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     expect((result as { daemon: { channels: string[] } }).daemon.channels).toContain('runpane:panes:rename');
   });
 
@@ -314,10 +319,12 @@ describe('runpane IPC handlers', () => {
   it('dry-runs adding an existing git repository without saving it', async () => {
     const repoPath = createTempGitRepo('pane-addon');
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         getAllProjects: vi.fn(() => []),
         createProject: vi.fn(),
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getSessionsForProject: vi.fn(() => []),
@@ -355,6 +362,7 @@ describe('runpane IPC handlers', () => {
     };
     const projects: Project[] = [];
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         getAllProjects: vi.fn(() => projects),
         createProject: vi.fn((name: string, savedPath: string): Project => {
@@ -363,6 +371,7 @@ describe('runpane IPC handlers', () => {
           return created;
         }),
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getSessionsForProject: vi.fn(() => []),
@@ -406,6 +415,7 @@ describe('runpane IPC handlers', () => {
     const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-runpane-test-'));
     tempDirs.push(parent);
     const registry = createRegistry(createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         getAllProjects: vi.fn(() => []),
         createProject: vi.fn(),
@@ -578,6 +588,7 @@ describe('runpane IPC handlers', () => {
 
   it('reads panel output as records and concatenated text', async () => {
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getPanelOutputs: vi.fn(() => [{
@@ -739,6 +750,7 @@ describe('runpane IPC handlers', () => {
 
   it('marks panel output as having more history when the internal fetch finds an extra record', async () => {
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getPanelOutputs: vi.fn(() => [{
@@ -1120,6 +1132,7 @@ describe('runpane IPC handlers', () => {
       return { stdout: '', stderr: '' };
     });
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getProjectContextByProjectId: vi.fn(() => ({
@@ -1170,6 +1183,7 @@ describe('runpane IPC handlers', () => {
       return { stdout: '', stderr: '' };
     });
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getProjectContextByProjectId: vi.fn(() => ({
@@ -1198,6 +1212,7 @@ describe('runpane IPC handlers', () => {
       executablePath: '/home/user/.local/bin/cursor-agent',
       version: '2026.08.11-e8db854',
     });
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     expect((result as { warnings?: string[] }).warnings?.some((w) => w.includes('PATH'))).toBe(true);
   });
 
@@ -1205,10 +1220,12 @@ describe('runpane IPC handlers', () => {
     const execAsync = vi.fn(async () => ({ stdout: '', stderr: '' }));
     const base = createServices();
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...base.databaseService,
         getAllProjects: vi.fn(() => [{ ...project, wsl_enabled: true, wsl_distribution: 'Ubuntu' }]),
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...base.sessionManager,
         getProjectContextByProjectId: vi.fn(() => ({
@@ -1241,6 +1258,7 @@ describe('runpane IPC handlers', () => {
     const wslProject = { ...project, wsl_enabled: true, wsl_distribution: 'Ubuntu' };
     const base = createServices();
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...base.databaseService,
         getAllProjects: vi.fn(() => [wslProject]),
@@ -1266,6 +1284,7 @@ describe('runpane IPC handlers', () => {
     const wslProject = { ...project, wsl_enabled: true, wsl_distribution: 'Ubuntu' };
     const base = createServices();
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...base.sessionManager,
         getProjectForSession: vi.fn(() => wslProject),
@@ -1280,6 +1299,7 @@ describe('runpane IPC handlers', () => {
   });
 
   it('creates a session, terminal panel, and initial-input state', async () => {
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     vi.mocked(panelManager.createPanel).mockResolvedValue({
       id: 'panel-1',
       sessionId: session.id,
@@ -1359,13 +1379,16 @@ describe('runpane IPC handlers', () => {
     const databaseRow = {
       id: session.id,
       is_favorite: 0,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       favorite_pinned_at: null as string | null,
     };
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...createServices().databaseService,
         getSession: vi.fn(() => databaseRow),
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       taskQueue: {
         createSessionAndWait: vi.fn(async (request: { startPinned?: boolean }) => {
           databaseRow.is_favorite = request.startPinned ? 1 : 0;
@@ -1404,6 +1427,7 @@ describe('runpane IPC handlers', () => {
     const databaseRow = {
       id: session.id,
       is_favorite: 0,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       favorite_pinned_at: null as string | null,
     };
     const setSessionFavorite = vi.fn((_id: string, pinned: boolean) => {
@@ -1415,10 +1439,12 @@ describe('runpane IPC handlers', () => {
     });
     const emit = vi.fn();
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...createServices().databaseService,
         setSessionFavorite,
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         emit,
@@ -1462,6 +1488,7 @@ describe('runpane IPC handlers', () => {
     const databaseRow = {
       id: session.id,
       is_favorite: 0,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       favorite_pinned_at: null as string | null,
     };
     const setSessionFavorite = vi.fn((_id: string, pinned: boolean) => {
@@ -1471,10 +1498,12 @@ describe('runpane IPC handlers', () => {
     });
     const emit = vi.fn();
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...createServices().databaseService,
         setSessionFavorite,
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         emit,
@@ -1515,10 +1544,12 @@ describe('runpane IPC handlers', () => {
     const updateSession = vi.fn(() => ({ id: session.id, name: 'renamed pane' }));
     const emit = vi.fn();
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...createServices().databaseService,
         updateSession,
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getSession: vi.fn(() => renamedSession),
@@ -1546,10 +1577,12 @@ describe('runpane IPC handlers', () => {
     const updateSession = vi.fn();
     const emit = vi.fn();
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...createServices().databaseService,
         updateSession,
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getSession: vi.fn(() => originalSession),
@@ -1579,10 +1612,12 @@ describe('runpane IPC handlers', () => {
     const renamedSession = { ...session };
     const updateSession = vi.fn(() => ({ id: session.id, name: longName }));
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       databaseService: {
         ...createServices().databaseService,
         updateSession,
       } as never,
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getSession: vi.fn(() => renamedSession),
@@ -1602,6 +1637,7 @@ describe('runpane IPC handlers', () => {
 
   it('rejects rename for a pane id that does not exist', async () => {
     const services = createServices({
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       sessionManager: {
         ...createServices().sessionManager,
         getSession: vi.fn(() => undefined),
@@ -1614,6 +1650,7 @@ describe('runpane IPC handlers', () => {
   });
 
   it('serializes multi-pane session creation before enqueueing the next pane', async () => {
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     vi.mocked(panelManager.createPanel).mockResolvedValue({
       id: 'panel-1',
       sessionId: session.id,
@@ -1634,6 +1671,7 @@ describe('runpane IPC handlers', () => {
       activeCreates -= 1;
       return { sessionId: session.id };
     });
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const services = createServices({
       taskQueue: {
         createSessionAndWait,
@@ -1659,6 +1697,7 @@ describe('runpane IPC handlers', () => {
   });
 
   it('creates panes with readiness validation when requested', async () => {
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     vi.mocked(panelManager.createPanel).mockResolvedValue({
       id: 'panel-1',
       sessionId: session.id,
@@ -1719,6 +1758,7 @@ describe('runpane IPC handlers', () => {
   });
 
   it('reports earned Claude argument delivery during wait-ready pane creation', async () => {
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const claudePanel = {
       id: 'panel-1',
       sessionId: session.id,
@@ -1790,6 +1830,7 @@ describe('runpane IPC handlers', () => {
   });
 
   it('marks pane creation unsuccessful when Claude argument delivery is unverified', async () => {
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     const claudePanel = {
       id: 'panel-1',
       sessionId: session.id,
@@ -2237,7 +2278,9 @@ describe('runpane IPC handlers', () => {
       execFileSync('git', ['commit', '--allow-empty', '-m', 'init'], { cwd: repoPath, stdio: 'ignore' });
 
       const cleanSession: Session = { ...session, worktreePath: repoPath };
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => cleanSession),
@@ -2269,6 +2312,7 @@ describe('runpane IPC handlers', () => {
 
     it('rejects archiving a pane that is already archived', async () => {
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => ({ ...session, archived: true })),
@@ -2284,6 +2328,7 @@ describe('runpane IPC handlers', () => {
 
     it('rejects archiving an unknown pane id', async () => {
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => undefined),
@@ -2304,6 +2349,7 @@ describe('runpane IPC handlers', () => {
 
       const dirtySession: Session = { ...session, worktreePath: repoPath };
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => dirtySession),
@@ -2341,7 +2387,9 @@ describe('runpane IPC handlers', () => {
       fs.writeFileSync(path.join(repoPath, 'tracked.txt'), 'modified');
 
       const dirtySession: Session = { ...session, worktreePath: repoPath };
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => dirtySession),
@@ -2376,10 +2424,12 @@ describe('runpane IPC handlers', () => {
 
       const unpushedSession: Session = { ...session, worktreePath: repoPath };
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => unpushedSession),
         } as never,
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         worktreeManager: {
           getUpstream: vi.fn(async () => 'origin/main'),
         } as never,
@@ -2411,11 +2461,14 @@ describe('runpane IPC handlers', () => {
       execFileSync('git', ['update-ref', 'refs/remotes/origin/main', 'HEAD'], { cwd: repoPath, stdio: 'ignore' });
 
       const mergedSession: Session = { ...session, worktreePath: repoPath };
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => mergedSession),
         } as never,
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         worktreeManager: {
           getUpstream: vi.fn(async () => 'origin/main'),
         } as never,
@@ -2447,6 +2500,7 @@ describe('runpane IPC handlers', () => {
 
       const mainRepoSession: Session = { ...session, worktreePath: repoPath, isMainRepo: true };
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => mainRepoSession),
@@ -2471,6 +2525,7 @@ describe('runpane IPC handlers', () => {
 
     it('fails safe with status-unknown when git status cannot be determined', async () => {
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         worktreeManager: {
           getUpstream: vi.fn(async () => {
             throw new Error('git command failed');
@@ -2501,7 +2556,9 @@ describe('runpane IPC handlers', () => {
       execFileSync('git', ['commit', '--allow-empty', '-m', 'init'], { cwd: repoPath, stdio: 'ignore' });
 
       const cleanSession: Session = { ...session, worktreePath: repoPath };
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => cleanSession),
@@ -2530,7 +2587,9 @@ describe('runpane IPC handlers', () => {
       const repoPath = createTempGitRepo('polling-repo');
       execFileSync('git', ['commit', '--allow-empty', '-m', 'init'], { cwd: repoPath, stdio: 'ignore' });
       const pollingSession: Session = { ...session, worktreePath: repoPath };
+      // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
       const services = createServices({
+        // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
         sessionManager: {
           ...createServices().sessionManager,
           getSession: vi.fn(() => pollingSession),

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import type { IpcMain } from 'electron';
 import type { AppServices } from './types';
-import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import type { PaneCommandRegistry, PaneCommandValue } from '../daemon/commandRegistry';
 import { PathResolver, ProjectEnvironment } from '../utils/pathResolver';
 import { sanitizeTerminalOutput } from '../utils/terminalOutputSanitizer';
 import { panelManager } from '../services/panelManager';
@@ -17,6 +17,7 @@ import type { Session, SessionOutput } from '../types/session';
 import type { CreatePanelRequest, TerminalPanelState, ToolPanel } from '../../../shared/types/panels';
 import { RUNPANE_CONTRACT } from '../../../shared/types/generatedRunpaneContract';
 import { isAgentSupportedOnPlatform } from '../../../shared/constants/agentLaunchPresets';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 import type {
   RunpaneAgentId,
   RunpaneAgentDoctorRequest,
@@ -154,7 +155,7 @@ export function registerRunpaneHandlers(
     }, result => ({ resultCount: result.repos.length }));
   });
 
-  commandRegistry.register('runpane:repos:add', async (request: unknown): Promise<RunpaneRepoAddResult> => {
+  commandRegistry.register('runpane:repos:add', async (request: PaneCommandValue): Promise<RunpaneRepoAddResult> => {
     return withRunpaneAction(services, 'repos:add', {}, async () => {
       const normalized = parseRepoAddRequest(request);
       const existing = resolveProjectByPath(databaseService.getAllProjects(), normalized.path);
@@ -219,7 +220,7 @@ export function registerRunpaneHandlers(
     }, result => ({ repoId: result.repo?.id, resultCount: result.created ? 1 : 0 }));
   });
 
-  commandRegistry.register('runpane:panes:list', async (request: unknown = {}): Promise<RunpanePaneListResult> => {
+  commandRegistry.register('runpane:panes:list', async (request: PaneCommandValue = {}): Promise<RunpanePaneListResult> => {
     return withRunpaneAction(services, 'panes:list', {}, () => {
       const normalized = parsePaneListRequest(request);
       const projects = databaseService.getAllProjects();
@@ -243,7 +244,7 @@ export function registerRunpaneHandlers(
     }, result => ({ repoId: result.repo?.id, resultCount: result.panes.length }));
   });
 
-  commandRegistry.register('runpane:panes:pin', async (request: unknown): Promise<RunpanePanePinResult> => {
+  commandRegistry.register('runpane:panes:pin', async (request: PaneCommandValue): Promise<RunpanePanePinResult> => {
     return withRunpaneAction(services, 'panes:pin', {}, () => {
       const normalized = parsePanePinRequest(request);
       const pane = resolvePane(sessionManager, normalized.paneId);
@@ -275,7 +276,7 @@ export function registerRunpaneHandlers(
     }, result => ({ paneId: result.paneId }));
   });
 
-  commandRegistry.register('runpane:panes:rename', async (request: unknown): Promise<RunpanePaneRenameResult> => {
+  commandRegistry.register('runpane:panes:rename', async (request: PaneCommandValue): Promise<RunpanePaneRenameResult> => {
     return withRunpaneAction(services, 'panes:rename', {}, () => {
       const normalized = parsePaneRenameRequest(request);
       const pane = resolvePane(sessionManager, normalized.paneId);
@@ -307,7 +308,7 @@ export function registerRunpaneHandlers(
     }, result => ({ paneId: result.pane.paneId }));
   });
 
-  commandRegistry.register('runpane:panes:create', async (request: unknown): Promise<RunpanePaneCreateResult> => {
+  commandRegistry.register('runpane:panes:create', async (request: PaneCommandValue): Promise<RunpanePaneCreateResult> => {
     return withRunpaneAction(services, 'panes:create', {}, async () => {
       const normalized = parsePaneCreateRequest(request);
       const repo = resolveRepoSelector(databaseService.getAllProjects(), normalized.repo);
@@ -349,7 +350,7 @@ export function registerRunpaneHandlers(
     }, result => ({ repoId: result.repo.id, resultCount: result.items.length }));
   });
 
-  commandRegistry.register('runpane:panes:archive', async (request: unknown): Promise<RunpanePaneArchiveResult> => {
+  commandRegistry.register('runpane:panes:archive', async (request: PaneCommandValue): Promise<RunpanePaneArchiveResult> => {
     return withRunpaneAction(services, 'panes:archive', {}, async () => {
       const normalized = parsePaneArchiveRequest(request);
       const pane = resolvePane(sessionManager, normalized.paneId);
@@ -384,8 +385,13 @@ export function registerRunpaneHandlers(
         ? waitForArchiveProgressCompletion(services.archiveProgressManager, normalized.paneId, DEFAULT_ARCHIVE_CLEANUP_TIMEOUT_MS)
         : null;
 
-      const deleteResult = await commandRegistry.invoke('sessions:delete', [normalized.paneId]) as
-        { success: boolean; error?: string };
+      const deleteResult = decodeBoundary(
+        await commandRegistry.invoke('sessions:delete', [normalized.paneId]),
+        boundary.object({
+          success: boundary.boolean,
+          error: boundary.optional(boundary.string),
+        }),
+      );
       if (!deleteResult.success) {
         throw new Error(deleteResult.error ?? `Failed to archive pane ${normalized.paneId}`);
       }
@@ -412,7 +418,7 @@ export function registerRunpaneHandlers(
     }, result => ({ paneId: result.paneId, ok: result.ok }));
   });
 
-  commandRegistry.register('runpane:panels:list', async (request: unknown): Promise<RunpanePanelListResult> => {
+  commandRegistry.register('runpane:panels:list', async (request: PaneCommandValue): Promise<RunpanePanelListResult> => {
     return withRunpaneAction(services, 'panels:list', {}, () => {
       const normalized = parsePanelListRequest(request);
       const pane = resolvePane(sessionManager, normalized.paneId);
@@ -426,7 +432,7 @@ export function registerRunpaneHandlers(
     }, result => ({ paneId: result.paneId, resultCount: result.panels.length }));
   });
 
-  commandRegistry.register('runpane:panels:create', async (request: unknown): Promise<RunpanePanelCreateResult> => {
+  commandRegistry.register('runpane:panels:create', async (request: PaneCommandValue): Promise<RunpanePanelCreateResult> => {
     return withRunpaneAction(services, 'panels:create', {}, async () => {
       const normalized = parsePanelCreateRequest(request);
       const pane = resolvePane(sessionManager, normalized.paneId);
@@ -461,7 +467,7 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:output', async (request: unknown): Promise<RunpanePanelOutputResult> => {
+  commandRegistry.register('runpane:panels:output', async (request: PaneCommandValue): Promise<RunpanePanelOutputResult> => {
     return withRunpaneAction(services, 'panels:output', {}, () => {
       const normalized = parsePanelOutputRequest(request);
       const panel = resolvePanel(normalized.panelId);
@@ -510,7 +516,7 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:input', async (request: unknown): Promise<RunpanePanelInputResult> => {
+  commandRegistry.register('runpane:panels:input', async (request: PaneCommandValue): Promise<RunpanePanelInputResult> => {
     return withRunpaneAction(services, 'panels:input', {}, () => {
       const normalized = parsePanelInputRequest(request);
       const panel = resolvePanel(normalized.panelId);
@@ -539,7 +545,7 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:screen', async (request: unknown): Promise<RunpanePanelScreenResult> => {
+  commandRegistry.register('runpane:panels:screen', async (request: PaneCommandValue): Promise<RunpanePanelScreenResult> => {
     return withRunpaneAction(services, 'panels:screen', {}, async () => {
       const normalized = parsePanelScreenRequest(request);
       const panel = resolveTerminalPanel(normalized.panelId);
@@ -552,7 +558,7 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:submit', async (request: unknown): Promise<RunpanePanelSubmitResult> => {
+  commandRegistry.register('runpane:panels:submit', async (request: PaneCommandValue): Promise<RunpanePanelSubmitResult> => {
     return withRunpaneAction(services, 'panels:submit', {}, () => {
       const normalized = parsePanelSubmitRequest(request);
       const panel = resolveTerminalPanel(normalized.panelId);
@@ -579,7 +585,7 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:submit-composer', async (request: unknown): Promise<RunpanePanelSubmitComposerResult> => {
+  commandRegistry.register('runpane:panels:submit-composer', async (request: PaneCommandValue): Promise<RunpanePanelSubmitComposerResult> => {
     return withRunpaneAction(services, 'panels:submit-composer', {}, async () => {
       const normalized = parsePanelSubmitComposerRequest(request);
       const panel = resolveTerminalPanel(normalized.panelId);
@@ -596,7 +602,7 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:wait', async (request: unknown): Promise<RunpanePanelWaitResult> => {
+  commandRegistry.register('runpane:panels:wait', async (request: PaneCommandValue): Promise<RunpanePanelWaitResult> => {
     return withRunpaneAction(services, 'panels:wait', {}, async () => {
       const normalized = parsePanelWaitRequest(request);
       const panel = resolveTerminalPanel(normalized.panelId);
@@ -611,7 +617,7 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:agents:doctor', async (request: unknown): Promise<RunpaneAgentDoctorResult> => {
+  commandRegistry.register('runpane:agents:doctor', async (request: PaneCommandValue): Promise<RunpaneAgentDoctorResult> => {
     return withRunpaneAction(services, 'agents:doctor', {}, async () => {
       const normalized = parseAgentDoctorRequest(request);
       const repo = normalized.repo
@@ -662,10 +668,8 @@ function sessionToPaneSummary(session: Session, project: Project) {
 
 function panelToSummary(panel: ToolPanel) {
   const customState = isRecord(panel.state.customState) ? panel.state.customState : {};
-  const agentType = typeof customState.agentType === 'string' && AGENT_IDS.has(customState.agentType)
-    ? customState.agentType as RunpaneAgentId
-    : undefined;
-  const isCliPanel = typeof customState.isCliPanel === 'boolean' ? customState.isCliPanel : undefined;
+  const agentType = optionalAgentId(customState.agentType);
+  const isCliPanel = optionalBoolean(customState.isCliPanel);
 
   return {
     id: panel.id,
@@ -677,7 +681,7 @@ function panelToSummary(panel: ToolPanel) {
     initialized: panel.type === 'terminal' ? terminalPanelManager.isTerminalInitialized(panel.id) : undefined,
     agentType,
     isCliPanel,
-    position: typeof panel.metadata.position === 'number' ? panel.metadata.position : undefined,
+    position: optionalNumber(panel.metadata.position),
     createdAt: toIsoString(panel.metadata.createdAt),
     lastActiveAt: toIsoString(panel.metadata.lastActiveAt),
   };
@@ -1124,9 +1128,7 @@ function panelStateSummary(
   snapshot: TerminalPanelSnapshot | null,
   customState: TerminalPanelState = getTerminalCustomState(panel),
 ): RunpanePanelStateSummary {
-  const customAgentType = typeof customState.agentType === 'string' && AGENT_IDS.has(customState.agentType)
-    ? customState.agentType as RunpaneAgentId
-    : undefined;
+  const customAgentType = optionalAgentId(customState.agentType);
   const hasLiveTerminal = Boolean(snapshot || terminalPanelManager.isTerminalInitialized(panel.id));
 
   return {
@@ -1141,13 +1143,24 @@ function panelStateSummary(
 }
 
 function getTerminalCustomState(panel: ToolPanel): TerminalPanelState {
-  return (isRecord(panel.state.customState) ? panel.state.customState : {}) as TerminalPanelState;
+  try {
+    return decodeBoundary(panel.state.customState, boundary.object({
+      alternateScreenBuffer: boundary.optional(boundary.string),
+      isAlternateScreen: boundary.optional(boundary.boolean),
+      scrollbackBuffer: boundary.optional(boundary.union(boundary.string, boundary.array(boundary.string))),
+      agentType: boundary.optional(boundary.enumeration(...RUNPANE_CONTRACT.enums.agents)),
+      isCliReady: boundary.optional(boundary.boolean),
+      isCliPanel: boundary.optional(boundary.boolean),
+      lastActivityTime: boundary.optional(boundary.string),
+    }));
+  } catch {
+    return {};
+  }
 }
 
 function normalizeScrollbackBuffer(value: TerminalPanelState['scrollbackBuffer']): string {
-  if (typeof value === 'string') {
-    return value;
-  }
+  const stringValue = optionalString(value);
+  if (stringValue !== undefined) return stringValue;
   if (Array.isArray(value)) {
     return value.join('\n');
   }
@@ -1539,8 +1552,10 @@ function outputToRecord(output: SessionOutput): RunpanePanelOutputRecord {
 }
 
 function outputToText(output: SessionOutput): string {
-  if (typeof output.data === 'string') {
-    return output.data;
+  try {
+    return decodeBoundary(output.data, boundary.string);
+  } catch {
+    // Non-string output is serialized below.
   }
 
   try {
@@ -1580,7 +1595,7 @@ function getPanelScrollback(panel: ToolPanel): string | null {
     return null;
   }
 
-  const persisted = normalizeScrollbackBuffer((customState as TerminalPanelState).scrollbackBuffer);
+  const persisted = normalizeScrollbackBuffer(getTerminalCustomState(panel).scrollbackBuffer);
   if (persisted) return persisted;
 
   return null;
@@ -1598,7 +1613,7 @@ function panelWaitCommand(panelId: string, condition: RunpanePanelWaitCondition 
   return `runpane panels wait --panel ${panelId} --for ${condition} --timeout-ms ${DEFAULT_PANEL_WAIT_TIMEOUT_MS} --json`;
 }
 
-function parsePaneListRequest(value: unknown): RunpanePaneListRequest {
+function parsePaneListRequest(value: PaneCommandValue): RunpanePaneListRequest {
   if (value === undefined || value === null) {
     return {};
   }
@@ -1614,7 +1629,7 @@ function parsePaneListRequest(value: unknown): RunpanePaneListRequest {
   };
 }
 
-function parsePaneCreateRequest(value: unknown): RunpanePaneCreateRequest {
+function parsePaneCreateRequest(value: PaneCommandValue): RunpanePaneCreateRequest {
   if (!isRecord(value)) {
     throw new Error('Pane create request must be an object');
   }
@@ -1634,18 +1649,18 @@ function parsePaneCreateRequest(value: unknown): RunpanePaneCreateRequest {
   return {
     repo,
     panes: panesValue.map(parsePaneCreateItem),
-    dryRun: typeof value.dryRun === 'boolean' ? value.dryRun : undefined,
-    timeoutMs: typeof value.timeoutMs === 'number' ? value.timeoutMs : undefined,
-    waitReady: typeof value.waitReady === 'boolean' ? value.waitReady : undefined,
+    dryRun: optionalBoolean(value.dryRun),
+    timeoutMs: optionalNumber(value.timeoutMs),
+    waitReady: optionalBoolean(value.waitReady),
     readyTimeoutMs: parsePositiveInteger(value.readyTimeoutMs, 'readyTimeoutMs'),
     concurrency: parsePositiveInteger(value.concurrency, 'concurrency'),
-    noFocus: typeof value.noFocus === 'boolean' ? value.noFocus : undefined,
-    focus: typeof value.focus === 'boolean' ? value.focus : undefined,
+    noFocus: optionalBoolean(value.noFocus),
+    focus: optionalBoolean(value.focus),
     source: value.source === 'user' || value.source === 'agent' ? value.source : undefined,
   };
 }
 
-function parsePanelListRequest(value: unknown): RunpanePanelListRequest {
+function parsePanelListRequest(value: PaneCommandValue): RunpanePanelListRequest {
   if (!isRecord(value)) {
     throw new Error('Panel list request must be an object');
   }
@@ -1658,7 +1673,7 @@ function parsePanelListRequest(value: unknown): RunpanePanelListRequest {
   return { paneId };
 }
 
-function parsePanelCreateRequest(value: unknown): RunpanePanelCreateRequest {
+function parsePanelCreateRequest(value: PaneCommandValue): RunpanePanelCreateRequest {
   if (!isRecord(value)) {
     throw new Error('Panel create request must be an object');
   }
@@ -1681,15 +1696,15 @@ function parsePanelCreateRequest(value: unknown): RunpanePanelCreateRequest {
     paneId,
     type: 'terminal',
     tool: parseRunpaneToolSpec(value.tool, 'Panel create request'),
-    noFocus: typeof value.noFocus === 'boolean' ? value.noFocus : undefined,
-    focus: typeof value.focus === 'boolean' ? value.focus : undefined,
+    noFocus: optionalBoolean(value.noFocus),
+    focus: optionalBoolean(value.focus),
     source: value.source === 'user' || value.source === 'agent' ? value.source : undefined,
-    waitReady: typeof value.waitReady === 'boolean' ? value.waitReady : undefined,
+    waitReady: optionalBoolean(value.waitReady),
     readyTimeoutMs: parsePositiveInteger(value.readyTimeoutMs, 'readyTimeoutMs'),
   };
 }
 
-function parsePanelOutputRequest(value: unknown): RunpanePanelOutputRequest {
+function parsePanelOutputRequest(value: PaneCommandValue): RunpanePanelOutputRequest {
   if (!isRecord(value)) {
     throw new Error('Panel output request must be an object');
   }
@@ -1705,7 +1720,7 @@ function parsePanelOutputRequest(value: unknown): RunpanePanelOutputRequest {
   };
 }
 
-function parsePanelInputRequest(value: unknown): RunpanePanelInputRequest {
+function parsePanelInputRequest(value: PaneCommandValue): RunpanePanelInputRequest {
   if (!isRecord(value)) {
     throw new Error('Panel input request must be an object');
   }
@@ -1714,17 +1729,18 @@ function parsePanelInputRequest(value: unknown): RunpanePanelInputRequest {
   if (!panelId) {
     throw new Error('Panel input request must include panelId');
   }
-  if (typeof value.input !== 'string') {
+  const input = optionalString(value.input);
+  if (input === undefined) {
     throw new Error('Panel input request must include input');
   }
 
   return {
     panelId,
-    input: value.input,
+    input,
   };
 }
 
-function parsePanelScreenRequest(value: unknown): RunpanePanelScreenRequest {
+function parsePanelScreenRequest(value: PaneCommandValue): RunpanePanelScreenRequest {
   if (!isRecord(value)) {
     throw new Error('Panel screen request must be an object');
   }
@@ -1740,7 +1756,7 @@ function parsePanelScreenRequest(value: unknown): RunpanePanelScreenRequest {
   };
 }
 
-function parsePanelSubmitRequest(value: unknown): RunpanePanelSubmitRequest {
+function parsePanelSubmitRequest(value: PaneCommandValue): RunpanePanelSubmitRequest {
   if (!isRecord(value)) {
     throw new Error('Panel submit request must be an object');
   }
@@ -1749,17 +1765,18 @@ function parsePanelSubmitRequest(value: unknown): RunpanePanelSubmitRequest {
   if (!panelId) {
     throw new Error('Panel submit request must include panelId');
   }
-  if (typeof value.input !== 'string') {
+  const input = optionalString(value.input);
+  if (input === undefined) {
     throw new Error('Panel submit request must include input');
   }
 
   return {
     panelId,
-    input: value.input,
+    input,
   };
 }
 
-function parsePanelSubmitComposerRequest(value: unknown): RunpanePanelSubmitComposerRequest {
+function parsePanelSubmitComposerRequest(value: PaneCommandValue): RunpanePanelSubmitComposerRequest {
   if (!isRecord(value)) {
     throw new Error('Panel submit-composer request must be an object');
   }
@@ -1779,11 +1796,13 @@ function parsePanelSubmitComposerRequest(value: unknown): RunpanePanelSubmitComp
 
   return {
     panelId,
-    strategy: value.strategy as RunpanePanelSubmitComposerStrategy | undefined,
+    strategy: value.strategy === undefined
+      ? undefined
+      : decodeBoundary(value.strategy, boundary.enumeration('auto', 'codex-ctrl-enter', 'enter')),
   };
 }
 
-function parsePanelWaitRequest(value: unknown): RunpanePanelWaitRequest {
+function parsePanelWaitRequest(value: PaneCommandValue): RunpanePanelWaitRequest {
   if (!isRecord(value)) {
     throw new Error('Panel wait request must be an object');
   }
@@ -1808,23 +1827,24 @@ function parsePanelWaitRequest(value: unknown): RunpanePanelWaitRequest {
   };
 }
 
-function parseAgentDoctorRequest(value: unknown): RunpaneAgentDoctorRequest {
+function parseAgentDoctorRequest(value: PaneCommandValue): RunpaneAgentDoctorRequest {
   if (!isRecord(value)) {
     throw new Error('Agent doctor request must be an object');
   }
-  if (typeof value.agent !== 'string' || !AGENT_IDS.has(value.agent)) {
+  const agent = optionalAgentId(value.agent);
+  if (!agent) {
     throw new Error(`Agent doctor request must include agent: ${[...AGENT_IDS].join(', ')}`);
   }
 
   return {
-    agent: value.agent as RunpaneAgentId,
+    agent,
     repo: value.repo === undefined || value.repo === null || value.repo === ''
       ? undefined
       : parseRepoSelector(value.repo),
   };
 }
 
-function parseWaitCondition(value: unknown, contains?: string): RunpanePanelWaitCondition | undefined {
+function parseWaitCondition(value: PaneCommandValue, contains?: string): RunpanePanelWaitCondition | undefined {
   if (value === undefined || value === null || value === '') {
     return contains ? 'text' : undefined;
   }
@@ -1834,23 +1854,24 @@ function parseWaitCondition(value: unknown, contains?: string): RunpanePanelWait
   throw new Error('Panel wait condition must be one of: initialized, ready, idle, text');
 }
 
-function parseRepoAddRequest(value: unknown): Required<Pick<RunpaneRepoAddRequest, 'path' | 'name'>> & Pick<RunpaneRepoAddRequest, 'dryRun'> {
+function parseRepoAddRequest(value: PaneCommandValue): Required<Pick<RunpaneRepoAddRequest, 'path' | 'name'>> & Pick<RunpaneRepoAddRequest, 'dryRun'> {
   if (!isRecord(value)) {
     throw new Error('Repo add request must be an object');
   }
 
-  if (typeof value.path !== 'string' || value.path.trim().length === 0) {
+  const requestedPath = optionalString(value.path)?.trim();
+  if (!requestedPath) {
     throw new Error('Repo add request must include a path');
   }
 
-  const repoPath = path.resolve(value.path);
+  const repoPath = path.resolve(requestedPath);
   const providedName = optionalString(value.name)?.trim();
   const defaultName = path.basename(repoPath) || repoPath;
 
   return {
     path: repoPath,
     name: providedName && providedName.length > 0 ? providedName : defaultName,
-    dryRun: typeof value.dryRun === 'boolean' ? value.dryRun : undefined,
+    dryRun: optionalBoolean(value.dryRun),
   };
 }
 
@@ -1989,7 +2010,7 @@ async function waitForWorktreeRemovalByPolling(
   return fs.existsSync(worktreePath) ? 'timeout' : 'completed';
 }
 
-function parsePaneArchiveRequest(value: unknown): RunpanePaneArchiveRequest {
+function parsePaneArchiveRequest(value: PaneCommandValue): RunpanePaneArchiveRequest {
   if (!isRecord(value)) {
     throw new Error('Pane archive request must be an object');
   }
@@ -2004,12 +2025,12 @@ function parsePaneArchiveRequest(value: unknown): RunpanePaneArchiveRequest {
 
   return {
     paneId,
-    force: typeof value.force === 'boolean' ? value.force : undefined,
+    force: optionalBoolean(value.force),
     source: value.source === 'user' || value.source === 'agent' ? value.source : undefined,
   };
 }
 
-function parsePanePinRequest(value: unknown): RunpanePanePinRequest {
+function parsePanePinRequest(value: PaneCommandValue): RunpanePanePinRequest {
   if (!isRecord(value)) {
     throw new Error('Pane pin request must be an object');
   }
@@ -2018,18 +2039,19 @@ function parsePanePinRequest(value: unknown): RunpanePanePinRequest {
   if (!paneId) {
     throw new Error('Pane pin request must include a paneId');
   }
-  if (typeof value.pinned !== 'boolean') {
+  const pinned = optionalBoolean(value.pinned);
+  if (pinned === undefined) {
     throw new Error('Pane pin request must include pinned as a boolean');
   }
 
   return {
     paneId,
-    pinned: value.pinned,
-    dryRun: typeof value.dryRun === 'boolean' ? value.dryRun : undefined,
+    pinned,
+    dryRun: optionalBoolean(value.dryRun),
   };
 }
 
-function parsePaneRenameRequest(value: unknown): RunpanePaneRenameRequest {
+function parsePaneRenameRequest(value: PaneCommandValue): RunpanePaneRenameRequest {
   if (!isRecord(value)) {
     throw new Error('Pane rename request must be an object');
   }
@@ -2046,7 +2068,7 @@ function parsePaneRenameRequest(value: unknown): RunpanePaneRenameRequest {
   return {
     paneId,
     name,
-    dryRun: typeof value.dryRun === 'boolean' ? value.dryRun : undefined,
+    dryRun: optionalBoolean(value.dryRun),
   };
 }
 
@@ -2058,21 +2080,22 @@ function resolvePanel(panelId: string): ToolPanel {
   return panel;
 }
 
-function parsePaneCreateItem(value: unknown, index: number): RunpanePaneCreateItem {
+function parsePaneCreateItem(value: PaneCommandValue, index: number): RunpanePaneCreateItem {
   if (!isRecord(value)) {
     throw new Error(`Pane create item ${index} must be an object`);
   }
 
-  if (typeof value.name !== 'string' || value.name.trim().length === 0) {
+  const name = optionalString(value.name);
+  if (!name || name.trim().length === 0) {
     throw new Error(`Pane create item ${index} must include a name`);
   }
 
   return {
-    name: value.name,
+    name,
     worktreeName: optionalString(value.worktreeName),
     baseBranch: optionalString(value.baseBranch),
     sessionPrompt: optionalString(value.sessionPrompt),
-    pinned: typeof value.pinned === 'boolean' ? value.pinned : undefined,
+    pinned: optionalBoolean(value.pinned),
     tool: parseRunpaneToolSpec(value.tool, `Pane create item ${index}`),
   };
 }
@@ -2104,25 +2127,24 @@ function validateRepositoryPath(repoPath: string): void {
   }
 }
 
-function parseRunpaneToolSpec(value: unknown, label: string): RunpaneToolSpec {
+function parseRunpaneToolSpec(value: PaneCommandValue, label: string): RunpaneToolSpec {
   if (!isRecord(value)) {
     throw new Error(`${label} must include a tool object`);
   }
 
-  if (typeof value.agent === 'string') {
-    if (!AGENT_IDS.has(value.agent)) {
-      throw new Error(`Unsupported agent "${value.agent}" in ${label}`);
-    }
+  const agent = optionalAgentId(value.agent);
+  if (agent) {
     return {
-      agent: value.agent as RunpaneAgentId,
+      agent,
       title: optionalString(value.title),
       initialInput: optionalString(value.initialInput),
     };
   }
 
-  if (typeof value.command === 'string' && value.command.trim().length > 0) {
+  const command = optionalString(value.command);
+  if (command && command.trim().length > 0) {
     return {
-      command: value.command,
+      command,
       title: optionalString(value.title),
       initialInput: optionalString(value.initialInput),
     };
@@ -2131,24 +2153,20 @@ function parseRunpaneToolSpec(value: unknown, label: string): RunpaneToolSpec {
   throw new Error(`${label} tool must include agent or command`);
 }
 
-function parseRepoSelector(value: unknown): RunpaneRepoSelector {
-  if (typeof value === 'string') {
-    return value;
-  }
+function parseRepoSelector(value: PaneCommandValue): RunpaneRepoSelector {
+  const selectorText = optionalString(value);
+  if (selectorText !== undefined) return selectorText;
 
   if (!isRecord(value)) {
     throw new Error('Pane create request must include a repo selector');
   }
 
-  if (typeof value.id === 'number') {
-    return { id: value.id };
-  }
-  if (typeof value.path === 'string') {
-    return { path: value.path };
-  }
-  if (typeof value.name === 'string') {
-    return { name: value.name };
-  }
+  const id = optionalNumber(value.id);
+  if (id !== undefined) return { id };
+  const selectorPath = optionalString(value.path);
+  if (selectorPath !== undefined) return { path: selectorPath };
+  const name = optionalString(value.name);
+  if (name !== undefined) return { name };
   if (value.active === true) {
     return { active: true };
   }
@@ -2157,44 +2175,52 @@ function parseRepoSelector(value: unknown): RunpaneRepoSelector {
 }
 
 function resolveRepoSelector(projects: Project[], selector: RunpaneRepoSelector): Project {
-  if (typeof selector === 'string') {
-    if (selector === 'active' || selector === 'default') {
+  const selectorText = optionalString(selector);
+  if (selectorText !== undefined) {
+    if (selectorText === 'active' || selectorText === 'default') {
       return resolveActiveProject(projects);
     }
 
-    if (/^\d+$/.test(selector)) {
-      const byId = projects.find(project => project.id === Number(selector));
+    if (/^\d+$/.test(selectorText)) {
+      const byId = projects.find(project => project.id === Number(selectorText));
       if (byId) {
         return byId;
       }
     }
 
-    const byPath = resolveProjectByPath(projects, selector);
+    const byPath = resolveProjectByPath(projects, selectorText);
     if (byPath) {
       return byPath;
     }
 
-    return resolveProjectByName(projects, selector);
+    return resolveProjectByName(projects, selectorText);
   }
 
-  if ('id' in selector) {
-    const project = projects.find(candidate => candidate.id === selector.id);
+  const selectorObject = decodeBoundary(selector, boundary.object({
+    id: boundary.optional(boundary.number),
+    path: boundary.optional(boundary.string),
+    name: boundary.optional(boundary.string),
+    active: boundary.optional(boundary.literal(true)),
+  }));
+
+  if (selectorObject.id !== undefined) {
+    const project = projects.find(candidate => candidate.id === selectorObject.id);
     if (!project) {
-      throw new Error(`No Pane repo found with id ${selector.id}`);
+      throw new Error(`No Pane repo found with id ${selectorObject.id}`);
     }
     return project;
   }
 
-  if ('path' in selector) {
-    const project = resolveProjectByPath(projects, selector.path);
+  if (selectorObject.path !== undefined) {
+    const project = resolveProjectByPath(projects, selectorObject.path);
     if (!project) {
-      throw new Error(`No Pane repo found at path ${selector.path}`);
+      throw new Error(`No Pane repo found at path ${selectorObject.path}`);
     }
     return project;
   }
 
-  if ('name' in selector) {
-    return resolveProjectByName(projects, selector.name);
+  if (selectorObject.name !== undefined) {
+    return resolveProjectByName(projects, selectorObject.name);
   }
 
   return resolveActiveProject(projects);
@@ -2253,26 +2279,27 @@ function describeTool(tool: RunpaneResolvedTool): { title: string; command: stri
   };
 }
 
-function createFailureItem(index: number, item: RunpanePaneCreateItem, error: unknown): RunpanePaneCreateFailureItem {
+function createFailureItem(index: number, item: RunpanePaneCreateItem, cause: unknown): RunpanePaneCreateFailureItem {
   return {
     ok: false,
     index,
     name: item.name,
     error: {
-      message: error instanceof Error ? error.message : String(error),
+      message: cause instanceof Error ? cause.message : String(cause),
       code: 'ERR_RUNPANE_PANE_CREATE_FAILED',
     },
   };
 }
 
-function parsePositiveInteger(value: unknown, label: string): number | undefined {
+function parsePositiveInteger(value: PaneCommandValue, label: string): number | undefined {
   if (value === undefined || value === null) {
     return undefined;
   }
-  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+  const numberValue = optionalNumber(value);
+  if (numberValue === undefined || !Number.isInteger(numberValue) || numberValue <= 0) {
     throw new Error(`${label} must be a positive integer`);
   }
-  return value;
+  return numberValue;
 }
 
 function toIsoString(value: Date | string | undefined): string | undefined {
@@ -2312,7 +2339,7 @@ interface RunpaneActionMetadata {
   environment?: string;
 }
 
-async function withRunpaneAction<T>(
+async function withRunpaneAction<T extends { ok: boolean }>(
   services: AppServices,
   action: string,
   metadata: RunpaneActionMetadata,
@@ -2322,7 +2349,7 @@ async function withRunpaneAction<T>(
   const startedAt = Date.now();
   try {
     const result = await handler();
-    const commandOk = isRecord(result) && typeof result.ok === 'boolean' ? result.ok : true;
+    const commandOk = result.ok;
     trackRunpaneAction(services, action, 'success', Date.now() - startedAt, {
       ...metadata,
       ok: commandOk,
@@ -2344,13 +2371,13 @@ function trackRunpaneAction(
   status: 'success' | 'failure',
   durationMs: number,
   metadata: RunpaneActionMetadata,
-  error?: unknown,
+  cause?: unknown,
 ): void {
   const analyticsManager = services.analyticsManager;
   const paneIdHash = metadata.paneId && analyticsManager?.hashSessionId(metadata.paneId);
   const panelIdHash = metadata.panelId && analyticsManager?.hashSessionId(metadata.panelId);
-  const errorMessage = error instanceof Error ? error.message : error ? String(error) : undefined;
-  const errorType = error instanceof Error ? error.name : error ? 'Error' : undefined;
+  const errorMessage = cause instanceof Error ? cause.message : cause ? String(cause) : undefined;
+  const errorType = cause instanceof Error ? cause.name : cause ? 'Error' : undefined;
 
   analyticsManager?.track('runpane_local_control', {
     action,
@@ -2410,15 +2437,21 @@ function firstNonEmptyLine(value: string | undefined): string | undefined {
     .find(line => line.length > 0);
 }
 
-function commandErrorMessage(error: unknown, fallback: string): string {
-  if (isRecord(error)) {
-    const stderr = firstNonEmptyLine(typeof error.stderr === 'string' ? error.stderr : undefined);
-    const stdout = firstNonEmptyLine(typeof error.stdout === 'string' ? error.stdout : undefined);
+function commandErrorMessage(cause: unknown, fallback: string): string {
+  try {
+    const details = decodeBoundary(cause, boundary.object({
+      stderr: boundary.optional(boundary.string),
+      stdout: boundary.optional(boundary.string),
+    }));
+    const stderr = firstNonEmptyLine(details.stderr);
+    const stdout = firstNonEmptyLine(details.stdout);
     if (stderr) return stderr;
     if (stdout) return stdout;
+  } catch {
+    // Fall through to the standard Error contract.
   }
-  if (error instanceof Error && error.message) {
-    return error.message;
+  if (cause instanceof Error && cause.message) {
+    return cause.message;
   }
   return fallback;
 }
@@ -2427,10 +2460,43 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function optionalString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
+function optionalString(value: PaneCommandValue): string | undefined {
+  try {
+    return decodeBoundary(value, boundary.string);
+  } catch {
+    return undefined;
+  }
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+function isRecord(value: PaneCommandValue): value is Record<string, PaneCommandValue> {
+  try {
+    decodeBoundary(value, boundary.jsonObject);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function optionalBoolean(value: PaneCommandValue): boolean | undefined {
+  try {
+    return decodeBoundary(value, boundary.boolean);
+  } catch {
+    return undefined;
+  }
+}
+
+function optionalNumber(value: PaneCommandValue): number | undefined {
+  try {
+    return decodeBoundary(value, boundary.number);
+  } catch {
+    return undefined;
+  }
+}
+
+function optionalAgentId(value: PaneCommandValue): RunpaneAgentId | undefined {
+  try {
+    return decodeBoundary(value, boundary.enumeration(...RUNPANE_CONTRACT.enums.agents));
+  } catch {
+    return undefined;
+  }
 }

--- a/main/src/ipc/script.ts
+++ b/main/src/ipc/script.ts
@@ -1,6 +1,7 @@
 import type { IpcMain } from 'electron';
 import type { AppServices } from './types';
-import type { PaneCommandRegistry } from '../daemon/commandRegistry';
+import type { PaneCommandRegistry, PaneCommandValue } from '../daemon/commandRegistry';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 import { getShellPath, findExecutableInPath } from '../utils/shellPath';
 import { logsManager } from '../services/panels/logPanel/logsManager';
 import { panelManager } from '../services/panelManager';
@@ -71,7 +72,8 @@ export function registerScriptHandlers(
         if (runningScript.type === 'session') {
           console.log('[Script] Stopping session script via logs panel');
           // Find and stop the logs panel for this session
-          const panels = await panelManager.getPanelsForSession(runningScript.id as string);
+          const sessionScriptId = decodeBoundary(runningScript.id, boundary.string);
+          const panels = await panelManager.getPanelsForSession(sessionScriptId);
           const logsPanel = panels?.find((p: { type: string }) => p.type === 'logs');
           if (logsPanel) {
             console.log('[Script] Found logs panel, stopping:', logsPanel.id);
@@ -139,7 +141,8 @@ export function registerScriptHandlers(
         // If it's a session script, stop the logs panel process (critical!)
         if (runningScript && runningScript.type === 'session') {
           console.log('[Script] Finding logs panel for session:', runningScript.id);
-          const panels = await panelManager.getPanelsForSession(runningScript.id as string);
+          const sessionScriptId = decodeBoundary(runningScript.id, boundary.string);
+          const panels = await panelManager.getPanelsForSession(sessionScriptId);
           const logsPanel = panels?.find((p: { type: string }) => p.type === 'logs');
           if (logsPanel) {
             console.log('[Script] Stopping logs panel:', logsPanel.id);
@@ -227,7 +230,7 @@ export function registerScriptHandlers(
   };
 
   // Opening a local IDE is a client-local adapter action, not daemon-owned runtime behavior.
-  ipcMain.handle('sessions:open-ide', async (_event, sessionId: string, ideKey?: unknown) => {
+  ipcMain.handle('sessions:open-ide', async (_event, sessionId: string, ideKey?: PaneCommandValue) => {
     try {
       const session = await sessionManager.getSession(sessionId);
       if (!session || !session.worktreePath) {
@@ -236,7 +239,12 @@ export function registerScriptHandlers(
 
       const project = sessionManager.getProjectForSession(sessionId);
       // Resolve command: use allowlisted key, fall back to project config
-      const safeKey = typeof ideKey === 'string' ? ideKey : undefined;
+      let safeKey: string | undefined;
+      try {
+        safeKey = decodeBoundary(ideKey, boundary.optional(boundary.string));
+      } catch {
+        safeKey = undefined;
+      }
       const ideCommand = (safeKey && IDE_COMMANDS[safeKey]) || project?.open_ide_command;
       if (!ideCommand) {
         return { success: false, error: 'No IDE command configured for this project' };

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -27,6 +27,7 @@ import {
 } from '../utils/sessionValidation';
 import type { SerializedArchiveTask } from '../services/archiveProgressManager';
 import { detectProjectConfig } from '../services/projectConfigDetector';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const DAEMON_SESSION_CHANNELS = [
   'sessions:get-all',
@@ -329,7 +330,12 @@ export function registerSessionHandlers(
         errorDetails = error.stack || error.toString();
 
         // Check if it's a git command error
-        const gitError = error as Error & { gitCommand?: string; cmd?: string; gitOutput?: string; stderr?: string };
+        const gitError = decodeBoundary(error, boundary.object({
+          gitCommand: boundary.optional(boundary.string),
+          cmd: boundary.optional(boundary.string),
+          gitOutput: boundary.optional(boundary.string),
+          stderr: boundary.optional(boundary.string),
+        }));
         if (gitError.gitCommand) {
           command = gitError.gitCommand;
         } else if (gitError.cmd) {
@@ -639,7 +645,7 @@ export function registerSessionHandlers(
         console.error(`[Session IPC] cleanupSessionPanelsInMemory failed for permanently deleted session ${sessionId}:`, err);
       }
 
-      await cleanupPermanentDeleteFiles(session as unknown as DatabaseSession);
+      await cleanupPermanentDeleteFiles(session);
 
       const deleted = databaseService.deleteArchivedSessionPermanently(sessionId);
       if (!deleted) {
@@ -671,7 +677,7 @@ export function registerSessionHandlers(
           console.error(`[Session IPC] cleanupSessionPanelsInMemory failed for permanently deleted session ${session.id}:`, err);
         }
 
-        await cleanupPermanentDeleteFiles(session as unknown as DatabaseSession);
+        await cleanupPermanentDeleteFiles(session);
       }
 
       const deletedCount = databaseService.deleteArchivedSessionsPermanently();
@@ -960,7 +966,9 @@ export function registerSessionHandlers(
         const transformedBatch = batch.map(output => {
           if (output.type === 'json') {
             // Generate formatted output from JSON
-            const outputText = formatJsonForOutputEnhanced(output.data as Record<string, unknown>);
+            const outputText = formatJsonForOutputEnhanced(
+              decodeBoundary(output.data, boundary.jsonObject),
+            );
             if (outputText) {
               // Return as stdout for the Output view
               return {
@@ -1085,38 +1093,25 @@ export function registerSessionHandlers(
       const jsonMessages = outputs
         .filter(output => output.type === 'json')
         .map(output => {
-          // Return the unwrapped message data with timestamp
-          // The message transformer expects the actual message object, not wrapped in { type: 'json', data: ... }
-          if (output.data && typeof output.data === 'object') {
+          const timestamp = output.timestamp instanceof Date
+            ? output.timestamp.toISOString()
+            : output.timestamp;
+          try {
             return {
-              ...output.data as Record<string, unknown>,
-              timestamp: output.timestamp instanceof Date
-                ? output.timestamp.toISOString()
-                : (typeof output.timestamp === 'string' ? output.timestamp : '')
+              ...decodeBoundary(output.data, boundary.jsonObject),
+              timestamp,
             };
-          }
-          // If data is a string, try to parse it
-          if (typeof output.data === 'string') {
+          } catch {
             try {
-              const parsed = JSON.parse(output.data);
+              const serialized = decodeBoundary(output.data, boundary.string);
               return {
-                ...parsed,
-                timestamp: output.timestamp instanceof Date
-                  ? output.timestamp.toISOString()
-                  : (typeof output.timestamp === 'string' ? output.timestamp : '')
+                ...decodeBoundary(JSON.parse(serialized), boundary.jsonObject),
+                timestamp,
               };
             } catch {
-              // If parsing fails, return as-is with timestamp
-              return {
-                data: output.data,
-                timestamp: output.timestamp instanceof Date
-                  ? output.timestamp.toISOString()
-                  : (typeof output.timestamp === 'string' ? output.timestamp : '')
-              };
+              return { data: String(output.data), timestamp };
             }
           }
-          // Fallback
-          return output.data;
         });
 
       console.log(`[IPC] Returning ${jsonMessages.length} JSON messages for panel ${panelId}`);
@@ -1284,7 +1279,6 @@ export function registerSessionHandlers(
       const updatedSession = databaseService.getSession(sessionId);
       console.log('[IPC] Verified skip_continue_next flag after update:', {
         raw_value: updatedSession?.skip_continue_next,
-        type: typeof updatedSession?.skip_continue_next,
         is_truthy: !!updatedSession?.skip_continue_next
       });
       console.log('[IPC] Generated compacted context summary and set skip_continue_next flag');
@@ -1335,15 +1329,22 @@ export function registerSessionHandlers(
 
       // Filter to JSON messages, error messages, and git operation stdout/stderr messages
       const jsonMessages = outputs
-        .filter(output =>
-          output.type === 'json' ||
-          output.type === 'error' ||
-          ((output.type === 'stdout' || output.type === 'stderr') && isGitOperation(output.data as string))
-        )
+        .filter(output => {
+          if (output.type === 'json' || output.type === 'error') return true;
+          if (output.type !== 'stdout' && output.type !== 'stderr') return false;
+          try {
+            return isGitOperation(decodeBoundary(output.data, boundary.string));
+          } catch {
+            return false;
+          }
+        })
         .map(output => {
           if (output.type === 'error') {
             // Transform error outputs to a format that RichOutputView can handle
-            const errorData = output.data as Record<string, unknown>;
+            const errorData = decodeBoundary(output.data, boundary.object({
+              error: boundary.string,
+              details: boundary.optional(boundary.string),
+            }));
             return {
               type: 'system',
               subtype: 'error',
@@ -1354,22 +1355,23 @@ export function registerSessionHandlers(
             };
           } else if (output.type === 'stdout' || output.type === 'stderr') {
             // Transform git operation stdout/stderr to system messages that RichOutputView can display
-            const isError = output.type === 'stderr' || (output.data as string).includes('failed:') || (output.data as string).includes('✗');
+            const outputText = decodeBoundary(output.data, boundary.string);
+            const isError = output.type === 'stderr' || outputText.includes('failed:') || outputText.includes('✗');
             return {
               type: 'system',
               subtype: isError ? 'git_error' : 'git_operation',
               timestamp: output.timestamp.toISOString(),
-              message: output.data,
+              message: outputText,
               // Add raw data for processing
-              raw_output: output.data
+              raw_output: outputText
             };
           } else {
             // Regular JSON messages - safe to spread since we know it's a Record
-            const jsonData = output.data as Record<string, unknown>;
+            const jsonData = decodeBoundary(output.data, boundary.jsonObject);
             return {
               ...jsonData,
               timestamp: output.timestamp.toISOString()
-            } as Record<string, unknown>;
+            };
           }
         });
 

--- a/main/src/ipc/spotlight.ts
+++ b/main/src/ipc/spotlight.ts
@@ -8,7 +8,7 @@ export function registerSpotlightHandlers(ipcMain: IpcMain, services: AppService
       return { success: true };
     } catch (error) {
       console.error('[Spotlight IPC] Enable failed:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -18,7 +18,7 @@ export function registerSpotlightHandlers(ipcMain: IpcMain, services: AppService
       return { success: true };
     } catch (error) {
       console.error('[Spotlight IPC] Disable failed:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -28,7 +28,7 @@ export function registerSpotlightHandlers(ipcMain: IpcMain, services: AppService
       return { success: true, data: spotlight || { active: false } };
     } catch (error) {
       console.error('[Spotlight IPC] Get status failed:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 }

--- a/main/src/ipc/updater.ts
+++ b/main/src/ipc/updater.ts
@@ -65,16 +65,11 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
           
           // Check if the working directory is clean (no uncommitted changes)
           try {
-            interface ExtendedExecOptions {
-              encoding: 'utf8';
-              cwd: string;
-              silent?: boolean;
-            }
             commandExecutor.execSync('git diff-index --quiet HEAD --', { 
               encoding: 'utf8',
               cwd: process.cwd(),
               silent: true
-            } as ExtendedExecOptions);
+            });
             gitCommit = gitHash;
           } catch {
             // Working directory has uncommitted changes

--- a/shared/types/panels.ts
+++ b/shared/types/panels.ts
@@ -187,7 +187,7 @@ export interface PanelEvent {
   type: PanelEventType;
   source: {
     panelId: string;
-    panelType: ToolPanelType;
+    panelType: ToolPanelType | 'git';
     sessionId: string;
   };
   data: unknown;


### PR DESCRIPTION
## Summary
- decode main-process IPC, persistence, process, and daemon inputs at their owning boundaries
- carry named values through handlers instead of downstream `unknown`, open dictionaries, and representation checks
- document irreducible SQLite and test-fixture assertions and extend the panel event contract for virtual git events
- reduce the exact Phase 2b inventory for the five boundary rules from 545 live findings to zero

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter main exec vitest run` (58 files, 572 tests)
- `pnpm --filter runpane build`
- `node scripts/test-runpane-contract.js`
- `pnpm build`
- exact Phase 2b advisory inventory: 0 findings for `no-runtime-typeof`, `no-unknown-parameters`, `no-unknown-returns`, `no-unsafe-dictionary-type`, and `require-safety-comment-for-type-assertion`
