### PR TITLE
Enable Cursor Agent for WSL repos on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to Pane will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Cursor Agent CLI (`cursor-agent`) as a third built-in agent tool: launch pill/menu entries with `mod+alt+5`, prompt-as-argument delivery, chat pre-creation with resume-after-restart, at-a-glance status detection, RunPane `--agent cursor` support with a doctor fallback probe for `~/.local/bin`, and a Cursor option for the Pane Chat orchestrator. macOS/Linux only; the tool is hidden on Windows.
+- Cursor Agent CLI (`cursor-agent`) as a third built-in agent tool: launch pill/menu entries with `mod+alt+5`, prompt-as-argument delivery, chat pre-creation with resume-after-restart, at-a-glance status detection, RunPane `--agent cursor` support with a doctor fallback probe for `~/.local/bin`, and a Cursor option for the Pane Chat orchestrator. Pane supports Cursor in macOS, Linux, and WSL repositories. Native Windows launches stay disabled.
 
 ### Changed
 - Custom-command keyboard shortcuts moved from `mod+alt+5..9` to `mod+alt+6..9` to make room for the Cursor slot.
+- Cursor Agent is now available inside WSL repositories.
 
 ## [1.1.123] - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ irm https://runpane.com/install.ps1 | iex
 - At least one AI coding agent CLI installed:
   - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — `npm install -g @anthropic-ai/claude-code`
   - [Codex](https://github.com/openai/codex) — `npm install -g @openai/codex`
-  - [Cursor Agent](https://cursor.com/docs/cli) — `curl https://cursor.com/install -fsS | bash` (macOS/Linux)
+  - [Cursor Agent](https://cursor.com/docs/cli) — `curl https://cursor.com/install -fsS | bash` (macOS/Linux, or inside WSL on Windows)
   - [Aider](https://aider.chat/) — `pip install aider-chat`
   - [Goose](https://github.com/block/goose) — or any other CLI agent
 

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -14,10 +14,12 @@ import { useResizable } from '../hooks/useResizable';
 import { CommitMessageDialog } from './session/CommitMessageDialog';
 import { SetTrackingBranchDialog } from './session/SetTrackingBranchDialog';
 import { useMainRepoGitActions } from '../hooks/useMainRepoGitActions';
+import type { ProjectEnvironment } from '../../../shared/types/panels';
 
 interface ProjectViewProps {
   projectId: number;
   projectName: string;
+  projectEnvironment: ProjectEnvironment | undefined;
   configuredIDECommand?: string | null;
   onConfigureIDE: () => void;
 }
@@ -25,6 +27,7 @@ interface ProjectViewProps {
 export const ProjectView: React.FC<ProjectViewProps> = ({ 
   projectId, 
   projectName,
+  projectEnvironment,
   configuredIDECommand,
   onConfigureIDE,
 }) => {
@@ -327,6 +330,7 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
             onPanelSelect={handlePanelSelect}
             onPanelClose={handlePanelClose}
             onPanelCreate={handlePanelCreate}
+            projectEnvironment={projectEnvironment}
             context="project"
             onToggleDetailPanel={() => setDetailVisible(v => !v)}
             detailPanelVisible={detailVisible}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -49,8 +49,6 @@ import {
 import { Download, Upload, GitMerge, GitPullRequestArrow, Terminal, ChevronDown, ChevronUp, RefreshCw, Archive, ArchiveRestore, GitCommitHorizontal, TerminalSquare, Undo2, X } from 'lucide-react';
 import { getCliBrandIcon } from './ui/BrandIcons';
 import { visibleAgentPresets } from '../utils/agentPresets';
-
-const agentPresets = visibleAgentPresets();
 import type { Project } from '../types/project';
 import { devLog, renderLog } from '../utils/console';
 import { useConfigStore } from '../stores/configStore';
@@ -101,6 +99,13 @@ export const SessionView = memo(() => {
     // Otherwise look in regular sessions
     return state.sessions.find(session => session.id === state.activeSessionId);
   });
+  const activeProjectEnvironment = sessionProject && sessionProject.id === activeSession?.projectId
+    ? sessionProject.environment
+    : undefined;
+  const agentPresets = useMemo(
+    () => visibleAgentPresets(activeProjectEnvironment),
+    [activeProjectEnvironment],
+  );
   const lastAnnouncedSessionStateRef = useRef<string | null>(activeSession?.status ?? null);
   const [sessionStatusAnnouncement, setSessionStatusAnnouncement] = useState('');
 
@@ -1148,11 +1153,10 @@ export const SessionView = memo(() => {
       });
     }
     return () => { ids.forEach(id => unregisterHotkey(id)); };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [agentPresets, registerHotkey, unregisterHotkey]);
 
   useEffect(() => {
-    const CUSTOM_CMD_START = 3 + agentPresets.length; // mod+alt+1-2 are panels, then one slot per agent
+    const CUSTOM_CMD_START = 6; // mod+alt+3-5 stay reserved for built-in agents on every platform
     const maxSlots = Math.min(customCommands.length, 10 - CUSTOM_CMD_START);
     const ids: string[] = [];
 
@@ -1631,6 +1635,7 @@ export const SessionView = memo(() => {
         <ProjectView
           projectId={activeProjectId}
           projectName={projectData.name || 'Project'}
+          projectEnvironment={projectData.environment}
           configuredIDECommand={projectData.open_ide_command}
           onConfigureIDE={() => setShowProjectSettings(true)}
         />
@@ -1675,6 +1680,7 @@ export const SessionView = memo(() => {
           onPanelSelect={handlePanelSelect}
           onPanelClose={handlePanelClose}
           onPanelCreate={handlePanelCreate}
+          projectEnvironment={activeProjectEnvironment}
           onToggleDetailPanel={handleToggleDetailPanel}
           detailPanelVisible={detailVisible}
           detailPanelToggleDisabled={immersiveMode}

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -13,8 +13,6 @@ import { Tooltip } from '../ui/Tooltip';
 import { Kbd } from '../ui/Kbd';
 import { CLI_BRAND_ICONS, getCliBrandIcon } from '../ui/BrandIcons';
 import { visibleAgentPresets } from '../../utils/agentPresets';
-
-const agentPresets = visibleAgentPresets();
 import { PanelTabStrip } from './PanelTabStrip';
 import type { WorktreeFileSyncEntry } from '../../../../shared/types/worktreeFileSync';
 
@@ -69,6 +67,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   onPanelSelect,
   onPanelClose,
   onPanelCreate,
+  projectEnvironment,
   context = 'worktree',  // Default to worktree for backward compatibility
   onToggleDetailPanel,
   detailPanelVisible,
@@ -86,6 +85,10 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   draggedPanelId,
   getPanelTabPresentation,
 }) => {
+  const agentPresets = useMemo(
+    () => visibleAgentPresets(projectEnvironment),
+    [projectEnvironment],
+  );
   const sessionContext = useSession();
   const session = sessionContext?.session;
   const [resolvedRunScript, setResolvedRunScript] = useState<{ command: string; source: string } | null>(null);

--- a/frontend/src/types/panelComponents.ts
+++ b/frontend/src/types/panelComponents.ts
@@ -1,4 +1,4 @@
-import { ToolPanel, ToolPanelType } from '../../../shared/types/panels';
+import { ProjectEnvironment, ToolPanel, ToolPanelType } from '../../../shared/types/panels';
 
 type PanelContext = 'project' | 'worktree';
 
@@ -21,6 +21,7 @@ export interface PanelTabBarProps {
   onPanelSelect: (panel: ToolPanel) => void;
   onPanelClose: (panel: ToolPanel) => void;
   onPanelCreate: (type: ToolPanelType, options?: PanelCreateOptions) => void;
+  projectEnvironment?: ProjectEnvironment;
   context?: PanelContext;  // Optional context to filter available panels
   onToggleDetailPanel?: () => void;
   detailPanelVisible?: boolean;

--- a/frontend/src/utils/agentPresets.test.ts
+++ b/frontend/src/utils/agentPresets.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { visibleAgentPresets } from './agentPresets';
+
+describe('visibleAgentPresets', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows Cursor for WSL repos on a Windows host', () => {
+    vi.stubGlobal('navigator', { platform: 'Win32' });
+
+    expect(visibleAgentPresets('wsl').map(preset => preset.id)).toEqual([
+      'claude',
+      'codex',
+      'cursor',
+    ]);
+  });
+
+  it('keeps Cursor hidden for native Windows repos and host-level tools', () => {
+    vi.stubGlobal('navigator', { platform: 'Win32' });
+
+    expect(visibleAgentPresets('windows').map(preset => preset.id)).toEqual([
+      'claude',
+      'codex',
+    ]);
+    expect(visibleAgentPresets().map(preset => preset.id)).toEqual([
+      'claude',
+      'codex',
+    ]);
+  });
+});

--- a/frontend/src/utils/agentPresets.test.ts
+++ b/frontend/src/utils/agentPresets.test.ts
@@ -28,4 +28,24 @@ describe('visibleAgentPresets', () => {
       'codex',
     ]);
   });
+
+  it('uses the remote repository environment instead of the renderer platform', () => {
+    vi.stubGlobal('navigator', { platform: 'MacIntel' });
+    expect(visibleAgentPresets('windows').map(preset => preset.id)).toEqual([
+      'claude',
+      'codex',
+    ]);
+
+    vi.stubGlobal('navigator', { platform: 'Win32' });
+    expect(visibleAgentPresets('macos').map(preset => preset.id)).toEqual([
+      'claude',
+      'codex',
+      'cursor',
+    ]);
+    expect(visibleAgentPresets('linux').map(preset => preset.id)).toEqual([
+      'claude',
+      'codex',
+      'cursor',
+    ]);
+  });
 });

--- a/frontend/src/utils/agentPresets.ts
+++ b/frontend/src/utils/agentPresets.ts
@@ -5,8 +5,6 @@ import { isMac, isWindows } from './platformUtils';
 export type { AgentLaunchPreset };
 
 export function visibleAgentPresets(projectEnvironment?: ProjectEnvironment): readonly AgentLaunchPreset[] {
-  const platform = isWindows()
-    ? projectEnvironment === 'wsl' ? 'wsl' : 'win32'
-    : isMac() ? 'darwin' : 'linux';
+  const platform = projectEnvironment ?? (isWindows() ? 'win32' : isMac() ? 'darwin' : 'linux');
   return agentPresetsForPlatform(platform);
 }

--- a/frontend/src/utils/agentPresets.ts
+++ b/frontend/src/utils/agentPresets.ts
@@ -1,9 +1,12 @@
 import { AgentLaunchPreset, agentPresetsForPlatform } from '../../../shared/constants/agentLaunchPresets';
+import type { ProjectEnvironment } from '../../../shared/types/panels';
 import { isMac, isWindows } from './platformUtils';
 
 export type { AgentLaunchPreset };
 
-export function visibleAgentPresets(): readonly AgentLaunchPreset[] {
-  const platform = isWindows() ? 'win32' : isMac() ? 'darwin' : 'linux';
+export function visibleAgentPresets(projectEnvironment?: ProjectEnvironment): readonly AgentLaunchPreset[] {
+  const platform = isWindows()
+    ? projectEnvironment === 'wsl' ? 'wsl' : 'win32'
+    : isMac() ? 'darwin' : 'linux';
   return agentPresetsForPlatform(platform);
 }

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -1216,8 +1216,10 @@ describe('runpane IPC handlers', () => {
     expect((result as { warnings?: string[] }).warnings?.some((w) => w.includes('PATH'))).toBe(true);
   });
 
-  it('reports cursor as unsupported for WSL repos', async () => {
-    const execAsync = vi.fn(async () => ({ stdout: '', stderr: '' }));
+  it('finds cursor installed inside a WSL repo environment', async () => {
+    const execAsync = vi.fn(async (command: string) => command.includes('--version')
+      ? { stdout: '2026.08.11-e8db854\n', stderr: '' }
+      : { stdout: '/home/user/.local/bin/cursor-agent\n', stderr: '' });
     const base = createServices();
     const services = createServices({
       // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
@@ -1244,17 +1246,17 @@ describe('runpane IPC handlers', () => {
     }]);
 
     expect(result).toMatchObject({
-      ok: false,
+      ok: true,
       agent: 'cursor',
-      available: false,
-      checks: expect.arrayContaining([
-        expect.objectContaining({ name: 'platform', ok: false }),
-      ]),
+      environment: 'wsl',
+      available: true,
+      executablePath: '/home/user/.local/bin/cursor-agent',
+      version: '2026.08.11-e8db854',
     });
-    expect(execAsync).not.toHaveBeenCalled();
+    expect(execAsync).toHaveBeenCalledWith('command -v cursor-agent', project.path, expect.any(Object));
   });
 
-  it('rejects cursor pane creation for WSL repos before creating a session', async () => {
+  it('allows cursor pane creation for WSL repos', async () => {
     const wslProject = { ...project, wsl_enabled: true, wsl_distribution: 'Ubuntu' };
     const base = createServices();
     const services = createServices({
@@ -1267,20 +1269,25 @@ describe('runpane IPC handlers', () => {
 
     const result = await createRegistry(services).invoke('runpane:panes:create', [{
       repo: 'active',
+      dryRun: true,
       panes: [{ name: 'cursor-wsl', tool: { agent: 'cursor' } }],
     }]);
 
     expect(result).toMatchObject({
-      ok: false,
+      ok: true,
       items: [{
-        ok: false,
-        error: { message: 'Cursor is not supported on wsl repos.' },
+        ok: true,
+        tool: {
+          title: 'Cursor',
+          command: 'cursor-agent --force --trust',
+          agent: 'cursor',
+        },
       }],
     });
     expect(services.taskQueue?.createSessionAndWait).not.toHaveBeenCalled();
   });
 
-  it('rejects cursor panel creation for WSL repos before creating a panel', async () => {
+  it('allows cursor panel creation for WSL repos', async () => {
     const wslProject = { ...project, wsl_enabled: true, wsl_distribution: 'Ubuntu' };
     const base = createServices();
     const services = createServices({
@@ -1288,14 +1295,45 @@ describe('runpane IPC handlers', () => {
       sessionManager: {
         ...base.sessionManager,
         getProjectForSession: vi.fn(() => wslProject),
+        getProjectContext: vi.fn(() => ({
+          commandRunner: {
+            wslContext: {
+              enabled: true,
+              distribution: 'Ubuntu',
+              linuxPath: session.worktreePath,
+            },
+          },
+        })),
       } as never,
     });
 
-    await expect(createRegistry(services).invoke('runpane:panels:create', [{
+    vi.mocked(panelManager.createPanel).mockResolvedValue({
+      ...terminalPanel,
+      title: 'Cursor',
+      state: { isActive: false },
+    });
+
+    const result = await createRegistry(services).invoke('runpane:panels:create', [{
       paneId: session.id,
       tool: { agent: 'cursor' },
-    }])).rejects.toThrow('Cursor is not supported on wsl repos.');
-    expect(panelManager.createPanel).not.toHaveBeenCalled();
+    }]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      paneId: session.id,
+      panelId: terminalPanel.id,
+      tool: {
+        title: 'Cursor',
+        command: 'cursor-agent --force --trust',
+        agent: 'cursor',
+      },
+    });
+    expect(panelManager.createPanel).toHaveBeenCalled();
+    expect(terminalPanelManager.initializeTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ id: terminalPanel.id }),
+      session.worktreePath,
+      expect.objectContaining({ enabled: true, distribution: 'Ubuntu' }),
+    );
   });
 
   it('creates a session, terminal panel, and initial-input state', async () => {

--- a/main/src/services/agents/agentLaunchPresets.test.ts
+++ b/main/src/services/agents/agentLaunchPresets.test.ts
@@ -22,14 +22,14 @@ describe('AGENT_LAUNCH_PRESETS', () => {
     expect(new Set(AGENT_LAUNCH_PRESETS.map(p => p.hotkeyId)).size).toBe(AGENT_LAUNCH_PRESETS.length);
   });
 
-  it('hides cursor on Windows and keeps it on macOS/Linux', () => {
+  it('supports cursor on POSIX hosts and WSL repos, but not native Windows', () => {
     expect(agentPresetsForPlatform('win32').map(p => p.id)).toEqual(['claude', 'codex']);
     expect(agentPresetsForPlatform('darwin').map(p => p.id)).toEqual(['claude', 'codex', 'cursor']);
     expect(agentPresetsForPlatform('linux').map(p => p.id)).toEqual(['claude', 'codex', 'cursor']);
     expect(agentPresetsForPlatform('windows').map(p => p.id)).toEqual(['claude', 'codex']);
     expect(agentPresetsForPlatform('macos').map(p => p.id)).toEqual(['claude', 'codex', 'cursor']);
-    expect(agentPresetsForPlatform('wsl').map(p => p.id)).toEqual(['claude', 'codex']);
+    expect(agentPresetsForPlatform('wsl').map(p => p.id)).toEqual(['claude', 'codex', 'cursor']);
     expect(isAgentSupportedOnPlatform('cursor', 'windows')).toBe(false);
-    expect(isAgentSupportedOnPlatform('cursor', 'wsl')).toBe(false);
+    expect(isAgentSupportedOnPlatform('cursor', 'wsl')).toBe(true);
   });
 });

--- a/shared/constants/agentLaunchPresets.ts
+++ b/shared/constants/agentLaunchPresets.ts
@@ -39,7 +39,7 @@ export const AGENT_LAUNCH_PRESETS: readonly AgentLaunchPreset[] = [
     iconKey: 'cursor',
     hotkeyId: 'add-tool-terminal-cursor',
     hotkey: 'mod+alt+5',
-    platforms: ['darwin', 'linux'],
+    platforms: ['darwin', 'linux', 'wsl'],
   },
 ];
 


### PR DESCRIPTION
## Summary

- Enable Cursor Agent for repositories that run inside WSL.
- Keep Cursor blocked for native Windows repositories and host-level Pane Chat, where Pane doesn't have a WSL distro context.
- Make Add Tool and agent hotkeys follow the active repository environment in both worktree and main-repo views.
- Keep Cursor on `mod+alt+5` and custom commands on `mod+alt+6` through `mod+alt+9` on every platform.
- Extend RunPane doctor, dry-run, panel creation, and launcher tests for Cursor inside WSL.

## Why

Cursor Agent supports Windows through WSL. Pane was checking the Windows host instead of the repository environment, so it hid and rejected Cursor even when the repo and binary lived inside WSL.

This moves the decision to the environment where Pane will actually launch the agent. Native Windows stays blocked.

## Visual Overview

<!-- pr-visual-overview:start -->
Before, a Windows host blocked Cursor before Pane considered that the repo ran inside WSL. After this change, Pane checks the active repo environment. WSL repos can launch Cursor inside their distro. Native Windows repos still stop at the safety gate.
<!-- pr-visual-overview:end -->

## Verification

- `pnpm exec vitest run frontend/src/utils/agentPresets.test.ts` (2 tests)
- `pnpm --dir main exec vitest run src/services/agents/agentLaunchPresets.test.ts src/services/agents/cursorLaunch.test.ts src/ipc/runpane.test.ts` (74 tests)
- `pnpm typecheck`
- `pnpm run build:frontend`
- `pnpm run build:main`
- `git diff --check`

The full main-process suite also reached 588 passing tests. Four database tests couldn't load the local `better-sqlite3` binary because it was built for Node module ABI 145 while this runner requires ABI 147.
