### PR TITLE
Add smooth keyboard scrolling for focused surfaces

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { useResizable } from './hooks/useResizable';
 import { useHotkey } from './hooks/useHotkey';
 import { useTerminalShortcuts } from './hooks/useTerminalShortcuts';
 import { useShortcutHintsOverlay } from './hooks/useShortcutHintsOverlay';
+import { useFocusedSurfaceScrolling } from './hooks/useFocusedSurfaceScrolling';
 
 import { ShortcutHintsOverlay } from './components/ShortcutHintsOverlay';
 import { Sidebar } from './components/Sidebar';
@@ -127,9 +128,11 @@ function App() {
   }, [sidebarCollapsed, setSidebarCollapsed]);
   const { currentError, clearError } = useErrorStore();
   const { sessions, isLoaded } = useSessionStore();
+  const activeSessionId = useSessionStore(state => state.activeSessionId);
   const { fetchConfig, config: appConfig } = useConfigStore();
   const terminalShortcuts = appConfig?.terminalShortcuts ?? EMPTY_TERMINAL_SHORTCUTS;
   const { isVisible: shortcutHintsVisible } = useShortcutHintsOverlay();
+  useFocusedSurfaceScrolling(activeSessionId);
 
   const openSettings = useCallback((target?: SettingsTarget) => {
     if (target) {

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -8,6 +8,7 @@ import { HorizontalDetailPanel } from './HorizontalDetailPanel';
 import { Button } from './ui/Button';
 import { Dropdown, DropdownMenuItem } from './ui/Dropdown';
 import { Tooltip } from './ui/Tooltip';
+import { useScrollSurface } from '../hooks/useScrollSurface';
 
 interface DetailPanelProps {
   isVisible: boolean;
@@ -55,6 +56,14 @@ export function DetailPanel({
 }: DetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(state => state.immersiveMode);
+  const detailPanelRef = React.useRef<HTMLDivElement>(null);
+  const detailScrollSurfaceRef = useScrollSurface<HTMLDivElement>({
+    id: `detail:${sessionContext?.session.id ?? 'unavailable'}`,
+    sessionId: sessionContext?.session.id,
+    enabled: Boolean(sessionContext && isVisible && !immersiveMode && orientation !== 'horizontal'),
+    priority: 30,
+    ownerElement: () => detailPanelRef.current,
+  });
   const ideItems = useMemo(() => {
     if (!sessionContext?.onOpenIDEWithCommand) return [];
     const handler = sessionContext.onOpenIDEWithCommand;
@@ -101,6 +110,7 @@ export function DetailPanel({
 
   return (
     <div
+      ref={detailPanelRef}
       className={`pane-detail-panel pane-detail-panel-vertical flex-shrink-0 min-w-0 bg-surface-primary flex flex-col overflow-hidden relative transition-[width] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${isVisible && !immersiveMode ? 'border-l border-border-primary' : ''}`}
       style={{ width: isVisible && !immersiveMode ? `${width}px` : '0px' }}
     >
@@ -236,7 +246,7 @@ export function DetailPanel({
         {!gitUnavailable && session.worktreePath && (
           <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
             <div className="px-2 pt-2 flex-shrink-0"><SectionHeader>History</SectionHeader></div>
-            <div role="region" tabIndex={0} aria-label="Commit history" className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
+            <div ref={detailScrollSurfaceRef} role="region" tabIndex={0} aria-label="Commit history" className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
               <GitHistoryGraph
                 sessionId={session.id}
                 baseBranch={session.baseBranch || 'main'}

--- a/frontend/src/components/ExecutionList.tsx
+++ b/frontend/src/components/ExecutionList.tsx
@@ -1,8 +1,10 @@
 import React, { useState, memo } from 'react';
 import { RotateCcw, GitCommitHorizontal } from 'lucide-react';
 import type { ExecutionListProps } from '../types/diff';
+import { useScrollSurface } from '../hooks/useScrollSurface';
 
 const ExecutionList: React.FC<ExecutionListProps> = memo(({
+  sessionId,
   executions,
   selectedExecutions,
   onSelectionChange,
@@ -14,6 +16,13 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
 }) => {
   const [rangeStart, setRangeStart] = useState<number | null>(null);
   const limitDisplay = historyLimit ?? 50;
+  const executionListRef = React.useRef<HTMLDivElement>(null);
+  const scrollSurfaceRef = useScrollSurface<HTMLDivElement>({
+    id: `review-history:${sessionId}`,
+    sessionId,
+    priority: 80,
+    ownerElement: () => executionListRef.current,
+  });
 
   const handleCommitClick = (executionId: number, event: React.MouseEvent) => {
     if (event.shiftKey && rangeStart !== null) {
@@ -58,7 +67,7 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
   }
 
   return (
-    <div className="execution-list h-full flex flex-col">
+    <div ref={executionListRef} className="execution-list h-full flex flex-col">
       {/* Header */}
       <div className="px-3 py-1.5 border-b border-border-primary flex items-center justify-between">
         <span className="text-[11px] font-medium text-text-tertiary uppercase tracking-wider">
@@ -74,7 +83,7 @@ const ExecutionList: React.FC<ExecutionListProps> = memo(({
       </div>
 
       {/* Commit list */}
-      <div className="flex-1 overflow-y-auto min-h-0">
+      <div ref={scrollSurfaceRef} tabIndex={-1} className="flex-1 overflow-y-auto min-h-0">
         {executions.map((execution, idx) => {
           const isSelected = isInRange(execution.id);
           const isUncommitted = execution.id === 0;

--- a/frontend/src/components/HorizontalDetailPanel.tsx
+++ b/frontend/src/components/HorizontalDetailPanel.tsx
@@ -6,6 +6,7 @@ import { Button } from './ui/Button';
 import { Dropdown, DropdownMenuItem } from './ui/Dropdown';
 import { Tooltip } from './ui/Tooltip';
 import { GitHistoryGraph } from './GitHistoryGraph';
+import { useScrollSurface } from '../hooks/useScrollSurface';
 
 interface HorizontalDetailPanelProps {
   height?: number;
@@ -30,6 +31,14 @@ export function HorizontalDetailPanel({
 }: HorizontalDetailPanelProps) {
   const sessionContext = useSession();
   const immersiveMode = useNavigationStore(state => state.immersiveMode);
+  const detailPanelRef = React.useRef<HTMLDivElement>(null);
+  const detailScrollSurfaceRef = useScrollSurface<HTMLDivElement>({
+    id: `detail:${sessionContext?.session.id ?? 'unavailable'}`,
+    sessionId: sessionContext?.session.id,
+    enabled: Boolean(sessionContext && !isCollapsed && !immersiveMode),
+    priority: 30,
+    ownerElement: () => detailPanelRef.current,
+  });
   const remoteIdeTooltip = 'Open in IDE is only available in local mode. Switch this client back to the local runtime to use your desktop IDE.';
   const ideItems = useMemo(() => {
     if (!sessionContext?.onOpenIDEWithCommand) return [];
@@ -62,6 +71,7 @@ export function HorizontalDetailPanel({
 
   return (
     <div
+      ref={detailPanelRef}
       className={`pane-detail-panel pane-detail-panel-horizontal flex-shrink-0 bg-surface-primary flex flex-col overflow-hidden relative transition-[height] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${immersiveMode ? '' : 'border-t border-border-primary'}`}
       style={{ height: immersiveMode ? '0px' : isCollapsed ? 'auto' : `${height ?? 200}px` }}
     >
@@ -169,7 +179,13 @@ export function HorizontalDetailPanel({
         </div>
 
         {!isCollapsed && !gitUnavailable && session.worktreePath && (
-          <div className="flex-1 min-h-0 overflow-y-auto px-2 py-2">
+          <div
+            ref={detailScrollSurfaceRef}
+            role="region"
+            tabIndex={0}
+            aria-label="Commit history"
+            className="flex-1 min-h-0 overflow-y-auto px-2 py-2"
+          >
             <GitHistoryGraph
               sessionId={session.id}
               baseBranch={session.baseBranch || 'main'}

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -963,8 +963,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
 
           const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
-          // Pane owns focused-surface scrolling before xterm encodes the key,
-          // except when a known CLI or alternate-screen TUI claims Shift+Arrow.
+          // Pane owns focused-surface scrolling before xterm encodes the key.
+          // Managed CLI panels (Claude, Codex, Cursor, etc.) reserve the exact
+          // Shift+Arrow chords for Pane; ordinary alternate-screen TUIs keep them.
           if (isFineSurfaceScrollKey(e) || isPageSurfaceScrollKey(e)) {
             if (terminalClaimsFineSurfaceScroll(e, {
               isCliPanel: isCliPanelRef.current,

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -11,7 +11,13 @@ import { TerminalPanelProps } from '../../types/panelComponents';
 import { isHotkeyEnabledForEvent, useHotkeyStore } from '../../stores/hotkeyStore';
 import { renderLog, devLog } from '../../utils/console';
 import { getTerminalTheme } from '../../utils/terminalTheme';
-import { resolveTerminalKeyHandling, shouldOpenTerminalSearch } from '../../utils/terminalKeyHandling';
+import {
+  isFineSurfaceScrollKey,
+  isPageSurfaceScrollKey,
+  resolveTerminalKeyHandling,
+  shouldOpenTerminalSearch,
+  terminalClaimsFineSurfaceScroll,
+} from '../../utils/terminalKeyHandling';
 import { isMac } from '../../utils/platformUtils';
 import { copyTerminalText, isTerminalCopyShortcut } from '../../utils/terminalClipboard';
 import { FileEdit, FolderOpen } from 'lucide-react';
@@ -20,6 +26,7 @@ import { TerminalLinkTooltip } from '../terminal/TerminalLinkTooltip';
 import { TerminalPopover, PopoverButton } from '../terminal/TerminalPopover';
 import { SelectionPopover } from '../terminal/SelectionPopover';
 import { useTerminalSearch } from '../../hooks/useTerminalSearch';
+import { useScrollSurface } from '../../hooks/useScrollSurface';
 import { TerminalSearchOverlay } from '../terminal/TerminalSearchOverlay';
 import type { TerminalPanelState } from '../../../../shared/types/panels';
 import { selectTerminalRestoreContent } from '../../utils/terminalRestore';
@@ -227,6 +234,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
   const isNearBottomRef = useRef(true); // Track if user is scrolled near the bottom
   const [showScrollDown, setShowScrollDown] = useState(false); // Show jump-to-bottom pill
   const tuiActiveRef = useRef(false);
+  const scrollLineRemainderRef = useRef(0);
   const [isInitialized, setIsInitialized] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
@@ -303,6 +311,29 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
   useEffect(() => {
     keyboardShortcutsEnabledRef.current = keyboardShortcutsEnabled;
   }, [keyboardShortcutsEnabled]);
+
+  const terminalScrollSurfaceRef = useScrollSurface<HTMLDivElement>({
+    id: `terminal:${panel.id}`,
+    sessionId: panel.sessionId,
+    enabled: isActive,
+    priority: autoFocus ? 100 : 20,
+    scrollByLines: (lines) => {
+      const terminal = xtermRef.current;
+      if (!terminal) return;
+      if (
+        scrollLineRemainderRef.current !== 0
+        && Math.sign(scrollLineRemainderRef.current) !== Math.sign(lines)
+      ) {
+        scrollLineRemainderRef.current = 0;
+      }
+      const total = scrollLineRemainderRef.current + lines;
+      const wholeLines = total > 0 ? Math.floor(total) : Math.ceil(total);
+      scrollLineRemainderRef.current = total - wholeLines;
+      if (wholeLines !== 0) terminal.scrollLines(wholeLines);
+    },
+    scrollPage: direction => xtermRef.current?.scrollPages(direction),
+    focus: () => xtermRef.current?.focus(),
+  });
 
   useEffect(() => {
     if (terminalState?.isCliReady && !isCliReady) {
@@ -931,6 +962,21 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           if (!keyboardShortcutsEnabledRef.current) return !isHotkeyEnabledForEvent(e);
 
           const ctrlOrMeta = e.ctrlKey || e.metaKey;
+
+          // Pane owns focused-surface scrolling before xterm encodes the key,
+          // except when a known CLI or alternate-screen TUI claims Shift+Arrow.
+          if (isFineSurfaceScrollKey(e) || isPageSurfaceScrollKey(e)) {
+            if (terminalClaimsFineSurfaceScroll(e, {
+              isCliPanel: isCliPanelRef.current,
+              isTuiActive: tuiActiveRef.current,
+            })) {
+              // The application hotkey registry listens on window, so accepting
+              // the key in xterm is not sufficient to keep it terminal-owned.
+              e.stopPropagation();
+              return true;
+            }
+            return !isHotkeyEnabledForEvent(e);
+          }
 
           // Ctrl/Cmd+K: clear xterm scrollback without writing ^K to the PTY.
           if (ctrlOrMeta && e.key.toLowerCase() === 'k') {
@@ -1928,6 +1974,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
   // Always render the terminal div to keep XTerm instance alive
   return (
     <div
+      ref={terminalScrollSurfaceRef}
       className="h-full w-full relative group/terminal"
       onMouseMove={onMouseMove}
       onKeyDown={handleTerminalKeyDown}

--- a/frontend/src/components/panels/diff/DiffViewer.tsx
+++ b/frontend/src/components/panels/diff/DiffViewer.tsx
@@ -5,6 +5,7 @@ import { getDiffViewHighlighter } from '@git-diff-view/shiki';
 import { FileText, ChevronRight, ChevronDown, ExternalLink, ChevronsUpDown, ChevronsDownUp } from 'lucide-react';
 import type { DiffViewerProps, FileDiff } from '../../../types/diff';
 import { useTheme } from '../../../contexts/ThemeContext';
+import { useScrollSurface } from '../../../hooks/useScrollSurface';
 import "@git-diff-view/react/styles/diff-view.css";
 
 // --- Shiki singleton ---
@@ -138,12 +139,23 @@ export interface DiffViewerHandle {
   scrollToFile: (index: number) => void;
 }
 
-const DiffViewer = memo(forwardRef<DiffViewerHandle, DiffViewerProps>(({ files, className = '', onOpenInEditor }, ref) => {
+const DiffViewer = memo(forwardRef<DiffViewerHandle, DiffViewerProps>(({ files, className = '', sessionId, onOpenInEditor }, ref) => {
   const { theme } = useTheme();
   const isDarkMode = theme !== 'light' && theme !== 'light-rounded';
   const [expandedFiles, setExpandedFiles] = useState<Set<number>>(new Set());
   const [highlighter, setHighlighter] = useState<DiffHighlighter | null>(null);
+  const viewerRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const registerScrollSurface = useScrollSurface<HTMLDivElement>({
+    id: `diff:${sessionId ?? 'unscoped'}`,
+    sessionId,
+    priority: 90,
+    ownerElement: () => viewerRef.current,
+  });
+  const setScrollContainerRef = useCallback((element: HTMLDivElement | null) => {
+    scrollContainerRef.current = element;
+    registerScrollSurface(element);
+  }, [registerScrollSurface]);
   const prevFingerprintRef = useRef<string>('');
 
   const [viewType, setViewType] = useState<DiffModeEnum>(() => {
@@ -212,7 +224,7 @@ const DiffViewer = memo(forwardRef<DiffViewerHandle, DiffViewerProps>(({ files, 
   }
 
   return (
-    <div className={`diff-viewer ${className}`} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <div ref={viewerRef} className={`diff-viewer ${className}`} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
       <div className="flex justify-between items-center px-4 py-2 flex-shrink-0 bg-surface-secondary border-b border-border-primary">
         <span className="text-sm text-text-secondary">
@@ -261,7 +273,7 @@ const DiffViewer = memo(forwardRef<DiffViewerHandle, DiffViewerProps>(({ files, 
       </div>
 
       {/* File list */}
-      <div ref={scrollContainerRef} className="flex-1 overflow-auto">
+      <div ref={setScrollContainerRef} tabIndex={-1} className="flex-1 overflow-auto">
         {files.map((file, index) => (
           <FileAccordion
             key={`${file.path}-${index}`}

--- a/frontend/src/components/panels/logPanel/LogsView.tsx
+++ b/frontend/src/components/panels/logPanel/LogsView.tsx
@@ -5,6 +5,7 @@ import AnsiToHtml from 'ansi-to-html';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { LiveRegion } from '../../ui/LiveRegion';
 import { areKeyboardShortcutsEnabled, useConfigStore } from '../../../stores/configStore';
+import { useScrollSurface } from '../../../hooks/useScrollSurface';
 
 interface LogEntry {
   timestamp: string;
@@ -27,7 +28,19 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
   const [searchMatches, setSearchMatches] = useState<number[]>([]);
   const [autoScroll, setAutoScroll] = useState(true);
   const [copied, setCopied] = useState(false);
+  const logsViewRef = useRef<HTMLDivElement>(null);
   const logContainerRef = useRef<HTMLDivElement>(null);
+  const registerScrollSurface = useScrollSurface<HTMLDivElement>({
+    id: `logs:${sessionId}`,
+    sessionId,
+    enabled: isVisible,
+    priority: 80,
+    ownerElement: () => logsViewRef.current,
+  });
+  const setLogContainerRef = useCallback((element: HTMLDivElement | null) => {
+    logContainerRef.current = element;
+    registerScrollSurface(element);
+  }, [registerScrollSurface]);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const lastLogCount = useRef(0);
   const { theme } = useTheme();
@@ -237,7 +250,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
 
 
   return (
-    <div className="h-full flex flex-col bg-bg-primary relative">
+    <div ref={logsViewRef} className="h-full flex flex-col bg-bg-primary relative">
       <LiveRegion>{copied ? 'Logs copied to clipboard' : ''}</LiveRegion>
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 bg-surface-secondary border-b border-border-primary">
@@ -368,7 +381,8 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
 
       {/* Logs Container */}
       <div 
-        ref={logContainerRef}
+        ref={setLogContainerRef}
+        tabIndex={-1}
         className="flex-1 min-h-0 overflow-y-auto overflow-x-auto font-mono text-sm p-4 bg-bg-primary text-text-primary whitespace-pre-wrap break-all"
         onScroll={(e) => {
           const target = e.target as HTMLDivElement;

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useScrollSurface } from '../../hooks/useScrollSurface';
 import type { SettingsCategoryDefinition } from './catalog';
 import type { SettingsCategoryId } from '../../types/settings';
 import {
@@ -17,6 +18,11 @@ interface SettingsLayoutProps {
   children: ReactNode;
 }
 export function SettingsLayout({ category, categories, onCategoryChange, children }: SettingsLayoutProps) {
+  const scrollSurfaceRef = useScrollSurface<HTMLElement>({
+    id: 'settings-content',
+    priority: 80,
+  });
+
   return (
     <div className="flex min-h-0 flex-1 flex-col md:grid md:grid-cols-[220px_minmax(0,1fr)]">
       <aside className="hidden min-h-0 border-r border-border-primary bg-surface-secondary/35 p-3 md:block">
@@ -66,7 +72,7 @@ export function SettingsLayout({ category, categories, onCategoryChange, childre
         </Select>
       </div>
 
-      <main className="min-h-0 overflow-y-auto px-5 py-6 sm:px-7 md:px-9" data-testid="settings-content">
+      <main ref={scrollSurfaceRef} tabIndex={-1} className="min-h-0 overflow-y-auto px-5 py-6 sm:px-7 md:px-9" data-testid="settings-content">
         {children}
       </main>
     </div>

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,8 +1,9 @@
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useId, useLayoutEffect, useRef, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { cn } from '../../utils/cn';
 import { X } from 'lucide-react';
 import { PortalContainerProvider } from '../../contexts/PortalContainerContext';
+import { useScrollSurface } from '../../hooks/useScrollSurface';
 
 export interface ModalProps {
   isOpen: boolean;
@@ -195,9 +196,21 @@ export interface ModalBodyProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const ModalBody = React.forwardRef<HTMLDivElement, ModalBodyProps>(
   ({ className, children, ...props }, ref) => {
+    const surfaceId = useId();
+    const scrollSurfaceRef = useScrollSurface<HTMLDivElement>({
+      id: `modal-body:${surfaceId}`,
+      priority: 50,
+    });
+    const setBodyRef = useCallback((element: HTMLDivElement | null) => {
+      scrollSurfaceRef(element);
+      if (typeof ref === 'function') ref(element);
+      else if (ref) ref.current = element;
+    }, [ref, scrollSurfaceRef]);
+
     return (
       <div
-        ref={ref}
+        ref={setBodyRef}
+        tabIndex={-1}
         className={cn(
           'flex-1 overflow-y-auto px-6 py-4',
           className

--- a/frontend/src/hooks/useFocusedSurfaceScrolling.ts
+++ b/frontend/src/hooks/useFocusedSurfaceScrolling.ts
@@ -1,0 +1,69 @@
+import { useEffect } from 'react';
+import { useHotkey } from './useHotkey';
+import { focusedSurfaceScroll, type ScrollDirection } from '../services/focusedSurfaceScroll';
+
+function useScrollHotkey(
+  id: string,
+  label: string,
+  keys: string,
+  direction: ScrollDirection,
+  page: boolean,
+): void {
+  useHotkey({
+    id,
+    label,
+    keys,
+    category: 'view',
+    action: () => {
+      if (page) focusedSurfaceScroll.page(direction);
+      else focusedSurfaceScroll.start(direction);
+    },
+    enabled: () => focusedSurfaceScroll.canScroll(),
+    allowInModal: true,
+    allowInXterm: true,
+  });
+}
+
+export function useFocusedSurfaceScrolling(activeSessionId: string | null): void {
+  useScrollHotkey('scroll-focused-surface-up', 'Scroll focused surface up', 'shift+ArrowUp', -1, false);
+  useScrollHotkey('scroll-focused-surface-down', 'Scroll focused surface down', 'shift+ArrowDown', 1, false);
+  useScrollHotkey('page-focused-surface-up', 'Page focused surface up', 'shift+PageUp', -1, true);
+  useScrollHotkey('page-focused-surface-down', 'Page focused surface down', 'shift+PageDown', 1, true);
+
+  useEffect(() => {
+    focusedSurfaceScroll.setActiveSession(activeSessionId);
+    let secondFrame: number | null = null;
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => focusedSurfaceScroll.restoreActiveSessionFocus());
+    });
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      if (secondFrame !== null) window.cancelAnimationFrame(secondFrame);
+    };
+  }, [activeSessionId]);
+
+  useEffect(() => {
+    const noteInteraction = (event: Event) => focusedSurfaceScroll.noteInteraction(event.target);
+    const stop = () => focusedSurfaceScroll.stop();
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === 'Shift' || event.key === 'ArrowUp' || event.key === 'ArrowDown') stop();
+    };
+    const handleVisibilityChange = () => {
+      if (document.hidden) stop();
+    };
+
+    window.addEventListener('focusin', noteInteraction, true);
+    window.addEventListener('pointerdown', noteInteraction, true);
+    window.addEventListener('keyup', handleKeyUp, true);
+    window.addEventListener('blur', stop);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('focusin', noteInteraction, true);
+      window.removeEventListener('pointerdown', noteInteraction, true);
+      window.removeEventListener('keyup', handleKeyUp, true);
+      window.removeEventListener('blur', stop);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      stop();
+    };
+  }, []);
+}

--- a/frontend/src/hooks/useScrollSurface.ts
+++ b/frontend/src/hooks/useScrollSurface.ts
@@ -1,0 +1,76 @@
+import { useCallback, useRef } from 'react';
+import {
+  focusedSurfaceScroll,
+  type FocusedScrollSurface,
+  type ScrollDirection,
+} from '../services/focusedSurfaceScroll';
+
+interface UseScrollSurfaceOptions {
+  id: string;
+  sessionId?: string;
+  enabled?: boolean;
+  priority?: number;
+  /** The larger panel boundary that owns interactions, when different from the scroller. */
+  ownerElement?: () => HTMLElement | null;
+  scrollByLines?: (lines: number) => void;
+  scrollPage?: (direction: ScrollDirection) => void;
+  focus?: () => void;
+}
+
+const DEFAULT_LINE_STEP_PX = 20;
+const PAGE_RATIO = 0.9;
+
+function lineStep(element: HTMLElement): number {
+  const parsed = Number.parseFloat(window.getComputedStyle(element).lineHeight);
+  return Number.isFinite(parsed) ? Math.max(parsed, 1) : DEFAULT_LINE_STEP_PX;
+}
+
+export function useScrollSurface<T extends HTMLElement>({
+  id,
+  sessionId,
+  enabled = true,
+  priority,
+  ownerElement,
+  scrollByLines,
+  scrollPage,
+  focus,
+}: UseScrollSurfaceOptions): (element: T | null) => void {
+  const optionsRef = useRef({ ownerElement, scrollByLines, scrollPage, focus });
+  optionsRef.current = { ownerElement, scrollByLines, scrollPage, focus };
+  const unregisterRef = useRef<(() => void) | null>(null);
+
+  return useCallback((element: T | null) => {
+    unregisterRef.current?.();
+    unregisterRef.current = null;
+    if (!element || !enabled) return;
+
+    const surface: FocusedScrollSurface = {
+      id,
+      element: optionsRef.current.ownerElement?.() ?? element,
+      sessionId,
+      priority,
+      scrollByLines: (lines) => {
+        if (optionsRef.current.scrollByLines) {
+          optionsRef.current.scrollByLines(lines);
+        } else {
+          element.scrollTop += lines * lineStep(element);
+        }
+      },
+      scrollPage: (direction) => {
+        if (optionsRef.current.scrollPage) {
+          optionsRef.current.scrollPage(direction);
+        } else {
+          element.scrollTop += direction * element.clientHeight * PAGE_RATIO;
+        }
+      },
+      focus: () => {
+        if (optionsRef.current.focus) {
+          optionsRef.current.focus();
+        } else {
+          element.focus({ preventScroll: true });
+        }
+      },
+    };
+    unregisterRef.current = focusedSurfaceScroll.register(surface);
+  }, [enabled, id, priority, sessionId]);
+}

--- a/frontend/src/services/focusedSurfaceScroll.test.ts
+++ b/frontend/src/services/focusedSurfaceScroll.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  FocusedSurfaceScrollCoordinator,
+  type FocusedScrollSurface,
+  type ScrollRuntime,
+} from './focusedSurfaceScroll';
+
+interface FakeElement {
+  parent: FakeElement | null;
+  contains: (candidate: unknown) => boolean;
+}
+
+function element(parent: FakeElement | null = null): FakeElement {
+  const value: FakeElement = {
+    parent,
+    contains: (candidate) => {
+      let current = candidate as FakeElement | null;
+      while (current) {
+        if (current === value) return true;
+        current = current.parent;
+      }
+      return false;
+    },
+  };
+  return value;
+}
+
+function asHtmlElement(value: FakeElement): HTMLElement {
+  return value as unknown as HTMLElement;
+}
+
+function createHarness(reducedMotion = false) {
+  let now = 0;
+  let nextFrameId = 1;
+  let activeElement: Element | null = null;
+  let activeModal: Element | null = null;
+  const frames = new Map<number, FrameRequestCallback>();
+  const cancelledFrames: number[] = [];
+  const runtime: ScrollRuntime = {
+    activeElement: () => activeElement,
+    activeModal: () => activeModal,
+    cancelFrame: (id) => {
+      cancelledFrames.push(id);
+      frames.delete(id);
+    },
+    isVisible: () => true,
+    isReducedMotion: () => reducedMotion,
+    now: () => now,
+    requestFrame: (callback) => {
+      const id = nextFrameId++;
+      frames.set(id, callback);
+      return id;
+    },
+  };
+
+  return {
+    runtime,
+    frames,
+    cancelledFrames,
+    setActiveElement: (value: FakeElement | null) => {
+      activeElement = value as unknown as Element | null;
+    },
+    setActiveModal: (value: FakeElement | null) => {
+      activeModal = value as unknown as Element | null;
+    },
+    runFrame: (timestamp: number) => {
+      now = timestamp;
+      const entry = frames.entries().next().value as [number, FrameRequestCallback] | undefined;
+      if (!entry) throw new Error('No animation frame scheduled');
+      frames.delete(entry[0]);
+      entry[1](timestamp);
+    },
+  };
+}
+
+function surface(
+  id: string,
+  owner: FakeElement,
+  overrides: Partial<FocusedScrollSurface> = {},
+): FocusedScrollSurface {
+  return {
+    id,
+    element: asHtmlElement(owner),
+    scrollByLines: vi.fn(),
+    scrollPage: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('FocusedSurfaceScrollCoordinator', () => {
+  it('starts immediately, ignores key-repeat starts, and ramps held scrolling', () => {
+    const harness = createHarness();
+    const coordinator = new FocusedSurfaceScrollCoordinator(harness.runtime);
+    const lines: number[] = [];
+    coordinator.register(surface('terminal', element(), {
+      scrollByLines: value => lines.push(value),
+    }));
+
+    expect(coordinator.start(1)).toBe(true);
+    expect(coordinator.start(1)).toBe(true);
+    expect(lines).toEqual([1]);
+
+    harness.runFrame(50);
+    harness.runFrame(100);
+    expect(lines[1]).toBeGreaterThan(0);
+    expect(lines[2]).toBeGreaterThan(lines[1]);
+
+    coordinator.stop();
+    expect(harness.frames.size).toBe(0);
+    expect(harness.cancelledFrames).toHaveLength(1);
+  });
+
+  it('uses a single discrete line when reduced motion is requested', () => {
+    const harness = createHarness(true);
+    const coordinator = new FocusedSurfaceScrollCoordinator(harness.runtime);
+    const scrollByLines = vi.fn();
+    coordinator.register(surface('detail', element(), { scrollByLines }));
+
+    coordinator.start(-1);
+
+    expect(scrollByLines).toHaveBeenCalledOnce();
+    expect(scrollByLines).toHaveBeenCalledWith(-1);
+    expect(harness.frames.size).toBe(0);
+  });
+
+  it('keeps modal scrolling inside the active modal', () => {
+    const harness = createHarness();
+    const coordinator = new FocusedSurfaceScrollCoordinator(harness.runtime);
+    const terminalOwner = element();
+    const terminalChild = element(terminalOwner);
+    const modal = element();
+    const modalBody = element(modal);
+    const terminalScroll = vi.fn();
+    const modalScroll = vi.fn();
+    coordinator.register(surface('terminal', terminalOwner, { scrollByLines: terminalScroll }));
+    coordinator.register(surface('modal', modalBody, { scrollByLines: modalScroll }));
+    harness.setActiveElement(terminalChild);
+    harness.setActiveModal(modal);
+
+    coordinator.start(1);
+
+    expect(modalScroll).toHaveBeenCalledWith(1);
+    expect(terminalScroll).not.toHaveBeenCalled();
+  });
+
+  it('remembers the interacted surface per session and restores its focus', () => {
+    const harness = createHarness();
+    const coordinator = new FocusedSurfaceScrollCoordinator(harness.runtime);
+    const terminalOwner = element();
+    const detailOwner = element();
+    const detailHeader = element(detailOwner);
+    const detailFocus = vi.fn();
+    coordinator.register(surface('terminal', terminalOwner, { sessionId: 'session-1', priority: 100 }));
+    coordinator.register(surface('detail', detailOwner, {
+      sessionId: 'session-1',
+      priority: 30,
+      focus: detailFocus,
+    }));
+    coordinator.setActiveSession('session-1');
+    harness.setActiveElement(detailHeader);
+    coordinator.start(1);
+    coordinator.stop();
+    harness.setActiveElement(null);
+
+    expect(coordinator.restoreActiveSessionFocus()).toBe(true);
+    expect(detailFocus).toHaveBeenCalledOnce();
+  });
+
+  it('does not let stale DOM focus override the active session', () => {
+    const harness = createHarness();
+    const coordinator = new FocusedSurfaceScrollCoordinator(harness.runtime);
+    const oldOwner = element();
+    const oldChild = element(oldOwner);
+    const oldScroll = vi.fn();
+    const activeScroll = vi.fn();
+    coordinator.register(surface('old', oldOwner, { sessionId: 'session-1', scrollByLines: oldScroll }));
+    coordinator.register(surface('active', element(), {
+      sessionId: 'session-2',
+      scrollByLines: activeScroll,
+    }));
+    coordinator.setActiveSession('session-2');
+    harness.setActiveElement(oldChild);
+
+    coordinator.start(1);
+
+    expect(activeScroll).toHaveBeenCalledWith(1);
+    expect(oldScroll).not.toHaveBeenCalled();
+  });
+
+  it('uses the surface page adapter for coarse scrolling', () => {
+    const harness = createHarness();
+    const coordinator = new FocusedSurfaceScrollCoordinator(harness.runtime);
+    const scrollPage = vi.fn();
+    coordinator.register(surface('logs', element(), { scrollPage }));
+
+    expect(coordinator.page(-1)).toBe(true);
+    expect(scrollPage).toHaveBeenCalledWith(-1);
+  });
+});

--- a/frontend/src/services/focusedSurfaceScroll.test.ts
+++ b/frontend/src/services/focusedSurfaceScroll.test.ts
@@ -102,8 +102,10 @@ describe('FocusedSurfaceScrollCoordinator', () => {
 
     harness.runFrame(50);
     harness.runFrame(100);
+    harness.runFrame(150);
     expect(lines[1]).toBeGreaterThan(0);
     expect(lines[2]).toBeGreaterThan(lines[1]);
+    expect(lines[3]).toBe(3);
 
     coordinator.stop();
     expect(harness.frames.size).toBe(0);

--- a/frontend/src/services/focusedSurfaceScroll.ts
+++ b/frontend/src/services/focusedSurfaceScroll.ts
@@ -1,0 +1,229 @@
+export type ScrollDirection = -1 | 1;
+
+export interface FocusedScrollSurface {
+  id: string;
+  element: HTMLElement;
+  sessionId?: string;
+  priority?: number;
+  scrollByLines: (lines: number) => void;
+  scrollPage: (direction: ScrollDirection) => void;
+  focus?: () => void;
+}
+
+export interface ScrollRuntime {
+  activeElement: () => Element | null;
+  activeModal: () => Element | null;
+  cancelFrame: (id: number) => void;
+  isVisible: (element: HTMLElement) => boolean;
+  isReducedMotion: () => boolean;
+  now: () => number;
+  requestFrame: (callback: FrameRequestCallback) => number;
+}
+
+const FULL_SPEED_LINES_PER_SECOND = 30;
+const RAMP_DURATION_MS = 150;
+const INITIAL_SPEED_RATIO = 0.2;
+const MAX_FRAME_SECONDS = 0.05;
+
+function defaultRuntime(): ScrollRuntime {
+  return {
+    activeElement: () => document.activeElement,
+    activeModal: () => document.querySelector('[aria-modal="true"]'),
+    cancelFrame: (id) => window.cancelAnimationFrame(id),
+    isVisible: isElementVisible,
+    isReducedMotion: () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    now: () => performance.now(),
+    requestFrame: (callback) => window.requestAnimationFrame(callback),
+  };
+}
+
+function isElementVisible(element: HTMLElement): boolean {
+  if (!element.isConnected) return false;
+  if (element.closest('[inert]')) return false;
+  if (typeof element.checkVisibility === 'function') {
+    return element.checkVisibility({ checkOpacity: false, checkVisibilityCSS: true });
+  }
+  return element.getClientRects().length > 0;
+}
+
+function deepestContainingSurface(
+  surfaces: FocusedScrollSurface[],
+  target: Element,
+): FocusedScrollSurface | null {
+  const containing = surfaces.filter(surface => surface.element.contains(target));
+  return containing.find(candidate => (
+    containing.every(other => candidate === other || !candidate.element.contains(other.element))
+  )) ?? containing[0] ?? null;
+}
+
+export class FocusedSurfaceScrollCoordinator {
+  private readonly surfaces = new Map<string, FocusedScrollSurface>();
+  private readonly lastSurfaceBySession = new Map<string, string>();
+  private activeSessionId: string | null = null;
+  private lastModalSurfaceId: string | null = null;
+  private lastGlobalSurfaceId: string | null = null;
+  private heldDirection: ScrollDirection | null = null;
+  private heldSurfaceId: string | null = null;
+  private frameId: number | null = null;
+  private rampStartedAt = 0;
+  private lastFrameAt = 0;
+
+  constructor(private readonly runtime: ScrollRuntime = defaultRuntime()) {}
+
+  register(surface: FocusedScrollSurface): () => void {
+    this.surfaces.set(surface.id, surface);
+    return () => {
+      if (this.surfaces.get(surface.id) !== surface) return;
+      this.surfaces.delete(surface.id);
+      if (this.heldSurfaceId === surface.id) this.stop();
+    };
+  }
+
+  setActiveSession(sessionId: string | null): void {
+    if (sessionId !== this.activeSessionId) this.stop();
+    this.activeSessionId = sessionId;
+  }
+
+  noteInteraction(target: EventTarget | null): void {
+    if (!(target instanceof Element)) return;
+    const surface = deepestContainingSurface(this.visibleSurfaces(), target);
+    if (!surface) return;
+    this.remember(surface);
+  }
+
+  canScroll(): boolean {
+    return this.resolveSurface() !== null;
+  }
+
+  start(direction: ScrollDirection): boolean {
+    const surface = this.resolveSurface();
+    if (!surface) return false;
+    this.remember(surface);
+
+    if (this.runtime.isReducedMotion()) {
+      surface.scrollByLines(direction);
+      return true;
+    }
+
+    if (this.heldDirection === direction && this.heldSurfaceId === surface.id) return true;
+
+    this.stop();
+    this.heldDirection = direction;
+    this.heldSurfaceId = surface.id;
+    this.rampStartedAt = this.runtime.now();
+    this.lastFrameAt = this.rampStartedAt;
+    surface.scrollByLines(direction);
+    this.frameId = this.runtime.requestFrame(this.tick);
+    return true;
+  }
+
+  page(direction: ScrollDirection): boolean {
+    const surface = this.resolveSurface();
+    if (!surface) return false;
+    this.remember(surface);
+    surface.scrollPage(direction);
+    return true;
+  }
+
+  stop(): void {
+    if (this.frameId !== null) this.runtime.cancelFrame(this.frameId);
+    this.frameId = null;
+    this.heldDirection = null;
+    this.heldSurfaceId = null;
+  }
+
+  restoreActiveSessionFocus(): boolean {
+    if (this.runtime.activeModal()) return false;
+    const surface = this.resolveSessionSurface();
+    if (!surface) return false;
+    this.remember(surface);
+    surface.focus?.();
+    return Boolean(surface.focus);
+  }
+
+  private readonly tick = (timestamp: number): void => {
+    if (this.heldDirection === null || !this.heldSurfaceId) return;
+    const surface = this.surfaces.get(this.heldSurfaceId);
+    if (!surface || !this.runtime.isVisible(surface.element)) {
+      this.stop();
+      return;
+    }
+
+    const elapsedSeconds = Math.min((timestamp - this.lastFrameAt) / 1000, MAX_FRAME_SECONDS);
+    this.lastFrameAt = timestamp;
+    const rampProgress = Math.min((timestamp - this.rampStartedAt) / RAMP_DURATION_MS, 1);
+    const easedProgress = 1 - Math.pow(1 - rampProgress, 3);
+    const speedRatio = INITIAL_SPEED_RATIO + (1 - INITIAL_SPEED_RATIO) * easedProgress;
+    surface.scrollByLines(
+      this.heldDirection * FULL_SPEED_LINES_PER_SECOND * speedRatio * elapsedSeconds,
+    );
+    this.frameId = this.runtime.requestFrame(this.tick);
+  };
+
+  private remember(surface: FocusedScrollSurface): void {
+    if (surface.sessionId) this.lastSurfaceBySession.set(surface.sessionId, surface.id);
+    else this.lastGlobalSurfaceId = surface.id;
+    if (this.runtime.activeModal()?.contains(surface.element)) this.lastModalSurfaceId = surface.id;
+  }
+
+  private visibleSurfaces(): FocusedScrollSurface[] {
+    return Array.from(this.surfaces.values()).filter(surface => this.runtime.isVisible(surface.element));
+  }
+
+  private resolveSurface(): FocusedScrollSurface | null {
+    const surfaces = this.visibleSurfaces();
+    const modal = this.runtime.activeModal();
+    const activeElement = this.runtime.activeElement();
+
+    if (modal) {
+      const modalSurfaces = surfaces.filter(surface => modal.contains(surface.element));
+      if (activeElement && modal.contains(activeElement)) {
+        const focused = deepestContainingSurface(modalSurfaces, activeElement);
+        if (focused) return focused;
+      }
+      if (this.lastModalSurfaceId) {
+        const remembered = this.surfaces.get(this.lastModalSurfaceId);
+        if (remembered && modalSurfaces.includes(remembered)) return remembered;
+      }
+      return this.highestPriority(modalSurfaces);
+    }
+
+    if (activeElement) {
+      const focused = deepestContainingSurface(surfaces, activeElement);
+      if (
+        focused
+        && (!focused.sessionId || !this.activeSessionId || focused.sessionId === this.activeSessionId)
+      ) return focused;
+    }
+
+    const sessionSurface = this.resolveSessionSurface(surfaces);
+    if (sessionSurface) return sessionSurface;
+
+    if (this.lastGlobalSurfaceId) {
+      const remembered = this.surfaces.get(this.lastGlobalSurfaceId);
+      if (remembered && !remembered.sessionId && surfaces.includes(remembered)) return remembered;
+    }
+    return this.highestPriority(surfaces.filter(surface => !surface.sessionId));
+  }
+
+  private resolveSessionSurface(
+    surfaces: FocusedScrollSurface[] = this.visibleSurfaces(),
+  ): FocusedScrollSurface | null {
+    if (!this.activeSessionId) return null;
+    const sessionSurfaces = surfaces.filter(surface => surface.sessionId === this.activeSessionId);
+    const rememberedId = this.lastSurfaceBySession.get(this.activeSessionId);
+    if (rememberedId) {
+      const remembered = this.surfaces.get(rememberedId);
+      if (remembered && sessionSurfaces.includes(remembered)) return remembered;
+    }
+    return this.highestPriority(sessionSurfaces);
+  }
+
+  private highestPriority(surfaces: FocusedScrollSurface[]): FocusedScrollSurface | null {
+    return surfaces.reduce<FocusedScrollSurface | null>((best, surface) => (
+      !best || (surface.priority ?? 0) > (best.priority ?? 0) ? surface : best
+    ), null);
+  }
+}
+
+export const focusedSurfaceScroll = new FocusedSurfaceScrollCoordinator();

--- a/frontend/src/services/focusedSurfaceScroll.ts
+++ b/frontend/src/services/focusedSurfaceScroll.ts
@@ -20,7 +20,7 @@ export interface ScrollRuntime {
   requestFrame: (callback: FrameRequestCallback) => number;
 }
 
-const FULL_SPEED_LINES_PER_SECOND = 30;
+const FULL_SPEED_LINES_PER_SECOND = 60;
 const RAMP_DURATION_MS = 150;
 const INITIAL_SPEED_RATIO = 0.2;
 const MAX_FRAME_SECONDS = 0.05;

--- a/frontend/src/stores/hotkeyStore.test.ts
+++ b/frontend/src/stores/hotkeyStore.test.ts
@@ -104,4 +104,86 @@ describe('hotkeyStore keyboard shortcut preference', () => {
     expect(paletteAction).toHaveBeenCalledOnce();
     expect(preventDefault).toHaveBeenCalledOnce();
   });
+
+  it('allows an opted-in unmodified shortcut from xterm but not ordinary textareas', () => {
+    const action = vi.fn();
+    const preventDefault = vi.fn();
+    useConfigStore.setState({ config: {} });
+    useHotkeyStore.getState().register({
+      id: 'test-shortcut',
+      label: 'Scroll terminal',
+      keys: 'shift+ArrowDown',
+      category: 'view',
+      action,
+      allowInXterm: true,
+    });
+    const event = {
+      key: 'ArrowDown',
+      code: 'ArrowDown',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      shiftKey: true,
+      getModifierState: () => false,
+      preventDefault,
+    };
+
+    keydownListener?.({
+      ...event,
+      target: {
+        tagName: 'TEXTAREA',
+        isContentEditable: false,
+        classList: { contains: (name: string) => name === 'xterm-helper-textarea' },
+        closest: () => null,
+      },
+    } as unknown as KeyboardEvent);
+    keydownListener?.({
+      ...event,
+      target: {
+        tagName: 'TEXTAREA',
+        isContentEditable: false,
+        classList: { contains: () => false },
+        closest: () => null,
+      },
+    } as unknown as KeyboardEvent);
+
+    expect(action).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it('runs only explicitly modal-safe shortcuts inside dialogs', () => {
+    const action = vi.fn();
+    const preventDefault = vi.fn();
+    useConfigStore.setState({ config: {} });
+    const definition = {
+      id: 'test-shortcut',
+      label: 'Scroll modal',
+      keys: 'shift+ArrowUp',
+      category: 'view' as const,
+      action,
+    };
+    const dispatch = () => keydownListener?.({
+      key: 'ArrowUp',
+      code: 'ArrowUp',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      shiftKey: true,
+      target: {
+        tagName: 'DIV',
+        isContentEditable: false,
+        closest: (selector: string) => selector === '[aria-modal="true"]' ? {} : null,
+      },
+      getModifierState: () => false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    useHotkeyStore.getState().register(definition);
+    dispatch();
+    useHotkeyStore.getState().register({ ...definition, allowInModal: true });
+    dispatch();
+
+    expect(action).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -50,6 +50,10 @@ export interface HotkeyDefinition {
   disabledReason?: () => string | null;
   /** If false, hotkey works but doesn't appear in Command Palette/Help. Defaults to true. */
   showInPalette?: boolean;
+  /** Allow this command to run inside a modal focus scope. */
+  allowInModal?: boolean;
+  /** Allow an unmodified command to run from xterm's helper textarea. */
+  allowInXterm?: boolean;
 }
 
 interface GetAllOptions {
@@ -178,10 +182,6 @@ function handleKeyDown(e: KeyboardEvent) {
     target.tagName === 'TEXTAREA' ||
     target.isContentEditable;
 
-  // Suppress all hotkeys when a modal dialog is open (settings, create session, etc.)
-  const isInsideModal = target.closest('[aria-modal="true"]') !== null;
-  if (isInsideModal) return;
-
   const pressed = normalizeKeyEvent(e);
   const hotkeyId = lookupIndex.get(pressed);
   if (!hotkeyId) return;
@@ -190,13 +190,22 @@ function handleKeyDown(e: KeyboardEvent) {
   const def = store.hotkeys.get(hotkeyId);
   if (!def) return;
 
+  // Modal-local commands can opt in, but all other application hotkeys remain
+  // suppressed while focus is trapped in a dialog.
+  const isInsideModal = target.closest('[aria-modal="true"]') !== null;
+  if (isInsideModal && !def.allowInModal) return;
+
   // Let native text editing win for shortcuts users expect in focused inputs.
   // In particular, tab cycling uses mod+a/mod+d, but inputs need mod+a
   // for select-all and mod+d for normal browser/text-field behavior.
   if (isInput && !isXtermHelperTarget(target) && (pressed === 'mod+a' || pressed === 'mod+d')) return;
 
   // Skip if typing in input and shortcut doesn't use mod key
-  if (isInput && !pressed.includes('mod')) return;
+  if (
+    isInput
+    && !pressed.includes('mod')
+    && !(def.allowInXterm && isXtermHelperTarget(target))
+  ) return;
 
   if (!isHotkeyEnabledForEvent(e)) return;
 

--- a/frontend/src/utils/terminalKeyHandling.test.ts
+++ b/frontend/src/utils/terminalKeyHandling.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isFineSurfaceScrollKey,
+  isPageSurfaceScrollKey,
   resolveTerminalKeyHandling,
   shouldOpenTerminalSearch,
+  terminalClaimsFineSurfaceScroll,
   TERMINAL_MULTILINE_NEWLINE_SEQUENCE,
   type TerminalKeyLike,
 } from './terminalKeyHandling';
@@ -15,6 +18,30 @@ const key = (overrides: Partial<TerminalKeyLike>): TerminalKeyLike => ({
   altKey: false,
   getModifierState: () => false,
   ...overrides,
+});
+
+describe('focused surface terminal key boundary', () => {
+  const shiftKey = (keyName: string) => key({ key: keyName, code: keyName, shiftKey: true });
+
+  it('recognizes only unmodified Shift+Arrow and Shift+Page chords', () => {
+    expect(isFineSurfaceScrollKey(shiftKey('ArrowUp'))).toBe(true);
+    expect(isPageSurfaceScrollKey(shiftKey('PageDown'))).toBe(true);
+    expect(isFineSurfaceScrollKey(key({ key: 'ArrowUp', shiftKey: true, ctrlKey: true }))).toBe(false);
+  });
+
+  it('lets known CLI panels and active TUIs claim fine scrolling', () => {
+    const event = shiftKey('ArrowDown');
+    expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: true, isTuiActive: false })).toBe(true);
+    expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: false, isTuiActive: true })).toBe(true);
+    expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: false, isTuiActive: false })).toBe(false);
+  });
+
+  it('keeps coarse page scrolling owned by the terminal surface', () => {
+    expect(terminalClaimsFineSurfaceScroll(
+      shiftKey('PageUp'),
+      { isCliPanel: true, isTuiActive: true },
+    )).toBe(false);
+  });
 });
 
 const tui = (overrides: Partial<{

--- a/frontend/src/utils/terminalKeyHandling.test.ts
+++ b/frontend/src/utils/terminalKeyHandling.test.ts
@@ -29,9 +29,14 @@ describe('focused surface terminal key boundary', () => {
     expect(isFineSurfaceScrollKey(key({ key: 'ArrowUp', shiftKey: true, ctrlKey: true }))).toBe(false);
   });
 
-  it('lets known CLI panels and active TUIs claim fine scrolling', () => {
+  it('reserves fine scrolling for Pane in known CLI agent panels', () => {
     const event = shiftKey('ArrowDown');
-    expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: true, isTuiActive: false })).toBe(true);
+    expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: true, isTuiActive: false })).toBe(false);
+    expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: true, isTuiActive: true })).toBe(false);
+  });
+
+  it('lets ordinary active TUIs claim fine scrolling', () => {
+    const event = shiftKey('ArrowDown');
     expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: false, isTuiActive: true })).toBe(true);
     expect(terminalClaimsFineSurfaceScroll(event, { isCliPanel: false, isTuiActive: false })).toBe(false);
   });

--- a/frontend/src/utils/terminalKeyHandling.ts
+++ b/frontend/src/utils/terminalKeyHandling.ts
@@ -49,7 +49,7 @@ export function terminalClaimsFineSurfaceScroll(
   event: SurfaceScrollKeyLike,
   state: Pick<TerminalKeyHandlingState, 'isCliPanel' | 'isTuiActive'>,
 ): boolean {
-  return isFineSurfaceScrollKey(event) && (state.isCliPanel || state.isTuiActive);
+  return isFineSurfaceScrollKey(event) && state.isTuiActive && !state.isCliPanel;
 }
 
 export function shouldOpenTerminalSearch(

--- a/frontend/src/utils/terminalKeyHandling.ts
+++ b/frontend/src/utils/terminalKeyHandling.ts
@@ -24,6 +24,34 @@ export interface TerminalKeyLike {
   getModifierState: (key: string) => boolean;
 }
 
+type SurfaceScrollKeyLike = Pick<
+  TerminalKeyLike,
+  'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'
+>;
+
+export function isFineSurfaceScrollKey(event: SurfaceScrollKeyLike): boolean {
+  return event.shiftKey
+    && !event.altKey
+    && !event.ctrlKey
+    && !event.metaKey
+    && (event.key === 'ArrowUp' || event.key === 'ArrowDown');
+}
+
+export function isPageSurfaceScrollKey(event: SurfaceScrollKeyLike): boolean {
+  return event.shiftKey
+    && !event.altKey
+    && !event.ctrlKey
+    && !event.metaKey
+    && (event.key === 'PageUp' || event.key === 'PageDown');
+}
+
+export function terminalClaimsFineSurfaceScroll(
+  event: SurfaceScrollKeyLike,
+  state: Pick<TerminalKeyHandlingState, 'isCliPanel' | 'isTuiActive'>,
+): boolean {
+  return isFineSurfaceScrollKey(event) && (state.isCliPanel || state.isTuiActive);
+}
+
 export function shouldOpenTerminalSearch(
   event: Pick<TerminalKeyLike, 'ctrlKey' | 'metaKey' | 'key'>,
   keyboardShortcutsEnabled: boolean,


### PR DESCRIPTION
## Summary

- add a focused-surface coordinator for terminal, detail, review, logs, settings, and modal scrolling
- make Shift+Up/Down scroll smoothly while held, with discrete steps for reduced motion and Shift+PageUp/PageDown for coarse scrolling
- preserve Shift+Arrow input for known CLI panels and active TUIs while exposing the new commands in the shortcuts list
- restore the remembered scroll owner when Ctrl+Up/Down changes the active pane

## Testing

- pnpm lint
- pnpm typecheck
- pnpm --filter frontend test
- pnpm --filter frontend build

Closes #421