### PR TITLE
Refactor process and service boundaries (phase 2c)

### DIFF
--- a/main/src/core/eventSink.ts
+++ b/main/src/core/eventSink.ts
@@ -6,8 +6,10 @@
  * WebSocket, or relay-backed client can subscribe to the same runtime events.
  * Auth, pairing, relay policy, and hosted VM lifecycle stay above this seam.
  */
+export type PaneEventArgument = object | string | number | boolean | bigint | symbol | null | undefined;
+
 export interface PaneEventSink {
-  send(channel: string, ...args: unknown[]): void;
+  send(channel: string, ...args: PaneEventArgument[]): void;
 }
 
 /**
@@ -24,14 +26,14 @@ export const noopPaneEventSink: PaneEventSink = {
  */
 export function createFanoutEventSink(sinks: readonly PaneEventSink[]): PaneEventSink {
   return {
-    send(channel: string, ...args: unknown[]) {
-      let firstError: unknown;
+    send(channel: string, ...args: PaneEventArgument[]) {
+      let firstError: Error | string | number | boolean | object | null | undefined;
 
       for (const sink of sinks) {
         try {
           sink.send(channel, ...args);
-        } catch (error) {
-          firstError ??= error;
+      } catch (error) {
+          firstError ??= error instanceof Error ? error : new Error(String(error));
         }
       }
 

--- a/main/src/core/runtime.test.ts
+++ b/main/src/core/runtime.test.ts
@@ -24,6 +24,7 @@ describe('pane runtime', () => {
   });
 
   it('returns the installed runtime and helper accessors', () => {
+    // SAFETY: This test only verifies ConfigManager reference identity; none of its methods are invoked.
     const configManager = { source: 'test' } as unknown as ConfigManager;
     const webviewContextMap = new Map([[1, { panelId: 'panel-1', sessionId: 'session-1' }]]);
     const daemonEventSink = {

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -708,7 +708,7 @@ export class RemotePaneClientController extends EventEmitter {
           flow: 'connect',
           result: 'failed',
           failure_stage: 'initial_connect_retrying',
-          failure_category: getRemoteFailureCategory(error),
+          failure_category: getRemoteFailureCategory(error instanceof Error ? error.message : String(error)),
           client_kind: 'desktop',
         });
         this.setConnectionState({
@@ -735,7 +735,7 @@ export class RemotePaneClientController extends EventEmitter {
         flow: 'connect',
         result: 'failed',
         failure_stage: 'initial_connect',
-        failure_category: getRemoteFailureCategory(error),
+        failure_category: getRemoteFailureCategory(error instanceof Error ? error.message : String(error)),
         client_kind: 'desktop',
       });
       this.setConnectionState({

--- a/main/src/daemon/remoteTransportController.ts
+++ b/main/src/daemon/remoteTransportController.ts
@@ -131,7 +131,7 @@ export class PaneRemoteTransportController {
           flow: 'setup',
           result: 'failed',
           failure_stage: 'start_host_transport',
-          failure_category: getRemoteFailureCategory(error),
+          failure_category: getRemoteFailureCategory(error instanceof Error ? error.message : String(error)),
         });
         throw error;
       }

--- a/main/src/events.ts
+++ b/main/src/events.ts
@@ -14,6 +14,8 @@ import type { GitCommit } from './services/gitDiffManager';
 import type { Project } from './database/models';
 import type { GitStatus } from './types/session';
 import { resourceMonitorService } from './services/resourceMonitorService';
+import type { ResourceSnapshot } from '../../shared/types/resourceMonitor';
+import type { PaneEventArgument } from './core/eventSink';
 
 function isArchivedSessionOutputValidation(validation: { error?: string; sessionId?: string }): boolean {
   return Boolean(
@@ -22,7 +24,7 @@ function isArchivedSessionOutputValidation(validation: { error?: string; session
   );
 }
 
-function sendRendererEvent(channel: string, ...args: unknown[]): void {
+function sendRendererEvent(channel: string, ...args: PaneEventArgument[]): void {
   try {
     getPaneEventSink().send(channel, ...args);
   } catch (error) {
@@ -50,7 +52,7 @@ export function setupEventListeners(services: AppServices): void {
   }
 
   // Bridge resource monitor events to renderer
-  resourceMonitorService.on('resource-update', (snapshot: unknown) => {
+  resourceMonitorService.on('resource-update', (snapshot: ResourceSnapshot) => {
     sendRendererEvent('resource-monitor:update', snapshot);
   });
 

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -136,7 +136,7 @@ function safeDiagnosticValue(value: PaneEventArgument, maxLength = 4_000): strin
     serialized = decodeString(value) ?? '';
   } else {
     try {
-      serialized = JSON.stringify(value);
+      serialized = JSON.stringify(value) ?? String(value);
     } catch {
       serialized = String(value);
     }

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -5,6 +5,8 @@ import { hasHeadlessDaemonLaunchArg, hasRemoteSetupLaunchArg } from './utils/run
 import { getAppDirectory } from './utils/appDirectory';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { boundary, decodeBoundary } from '../../shared/validation/boundaryDecoder';
+import type { PaneEventArgument } from './core/eventSink';
 
 const launchHeadlessDaemon = hasHeadlessDaemonLaunchArg();
 const launchRemoteSetup = hasRemoteSetupLaunchArg();
@@ -21,9 +23,9 @@ if (process.platform === 'darwin') {
 
 function getStartupTerminalPowerMode(): 'performance' | 'batterySaver' {
   try {
-    const rawConfig = JSON.parse(
+    const rawConfig = decodeBoundary(JSON.parse(
       readFileSync(join(getAppDirectory(), 'config.json'), 'utf-8'),
-    ) as { terminalPowerMode?: unknown };
+    ), boundary.object({ terminalPowerMode: boundary.optional(boundary.string) }));
 
     return rawConfig.terminalPowerMode === 'batterySaver'
       ? 'batterySaver'
@@ -126,12 +128,12 @@ type RendererDiagnosticPayload = {
   column?: number;
 };
 
-function safeDiagnosticValue(value: unknown, maxLength = 4_000): string {
+function safeDiagnosticValue(value: PaneEventArgument, maxLength = 4_000): string {
   let serialized: string;
   if (value instanceof Error) {
     serialized = `${value.name}: ${value.message}\n${value.stack || ''}`;
-  } else if (typeof value === 'string') {
-    serialized = value;
+  } else if (decodeString(value) !== undefined) {
+    serialized = decodeString(value) ?? '';
   } else {
     try {
       serialized = JSON.stringify(value);
@@ -143,6 +145,14 @@ function safeDiagnosticValue(value: unknown, maxLength = 4_000): string {
   return serialized.length > maxLength
     ? `${serialized.slice(0, maxLength)} ... [truncated ${serialized.length - maxLength} chars]`
     : serialized;
+}
+
+function decodeString(value: PaneEventArgument): string | undefined {
+  try {
+    return decodeBoundary(value, boundary.string);
+  } catch {
+    return undefined;
+  }
 }
 
 function formatRendererDiagnostic(payload: RendererDiagnosticPayload): string {
@@ -220,6 +230,7 @@ const originalLog: typeof console.log = console.log;
 const originalError: typeof console.error = console.error;
 const originalWarn: typeof console.warn = console.warn;
 const originalInfo: typeof console.info = console.info;
+let isHandlingConsoleError = false;
 
 const isDevelopment = process.env.NODE_ENV !== 'production' && !app.isPackaged;
 
@@ -505,7 +516,7 @@ async function createWindow() {
       return { success: true };
     } catch (error) {
       console.error('[IPC] Failed to open inline devtools:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
 
@@ -528,7 +539,7 @@ async function createWindow() {
       return { success: true };
     } catch (error) {
       console.error('[IPC] Failed to close devtools:', error);
-      return { success: false, error: (error as Error).message };
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   });
   } // end devToolsHandlersRegistered guard
@@ -556,21 +567,6 @@ async function createWindow() {
     await mainWindow.loadURL(`http://localhost:${devPort}`);
     mainWindow.webContents.openDevTools();
     
-    // Enable IPC debugging in development
-    
-    // Log all IPC calls in main process
-    const originalHandle = ipcMain.handle;
-    ipcMain.handle = function(channel: string, listener: (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown> | unknown) {
-      const wrappedListener = async (event: IpcMainInvokeEvent, ...args: unknown[]) => {
-        if (channel.startsWith('stravu:')) {
-        }
-        const result = await listener(event, ...args);
-        if (channel.startsWith('stravu:')) {
-        }
-        return result;
-      };
-      return originalHandle.call(this, channel, wrappedListener);
-    };
   } else {
     // In production, use app.getAppPath() to get the root directory
     // This works correctly whether the app is packaged in ASAR or not
@@ -650,11 +646,9 @@ async function createWindow() {
   });
 
   // Override console methods to forward to renderer and logger
-  console.log = (...args: unknown[]) => {
+  console.log = (...args: PaneEventArgument[]) => {
     // Format the message
-    const message = args.map(arg =>
-      typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg)
-    ).join(' ');
+    const message = args.map(arg => safeDiagnosticValue(arg)).join(' ');
 
     // Write to logger if available
     if (logger) {
@@ -689,13 +683,13 @@ async function createWindow() {
     }
   };
 
-  console.error = (...args: unknown[]) => {
+  console.error = (...args: PaneEventArgument[]) => {
     // Prevent infinite recursion by checking if we're already in an error handler
-    if ((console.error as typeof console.error & { __isHandlingError?: boolean }).__isHandlingError) {
+    if (isHandlingConsoleError) {
       return originalError.apply(console, args);
     }
     
-    (console.error as typeof console.error & { __isHandlingError?: boolean }).__isHandlingError = true;
+    isHandlingConsoleError = true;
     
     try {
       // If logger is not initialized or we're in the logger itself, use original console
@@ -704,23 +698,10 @@ async function createWindow() {
         return;
       }
 
-      const message = args.map(arg => {
-        if (typeof arg === 'object' && arg !== null) {
-          if (arg instanceof Error) {
-            return `Error: ${arg.message}\nStack: ${arg.stack}`;
-          }
-          try {
-            return JSON.stringify(arg, null, 2);
-          } catch (e) {
-            // Handle circular structure
-            return `[Object with circular structure: ${arg.constructor?.name || 'Object'}]`;
-          }
-        }
-        return String(arg);
-      }).join(' ');
+      const message = args.map(arg => safeDiagnosticValue(arg)).join(' ');
 
       // Extract Error object if present
-      const errorObj = args.find(arg => arg instanceof Error) as Error | undefined;
+      const errorObj = args.find((arg): arg is Error => arg instanceof Error);
 
       // Use logger but with recursion protection
       logger.error(message, errorObj);
@@ -752,28 +733,15 @@ async function createWindow() {
       // If anything fails in the error handler, fall back to original
       originalError.apply(console, args);
     } finally {
-      (console.error as typeof console.error & { __isHandlingError?: boolean }).__isHandlingError = false;
+      isHandlingConsoleError = false;
     }
   };
 
-  console.warn = (...args: unknown[]) => {
-    const message = args.map(arg => {
-      if (typeof arg === 'object' && arg !== null) {
-        if (arg instanceof Error) {
-          return `Error: ${arg.message}\nStack: ${arg.stack}`;
-        }
-        try {
-          return JSON.stringify(arg, null, 2);
-        } catch (e) {
-          // Handle circular structure
-          return `[Object with circular structure: ${arg.constructor?.name || 'Object'}]`;
-        }
-      }
-      return String(arg);
-    }).join(' ');
+  console.warn = (...args: PaneEventArgument[]) => {
+    const message = args.map(arg => safeDiagnosticValue(arg)).join(' ');
 
     // Extract Error object if present for warnings too
-    const errorObj = args.find(arg => arg instanceof Error) as Error | undefined;
+    const errorObj = args.find((arg): arg is Error => arg instanceof Error);
 
     if (logger) {
       logger.warn(message, errorObj);
@@ -806,21 +774,8 @@ async function createWindow() {
     }
   };
 
-  console.info = (...args: unknown[]) => {
-    const message = args.map(arg => {
-      if (typeof arg === 'object' && arg !== null) {
-        if (arg instanceof Error) {
-          return `Error: ${arg.message}\nStack: ${arg.stack}`;
-        }
-        try {
-          return JSON.stringify(arg, null, 2);
-        } catch (e) {
-          // Handle circular structure
-          return `[Object with circular structure: ${arg.constructor?.name || 'Object'}]`;
-        }
-      }
-      return String(arg);
-    }).join(' ');
+  console.info = (...args: PaneEventArgument[]) => {
+    const message = args.map(arg => safeDiagnosticValue(arg)).join(' ');
 
     if (logger) {
       logger.info(message);
@@ -853,21 +808,8 @@ async function createWindow() {
     }
   };
 
-  console.debug = (...args: unknown[]) => {
-    const message = args.map(arg => {
-      if (typeof arg === 'object' && arg !== null) {
-        if (arg instanceof Error) {
-          return `Error: ${arg.message}\nStack: ${arg.stack}`;
-        }
-        try {
-          return JSON.stringify(arg, null, 2);
-        } catch (e) {
-          // Handle circular structure
-          return `[Object with circular structure: ${arg.constructor?.name || 'Object'}]`;
-        }
-      }
-      return String(arg);
-    }).join(' ');
+  console.debug = (...args: PaneEventArgument[]) => {
+    const message = args.map(arg => safeDiagnosticValue(arg)).join(' ');
 
     // In development, also write to backend debug log file
     if (isDevelopment) {
@@ -963,7 +905,7 @@ async function createWindow() {
 
 async function initializeServices() {
   const electronPaneEventSink = {
-    send(channel: string, ...args: unknown[]) {
+    send(channel: string, ...args: PaneEventArgument[]) {
       if (!remotePaneClientController.shouldForwardLocalRendererEvent(channel)) {
         return;
       }
@@ -986,6 +928,9 @@ async function initializeServices() {
   });
 
   const services = paneDaemonHost.services;
+  if (!services.logger || !services.archiveProgressManager || !services.analyticsManager) {
+    throw new Error('Pane daemon host did not initialize required core services');
+  }
   configManager = services.configManager;
   databaseService = services.databaseService;
   sessionManager = services.sessionManager;
@@ -994,9 +939,9 @@ async function initializeServices() {
   gitStatusManager = services.gitStatusManager;
   runCommandManager = services.runCommandManager;
   versionChecker = services.versionChecker;
-  logger = services.logger as Logger;
-  archiveProgressManager = services.archiveProgressManager as ArchiveProgressManager;
-  analyticsManager = services.analyticsManager as AnalyticsManager;
+  logger = services.logger;
+  archiveProgressManager = services.archiveProgressManager;
+  analyticsManager = services.analyticsManager;
   powerSaveManager = new PowerSaveManager(configManager, sessionManager);
   powerSaveManager.sync();
 
@@ -1388,13 +1333,15 @@ if (launchRemoteSetup) {
       const panel = panelManager.getPanel(panelId);
       if (!panel) continue;
 
-      const customState = (panel.state?.customState || {}) as TerminalPanelState;
-      const agentType = customState.agentType ?? resolveAgentTypeFromCommand(customState.initialCommand);
+      const customState = decodeBoundary(panel.state?.customState ?? {}, boundary.jsonObject);
+      const resumeState = decodeBoundary(customState, boundary.object({
+        agentType: boundary.optional(boundary.enumeration('claude', 'codex', 'cursor')),
+        initialCommand: boundary.optional(boundary.string),
+      }));
+      const agentType = resumeState.agentType ?? resolveAgentTypeFromCommand(resumeState.initialCommand);
 
       if (isCliAgentType(agentType)) {
-        customState.wasInterrupted = true;
-        customState.agentType = agentType;
-        panel.state.customState = customState;
+        panel.state.customState = { ...customState, wasInterrupted: true, agentType };
         await panelManager.updatePanel(panelId, { state: panel.state });
 
         const existing = interruptedPanels.get(panel.sessionId);

--- a/main/src/ipc/remoteDaemon.test.ts
+++ b/main/src/ipc/remoteDaemon.test.ts
@@ -599,6 +599,27 @@ describe('remote daemon IPC', () => {
     }));
   });
 
+  it('accepts explicitly undefined optional setup fields from the Remote Access UI', async () => {
+    const ipcMain = createIpcMainStub();
+    const configManager = createConfigManagerStub();
+    vi.mocked(setupRemoteHost).mockResolvedValue(createSetupResult());
+
+    registerRemoteDaemonHandlers(ipcMain, { configManager });
+
+    const setupHost = ipcMain.handlers.get('remote-daemon:setup-host');
+    const response = await setupHost?.({}, {
+      dataDirectoryMode: 'current',
+      paneDir: undefined,
+      preferTunnel: 'auto',
+      baseUrl: undefined,
+    });
+
+    expect(response).toMatchObject({ success: true });
+    expect(setupRemoteHost).toHaveBeenCalledWith(expect.objectContaining({
+      preferTunnel: 'auto',
+    }));
+  });
+
   it('rejects non-loopback HTTP manual setup URLs', async () => {
     const ipcMain = createIpcMainStub();
     const configManager = createConfigManagerStub();

--- a/main/src/ipc/remoteDaemon.ts
+++ b/main/src/ipc/remoteDaemon.ts
@@ -213,7 +213,7 @@ export function registerRemoteDaemonHandlers(
         ...(request ? getRemoteSetupProperties(request) : { surface: 'desktop', role: 'host', flow: 'setup' }),
         result: 'failed',
         failure_stage: 'setup_host',
-        failure_category: getRemoteFailureCategory(error),
+        failure_category: getRemoteFailureCategory(error instanceof Error ? error.message : String(error)),
       });
       return { success: false, error: getErrorMessage(error, 'Failed to set up remote daemon host') };
     }
@@ -393,7 +393,7 @@ export function registerRemoteDaemonHandlers(
         ...(payload ? getRemoteImportProperties(payload) : { surface: 'desktop', role: 'client', flow: 'connect' }),
         result: 'failed',
         failure_stage: 'import_connection_code',
-        failure_category: getRemoteFailureCategory(error),
+        failure_category: getRemoteFailureCategory(error instanceof Error ? error.message : String(error)),
       });
       return { success: false, error: getErrorMessage(error, 'Failed to import remote daemon connection code') };
     }
@@ -614,7 +614,7 @@ export function registerRemoteDaemonHandlers(
         flow: 'connect',
         result: 'failed',
         failure_stage: 'update_client_state',
-        failure_category: getRemoteFailureCategory(error),
+        failure_category: getRemoteFailureCategory(error instanceof Error ? error.message : String(error)),
         client_kind: 'desktop',
       });
       return { success: false, error: getErrorMessage(error, 'Failed to update remote daemon client state') };
@@ -725,7 +725,18 @@ function parseRemoteHostSetupRequest(input: PaneCommandValue): RemoteHostSetupRe
   if (input === undefined || input === null) {
     return {};
   }
-  const requestInput = decodeBoundary(input, boundary.jsonObject);
+  const requestInput = decodeBoundary(input, boundary.object({
+    dataDirectoryMode: boundary.optional(boundary.nullable(boundary.string)),
+    paneDir: boundary.optional(boundary.nullable(boundary.string)),
+    label: boundary.optional(boundary.nullable(boundary.string)),
+    listenPort: boundary.optional(boundary.nullable(boundary.union(boundary.number, boundary.string))),
+    channel: boundary.optional(boundary.nullable(boundary.string)),
+    repoRef: boundary.optional(boundary.nullable(boundary.string)),
+    installService: boundary.optional(boundary.nullable(boundary.boolean)),
+    exposeTailscale: boundary.optional(boundary.nullable(boundary.boolean)),
+    preferTunnel: boundary.optional(boundary.nullable(boundary.string)),
+    baseUrl: boundary.optional(boundary.nullable(boundary.string)),
+  }));
 
   const request: RemoteHostSetupRequest = {};
   const dataDirectoryMode = readOptionalDataDirectoryMode(requestInput.dataDirectoryMode);

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -691,6 +691,7 @@ describe('runpane IPC handlers', () => {
         customState: {
           ...terminalPanel.state.customState,
           scrollbackBuffer: 'persisted one\npersisted two\n',
+          serializedBuffer: undefined,
         },
       },
     };

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -1593,11 +1593,6 @@ function getPanelScrollback(panel: ToolPanel): string | null {
     return liveScrollback;
   }
 
-  const customState = panel.state.customState;
-  if (!isRecord(customState) || !('scrollbackBuffer' in customState)) {
-    return null;
-  }
-
   const persisted = normalizeScrollbackBuffer(getTerminalCustomState(panel).scrollbackBuffer);
   if (persisted) return persisted;
 

--- a/main/src/polyfills/readablestream.ts
+++ b/main/src/polyfills/readablestream.ts
@@ -4,7 +4,7 @@
  */
 
 // Check if ReadableStream is already available
-if (typeof globalThis.ReadableStream === 'undefined') {
+if (!globalThis.ReadableStream) {
   try {
     // Try to import from Node.js built-in stream/web module (Node 16.5+)
     const { ReadableStream, WritableStream, TransformStream } = require('stream/web');

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -20,6 +20,14 @@ import type {
 import type { ToolPanel } from '../../shared/types/panels';
 import type { PanelAgentStatusEvent } from '../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../shared/types/agentUsage';
+import type { CloudVmState } from '../../shared/types/cloud';
+import type { ResourceSnapshot } from '../../shared/types/resourceMonitor';
+import type {
+  PanePermissionRequest as PermissionRequest,
+  PanePermissionResponse as PermissionResponse,
+  PanePermissionResolvedEvent as PermissionResolvedEvent,
+} from '../../shared/types/permissions';
+import { boundary, decodeBoundary, type JsonObject } from '../../shared/validation/boundaryDecoder';
 
 interface LogEntry {
   timestamp: string;
@@ -31,11 +39,11 @@ interface LogEntry {
 // Buffer analytics events that arrive before the renderer registers its callback.
 // This prevents race conditions where main-process events (e.g. app_opened) are
 // sent before the React useEffect listener is attached.
-type AnalyticsEvent = { eventName: string; properties: Record<string, unknown> };
+type AnalyticsEvent = { eventName: string; properties: JsonObject };
 const analyticsEventBuffer: AnalyticsEvent[] = [];
 let analyticsForwardCallback: ((event: AnalyticsEvent) => void) | null = null;
 
-ipcRenderer.on('analytics:main-event', (_event: unknown, data: AnalyticsEvent) => {
+ipcRenderer.on('analytics:main-event', (_event: Electron.IpcRendererEvent, data: AnalyticsEvent) => {
   if (analyticsForwardCallback) {
     analyticsForwardCallback(data);
   } else {
@@ -97,25 +105,6 @@ interface VersionInfo {
   releaseNotes?: string;
 }
 
-interface PermissionRequest {
-  id: string;
-  sessionId: string;
-  toolName: string;
-  input: Record<string, unknown>;
-  timestamp: number;
-}
-
-interface PermissionResponse {
-  behavior: 'allow' | 'deny';
-  updatedInput?: Record<string, unknown>;
-  message?: string;
-}
-
-interface PermissionResolvedEvent {
-  request: PermissionRequest;
-  response: PermissionResponse;
-}
-
 interface UpdaterInfo {
   version: string;
   releaseDate?: string;
@@ -170,6 +159,7 @@ const DAEMON_OWNED_EXACT_CHANNELS = [
   'file:write-binary',
   'file:write-project',
 ] as const;
+const DAEMON_OWNED_EXACT_CHANNEL_SET = new Set<string>(DAEMON_OWNED_EXACT_CHANNELS);
 
 const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
   'file:showInFolder',
@@ -185,7 +175,7 @@ function isDaemonOwnedChannel(channel: string): boolean {
     return false;
   }
 
-  if (DAEMON_OWNED_EXACT_CHANNELS.includes(channel as (typeof DAEMON_OWNED_EXACT_CHANNELS)[number])) {
+  if (DAEMON_OWNED_EXACT_CHANNEL_SET.has(channel)) {
     return true;
   }
 
@@ -215,6 +205,15 @@ type PtyHostExitFrame = {
   signal: number | null;
 };
 type PtyHostInboundFrame = PtyHostDataFrame | PtyHostExitFrame;
+const ptyHostInboundSchema = boundary.union(
+  boundary.object({ type: boundary.literal('data'), ptyId: boundary.string, data: boundary.string }),
+  boundary.object({
+    type: boundary.literal('exit'),
+    ptyId: boundary.string,
+    exitCode: boundary.nullable(boundary.number),
+    signal: boundary.nullable(boundary.number),
+  }),
+);
 
 type PtyDataCallback = (data: string) => void;
 type PtyExitCallback = (exitCode: number | null, signal: number | null) => void;
@@ -222,13 +221,6 @@ type PtyExitCallback = (exitCode: number | null, signal: number | null) => void;
 let ptyHostPort: MessagePort | null = null;
 const ptyDataSubscribers = new Map<string, Set<PtyDataCallback>>();
 const ptyExitSubscribers = new Map<string, Set<PtyExitCallback>>();
-
-function isPtyHostInboundFrame(frame: unknown): frame is PtyHostInboundFrame {
-  if (typeof frame !== 'object' || frame === null) return false;
-  const f = frame as { type?: unknown; ptyId?: unknown };
-  if (typeof f.ptyId !== 'string') return false;
-  return f.type === 'data' || f.type === 'exit';
-}
 
 ipcRenderer.on('ptyHost-port', (event) => {
   const [port] = event.ports;
@@ -239,8 +231,10 @@ ipcRenderer.on('ptyHost-port', (event) => {
   // Renderer-world MessagePort is DOM-style: use .start() + .onmessage.
   port.start();
   port.onmessage = (e: MessageEvent) => {
-    const frame = e.data as unknown;
-    if (!isPtyHostInboundFrame(frame)) {
+    let frame: PtyHostInboundFrame;
+    try {
+      frame = decodeBoundary(e.data, ptyHostInboundSchema);
+    } catch {
       return;
     }
     if (frame.type === 'data') {
@@ -319,7 +313,7 @@ try {
     }
   });
 
-  ipcRenderer.on('resource-monitor:update', (_event: Electron.IpcRendererEvent, data: unknown) => {
+  ipcRenderer.on('resource-monitor:update', (_event: Electron.IpcRendererEvent, data: ResourceSnapshot) => {
     try {
       window.dispatchEvent(new CustomEvent('resource-monitor:update', { detail: data }));
     } catch (e) {
@@ -347,7 +341,7 @@ try {
       console.error('Failed to dispatch synthetic-keydown to window:', e);
     }
   });
-  ipcRenderer.on('browser-panel:popup-requested', (_event: unknown, data: { url: string; sourceSessionId: string; sourcePanelId: string }) => {
+  ipcRenderer.on('browser-panel:popup-requested', (_event: Electron.IpcRendererEvent, data: { url: string; sourceSessionId: string; sourcePanelId: string }) => {
     try {
       window.dispatchEvent(new CustomEvent('browser-panel:popup-requested', { detail: data }));
     } catch (e) {
@@ -370,24 +364,15 @@ if (process.env.NODE_ENV !== 'production') {
 
   // Override console methods to capture frontend logs
   (['log', 'warn', 'error', 'info', 'debug'] as const).forEach(level => {
-    (console as unknown as Record<string, (...args: unknown[]) => void>)[level] = (...args: unknown[]) => {
+    console[level] = (...args: Parameters<typeof console.log>) => {
       // Call original console first so they still appear in DevTools
-      (originalConsole as unknown as Record<string, (...args: unknown[]) => void>)[level](...args);
+      originalConsole[level](...args);
       
       // Send to main process for file logging
       try {
         invokeIpc('console:log', {
           level,
-          args: args.map(arg => {
-            if (typeof arg === 'object') {
-              try {
-                return JSON.stringify(arg, null, 2);
-              } catch (e) {
-                return String(arg);
-              }
-            }
-            return String(arg);
-          }),
+          args: args.map(arg => serializeConsoleArg(arg)),
           timestamp: new Date().toISOString(),
           source: 'renderer'
         });
@@ -397,6 +382,18 @@ if (process.env.NODE_ENV !== 'production') {
       }
     };
   });
+}
+
+function serializeConsoleArg(arg: Parameters<typeof console.log>[number]): string {
+  try {
+    return decodeBoundary(arg, boundary.string);
+  } catch {
+    try {
+      return JSON.stringify(arg, null, 2);
+    } catch {
+      return String(arg);
+    }
+  }
 }
 
 // Response type for IPC calls
@@ -1016,7 +1013,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Panels API for Claude panels and other panel types
   panels: {
-    createPanel: (sessionId: string, type: string, name: string, config?: Record<string, unknown>): Promise<IPCResponse> => 
+    createPanel: (sessionId: string, type: string, name: string, config?: JsonObject): Promise<IPCResponse> =>
       invokeIpc('panels:create', { sessionId, type, title: name, initialState: config }),
     getSessionPanels: (sessionId: string): Promise<IPCResponse> => invokeIpc('panels:list', sessionId),
     deletePanel: (panelId: string): Promise<IPCResponse> => invokeIpc('panels:delete', panelId),
@@ -1053,7 +1050,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Analytics tracking
   analytics: {
     getIdentity: () => invokeIpc('analytics:get-identity'),
-    onMainEvent: (callback: (event: { eventName: string; properties: Record<string, unknown> }) => void) => {
+    onMainEvent: (callback: (event: AnalyticsEvent) => void) => {
       // Replay any events that arrived before this callback was registered
       for (const buffered of analyticsEventBuffer) {
         callback(buffered);
@@ -1088,8 +1085,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     disconnectWorkspace: (): Promise<IPCResponse> => invokeIpc('cloud:disconnect-workspace'),
     startPolling: (): Promise<IPCResponse> => invokeIpc('cloud:start-polling'),
     stopPolling: (): Promise<IPCResponse> => invokeIpc('cloud:stop-polling'),
-    onStateChanged: (callback: (state: unknown) => void): (() => void) => {
-      const wrappedCallback = (_event: unknown, state: unknown) => callback(state);
+    onStateChanged: (callback: (state: CloudVmState) => void): (() => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, state: CloudVmState) => callback(state);
       ipcRenderer.on('cloud:state-changed', wrappedCallback);
       return () => ipcRenderer.removeListener('cloud:state-changed', wrappedCallback);
     },
@@ -1110,7 +1107,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Window state queries (invoke, not event subscriptions)
   window: {
-    isFocused: (): Promise<boolean> => invokeIpc('window:is-focused') as Promise<boolean>,
+    isFocused: async (): Promise<boolean> => decodeBoundary(await invokeIpc('window:is-focused'), boundary.boolean),
   },
 
   // ptyHost: typed wrapper over the per-window MessagePort. The raw port is

--- a/main/src/ptyHost/ptyHostMain.ts
+++ b/main/src/ptyHost/ptyHostMain.ts
@@ -32,12 +32,14 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { boundary, decodeBoundary, type JsonValue } from '../../../shared/validation/boundaryDecoder';
 
 // node-pty's CommonJS export shape matches what main uses at
 // `terminalPanelManager.ts:1`. We use a typed `require` here because this
 // UtilityProcess entry is deliberately self-contained; importing via
 // `import * as pty` would couple to main's module graph.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
+// SAFETY: This package's CommonJS entry exports the same typed node-pty API.
 const pty = require('@lydell/node-pty') as typeof import('@lydell/node-pty');
 
 // Electron exposes UtilityProcess parentPort on `process.parentPort` in this
@@ -45,7 +47,8 @@ const pty = require('@lydell/node-pty') as typeof import('@lydell/node-pty');
 // compatibility without depending on a named export that Electron's main
 // process type surface does not expose.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const electron = require('electron') as { parentPort?: unknown };
+// SAFETY: Electron's UtilityProcess runtime exposes the documented HostPort surface.
+const electron = require('electron') as { parentPort?: HostPort };
 
 import type {
   PtyHostRequest,
@@ -80,6 +83,12 @@ interface HeartbeatPing {
   type: 'heartbeat-ping';
 }
 
+interface SpawnFailure {
+  message: string;
+  code?: string;
+  errno?: number;
+}
+
 /**
  * Minimal typing for the MessagePortMain we receive from Electron's `parentPort`.
  * We intentionally avoid importing `electron`'s types here so this module can
@@ -89,9 +98,32 @@ interface HeartbeatPing {
  */
 interface HostPort {
   start(): void;
-  postMessage(message: unknown): void;
-  on(event: 'message', listener: (event: { data: unknown; ports: unknown[] }) => void): void;
+  postMessage(message: PtyHostResponse | PtyHostEvent | { type: 'heartbeat-pong' } | { type: 'host-ready' }): void;
+  on(event: 'message', listener: (event: { data: JsonValue; ports: HostPort[] }) => void): void;
 }
+
+type PtyHostEvent = import('./types').PtyHostEvent;
+
+const initSchema = boundary.object({ type: boundary.literal('init') });
+const heartbeatSchema = boundary.object({ type: boundary.literal('heartbeat-ping') });
+const spawnOptsSchema = boundary.object({
+  shell: boundary.string,
+  args: boundary.array(boundary.string),
+  cwd: boundary.optional(boundary.string),
+  cols: boundary.number,
+  rows: boundary.number,
+  env: boundary.jsonObject,
+  name: boundary.optional(boundary.string),
+});
+const requestSchema = boundary.union(
+  boundary.object({ id: boundary.number, method: boundary.literal('spawn'), args: spawnOptsSchema }),
+  boundary.object({ id: boundary.number, method: boundary.literal('write'), args: boundary.object({ ptyId: boundary.string, data: boundary.string }) }),
+  boundary.object({ id: boundary.number, method: boundary.literal('resize'), args: boundary.object({ ptyId: boundary.string, cols: boundary.number, rows: boundary.number }) }),
+  boundary.object({ id: boundary.number, method: boundary.literal('kill'), args: boundary.object({ ptyId: boundary.string, signal: boundary.optional(boundary.string) }) }),
+  boundary.object({ id: boundary.number, method: boundary.literal('ack'), args: boundary.object({ ptyId: boundary.string, bytes: boundary.number }) }),
+  boundary.object({ id: boundary.number, method: boundary.literal('pause'), args: boundary.object({ ptyId: boundary.string }) }),
+  boundary.object({ id: boundary.number, method: boundary.literal('resume'), args: boundary.object({ ptyId: boundary.string }) }),
+);
 
 // Module-scoped port and PTY map. Both MUST live at module scope: the port
 // would otherwise be collected and close the channel; the PTY map must
@@ -107,6 +139,8 @@ const ptyMap = new Map<string, HostPty>();
  * the attached `MessagePortMain`.
  */
 function bootstrap(): void {
+  // SAFETY: Electron UtilityProcess injects a MessagePort-compatible
+  // `process.parentPort`; the fallback exposes the same documented surface.
   const parent = (
     (process as unknown as { parentPort?: unknown }).parentPort ?? electron.parentPort
   ) as (HostPort & { once: HostPort['on'] }) | undefined;
@@ -116,13 +150,13 @@ function bootstrap(): void {
     return;
   }
 
-  parent.once('message', (event: { data: unknown; ports: unknown[] }) => {
-    if (!isInitMessage(event.data)) {
+  parent.once('message', (event) => {
+    if (!decodeFrame(event.data, initSchema)) {
       console.error('[ptyHost] first parentPort message was not { type: "init" }; exiting', event.data);
       process.exit(1);
       return;
     }
-    const [port] = event.ports as HostPort[];
+    const [port] = event.ports;
     if (!port) {
       console.error('[ptyHost] init message arrived without a MessagePort; exiting');
       process.exit(1);
@@ -148,15 +182,16 @@ function bootstrap(): void {
  * requests carry `id` (number) and `method` (string). Everything else is
  * logged and dropped.
  */
-function handleInboundFrame(frame: unknown): void {
-  if (isHeartbeatPing(frame)) {
+function handleInboundFrame(frame: JsonValue): void {
+  if (decodeFrame(frame, heartbeatSchema)) {
     if (rpcPort) {
       rpcPort.postMessage({ type: 'heartbeat-pong' });
     }
     return;
   }
-  if (isPtyHostRequest(frame)) {
-    handleRequest(frame).catch((err: unknown) => {
+  const request = decodeRequest(frame);
+  if (request) {
+    handleRequest(request).catch((err) => {
       console.error('[ptyHost] unhandled error in request dispatch', err);
     });
     return;
@@ -206,17 +241,26 @@ function handleSpawn(id: number, opts: PtyHostSpawnOpts): void {
   const ptyId = randomUUID();
   let ptyProcess: HostPty;
   try {
-    // Cast via `unknown` to keep the HostPty shape narrow; node-pty's own
-    // `IPty` is a superset we don't need here.
     ptyProcess = pty.spawn(opts.shell, opts.args, {
       name: opts.name ?? 'xterm-256color',
       cwd: opts.cwd,
       cols: opts.cols,
       rows: opts.rows,
       env: opts.env,
-    }) as unknown as HostPty;
+    });
   } catch (err) {
-    const classified = classifySpawnError(err);
+    let failure: SpawnFailure;
+    try {
+      const decoded = decodeBoundary(err, boundary.object({
+        message: boundary.optional(boundary.string),
+        code: boundary.optional(boundary.string),
+        errno: boundary.optional(boundary.number),
+      }));
+      failure = { ...decoded, message: decoded.message ?? String(err) };
+    } catch {
+      failure = { message: err instanceof Error ? err.message : String(err) };
+    }
+    const classified = classifySpawnError(failure);
     console.error(`[ptyHost] spawn failed: code=${classified.code} message=${classified.message}`);
     respondErr(id, classified);
     return;
@@ -260,7 +304,7 @@ function handleWrite(id: number, ptyId: string, data: string): void {
     p.write(data);
     respondOk(id, undefined);
   } catch (err) {
-    respondErr(id, { code: 'OTHER', message: errorMessage(err) });
+    respondErr(id, { code: 'OTHER', message: (err instanceof Error ? err.message : String(err)) });
   }
 }
 
@@ -274,11 +318,11 @@ function handleResize(id: number, ptyId: string, cols: number, rows: number): vo
     p.resize(cols, rows);
     respondOk(id, undefined);
   } catch (err) {
-    respondErr(id, { code: 'OTHER', message: errorMessage(err) });
+    respondErr(id, { code: 'OTHER', message: (err instanceof Error ? err.message : String(err)) });
   }
 }
 
-function handleKill(id: number, ptyId: string, signal: NodeJS.Signals | undefined): void {
+function handleKill(id: number, ptyId: string, signal: string | undefined): void {
   const p = ptyMap.get(ptyId);
   if (!p) {
     respondErr(id, { code: 'OTHER', message: `unknown ptyId: ${ptyId}` });
@@ -290,7 +334,7 @@ function handleKill(id: number, ptyId: string, signal: NodeJS.Signals | undefine
     p.kill(signal);
     respondOk(id, undefined);
   } catch (err) {
-    respondErr(id, { code: 'OTHER', message: errorMessage(err) });
+    respondErr(id, { code: 'OTHER', message: (err instanceof Error ? err.message : String(err)) });
   }
 }
 
@@ -304,7 +348,7 @@ function handlePause(id: number, ptyId: string): void {
     p.pause();
     respondOk(id, undefined);
   } catch (err) {
-    respondErr(id, { code: 'OTHER', message: errorMessage(err) });
+    respondErr(id, { code: 'OTHER', message: (err instanceof Error ? err.message : String(err)) });
   }
 }
 
@@ -318,7 +362,7 @@ function handleResume(id: number, ptyId: string): void {
     p.resume();
     respondOk(id, undefined);
   } catch (err) {
-    respondErr(id, { code: 'OTHER', message: errorMessage(err) });
+    respondErr(id, { code: 'OTHER', message: (err instanceof Error ? err.message : String(err)) });
   }
 }
 
@@ -327,10 +371,9 @@ function handleResume(id: number, ptyId: string): void {
  * path at `AbstractCliManager.ts:604-717, 781-795` recognizes. Mirrors the
  * substring checks at lines 717-722.
  */
-function classifySpawnError(err: unknown): PtyHostSpawnError {
-  const message = errorMessage(err);
-  const errObj = err as { code?: unknown; errno?: unknown } | undefined;
-  const code = typeof errObj?.code === 'string' ? errObj.code : undefined;
+function classifySpawnError(err: SpawnFailure): PtyHostSpawnError {
+  const message = err.message;
+  const code = err.code;
 
   // Windows error 193 ("not a valid Win32 application"): `code === 'UNKNOWN'`
   // with `errno === -4094` historically, but the classifier in AbstractCli
@@ -338,7 +381,7 @@ function classifySpawnError(err: unknown): PtyHostSpawnError {
   if (
     message.includes('error code: 193') ||
     message.includes('not a valid Win32 application') ||
-    (code === 'UNKNOWN' && (errObj?.errno === 193 || errObj?.errno === -193))
+    (code === 'UNKNOWN' && (err.errno === 193 || err.errno === -193))
   ) {
     return { code: 'E193', message };
   }
@@ -387,51 +430,26 @@ function respondErr(id: number, error: PtyHostSpawnError): void {
   rpcPort.postMessage(frame);
 }
 
-function errorMessage(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
-  }
-  if (typeof err === 'string') {
-    return err;
-  }
+function decodeFrame<Value>(frame: JsonValue, schema: import('../../../shared/validation/boundaryDecoder').BoundarySchema<Value>): Value | undefined {
   try {
-    return JSON.stringify(err);
+    return decodeBoundary(frame, schema);
   } catch {
-    return String(err);
+    return undefined;
   }
 }
 
-function isInitMessage(frame: unknown): frame is InitMessage {
-  if (typeof frame !== 'object' || frame === null) {
-    return false;
-  }
-  const candidate = frame as { type?: unknown };
-  return candidate.type === 'init';
-}
+function decodeRequest(frame: JsonValue): PtyHostRequest | undefined {
+  const decoded = decodeFrame(frame, requestSchema);
+  if (!decoded) return undefined;
+  if (decoded.method !== 'spawn') return decoded;
 
-function isHeartbeatPing(frame: unknown): frame is HeartbeatPing {
-  if (typeof frame !== 'object' || frame === null) {
-    return false;
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(decoded.args.env)) {
+    const text = decodeFrame(value, boundary.string);
+    if (text === undefined) return undefined;
+    env[key] = text;
   }
-  const candidate = frame as { type?: unknown };
-  return candidate.type === 'heartbeat-ping';
-}
-
-/**
- * Cheap structural check; mirrors the shape guard in `rpc.ts` but lives here
- * so this file stays self-contained relative to any main-side helpers.
- */
-function isPtyHostRequest(frame: unknown): frame is PtyHostRequest {
-  if (typeof frame !== 'object' || frame === null) {
-    return false;
-  }
-  const candidate = frame as { id?: unknown; method?: unknown; args?: unknown };
-  return (
-    typeof candidate.id === 'number' &&
-    typeof candidate.method === 'string' &&
-    typeof candidate.args === 'object' &&
-    candidate.args !== null
-  );
+  return { ...decoded, args: { ...decoded.args, env } };
 }
 
 bootstrap();

--- a/main/src/ptyHost/ptyHostMain.ts
+++ b/main/src/ptyHost/ptyHostMain.ts
@@ -418,7 +418,7 @@ function respondOk(id: number, result: { ptyId: string; pid: number } | undefine
   }
   const frame: PtyHostResponse = result
     ? { id, ok: true, result }
-    : { id, ok: true, result: undefined };
+    : { id, ok: true };
   rpcPort.postMessage(frame);
 }
 

--- a/main/src/ptyHost/ptyHostSupervisor.ts
+++ b/main/src/ptyHost/ptyHostSupervisor.ts
@@ -54,6 +54,7 @@ import type {
   PtyHostRequest,
   PtyHostSpawnOpts,
 } from './types';
+import { boundary, decodeBoundary, type BoundarySchema, type JsonValue } from '../../../shared/validation/boundaryDecoder';
 
 /** Max restart attempts before we give up and leave the host down. */
 const MAX_RESTART_ATTEMPTS = 5;
@@ -71,29 +72,28 @@ const STARTUP_READY_TIMEOUT_MS = 5_000;
  * four kinds: the two heartbeat events, data/exit events, and RPC responses.
  * The rest is handled in `onRpcMessage` via the shared `isPtyHostResponse`.
  */
-function isHeartbeatPong(frame: unknown): frame is { type: 'heartbeat-pong' } {
-  return typeof frame === 'object' && frame !== null && (frame as { type?: unknown }).type === 'heartbeat-pong';
-}
+const heartbeatPongSchema = boundary.object({ type: boundary.literal('heartbeat-pong') });
+const hostReadySchema = boundary.object({ type: boundary.literal('host-ready') });
+const dataEventSchema = boundary.object({
+  type: boundary.literal('data'), ptyId: boundary.string, data: boundary.string,
+});
+const exitEventSchema = boundary.object({
+  type: boundary.literal('exit'),
+  ptyId: boundary.string,
+  exitCode: boundary.nullable(boundary.number),
+  signal: boundary.nullable(boundary.number),
+});
+const rendererFrameSchema = boundary.union(
+  boundary.object({ type: boundary.literal('ack'), ptyId: boundary.string, bytes: boundary.number }),
+  boundary.object({ type: boundary.literal('write'), ptyId: boundary.string, data: boundary.string }),
+);
 
-function isHostReady(frame: unknown): frame is { type: 'host-ready' } {
-  return typeof frame === 'object' && frame !== null && (frame as { type?: unknown }).type === 'host-ready';
-}
-
-function isDataEvent(frame: unknown): frame is Extract<PtyHostEvent, { type: 'data' }> {
-  if (typeof frame !== 'object' || frame === null) return false;
-  const f = frame as { type?: unknown; ptyId?: unknown; data?: unknown };
-  return f.type === 'data' && typeof f.ptyId === 'string' && typeof f.data === 'string';
-}
-
-function isExitEvent(frame: unknown): frame is Extract<PtyHostEvent, { type: 'exit' }> {
-  if (typeof frame !== 'object' || frame === null) return false;
-  const f = frame as { type?: unknown; ptyId?: unknown; exitCode?: unknown; signal?: unknown };
-  return (
-    f.type === 'exit' &&
-    typeof f.ptyId === 'string' &&
-    (typeof f.exitCode === 'number' || f.exitCode === null) &&
-    (typeof f.signal === 'number' || f.signal === null)
-  );
+function decodeFrame<Value>(frame: JsonValue, schema: BoundarySchema<Value>): Value | undefined {
+  try {
+    return decodeBoundary(frame, schema);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Listener signatures kept explicit so `PtyHandle` type stays analyzable. */
@@ -314,15 +314,22 @@ export class PtyHostSupervisor extends EventEmitter {
     // can interleave with the listener install (plan gotchas line 322, 738).
     this.rpcPort.start();
     this.rpcPort.on('message', (event: Electron.MessageEvent) => {
-      this.onRpcMessage(event.data);
+      try {
+        this.onRpcMessage(decodeBoundary(event.data, boundary.json));
+      } catch {
+        console.log('[ptyHost] malformed RPC frame, dropping');
+      }
     });
 
-    this.proc.on('message', (message: unknown) => {
-      if (isHostReady(message)) {
-        this.hostReadyResolve?.();
-        this.hostReadyResolve = null;
-        this.hostReadyReject = null;
-      }
+    this.proc.on('message', (message) => {
+      try {
+        const ready = decodeFrame(decodeBoundary(message, boundary.json), hostReadySchema);
+        if (ready) {
+          this.hostReadyResolve?.();
+          this.hostReadyResolve = null;
+          this.hostReadyReject = null;
+        }
+      } catch { /* Ignore non-JSON utility-process control messages. */ }
     });
 
     this.proc.on('exit', (code: number | null) => {
@@ -383,8 +390,8 @@ export class PtyHostSupervisor extends EventEmitter {
    * - `exit` event → fan to `PtyHandle.emitExit`, drop from `liveHandles`
    * - `PtyHostResponse` → dispatch via `RpcDispatcher`
    */
-  private onRpcMessage(data: unknown): void {
-    if (isHeartbeatPong(data)) {
+  private onRpcMessage(data: JsonValue): void {
+    if (decodeFrame(data, heartbeatPongSchema)) {
       if (this.pongTimer) {
         clearTimeout(this.pongTimer);
         this.pongTimer = null;
@@ -392,10 +399,11 @@ export class PtyHostSupervisor extends EventEmitter {
       return;
     }
 
-    if (isDataEvent(data)) {
-      const handle = this.liveHandles.get(data.ptyId);
+    const dataEvent = decodeFrame(data, dataEventSchema);
+    if (dataEvent) {
+      const handle = this.liveHandles.get(dataEvent.ptyId);
       if (handle) {
-        handle.emitData(data.data);
+        handle.emitData(dataEvent.data);
       }
       // Data frames are NOT auto-teed to renderers here. Main-side managers
       // (`terminalPanelManager.setupTerminalHandlers`) subscribe via the
@@ -405,17 +413,18 @@ export class PtyHostSupervisor extends EventEmitter {
       return;
     }
 
-    if (isExitEvent(data)) {
-      const handle = this.liveHandles.get(data.ptyId);
+    const exitEvent = decodeFrame(data, exitEventSchema);
+    if (exitEvent) {
+      const handle = this.liveHandles.get(exitEvent.ptyId);
       if (handle) {
-        handle.emitExit(data.exitCode, data.signal);
-        this.liveHandles.delete(data.ptyId);
+        handle.emitExit(exitEvent.exitCode, exitEvent.signal);
+        this.liveHandles.delete(exitEvent.ptyId);
       }
       // Exit frames ARE mirrored to renderers so `electronAPI.ptyHost.onExit`
       // subscribers fire. No main-side filtering is required for exit frames;
       // the preload dispatches by ptyId. Stale listeners (e.g. for a ptyId
       // whose panel already unmounted) drop the frame on the floor.
-      this.broadcastToRenderers(data);
+      this.broadcastToRenderers(exitEvent);
       return;
     }
 
@@ -533,7 +542,7 @@ export class PtyHostSupervisor extends EventEmitter {
     }
     const req: Omit<PtyHostRequest, 'id'> = { method: 'spawn', args: opts };
     const result = await this.dispatcher.send(this.rpcPort, req);
-    const spawned = result as { ptyId: string; pid: number };
+    const spawned = decodeBoundary(result, boundary.object({ ptyId: boundary.string, pid: boundary.number }));
     const handle = new PtyHandle(spawned.ptyId, spawned.pid, this);
     this.liveHandles.set(spawned.ptyId, handle);
     return spawned;
@@ -616,7 +625,11 @@ export class PtyHostSupervisor extends EventEmitter {
     // frames from the renderer in Chunk D.
     mainPort.start();
     mainPort.on('message', (event: Electron.MessageEvent) => {
-      this.onRendererMessage(webContents.id, event.data);
+      try {
+        this.onRendererMessage(webContents.id, decodeBoundary(event.data, boundary.json));
+      } catch {
+        /* Ignore malformed renderer frames at the port boundary. */
+      }
     });
 
     // Hand the renderer end to the window. The preload listener for
@@ -641,12 +654,12 @@ export class PtyHostSupervisor extends EventEmitter {
    * managers track flow-control state on the main side via
    * `acknowledgeBytes()` elsewhere.
    */
-  private onRendererMessage(webContentsId: number, data: unknown): void {
+  private onRendererMessage(webContentsId: number, data: JsonValue): void {
     void webContentsId;
-    if (typeof data !== 'object' || data === null) return;
-    const frame = data as { type?: unknown; ptyId?: unknown; bytes?: unknown; data?: unknown };
+    const frame = decodeFrame(data, rendererFrameSchema);
+    if (!frame) return;
 
-    if (frame.type === 'ack' && typeof frame.ptyId === 'string' && typeof frame.bytes === 'number') {
+    if (frame.type === 'ack') {
       // Managers still track flow control on the main side. Emit first so
       // TerminalPanelManager can decrement pending bytes and resume the PTY.
       this.emit('renderer-ack', frame.ptyId, frame.bytes);
@@ -659,7 +672,7 @@ export class PtyHostSupervisor extends EventEmitter {
       return;
     }
 
-    if (frame.type === 'write' && typeof frame.ptyId === 'string' && typeof frame.data === 'string') {
+    if (frame.type === 'write') {
       this.write(frame.ptyId, frame.data).catch(() => {
         /* ignore; stale write after host restart */
       });

--- a/main/src/ptyHost/rpc.test.ts
+++ b/main/src/ptyHost/rpc.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isPtyHostResponse } from './rpc';
+
+describe('isPtyHostResponse', () => {
+  it('accepts successful void responses with no result property', () => {
+    expect(isPtyHostResponse({ id: 7, ok: true })).toBe(true);
+  });
+
+  it('accepts successful spawn responses', () => {
+    expect(isPtyHostResponse({
+      id: 8,
+      ok: true,
+      result: { ptyId: 'pty-8', pid: 42 },
+    })).toBe(true);
+  });
+});

--- a/main/src/ptyHost/rpc.ts
+++ b/main/src/ptyHost/rpc.ts
@@ -19,7 +19,9 @@ import type {
   PtyHostRequest,
   PtyHostResponse,
   PtyHostSpawnError,
+  PtyHostSuccessResult,
 } from './types';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 /**
  * Minimal poster contract; anything with a `postMessage(msg)` method fits.
@@ -30,7 +32,7 @@ import type {
  * `transfer` argument is compatible with a single-argument call).
  */
 export interface RpcPoster {
-  postMessage(message: unknown): void;
+  postMessage(message: PtyHostRequest): void;
 }
 
 /**
@@ -59,7 +61,7 @@ class RpcIdAllocator {
  * the response handler.
  */
 export type PendingResolver = {
-  resolve: (result: unknown) => void;
+  resolve: (result: PtyHostSuccessResult) => void;
   reject: (error: Error) => void;
 };
 
@@ -82,13 +84,15 @@ export class RpcDispatcher {
    * The caller provides the request minus its `id`; the dispatcher allocates
    * an id, stores the promise resolvers, and posts the fully-formed frame.
    */
-  send<Req extends Omit<PtyHostRequest, 'id'>>(
+  send(
     poster: RpcPoster,
-    request: Req,
-  ): Promise<unknown> {
+    request: Omit<PtyHostRequest, 'id'>,
+  ): Promise<PtyHostSuccessResult> {
     return new Promise((resolve, reject) => {
       const id = this.ids.allocate();
       this.pending.set(id, { resolve, reject });
+      // SAFETY: `request` is the id-less form of Pane's closed request union;
+      // adding the dispatcher-owned numeric id reconstructs a request frame.
       const framed = { id, ...request } as PtyHostRequest;
       try {
         poster.postMessage(framed);
@@ -147,12 +151,27 @@ export class RpcDispatcher {
  * the frame has a numeric `id` and an `ok` boolean; the minimum shape a
  * response must satisfy.
  */
-export function isPtyHostResponse(frame: unknown): frame is PtyHostResponse {
-  if (typeof frame !== 'object' || frame === null) {
+export function isPtyHostResponse(frame: Parameters<typeof decodeBoundary>[0]): frame is PtyHostResponse {
+  try {
+    decodeBoundary(frame, boundary.union(
+      boundary.object({
+        id: boundary.number,
+        ok: boundary.literal(true),
+        result: boundary.optional(boundary.object({ ptyId: boundary.string, pid: boundary.number })),
+      }),
+      boundary.object({
+        id: boundary.number,
+        ok: boundary.literal(false),
+        error: boundary.object({
+          code: boundary.enumeration('ENOENT', 'E193', 'SHEBANG', 'OTHER'),
+          message: boundary.string,
+        }),
+      }),
+    ));
+    return true;
+  } catch {
     return false;
   }
-  const candidate = frame as { id?: unknown; ok?: unknown };
-  return typeof candidate.id === 'number' && typeof candidate.ok === 'boolean';
 }
 
 /**
@@ -162,7 +181,11 @@ export function isPtyHostResponse(frame: unknown): frame is PtyHostResponse {
  * message string.
  */
 function toError(spawnError: PtyHostSpawnError): Error {
-  const err = new Error(spawnError.message) as Error & { code: PtyHostSpawnError['code'] };
-  err.code = spawnError.code;
-  return err;
+  return new PtyHostRpcError(spawnError.message, spawnError.code);
+}
+
+class PtyHostRpcError extends Error {
+  constructor(message: string, readonly code: PtyHostSpawnError['code']) {
+    super(message);
+  }
 }

--- a/main/src/ptyHost/types.ts
+++ b/main/src/ptyHost/types.ts
@@ -45,10 +45,12 @@ export type PtyHostRequest =
   | { id: number; method: 'spawn'; args: PtyHostSpawnOpts }
   | { id: number; method: 'write'; args: { ptyId: string; data: string } }
   | { id: number; method: 'resize'; args: { ptyId: string; cols: number; rows: number } }
-  | { id: number; method: 'kill'; args: { ptyId: string; signal?: NodeJS.Signals } }
+  | { id: number; method: 'kill'; args: { ptyId: string; signal?: string } }
   | { id: number; method: 'ack'; args: { ptyId: string; bytes: number } }
   | { id: number; method: 'pause'; args: { ptyId: string } }
   | { id: number; method: 'resume'; args: { ptyId: string } };
+
+export type PtyHostSuccessResult = { ptyId: string; pid: number } | void;
 
 /**
  * Classified spawn error.
@@ -75,7 +77,7 @@ export type PtyHostSpawnError = {
  * Failure always carries a `PtyHostSpawnError`.
  */
 export type PtyHostResponse =
-  | { id: number; ok: true; result: { ptyId: string; pid: number } | void }
+  | { id: number; ok: true; result: PtyHostSuccessResult }
   | { id: number; ok: false; error: PtyHostSpawnError };
 
 /**

--- a/main/src/ptyHost/types.ts
+++ b/main/src/ptyHost/types.ts
@@ -77,7 +77,7 @@ export type PtyHostSpawnError = {
  * Failure always carries a `PtyHostSpawnError`.
  */
 export type PtyHostResponse =
-  | { id: number; ok: true; result: PtyHostSuccessResult }
+  | { id: number; ok: true; result?: PtyHostSuccessResult }
   | { id: number; ok: false; error: PtyHostSpawnError };
 
 /**

--- a/main/src/services/__tests__/gitFileWatcher.test.ts
+++ b/main/src/services/__tests__/gitFileWatcher.test.ts
@@ -9,25 +9,36 @@ interface GitFileWatcherInternals {
   getGitignoredDirs(watchPath: string): Set<string>;
   transitionToPolling(sessionId: string, worktreePath: string, err: Error): void;
   pollStatusSnapshot(sessionId: string): void;
-  handleWatcherFailure(sessionId: string, err: unknown): void;
+  handleWatcherFailure(sessionId: string, err: Error): void;
   watchedSessions: Map<string, { mode: string; watcherErrorLogged: boolean; lastStatusSnapshot?: string }>;
+}
+
+function partialMock<Contract>(implementation: Partial<Contract>): Contract {
+  // SAFETY: These fixtures implement every collaborator member exercised by
+  // the watcher scenarios; unexpected calls fail immediately.
+  return implementation as Contract;
+}
+
+function watcherInternals(watcher: GitFileWatcher): GitFileWatcherInternals {
+  // SAFETY: The interface above mirrors the private pure/test seam exactly.
+  return watcher as GitFileWatcherInternals;
 }
 
 function makeLogger(): Logger & { warns: string[]; errors: string[] } {
   const warns: string[] = [];
   const errors: string[] = [];
-  return {
+  return partialMock<Logger & { warns: string[]; errors: string[] }>({
     warns,
     errors,
     info: vi.fn(),
     verbose: vi.fn(),
     warn: (m: string) => warns.push(m),
     error: (m: string) => errors.push(m),
-  } as unknown as Logger & { warns: string[]; errors: string[] };
+  });
 }
 
 function makeCommandRunner(exec: (command: string, cwd: string) => string): CommandRunner {
-  return { exec, wslContext: undefined } as unknown as CommandRunner;
+  return partialMock<CommandRunner>({ exec, wslContext: undefined });
 }
 
 describe('GitFileWatcher pure logic', () => {
@@ -47,7 +58,7 @@ describe('GitFileWatcher pure logic', () => {
 
   function build(exec: (command: string, cwd: string) => string = () => ''): void {
     watcher = new GitFileWatcher(logger, makeCommandRunner(exec));
-    internals = watcher as unknown as GitFileWatcherInternals;
+    internals = watcherInternals(watcher);
   }
 
   describe('isIgnoredEventPath', () => {

--- a/main/src/services/__tests__/gitStatusManager.test.ts
+++ b/main/src/services/__tests__/gitStatusManager.test.ts
@@ -29,6 +29,25 @@ interface GitStatusManagerPrivates {
   activeSessionId: string | null;
 }
 
+function managerPrivates(manager: GitStatusManager): GitStatusManagerPrivates {
+  // SAFETY: These tests intentionally exercise GitStatusManager's private state;
+  // the interface above mirrors only the members used by this test suite.
+  return manager as GitStatusManagerPrivates;
+}
+
+function partialMock<Contract>(implementation: Partial<Contract>): Contract {
+  // SAFETY: Tests supply the subset invoked by each scenario, and Vitest fails
+  // immediately if the subject reaches an unstubbed contract member.
+  return implementation as Contract;
+}
+
+function requireValue<Value>(value: Value | null | undefined): Value {
+  if (value === null || value === undefined) {
+    throw new Error('Expected test subject to return a value');
+  }
+  return value;
+}
+
 // Mock modules
 vi.mock('../../utils/commandExecutor');
 vi.mock('fs');
@@ -101,27 +120,27 @@ describe('GitStatusManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockSessionManager = {
+    mockSessionManager = partialMock<SessionManager>({
       getSession: vi.fn().mockResolvedValue(mockSession),
       getProjectContext: vi.fn().mockReturnValue(mockProjectContext),
       getProjectForSession: vi.fn().mockReturnValue(mockProject),
       getAllSessions: vi.fn().mockResolvedValue([]),
-    } as Partial<SessionManager> as SessionManager;
+    });
 
-    mockWorktreeManager = {
+    mockWorktreeManager = partialMock<WorktreeManager>({
       getProjectMainBranch: vi.fn().mockResolvedValue('main'),
       getSessionComparisonBranch: vi.fn().mockResolvedValue('main'),
-    } as Partial<WorktreeManager> as WorktreeManager;
+    });
 
-    mockGitDiffManager = {} as Partial<GitDiffManager> as GitDiffManager;
+    mockGitDiffManager = partialMock<GitDiffManager>({});
 
-    mockLogger = {
+    mockLogger = partialMock<Logger>({
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
       debug: vi.fn(),
       verbose: vi.fn(),
-    } as Partial<Logger> as Logger;
+    });
 
     mockDatabaseService = {
       getAllSessionGitStatusCache: vi.fn().mockReturnValue([]),
@@ -135,59 +154,59 @@ describe('GitStatusManager', () => {
       mockWorktreeManager,
       mockGitDiffManager,
       mockLogger,
-      mockDatabaseService as DatabaseService
+      partialMock<DatabaseService>(mockDatabaseService)
     );
 
     // Default: no uncommitted changes, no ahead/behind
-    (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
-    (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 0, behind: 0 });
-    (fastGetDiffStats as Mock).mockReturnValue({ additions: 0, deletions: 0, filesChanged: 0 });
+    vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
+    vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
+    vi.mocked(fastGetDiffStats).mockReturnValue({ additions: 0, deletions: 0, filesChanged: 0 });
 
     // Default execSync returns empty buffer
-    (execSync as Mock).mockReturnValue(Buffer.from(''));
+    vi.mocked(execSync).mockReturnValue(Buffer.from(''));
 
     // Default commandRunner.exec returns empty string
-    (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('');
+    vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('');
   });
 
   describe('fetchGitStatus via getGitStatus (cache miss scenarios)', () => {
     it('returns clean state when no changes, no ahead/behind, no untracked', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
       expect(status).not.toBeNull();
-      expect(status!.state).toBe('clean');
-      expect(status!.ahead).toBeUndefined();
-      expect(status!.behind).toBeUndefined();
-      expect(status!.hasUncommittedChanges).toBe(false);
-      expect(status!.hasUntrackedFiles).toBe(false);
+      expect(requireValue(status).state).toBe('clean');
+      expect(requireValue(status).ahead).toBeUndefined();
+      expect(requireValue(status).behind).toBeUndefined();
+      expect(requireValue(status).hasUncommittedChanges).toBe(false);
+      expect(requireValue(status).hasUntrackedFiles).toBe(false);
     });
 
     it('returns modified state when uncommitted changes exist', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
         hasModified: true,
         hasStaged: false,
         hasUntracked: false,
         hasConflicts: false,
       });
-      (fastGetDiffStats as Mock).mockReturnValue({ additions: 15, deletions: 5, filesChanged: 3 });
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastGetDiffStats).mockReturnValue({ additions: 15, deletions: 5, filesChanged: 3 });
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
-      expect(status!.state).toBe('modified');
-      expect(status!.hasUncommittedChanges).toBe(true);
-      expect(status!.filesChanged).toBe(3);
-      expect(status!.additions).toBe(15);
-      expect(status!.deletions).toBe(5);
+      expect(requireValue(status).state).toBe('modified');
+      expect(requireValue(status).hasUncommittedChanges).toBe(true);
+      expect(requireValue(status).filesChanged).toBe(3);
+      expect(requireValue(status).additions).toBe(15);
+      expect(requireValue(status).deletions).toBe(5);
     });
 
     it('returns ahead state when commits ahead of main', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 3, behind: 0 });
-      (mockProjectContext.commandRunner.exec as Mock).mockImplementation((cmd: string) => {
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 3, behind: 0 });
+      vi.mocked(mockProjectContext.commandRunner.exec).mockImplementation((cmd: string) => {
         if (cmd.includes('diff --shortstat')) {
           return ' 5 files changed, 20 insertions(+), 10 deletions(-)';
         }
@@ -197,32 +216,32 @@ describe('GitStatusManager', () => {
         return '';
       });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
-      expect(status!.state).toBe('ahead');
-      expect(status!.ahead).toBe(3);
-      expect(status!.totalCommits).toBe(3);
-      expect(status!.isReadyToMerge).toBe(true);
-      expect(status!.commitFilesChanged).toBe(5);
-      expect(status!.commitAdditions).toBe(20);
-      expect(status!.commitDeletions).toBe(10);
+      expect(requireValue(status).state).toBe('ahead');
+      expect(requireValue(status).ahead).toBe(3);
+      expect(requireValue(status).totalCommits).toBe(3);
+      expect(requireValue(status).isReadyToMerge).toBe(true);
+      expect(requireValue(status).commitFilesChanged).toBe(5);
+      expect(requireValue(status).commitAdditions).toBe(20);
+      expect(requireValue(status).commitDeletions).toBe(10);
     });
 
     it('returns behind state when commits behind main', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 0, behind: 5 });
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 5 });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
-      expect(status!.state).toBe('behind');
-      expect(status!.behind).toBe(5);
-      expect(status!.ahead).toBeUndefined();
+      expect(requireValue(status).state).toBe('behind');
+      expect(requireValue(status).behind).toBe(5);
+      expect(requireValue(status).ahead).toBeUndefined();
     });
 
     it('returns diverged state when both ahead and behind', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue(cleanIndexStatus);
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 2, behind: 3 });
-      (mockProjectContext.commandRunner.exec as Mock).mockImplementation((cmd: string) => {
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 2, behind: 3 });
+      vi.mocked(mockProjectContext.commandRunner.exec).mockImplementation((cmd: string) => {
         if (cmd.includes('diff --shortstat')) {
           return ' 4 files changed, 15 insertions(+), 8 deletions(-)';
         }
@@ -232,60 +251,60 @@ describe('GitStatusManager', () => {
         return '';
       });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
-      expect(status!.state).toBe('diverged');
-      expect(status!.ahead).toBe(2);
-      expect(status!.behind).toBe(3);
+      expect(requireValue(status).state).toBe('diverged');
+      expect(requireValue(status).ahead).toBe(2);
+      expect(requireValue(status).behind).toBe(3);
     });
 
     it('returns conflict state when merge conflicts exist', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
         hasModified: false,
         hasStaged: false,
         hasUntracked: false,
         hasConflicts: true,
       });
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
-      expect(status!.state).toBe('conflict');
+      expect(requireValue(status).state).toBe('conflict');
     });
 
     it('returns untracked state when only untracked files exist', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
         hasModified: false,
         hasStaged: false,
         hasUntracked: true,
         hasConflicts: false,
       });
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
-      expect(status!.state).toBe('untracked');
-      expect(status!.hasUntrackedFiles).toBe(true);
+      expect(requireValue(status).state).toBe('untracked');
+      expect(requireValue(status).hasUntrackedFiles).toBe(true);
     });
 
     it('returns null when session is not found', async () => {
-      (mockSessionManager.getSession as Mock).mockResolvedValue(null);
+      vi.mocked(mockSessionManager.getSession).mockResolvedValue(null);
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
       expect(status).toBeNull();
     });
 
     it('sets modified as primary state and ahead as secondary when uncommitted changes and ahead', async () => {
-      (fastCheckWorkingDirectory as Mock).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
         hasModified: true,
         hasStaged: false,
         hasUntracked: false,
         hasConflicts: false,
       });
-      (fastGetDiffStats as Mock).mockReturnValue({ additions: 5, deletions: 2, filesChanged: 2 });
-      (fastGetAheadBehind as Mock).mockReturnValue({ ahead: 2, behind: 0 });
-      (mockProjectContext.commandRunner.exec as Mock).mockImplementation((cmd: string) => {
+      vi.mocked(fastGetDiffStats).mockReturnValue({ additions: 5, deletions: 2, filesChanged: 2 });
+      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 2, behind: 0 });
+      vi.mocked(mockProjectContext.commandRunner.exec).mockImplementation((cmd: string) => {
         if (cmd.includes('diff --shortstat')) {
           return ' 3 files changed, 10 insertions(+), 5 deletions(-)';
         }
@@ -295,23 +314,23 @@ describe('GitStatusManager', () => {
         return '';
       });
 
-      const status = await (gitStatusManager as unknown as GitStatusManagerPrivates).fetchGitStatus('test-session');
+      const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
-      expect(status!.state).toBe('modified');
-      expect(status!.secondaryStates).toContain('ahead');
+      expect(requireValue(status).state).toBe('modified');
+      expect(requireValue(status).secondaryStates).toContain('ahead');
     });
   });
 
   describe('caching', () => {
     it('returns cached status within TTL without re-fetching', async () => {
       const cachedStatus: GitStatus = { state: 'clean', lastChecked: new Date().toISOString() };
-      (gitStatusManager as unknown as GitStatusManagerPrivates).cache['test-session'] = {
+      managerPrivates(gitStatusManager).cache['test-session'] = {
         status: cachedStatus,
         lastChecked: Date.now(),
       };
 
       const fetchSpy = vi.spyOn(
-        gitStatusManager as unknown as GitStatusManagerPrivates,
+        managerPrivates(gitStatusManager),
         'fetchGitStatus'
       );
 
@@ -323,14 +342,14 @@ describe('GitStatusManager', () => {
 
     it('fetches fresh status after TTL has expired', async () => {
       const expiredStatus: GitStatus = { state: 'clean', lastChecked: new Date().toISOString() };
-      (gitStatusManager as unknown as GitStatusManagerPrivates).cache['test-session'] = {
+      managerPrivates(gitStatusManager).cache['test-session'] = {
         status: expiredStatus,
         lastChecked: Date.now() - 10000, // 10s ago — beyond the 5s TTL
       };
 
       const freshStatus: GitStatus = { state: 'modified', lastChecked: new Date().toISOString() };
       vi.spyOn(
-        gitStatusManager as unknown as GitStatusManagerPrivates,
+        managerPrivates(gitStatusManager),
         'fetchGitStatus'
       ).mockResolvedValue(freshStatus);
 
@@ -352,9 +371,9 @@ describe('GitStatusManager', () => {
         mockWorktreeManager,
         mockGitDiffManager,
         mockLogger,
-        mockDatabaseService as DatabaseService,
+        partialMock<DatabaseService>(mockDatabaseService),
       );
-      const privates = manager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(manager);
 
       expect(privates.cache['cached-session']).toEqual({
         status: cachedStatus,
@@ -363,7 +382,7 @@ describe('GitStatusManager', () => {
     });
 
     it('persists successful cache updates', () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       const status: GitStatus = { state: 'modified', hasUncommittedChanges: true };
 
       privates.updateCache('test-session', status);
@@ -376,7 +395,7 @@ describe('GitStatusManager', () => {
     });
 
     it('preserves cached PR fields when local status refresh has no PR fields', () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       privates.cache['test-session'] = {
         status: {
           state: 'ahead',
@@ -416,9 +435,9 @@ describe('GitStatusManager', () => {
 
   describe('PR enrichment', () => {
     it('caches PR misses for 20 seconds', async () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       const commandRunner = mockProjectContext.commandRunner;
-      (commandRunner.execAsync as Mock).mockResolvedValue({ stdout: '[]' });
+      vi.mocked(commandRunner.execAsync).mockResolvedValue({ stdout: '[]' });
 
       await privates.fetchPrForSession('feature-branch', mockProject.path, commandRunner);
       await privates.fetchPrForSession('feature-branch', mockProject.path, commandRunner);
@@ -433,9 +452,9 @@ describe('GitStatusManager', () => {
     });
 
     it('keeps PR hits cached longer than misses', async () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       const commandRunner = mockProjectContext.commandRunner;
-      (commandRunner.execAsync as Mock).mockResolvedValue({
+      vi.mocked(commandRunner.execAsync).mockResolvedValue({
         stdout: JSON.stringify([{
           number: 12,
           url: 'https://github.com/example/repo/pull/12',
@@ -462,10 +481,10 @@ describe('GitStatusManager', () => {
     });
 
     it('invalidates active-session PR misses when the app regains focus', async () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       privates.activeSessionId = 'test-session';
       privates.prCache.set(`${mockProject.path}:feature-branch`, { fetchedAt: Date.now() });
-      (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('feature-branch\n');
+      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('feature-branch\n');
       const refreshSpy = vi
         .spyOn(gitStatusManager, 'refreshSessionGitStatus')
         .mockResolvedValue({ state: 'clean', lastChecked: new Date().toISOString() });
@@ -478,17 +497,17 @@ describe('GitStatusManager', () => {
     });
 
     it('uses the checked-out git branch when enriching PR data', async () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       privates.cache['test-session'] = {
         status: { state: 'ahead', lastChecked: new Date().toISOString() },
         lastChecked: Date.now(),
       };
-      (mockSessionManager.getSession as Mock).mockResolvedValue({
+      vi.mocked(mockSessionManager.getSession).mockResolvedValue({
         ...mockSession,
         worktreePath: '/test/worktrees/not-the-branch',
       });
-      (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('real-feature-branch\n');
-      (mockProjectContext.commandRunner.execAsync as Mock).mockResolvedValue({
+      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('real-feature-branch\n');
+      vi.mocked(mockProjectContext.commandRunner.execAsync).mockResolvedValue({
         stdout: JSON.stringify([{
           number: 12,
           url: 'https://github.com/example/repo/pull/12',
@@ -514,13 +533,13 @@ describe('GitStatusManager', () => {
         mockProject.path,
         { timeout: 5000 }
       );
-      expect((mockProjectContext.commandRunner.execAsync as Mock).mock.calls[0][0]).not.toContain('not-the-branch');
+      expect(vi.mocked(mockProjectContext.commandRunner.execAsync).mock.calls[0][0]).not.toContain('not-the-branch');
       expect(status.prNumber).toBe(12);
       expect(status.prUrl).toBe('https://github.com/example/repo/pull/12');
     });
 
     it('clears cached PR fields on a confirmed PR miss', async () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       privates.cache['test-session'] = {
         status: {
           state: 'ahead',
@@ -533,8 +552,8 @@ describe('GitStatusManager', () => {
         },
         lastChecked: Date.now(),
       };
-      (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('feature-branch\n');
-      (mockProjectContext.commandRunner.execAsync as Mock).mockResolvedValue({ stdout: '[]' });
+      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('feature-branch\n');
+      vi.mocked(mockProjectContext.commandRunner.execAsync).mockResolvedValue({ stdout: '[]' });
 
       const updated = new Promise<GitStatus>((resolve) => {
         gitStatusManager.once('git-status-updated', (_sessionId, status) => resolve(status));
@@ -556,7 +575,7 @@ describe('GitStatusManager', () => {
     });
 
     it('keeps cached PR fields when PR lookup fails', async () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       const cachedStatus: GitStatus = {
         state: 'ahead',
         ahead: 1,
@@ -570,8 +589,8 @@ describe('GitStatusManager', () => {
         status: cachedStatus,
         lastChecked: Date.now(),
       };
-      (mockProjectContext.commandRunner.exec as Mock).mockReturnValue('feature-branch\n');
-      (mockProjectContext.commandRunner.execAsync as Mock).mockRejectedValue(new Error('gh unavailable'));
+      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('feature-branch\n');
+      vi.mocked(mockProjectContext.commandRunner.execAsync).mockRejectedValue(new Error('gh unavailable'));
 
       await privates.enrichWithPrData('test-session');
 
@@ -580,7 +599,7 @@ describe('GitStatusManager', () => {
     });
 
     it('schedules staggered PR enrichment for non-active relevant initial-load status', async () => {
-      const privates = gitStatusManager as unknown as GitStatusManagerPrivates;
+      const privates = managerPrivates(gitStatusManager);
       privates.initialLoadQueue.push('test-session');
       privates.activeSessionId = null;
       const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);

--- a/main/src/services/__tests__/worktreeFileSyncService.test.ts
+++ b/main/src/services/__tests__/worktreeFileSyncService.test.ts
@@ -4,6 +4,16 @@ import { DEFAULT_WORKTREE_FILE_SYNC_ENTRIES, type WorktreeFileSyncEntry } from '
 import type { CommandRunner } from '../../utils/commandRunner';
 import type { ProjectEnvironment } from '../../utils/pathResolver';
 
+type MockCommandRunner = CommandRunner & { execAsync: ReturnType<typeof vi.fn> };
+
+function commandRunnerWith(
+  execAsync: ReturnType<typeof vi.fn>,
+): MockCommandRunner {
+  // SAFETY: WorktreeFileSyncService only invokes execAsync in these scenarios;
+  // each fixture supplies that method with the real result shape.
+  return { execAsync } as MockCommandRunner;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -21,7 +31,7 @@ function makeMockCommandRunner(
   findOutput: string,
   existingDests: ReadonlySet<string>,
   cpCommands: string[],
-): CommandRunner {
+): MockCommandRunner {
   const execAsync = vi.fn().mockImplementation((cmd: string, _cwd: string) => {
     if (cmd.startsWith('find ') || cmd.startsWith('dir /') || cmd.startsWith('sh -c ')) {
       return Promise.resolve({ stdout: findOutput, stderr: '' });
@@ -59,7 +69,7 @@ function makeMockCommandRunner(
     return Promise.resolve({ stdout: '', stderr: '' });
   });
 
-  return { execAsync } as unknown as CommandRunner;
+  return commandRunnerWith(execAsync);
 }
 
 function isMatchCommand(cmd: string): boolean {
@@ -319,8 +329,7 @@ describe('worktreeFileSyncService', () => {
         [envEntry],
       );
 
-      const execAsync = runner.execAsync as ReturnType<typeof vi.fn>;
-      const matchCall = execAsync.mock.calls.find((call) => isMatchCommand(String(call[0])));
+      const matchCall = runner.execAsync.mock.calls.find((call) => isMatchCommand(String(call[0])));
       expect(matchCall).toBeDefined();
       expect(String(matchCall?.[0])).toContain('-type d -name worktrees');
       expect(String(matchCall?.[0])).toContain('-prune -o -print');
@@ -402,7 +411,7 @@ describe('worktreeFileSyncService', () => {
         return Promise.resolve({ stdout: '', stderr: '' });
       });
 
-      return { execAsync } as unknown as CommandRunner;
+      return commandRunnerWith(execAsync);
     }
 
     it('copies .claude contents without entering nested worktrees', async () => {
@@ -487,7 +496,7 @@ describe('worktreeFileSyncService', () => {
         return Promise.resolve({ stdout: '', stderr: '' });
       });
 
-      const runner = { execAsync } as unknown as CommandRunner;
+      const runner = commandRunnerWith(execAsync);
 
       await worktreeFileSyncService.syncWorktree(
         mainRepoPath,
@@ -523,7 +532,7 @@ describe('worktreeFileSyncService', () => {
         return Promise.resolve({ stdout: '', stderr: '' });
       });
 
-      const runner = { execAsync } as unknown as CommandRunner;
+      const runner = commandRunnerWith(execAsync);
 
       await worktreeFileSyncService.syncWorktree(
         mainRepoPath,
@@ -637,7 +646,7 @@ describe('worktreeFileSyncService', () => {
         }
         return Promise.resolve({ stdout: '', stderr: '' });
       });
-      return { execAsync } as unknown as CommandRunner;
+      return commandRunnerWith(execAsync);
     }
 
     it('copies .env entries before node_modules even when node_modules is listed first', async () => {
@@ -687,7 +696,7 @@ describe('worktreeFileSyncService', () => {
         }
         return Promise.resolve({ stdout: '', stderr: '' });
       });
-      const runner = { execAsync } as unknown as CommandRunner;
+      const runner = commandRunnerWith(execAsync);
 
       await worktreeFileSyncService.syncWorktree(
         mainRepoPath,
@@ -724,8 +733,7 @@ describe('worktreeFileSyncService', () => {
         [nodeModulesEntry],
       );
 
-      const execAsync = runner.execAsync as ReturnType<typeof vi.fn>;
-      const cpCall = execAsync.mock.calls.find((call) => String(call[0]).startsWith('cp '));
+      const cpCall = runner.execAsync.mock.calls.find((call) => String(call[0]).startsWith('cp '));
       expect(cpCall).toBeDefined();
       expect(cpCall?.[2]).toMatchObject({ timeout: 600_000 });
     });
@@ -778,7 +786,7 @@ describe('worktreeFileSyncService', () => {
         }
         return Promise.resolve({ stdout: '', stderr: '' });
       });
-      const runner = { execAsync } as unknown as CommandRunner;
+      const runner = commandRunnerWith(execAsync);
 
       const result = await worktreeFileSyncService.syncWorktree(
         mainRepoPath,
@@ -820,7 +828,7 @@ describe('worktreeFileSyncService', () => {
         }
         return Promise.resolve({ stdout: '', stderr: '' });
       });
-      const runner = { execAsync } as unknown as CommandRunner;
+      const runner = commandRunnerWith(execAsync);
 
       const result = await worktreeFileSyncService.syncWorktree(
         mainRepoPath,

--- a/main/src/services/__tests__/worktreeManager.test.ts
+++ b/main/src/services/__tests__/worktreeManager.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CommandRunner } from '../../utils/commandRunner';
+
+function partialMock<Contract>(implementation: Partial<Contract>): Contract {
+  // SAFETY: Each test fixture implements every dependency member reached by
+  // its scenario; unexpected calls fail immediately.
+  return implementation as Contract;
+}
 import type { PathResolver } from '../../utils/pathResolver';
 import { resolveDefaultWorktreeBase, WorktreeManager } from '../worktreeManager';
 import { worktreePoolManager } from '../worktreePoolManager';
@@ -7,7 +13,7 @@ import { worktreePoolManager } from '../worktreePoolManager';
 function commandRunner(
   execAsync: (command: string, cwd: string) => Promise<{ stdout: string; stderr: string }>,
 ): CommandRunner {
-  return { execAsync: vi.fn(execAsync) } as CommandRunner;
+  return partialMock<CommandRunner>({ execAsync: vi.fn(execAsync) });
 }
 
 afterEach(() => {
@@ -98,7 +104,7 @@ describe('WorktreeManager.resolveWorkingDirectory', () => {
       undefined,
       'origin/main',
       undefined,
-      { join: (...parts: string[]) => parts.join('/') } as PathResolver,
+      partialMock<PathResolver>({ join: (...parts: string[]) => parts.join('/') }),
       runner,
     );
 
@@ -136,7 +142,7 @@ describe('WorktreeManager.resolveWorkingDirectory', () => {
       '/repo',
       'origin/main',
       undefined,
-      { join: (...parts: string[]) => parts.join('/') } as PathResolver,
+      partialMock<PathResolver>({ join: (...parts: string[]) => parts.join('/') }),
       runner,
     );
 
@@ -175,7 +181,7 @@ describe('WorktreeManager.resolveWorkingDirectory', () => {
       undefined,
       true,
       undefined,
-      {} as PathResolver,
+      partialMock<PathResolver>({}),
       runner,
     );
 
@@ -220,7 +226,7 @@ describe('WorktreeManager.resolveWorkingDirectory', () => {
       undefined,
       true,
       undefined,
-      {} as PathResolver,
+      partialMock<PathResolver>({}),
       runner,
     );
 

--- a/main/src/services/agentContextManager.ts
+++ b/main/src/services/agentContextManager.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import type { Project } from '../database/models';
 import type { AppConfig } from '../types/config';
 import { PathResolver } from '../utils/pathResolver';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 import { RUNPANE_CONTRACT } from '../../../shared/types/generatedRunpaneContract';
 
 export const PANE_AGENT_CONTEXT_START = '<!-- pane-agent-context:start -->';
@@ -123,7 +124,13 @@ async function findExistingAgentsFile(root: string): Promise<{ filePath?: string
   try {
     entries = await fs.readdir(root);
   } catch (error) {
-    if (isNotFound(error)) {
+    let code: string | undefined;
+    try {
+      code = decodeBoundary(error, boundary.object({ code: boundary.optional(boundary.string) })).code;
+    } catch {
+      code = undefined;
+    }
+    if (code === 'ENOENT') {
       return { hasUnsafeCandidate: false };
     }
     throw error;
@@ -157,7 +164,13 @@ async function readFileIfExists(filePath: string): Promise<string | undefined> {
       await handle.close();
     }
   } catch (error) {
-    if (isNotFound(error)) {
+    let code: string | undefined;
+    try {
+      code = decodeBoundary(error, boundary.object({ code: boundary.optional(boundary.string) })).code;
+    } catch {
+      code = undefined;
+    }
+    if (code === 'ENOENT') {
       return undefined;
     }
     throw error;
@@ -169,7 +182,13 @@ async function inspectAgentsFile(filePath: string): Promise<'file' | 'missing' |
     const stat = await fs.lstat(filePath);
     return stat.isFile() ? 'file' : 'unsafe';
   } catch (error) {
-    if (isNotFound(error)) {
+    let code: string | undefined;
+    try {
+      code = decodeBoundary(error, boundary.object({ code: boundary.optional(boundary.string) })).code;
+    } catch {
+      code = undefined;
+    }
+    if (code === 'ENOENT') {
       return 'missing';
     }
     throw error;
@@ -208,10 +227,4 @@ function consumeTrailingNewline(value: string, index: number): number {
     return index + 1;
   }
   return index;
-}
-
-function isNotFound(error: unknown): boolean {
-  return error instanceof Error
-    && 'code' in error
-    && (error as NodeJS.ErrnoException).code === 'ENOENT';
 }

--- a/main/src/services/agentUsageService.test.ts
+++ b/main/src/services/agentUsageService.test.ts
@@ -45,6 +45,7 @@ const rateLimitsResponse = {
 };
 
 function createFakeChild(stdin: Writable): ChildProcessWithoutNullStreams {
+  // SAFETY: The service test exercises only these modeled child-process streams, state fields, and kill method.
   return Object.assign(new EventEmitter(), {
     stdin,
     stdout: new PassThrough(),

--- a/main/src/services/agentUsageService.ts
+++ b/main/src/services/agentUsageService.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../shared/types/agentUsage';
 import { getShellPath } from '../utils/shellPath';
 import { getWSLExecArgs, type WSLContext } from '../utils/wslUtils';
+import { boundary, decodeBoundary, type JsonObject, type JsonValue } from '../../../shared/validation/boundaryDecoder';
 
 const CACHE_TTL_MS = 60_000;
 const PROBE_TIMEOUT_MS = 12_000;
@@ -25,19 +26,19 @@ interface CachedSnapshot {
 
 interface JsonRpcMessage {
   id?: number | string;
-  result?: unknown;
-  error?: unknown;
+  result?: JsonValue;
+  error?: JsonValue;
 }
 
 interface JsonRpcRequest {
   method: string;
   id?: number | string;
-  params?: Record<string, unknown>;
+  params?: JsonObject;
 }
 
 interface CodexProbeResult {
-  account: unknown;
-  rateLimits: unknown;
+  account: JsonValue | undefined;
+  rateLimits: JsonValue | undefined;
 }
 
 type CodexProbe = (target: AgentUsageTarget) => Promise<CodexProbeResult>;
@@ -51,16 +52,30 @@ interface CodexSpawnCommand {
   cwd: string | undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+function optionalObject(value: JsonValue | undefined): JsonObject | null {
+  try {
+    return decodeBoundary(value, boundary.jsonObject);
+  } catch {
+    return null;
+  }
 }
 
-function optionalString(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim() : null;
+function optionalString(value: JsonValue | undefined): string | null {
+  try {
+    const decoded = decodeBoundary(value, boundary.string).trim();
+    return decoded || null;
+  } catch {
+    return null;
+  }
 }
 
-function optionalNumber(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+function optionalNumber(value: JsonValue | undefined): number | null {
+  try {
+    const decoded = decodeBoundary(value, boundary.number);
+    return Number.isFinite(decoded) ? decoded : null;
+  } catch {
+    return null;
+  }
 }
 
 function titleCaseIdentifier(value: string): string {
@@ -88,14 +103,15 @@ function normalizeWindow(
   limitId: string,
   limitName: string | null,
   windowKind: 'primary' | 'secondary',
-  value: unknown,
+  value: JsonValue | undefined,
 ): AgentUsageLimit | null {
-  if (!isRecord(value)) return null;
-  const usedPercent = optionalNumber(value.usedPercent);
+  const record = optionalObject(value);
+  if (!record) return null;
+  const usedPercent = optionalNumber(record.usedPercent);
   if (usedPercent === null) return null;
 
-  const windowDurationMinutes = optionalNumber(value.windowDurationMins);
-  const resetSeconds = optionalNumber(value.resetsAt);
+  const windowDurationMinutes = optionalNumber(record.windowDurationMins);
+  const resetSeconds = optionalNumber(record.resetsAt);
   const windowName = formatWindowName(windowDurationMinutes);
   const name = limitName
     ? windowDurationMinutes === null ? limitName : `${limitName} ${windowName.toLowerCase()}`
@@ -110,33 +126,37 @@ function normalizeWindow(
   };
 }
 
-function normalizeLimitSnapshot(value: unknown, fallbackId: string): AgentUsageLimit[] {
-  if (!isRecord(value)) return [];
-  const limitId = optionalString(value.limitId) ?? fallbackId;
-  const limitName = optionalString(value.limitName);
-  const primary = normalizeWindow(limitId, limitName, 'primary', value.primary);
-  const secondary = normalizeWindow(limitId, limitName, 'secondary', value.secondary);
+function normalizeLimitSnapshot(value: JsonValue | undefined, fallbackId: string): AgentUsageLimit[] {
+  const record = optionalObject(value);
+  if (!record) return [];
+  const limitId = optionalString(record.limitId) ?? fallbackId;
+  const limitName = optionalString(record.limitName);
+  const primary = normalizeWindow(limitId, limitName, 'primary', record.primary);
+  const secondary = normalizeWindow(limitId, limitName, 'secondary', record.secondary);
   return [primary, secondary].filter((limit): limit is AgentUsageLimit => limit !== null);
 }
 
 export function normalizeCodexUsage(
-  accountPayload: unknown,
-  rateLimitsPayload: unknown,
+  accountPayload: JsonValue | undefined,
+  rateLimitsPayload: JsonValue | undefined,
   fetchedAt = new Date(),
 ): AgentUsageProviderSnapshot {
-  if (!isRecord(accountPayload) || !isRecord(rateLimitsPayload)) {
+  const accountResponse = optionalObject(accountPayload);
+  const rateLimitsResponse = optionalObject(rateLimitsPayload);
+  if (!accountResponse || !rateLimitsResponse) {
     throw new Error('Codex returned an invalid account usage response');
   }
 
-  const account = isRecord(accountPayload.account) ? accountPayload.account : null;
+  const account = optionalObject(accountResponse.account);
   const rawPlan = optionalString(account?.planType);
 
-  const buckets = isRecord(rateLimitsPayload.rateLimitsByLimitId)
-    ? Object.entries(rateLimitsPayload.rateLimitsByLimitId)
+  const rateLimitsById = optionalObject(rateLimitsResponse.rateLimitsByLimitId);
+  const buckets = rateLimitsById
+    ? Object.entries(rateLimitsById)
     : [];
   const rawLimits = buckets.length > 0
     ? buckets
-    : [['codex', rateLimitsPayload.rateLimits] as const];
+    : [['codex', rateLimitsResponse.rateLimits] as const];
   const limits = rawLimits.flatMap(([limitId, value]) => normalizeLimitSnapshot(value, limitId));
   limits.sort((left, right) => {
     const leftDefault = left.id.startsWith('codex:') ? 0 : 1;
@@ -188,7 +208,7 @@ function createCodexProcess(target: AgentUsageTarget): ChildProcessWithoutNullSt
     cwd: command.cwd,
     env,
     windowsHide: true,
-    stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe'],
+    stdio: ['pipe', 'pipe', 'pipe'] satisfies ['pipe', 'pipe', 'pipe'],
   };
   return spawn(command.file, command.args, spawnOptions);
 }
@@ -279,8 +299,8 @@ export async function probeCodexUsage(
     const child = createProcess(target);
     let stdoutBuffer = '';
     let stderr = '';
-    let account: unknown;
-    let rateLimits: unknown;
+    let account: JsonValue | undefined;
+    let rateLimits: JsonValue | undefined;
     let settled = false;
 
     const finish = (error?: Error) => {
@@ -334,7 +354,11 @@ export async function probeCodexUsage(
 
         let message: JsonRpcMessage;
         try {
-          message = JSON.parse(line) as JsonRpcMessage;
+          message = decodeBoundary(JSON.parse(line), boundary.object({
+            id: boundary.optional(boundary.union(boundary.number, boundary.string)),
+            result: boundary.optional(boundary.json),
+            error: boundary.optional(boundary.json),
+          }));
         } catch {
           continue;
         }

--- a/main/src/services/agents/agentIdentity.ts
+++ b/main/src/services/agents/agentIdentity.ts
@@ -1,4 +1,6 @@
 import { TerminalPanelState } from '../../../../shared/types/panels';
+import type { PaneCommandValue } from '../../daemon/commandRegistry';
+import { boundary, decodeBoundary } from '../../../../shared/validation/boundaryDecoder';
 
 export type CliAgentType = NonNullable<TerminalPanelState['agentType']>;
 
@@ -285,8 +287,13 @@ function resolveExecutableToken(command: string, platformHint: NodeJS.Platform):
   return tokens[index];
 }
 
-export function isCliAgentType(value: unknown): value is CliAgentType {
-  return typeof value === 'string' && (CLI_AGENT_TYPES as readonly string[]).includes(value);
+export function isCliAgentType(value: PaneCommandValue): value is CliAgentType {
+  try {
+    decodeBoundary(value, boundary.enumeration(...CLI_AGENT_TYPES));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/main/src/services/analyticsIdentity.test.ts
+++ b/main/src/services/analyticsIdentity.test.ts
@@ -16,6 +16,7 @@ vi.mock('../utils/shellPath', () => ({
 const execFileSyncMock = vi.mocked(execFileSync);
 
 function mockCommandOutput(outputs: Record<string, string>): void {
+  // SAFETY: The mock implements only the string-returning execFileSync overload used by analyticsIdentity.
   execFileSyncMock.mockImplementation(((command: string, args: string[]) => {
     const key = `${command} ${args.join(' ')}`;
     if (key in outputs) {

--- a/main/src/services/cliManagerFactory.ts
+++ b/main/src/services/cliManagerFactory.ts
@@ -9,13 +9,14 @@ import {
   CliManagerFactory as ManagerFactoryFunction,
   CLI_OUTPUT_FORMATS 
 } from './cliToolRegistry';
+import { boundary, decodeBoundary, type JsonObject } from '../../../shared/validation/boundaryDecoder';
 
 /**
  * Factory configuration for CLI manager creation
  */
 export interface CliManagerFactoryConfig {
   /** Session manager instance */
-  sessionManager: unknown;
+  sessionManager: SessionManager;
 
   /** Logger instance */
   logger?: Logger;
@@ -24,7 +25,7 @@ export interface CliManagerFactoryConfig {
   configManager?: ConfigManager;
 
   /** Additional tool-specific options */
-  additionalOptions?: Record<string, unknown>;
+  additionalOptions?: JsonObject;
 
   /** Skip tool availability validation (useful for startup) */
   skipValidation?: boolean;
@@ -71,7 +72,7 @@ export class CliManagerFactory {
 
       const manager = await this.registry.createManager(
         toolId,
-        config.sessionManager as SessionManager,
+        config.sessionManager,
         config.additionalOptions,
         config.skipValidation
       );
@@ -193,20 +194,25 @@ export class CliManagerFactory {
    */
   private registerClaudeTool(): void {
     const claudeManagerFactory: ManagerFactoryFunction = (
-      sessionManager: unknown,
+      sessionManager: SessionManager | null,
       logger?: Logger,
       configManager?: ConfigManager,
-      additionalOptions?: unknown
+      additionalOptions?: JsonObject
     ) => {
-      // Extract Claude-specific options
-      const options = additionalOptions as Record<string, unknown> | undefined;
-      const permissionIpcPath = options?.permissionIpcPath || null;
+      let permissionIpcPath: string | null = null;
+      if (additionalOptions?.permissionIpcPath !== undefined) {
+        permissionIpcPath = decodeBoundary(additionalOptions.permissionIpcPath, boundary.string);
+      }
+
+      // SAFETY: A null manager is created only for the availability probe,
+      // which calls no session-dependent operations before disposal.
+      const availabilitySessionManager = sessionManager as SessionManager;
       
       return new ClaudeCodeManager(
-        sessionManager as SessionManager,
+        availabilitySessionManager,
         logger,
         configManager,
-        (typeof permissionIpcPath === 'string' ? permissionIpcPath : null) as string | null
+        permissionIpcPath
       );
     };
 

--- a/main/src/services/cliToolRegistry.ts
+++ b/main/src/services/cliToolRegistry.ts
@@ -3,6 +3,7 @@ import type { Logger } from '../utils/logger';
 import type { ConfigManager } from './configManager';
 import { AbstractCliManager } from './panels/cli/AbstractCliManager';
 import type { SessionManager } from './sessionManager';
+import type { JsonObject } from '../../../shared/validation/boundaryDecoder';
 
 /**
  * Defines the capabilities and features of a CLI tool
@@ -28,6 +29,9 @@ export interface CliToolDefinition {
   
   /** Factory function to create the CLI manager instance */
   managerFactory: CliManagerFactory;
+
+  /** Selection priority assigned at registration. */
+  priority?: number;
 }
 
 /**
@@ -112,7 +116,7 @@ export type CliManagerFactory = (
   sessionManager: SessionManager | null,
   logger?: Logger,
   configManager?: ConfigManager,
-  additionalOptions?: Record<string, unknown>
+  additionalOptions?: JsonObject
 ) => AbstractCliManager;
 
 /**
@@ -146,7 +150,7 @@ export interface ToolAvailabilityResult {
   path?: string;
   
   /** Additional metadata */
-  metadata?: Record<string, unknown>;
+  metadata?: JsonObject;
 }
 
 /**
@@ -303,7 +307,7 @@ export class CliToolRegistry extends EventEmitter {
   public async createManager(
     toolId: string,
     sessionManager: SessionManager,
-    additionalOptions?: Record<string, unknown>,
+    additionalOptions?: JsonObject,
     skipValidation = false
   ): Promise<AbstractCliManager> {
     const tool = this.tools.get(toolId);
@@ -385,8 +389,7 @@ export class CliToolRegistry extends EventEmitter {
     try {
       // Create a temporary manager instance to test availability
       const tempManager = tool.managerFactory(null, this.logger, this.configManager);
-      // Access the protected method via type assertion as a temporary workaround
-      const result = await (tempManager as AbstractCliManager & { getCachedAvailability(): Promise<ToolAvailabilityResult> }).getCachedAvailability();
+      const result = await tempManager.getCachedAvailability();
 
       // Cache the result
       this.availabilityCache.set(toolId, {
@@ -452,8 +455,8 @@ export class CliToolRegistry extends EventEmitter {
    * Get the default CLI tool (first available tool with highest priority)
    */
   public async getDefaultTool(): Promise<CliToolDefinition | null> {
-    const tools = Array.from(this.tools.values()).sort((a, b) => 
-      ((b as CliToolDefinition & { priority?: number }).priority || 0) - ((a as CliToolDefinition & { priority?: number }).priority || 0)
+    const tools = Array.from(this.tools.values()).sort((a, b) =>
+      (b.priority || 0) - (a.priority || 0)
     );
 
     for (const tool of tools) {
@@ -493,35 +496,13 @@ export class CliToolRegistry extends EventEmitter {
    * Validate a tool definition for completeness and consistency
    */
   private validateToolDefinition(definition: CliToolDefinition): void {
-    const required = ['id', 'name', 'description', 'version', 'capabilities', 'config', 'managerFactory'];
-    
-    for (const field of required) {
-      if (!(field in definition) || definition[field as keyof CliToolDefinition] == null) {
-        throw new Error(`CLI tool definition missing required field: ${field}`);
-      }
-    }
-
-    if (typeof definition.managerFactory !== 'function') {
-      throw new Error(`CLI tool definition managerFactory must be a function`);
-    }
-
     if (!definition.config.defaultExecutable) {
       throw new Error(`CLI tool definition must specify a defaultExecutable`);
     }
 
-    // Validate capabilities
     const capabilities = definition.capabilities;
-    if (typeof capabilities !== 'object') {
-      throw new Error(`CLI tool capabilities must be an object`);
-    }
-
-    // Validate output formats
-    if (!Array.isArray(capabilities.outputFormats)) {
-      throw new Error(`CLI tool capabilities.outputFormats must be an array`);
-    }
-
     for (const format of capabilities.outputFormats) {
-      if (!format.id || !format.name || typeof format.isStructured !== 'boolean') {
+      if (!format.id || !format.name) {
         throw new Error(`Invalid output format definition: ${JSON.stringify(format)}`);
       }
     }

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -4,6 +4,8 @@ import {
   createDefaultCloudVmState,
   normalizeCloudVmConfig,
   type CloudVmConfig,
+  type CloudVmState,
+  type VmStatus,
 } from '../../../shared/types/cloud';
 import {
   createDefaultRemoteDaemonConfig,
@@ -11,6 +13,26 @@ import {
 } from '../../../shared/types/remoteDaemon';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import { CloudVmManager } from './cloudVmManager';
+import type { ConfigManager } from './configManager';
+
+interface CloudVmManagerTestAccess {
+  fetchVmStatus(config: CloudVmConfig): Promise<VmStatus>;
+  checkTunnelHealth(port: number): Promise<boolean>;
+  gcpAction(config: CloudVmConfig, action: 'start' | 'stop'): Promise<void>;
+  waitForStatus(config: CloudVmConfig, targetStatus: VmStatus, timeoutMs: number): Promise<CloudVmState>;
+}
+
+function createManager(configManager: ConfigManagerStub): CloudVmManager {
+  // SAFETY: The stub implements the EventEmitter and configuration methods
+  // CloudVmManager reaches in these isolated lifecycle tests.
+  return new CloudVmManager(configManager as ConfigManager);
+}
+
+function managerAccess(manager: CloudVmManager): CloudVmManagerTestAccess {
+  // SAFETY: This interface mirrors only the private lifecycle methods that
+  // these tests intentionally replace with deterministic spies.
+  return manager as CloudVmManagerTestAccess;
+}
 
 class ConfigManagerStub extends EventEmitter {
   constructor(
@@ -124,7 +146,7 @@ describe('CloudVmManager', () => {
   });
 
   it('returns the default hosted workspace state when cloud is not configured', async () => {
-    const manager = new CloudVmManager(new ConfigManagerStub() as never);
+    const manager = createManager(new ConfigManagerStub());
 
     await expect(manager.getState()).resolves.toEqual(createDefaultCloudVmState());
   });
@@ -147,7 +169,7 @@ describe('CloudVmManager', () => {
       lastError: null,
     });
 
-    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+    const manager = createManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       apiToken: 'secret-token',
       serverId: 'pane-user123',
@@ -160,10 +182,10 @@ describe('CloudVmManager', () => {
       linkedRemoteProfileId: 'remote-profile-1',
       preferredAccess: 'daemon',
       allowNoVncFallback: false,
-    }), remoteDaemonConfig) as never);
+    }), remoteDaemonConfig));
 
-    vi.spyOn(manager as never, 'fetchVmStatus').mockResolvedValue('running');
-    vi.spyOn(manager as never, 'checkTunnelHealth').mockResolvedValue(true);
+    vi.spyOn(managerAccess(manager), 'fetchVmStatus').mockResolvedValue('running');
+    vi.spyOn(managerAccess(manager), 'checkTunnelHealth').mockResolvedValue(true);
 
     const state = await manager.getState();
 
@@ -202,15 +224,15 @@ describe('CloudVmManager', () => {
       lastError: null,
     });
 
-    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+    const manager = createManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       serverId: 'pane-user123',
       daemonStatus: 'ready',
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
-    }), remoteDaemonConfig) as never);
+    }), remoteDaemonConfig));
 
-    const fetchVmStatusSpy = vi.spyOn(manager as never, 'fetchVmStatus');
+    const fetchVmStatusSpy = vi.spyOn(managerAccess(manager), 'fetchVmStatus');
 
     const state = await manager.getState();
 
@@ -233,16 +255,16 @@ describe('CloudVmManager', () => {
   });
 
   it('surfaces daemon-backed hosted workspace state when lifecycle fields are incomplete', async () => {
-    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+    const manager = createManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       apiToken: 'stale-token',
       serverId: 'pane-user123',
       daemonStatus: 'ready',
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
-    })) as never);
+    })));
 
-    const fetchVmStatusSpy = vi.spyOn(manager as never, 'fetchVmStatus');
+    const fetchVmStatusSpy = vi.spyOn(managerAccess(manager), 'fetchVmStatus');
 
     const state = await manager.getState();
 
@@ -260,7 +282,7 @@ describe('CloudVmManager', () => {
   });
 
   it('falls back to daemon-backed hosted workspace state when lifecycle status fetch fails', async () => {
-    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+    const manager = createManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       apiToken: 'stale-token',
       serverId: 'pane-user123',
@@ -269,9 +291,9 @@ describe('CloudVmManager', () => {
       daemonStatus: 'ready',
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
-    })) as never);
+    })));
 
-    vi.spyOn(manager as never, 'fetchVmStatus').mockRejectedValue(new Error('401 Unauthorized'));
+    vi.spyOn(managerAccess(manager), 'fetchVmStatus').mockRejectedValue(new Error('401 Unauthorized'));
 
     const state = await manager.getState();
 
@@ -323,9 +345,9 @@ describe('CloudVmManager', () => {
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
     }), remoteDaemonConfig);
-    const manager = new CloudVmManager(configManager as never);
-    vi.spyOn(manager as never, 'fetchVmStatus').mockResolvedValue('running');
-    vi.spyOn(manager as never, 'checkTunnelHealth').mockResolvedValue(true);
+    const manager = createManager(configManager);
+    vi.spyOn(managerAccess(manager), 'fetchVmStatus').mockResolvedValue('running');
+    vi.spyOn(managerAccess(manager), 'checkTunnelHealth').mockResolvedValue(true);
 
     const state = await manager.connectWorkspace();
 
@@ -375,13 +397,13 @@ describe('CloudVmManager', () => {
       lastError: null,
     });
 
-    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+    const manager = createManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       serverId: 'pane-user123',
       daemonStatus: 'ready',
       daemonBaseUrl: 'https://new.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
-    }), remoteDaemonConfig) as never);
+    }), remoteDaemonConfig));
 
     const state = await manager.getState();
 
@@ -405,13 +427,13 @@ describe('CloudVmManager', () => {
       lastError: null,
     });
 
-    const manager = new CloudVmManager(new ConfigManagerStub(normalizeCloudVmConfig({
+    const manager = createManager(new ConfigManagerStub(normalizeCloudVmConfig({
       provider: 'gcp',
       serverId: 'pane-user123',
       daemonStatus: 'ready',
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
-    }), remoteDaemonConfig) as never);
+    }), remoteDaemonConfig));
 
     const state = await manager.getState();
 
@@ -463,9 +485,9 @@ describe('CloudVmManager', () => {
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
     }), remoteDaemonConfig);
-    const manager = new CloudVmManager(configManager as never);
-    vi.spyOn(manager as never, 'fetchVmStatus').mockResolvedValue('running');
-    vi.spyOn(manager as never, 'checkTunnelHealth').mockResolvedValue(true);
+    const manager = createManager(configManager);
+    vi.spyOn(managerAccess(manager), 'fetchVmStatus').mockResolvedValue('running');
+    vi.spyOn(managerAccess(manager), 'checkTunnelHealth').mockResolvedValue(true);
 
     const state = await manager.disconnectWorkspace();
 
@@ -520,11 +542,11 @@ describe('CloudVmManager', () => {
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
     }), remoteDaemonConfig);
-    const manager = new CloudVmManager(configManager as never);
-    vi.spyOn(manager as never, 'fetchVmStatus').mockResolvedValue('running');
-    vi.spyOn(manager as never, 'checkTunnelHealth').mockResolvedValue(true);
-    vi.spyOn(manager as never, 'gcpAction').mockResolvedValue(undefined);
-    vi.spyOn(manager as never, 'waitForStatus').mockResolvedValue({
+    const manager = createManager(configManager);
+    vi.spyOn(managerAccess(manager), 'fetchVmStatus').mockResolvedValue('running');
+    vi.spyOn(managerAccess(manager), 'checkTunnelHealth').mockResolvedValue(true);
+    vi.spyOn(managerAccess(manager), 'gcpAction').mockResolvedValue(undefined);
+    vi.spyOn(managerAccess(manager), 'waitForStatus').mockResolvedValue({
       ...createDefaultCloudVmState(),
       status: 'off',
     });
@@ -571,8 +593,8 @@ describe('CloudVmManager', () => {
       daemonBaseUrl: 'https://pane.example.com/daemon/',
       linkedRemoteProfileId: 'remote-profile-1',
     }), remoteDaemonConfig);
-    const manager = new CloudVmManager(configManager as never);
-    const gcpAction = vi.spyOn(manager as never, 'gcpAction').mockResolvedValue(undefined);
+    const manager = createManager(configManager);
+    const gcpAction = vi.spyOn(managerAccess(manager), 'gcpAction').mockResolvedValue(undefined);
 
     await expect(manager.stopVm()).rejects.toThrow('config write failed');
 

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -12,6 +12,7 @@ import os from 'os';
 import { randomUUID } from 'crypto';
 import { getAppDirectory } from '../utils/appDirectory';
 import { clearShellPathCache } from '../utils/shellPath';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const DEFAULT_POSTHOG_API_KEY = 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1';
 const LEGACY_POSTHOG_HOST = 'https://us.i.posthog.com';
@@ -128,10 +129,15 @@ export class ConfigManager extends EventEmitter {
       // Migrate legacy notification fields from older config files.
       // notifyWhenBackgrounded -> enabled (if enabled is not explicitly set)
       // notifyWhenViewingOtherPanel is dropped silently.
-      const incomingNotifications = loadedConfig.notifications as (
-        Partial<{ playSound: boolean; enabled: boolean }> &
-        { notifyWhenBackgrounded?: boolean; notifyWhenViewingOtherPanel?: boolean }
-      ) | undefined;
+      const incomingNotifications = decodeBoundary(
+        loadedConfig.notifications,
+        boundary.optional(boundary.object({
+          playSound: boundary.optional(boundary.boolean),
+          enabled: boundary.optional(boundary.boolean),
+          notifyWhenBackgrounded: boundary.optional(boundary.boolean),
+          notifyWhenViewingOtherPanel: boundary.optional(boundary.boolean),
+        })),
+      );
       const migratedNotifications = incomingNotifications
         ? {
             playSound: incomingNotifications.playSound ?? this.config.notifications!.playSound,
@@ -183,7 +189,15 @@ export class ConfigManager extends EventEmitter {
         await this.saveConfig();
       }
     } catch (error: unknown) {
-      const isNotFound = error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+      let errorCode: string | undefined;
+      try {
+        errorCode = decodeBoundary(error, boundary.object({
+          code: boundary.optional(boundary.string),
+        })).code;
+      } catch {
+        errorCode = undefined;
+      }
+      const isNotFound = errorCode === 'ENOENT';
       if (isNotFound) {
         // Config file doesn't exist — create with defaults
         await this.saveConfig();

--- a/main/src/services/gitFileWatcher.ts
+++ b/main/src/services/gitFileWatcher.ts
@@ -5,6 +5,7 @@ import type { Stats } from 'fs';
 // node:fs recursive watcher — aliased so it doesn't collide with chokidar's
 // imported `watch`/`FSWatcher`. Used for the darwin/win32 native path.
 import { watch as fsWatch, type FSWatcher as NodeFsWatcher, type WatchEventType } from 'node:fs';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 import { spawn, type ChildProcess } from 'child_process';
 import { execSync } from '../utils/commandExecutor';
 import type { CommandRunner } from '../utils/commandRunner';
@@ -150,14 +151,16 @@ export class GitFileWatcher extends EventEmitter {
           // polling it would be a silent no-op loop, so log and give up (the
           // pre-native behavior). Everything else (EMFILE/ENOSPC-style handle
           // exhaustion) degrades to polling before any record exists.
-          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          const normalizedError = err instanceof Error ? err : new Error(String(err));
+          const code = decodeBoundary(err, boundary.object({ code: boundary.optional(boundary.string) })).code;
+          if (code === 'ENOENT') {
             this.logger?.error(
               `[GitFileWatcher] Failed to start watching session ${sessionId} (worktree missing):`,
-              err as Error,
+              normalizedError,
             );
             return;
           }
-          this.transitionToPolling(sessionId, worktreePath, err as Error);
+          this.transitionToPolling(sessionId, worktreePath, normalizedError);
           return;
         }
         nativeWatcher.on('error', (err) => this.handleWatcherFailure(sessionId, err));
@@ -230,17 +233,18 @@ export class GitFileWatcher extends EventEmitter {
         // via ErrnoException cast (the no-any-compliant route). Only the
         // handle-exhaustion errors degrade to polling — other chokidar errors
         // stay log-only to avoid over-eager fallback on transient stat blips.
-        const code = (err as NodeJS.ErrnoException).code;
+        const code = decodeBoundary(err, boundary.object({ code: boundary.optional(boundary.string) })).code;
+        const normalizedError = err instanceof Error ? err : new Error(String(err));
         if (code === 'EMFILE' || code === 'ENOSPC') {
-          this.logger?.error(`[GitFileWatcher] worktree watcher error`, err as Error);
-          this.handleWatcherFailure(sessionId, err);
+          this.logger?.error(`[GitFileWatcher] worktree watcher error`, normalizedError);
+          this.handleWatcherFailure(sessionId, normalizedError);
           return;
         }
         // log-only errors are rate-limited to the first per session — repeated
         // transient blips must not turn into a sustained logger/IPC storm
         if (!session.nonFatalErrorLogged) {
           session.nonFatalErrorLogged = true;
-          this.logger?.error(`[GitFileWatcher] worktree watcher error`, err as Error);
+          this.logger?.error(`[GitFileWatcher] worktree watcher error`, normalizedError);
         }
       });
 
@@ -269,7 +273,7 @@ export class GitFileWatcher extends EventEmitter {
     } catch (error) {
       this.logger?.error(
         `[GitFileWatcher] Failed to start watching session ${sessionId}:`,
-        error as Error
+        error instanceof Error ? error : new Error(String(error))
       );
     }
   }
@@ -467,7 +471,7 @@ export class GitFileWatcher extends EventEmitter {
         this.logger?.info(`[GitFileWatcher] Session ${sessionId} no refresh needed`);
       }
     } catch (error) {
-      this.logger?.error(`[GitFileWatcher] Error checking session ${sessionId}:`, error as Error);
+      this.logger?.error(`[GitFileWatcher] Error checking session ${sessionId}:`, error instanceof Error ? error : new Error(String(error)));
       // On error, emit refresh to be safe
       this.emit('needs-refresh', sessionId);
     }
@@ -478,7 +482,7 @@ export class GitFileWatcher extends EventEmitter {
     if (this.commandRunner) {
       return this.commandRunner.exec(command, cwd, { silent: true });
     }
-    return execSync(command, { cwd, encoding: 'utf8', silent: true }) as string;
+    return execSync(command, { cwd, encoding: 'utf8', silent: true });
   }
 
   /**
@@ -591,13 +595,13 @@ export class GitFileWatcher extends EventEmitter {
    * EMFILE error events collapse to a single degrade. Reads worktreePath from
    * the session record and normalizes non-Error values.
    */
-  private handleWatcherFailure(sessionId: string, err: unknown): void {
+  private handleWatcherFailure(sessionId: string, err: Error): void {
     const session = this.watchedSessions.get(sessionId);
     if (!session || session.mode === 'polling') return; // already degraded (or torn down); swallow the storm
     this.transitionToPolling(
       sessionId,
       session.worktreePath,
-      err instanceof Error ? err : new Error(String(err)),
+      err,
     );
   }
 
@@ -702,7 +706,7 @@ export class GitFileWatcher extends EventEmitter {
       // today; do NOT route to handleWatcherFailure or a stat blip on
       // refs/heads would needlessly degrade a healthy session to polling
       gitWatcher.on('error', (err) => {
-        this.logger?.error(`[GitFileWatcher] .git watcher error`, err as Error);
+        this.logger?.error(`[GitFileWatcher] .git watcher error`, err instanceof Error ? err : new Error(String(err)));
       });
       return gitWatcher;
     } catch (gitDirErr) {
@@ -710,7 +714,7 @@ export class GitFileWatcher extends EventEmitter {
         `[GitFileWatcher] Failed to resolve gitdir for ${sessionId}, ` +
           `narrow .git watcher disabled (metadata-only operations will ` +
           `not trigger refresh until worktree watcher fires):`,
-        gitDirErr as Error,
+        gitDirErr instanceof Error ? gitDirErr : new Error(String(gitDirErr)),
       );
       return undefined;
     }
@@ -760,7 +764,7 @@ export class GitFileWatcher extends EventEmitter {
       return false;
     } catch (error) {
       // If any command fails unexpectedly, assume refresh is needed
-      this.logger?.warn(`[GitFileWatcher] Unexpected refresh check failure for ${worktreePath}; scheduling refresh`, error as Error);
+      this.logger?.warn(`[GitFileWatcher] Unexpected refresh check failure for ${worktreePath}; scheduling refresh`, error instanceof Error ? error : new Error(String(error)));
       return true;
     }
   }

--- a/main/src/services/gitStatusManager.ts
+++ b/main/src/services/gitStatusManager.ts
@@ -10,6 +10,15 @@ import { GitStatusLogger } from './gitStatusLogger';
 import { GitFileWatcher } from './gitFileWatcher';
 import { fastCheckWorkingDirectory, fastGetAheadBehind, fastGetDiffStats } from './gitPlumbingCommands';
 import { escapeShellArg } from '../utils/shellEscape';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+
+const githubPrListSchema = boundary.array(boundary.object({
+  number: boundary.optional(boundary.number),
+  url: boundary.optional(boundary.string),
+  title: boundary.optional(boundary.string),
+  state: boundary.optional(boundary.string),
+  body: boundary.optional(boundary.string),
+}));
 
 interface GitStatusCache {
   [sessionId: string]: {
@@ -114,7 +123,7 @@ export class GitStatusManager extends EventEmitter {
         this.logger?.info(`[GitStatus] Hydrated ${cachedStatuses.length} cached git statuses`);
       }
     } catch (error) {
-      this.logger?.error('[GitStatus] Failed to hydrate persisted git status cache:', error as Error);
+      this.logger?.error('[GitStatus] Failed to hydrate persisted git status cache:', error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -122,7 +131,7 @@ export class GitStatusManager extends EventEmitter {
     try {
       this.databaseService?.saveSessionGitStatusCache(sessionId, status, lastChecked);
     } catch (error) {
-      this.logger?.error(`[GitStatus] Failed to persist status cache for ${sessionId}:`, error as Error);
+      this.logger?.error(`[GitStatus] Failed to persist status cache for ${sessionId}:`, error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -168,7 +177,7 @@ export class GitStatusManager extends EventEmitter {
         this.logger?.info(`[GitStatus] Started file watching for session ${sessionId}`);
       }
     } catch (error) {
-      this.logger?.error(`[GitStatus] Failed to start file watching for session ${sessionId}:`, error as Error);
+      this.logger?.error(`[GitStatus] Failed to start file watching for session ${sessionId}:`, error instanceof Error ? error : new Error(String(error)));
     }
   }
   
@@ -288,7 +297,7 @@ export class GitStatusManager extends EventEmitter {
         })
       ));
     } catch (error) {
-      this.logger?.error(`[GitStatus] Failed to refresh git status for project ${projectId}:`, error as Error);
+      this.logger?.error(`[GitStatus] Failed to refresh git status for project ${projectId}:`, error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -339,7 +348,7 @@ export class GitStatusManager extends EventEmitter {
       
       this.logger?.info(`[GitStatus] Updated all sessions in project ${projectId} after main branch update`);
     } catch (error) {
-      this.logger?.error(`[GitStatus] Error updating project statuses after main update:`, error as Error);
+      this.logger?.error(`[GitStatus] Error updating project statuses after main update:`, error instanceof Error ? error : new Error(String(error)));
       // Fall back to refreshing all
       await this.refreshGitStatusForProject(projectId);
     }
@@ -423,7 +432,7 @@ export class GitStatusManager extends EventEmitter {
       
       this.logger?.info(`[GitStatus] Updated status after ${rebaseType} rebase for session ${sessionId}`);
     } catch (error) {
-      this.logger?.error(`[GitStatus] Error updating status after rebase for session ${sessionId}:`, error as Error);
+      this.logger?.error(`[GitStatus] Error updating status after rebase for session ${sessionId}:`, error instanceof Error ? error : new Error(String(error)));
       // Fall back to full refresh on error
       await this.refreshSessionGitStatus(sessionId, false);
     }
@@ -552,7 +561,7 @@ export class GitStatusManager extends EventEmitter {
               }
             }
           } catch (error) {
-            this.logger?.error(`[GitStatus] Error fetching status for session ${sessionId}:`, error as Error);
+            this.logger?.error(`[GitStatus] Error fetching status for session ${sessionId}:`, error instanceof Error ? error : new Error(String(error)));
           }
         })
       );
@@ -600,7 +609,7 @@ export class GitStatusManager extends EventEmitter {
         projectPath,
         { timeout: 5000 }
       );
-      const prs = JSON.parse(result.stdout.trim() || '[]') as Array<{ number?: number; url?: string; title?: string; state?: string; body?: string }>;
+      const prs = decodeBoundary(JSON.parse(result.stdout.trim() || '[]'), githubPrListSchema);
       const pr = prs[0];
       const entry = {
         prNumber: pr?.number,
@@ -777,7 +786,7 @@ export class GitStatusManager extends EventEmitter {
       
       this.gitLogger.logPollComplete(successCount, errorCount);
     } catch (error) {
-      this.logger?.error('[GitStatus] Critical error during refresh:', error as Error);
+      this.logger?.error('[GitStatus] Critical error during refresh:', error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -1010,7 +1019,7 @@ export class GitStatusManager extends EventEmitter {
         return null;
       }
       
-      this.gitLogger.logSessionError(sessionId, error as Error);
+      this.gitLogger.logSessionError(sessionId, error instanceof Error ? error : new Error(String(error)));
       return {
         state: 'unknown',
         lastChecked: new Date().toISOString()
@@ -1111,7 +1120,7 @@ export class GitStatusManager extends EventEmitter {
     try {
       this.databaseService?.deleteSessionGitStatusCache(sessionId);
     } catch (error) {
-      this.logger?.error(`[GitStatus] Failed to delete persisted status cache for ${sessionId}:`, error as Error);
+      this.logger?.error(`[GitStatus] Failed to delete persisted status cache for ${sessionId}:`, error instanceof Error ? error : new Error(String(error)));
     }
 
     // L3: stop the file watcher for this session. No-op for
@@ -1129,7 +1138,7 @@ export class GitStatusManager extends EventEmitter {
     try {
       this.databaseService?.clearSessionGitStatusCache();
     } catch (error) {
-      this.logger?.error('[GitStatus] Failed to clear persisted status cache:', error as Error);
+      this.logger?.error('[GitStatus] Failed to clear persisted status cache:', error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -1204,7 +1213,7 @@ export class GitStatusManager extends EventEmitter {
         const nextOp = this.operationQueue.shift();
         if (nextOp) {
           nextOp().catch(error => {
-            this.logger?.error('[GitStatus] Queued operation failed:', error as Error);
+            this.logger?.error('[GitStatus] Queued operation failed:', error instanceof Error ? error : new Error(String(error)));
           });
         }
       }

--- a/main/src/services/mcpPermissionBridge.ts
+++ b/main/src/services/mcpPermissionBridge.ts
@@ -14,6 +14,8 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import type { PermissionResponse } from './permissionManager';
+import type { PanePermissionInput } from '../../../shared/types/daemon';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const sessionId = process.argv[2];
 const ipcPath = process.argv[3];
@@ -60,7 +62,7 @@ function connectToMainProcess() {
   });
 }
 
-async function requestPermission(toolName: string, input: Record<string, unknown>): Promise<PermissionResponse> {
+async function requestPermission(toolName: string, input: PanePermissionInput): Promise<PermissionResponse> {
   return new Promise((resolve, reject) => {
     const requestId = `${Date.now()}-${Math.random()}`;
     
@@ -126,7 +128,10 @@ async function main() {
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     if (request.params.name === 'approve_permission') {
-      const { tool_name, input } = request.params.arguments as { tool_name: string; input: Record<string, unknown> };
+      const { tool_name, input } = decodeBoundary(request.params.arguments, boundary.object({
+        tool_name: boundary.string,
+        input: boundary.jsonObject,
+      }));
       
       try {
         const response = await requestPermission(tool_name, input);

--- a/main/src/services/paneChatManager.ts
+++ b/main/src/services/paneChatManager.ts
@@ -23,8 +23,8 @@ const PANE_CHAT_TITLE = 'Pane Chat';
 const PANE_CHAT_BOOTSTRAP_VERSION = 9;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function isValidUuid(value: unknown): value is string {
-  return typeof value === 'string' && UUID_PATTERN.test(value);
+function isValidUuid(value: string | undefined): value is string {
+  return value !== undefined && UUID_PATTERN.test(value);
 }
 
 export class PaneChatManager {
@@ -138,6 +138,7 @@ export class PaneChatManager {
   }
 
   private async updatePanelLaunchState(panel: ToolPanel, agent: PaneChatAgent, guidePath: string): Promise<void> {
+    // SAFETY: Pane Chat owns this terminal panel and writes its custom state exclusively as TerminalPanelState.
     const previousCustomState = panel.state.customState as TerminalPanelState | undefined;
     const shouldRefreshBootstrap = this.needsBootstrapRefresh(previousCustomState);
     const shouldResetClaudeLaunch = agent === 'claude' && (
@@ -214,6 +215,7 @@ export class PaneChatManager {
   }
 
   private needsLaunchStateRepair(panel: ToolPanel, agent: PaneChatAgent): boolean {
+    // SAFETY: Pane Chat owns this terminal panel and writes its custom state exclusively as TerminalPanelState.
     const customState = panel.state.customState as TerminalPanelState | undefined;
     return this.needsBootstrapRefresh(customState) || (agent === 'claude' && (
       !isValidUuid(customState?.agentSessionId) ||
@@ -232,6 +234,7 @@ export class PaneChatManager {
   }
 
   private resolvePanelAgent(panel: ToolPanel): PaneChatAgent | undefined {
+    // SAFETY: Pane Chat owns this terminal panel and writes its custom state exclusively as TerminalPanelState.
     const customState = panel.state.customState as TerminalPanelState | undefined;
     return isCliAgentType(customState?.agentType) ? customState?.agentType : undefined;
   }

--- a/main/src/services/panelManager.ts
+++ b/main/src/services/panelManager.ts
@@ -5,6 +5,24 @@ import { databaseService } from './database';
 import { panelEventBus } from './panelEventBus';
 import { withLock } from '../utils/mutex';
 import type { AnalyticsManager } from './analyticsManager';
+import type { PaneEventArgument } from '../core/eventSink';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+
+type PersistedPanelValue = ToolPanelState | ToolPanelMetadata | string;
+
+function serializedPanelValue(value: PersistedPanelValue): string | null {
+  try {
+    return decodeBoundary(value, boundary.string);
+  } catch {
+    return null;
+  }
+}
+
+function logsPanelState(panel: ToolPanel): LogsPanelState {
+  // SAFETY: Callers first discriminate `panel.type === 'logs'`; this state is
+  // created and persisted by the logs manager as LogsPanelState.
+  return panel.state.customState as LogsPanelState;
+}
 
 class PanelManager {
   private panels = new Map<string, ToolPanel>();
@@ -21,7 +39,7 @@ class PanelManager {
     this.analyticsManager = analyticsManager;
   }
 
-  private sendRendererEvent(channel: string, ...args: unknown[]): void {
+  private sendRendererEvent(channel: string, ...args: PaneEventArgument[]): void {
     getPaneEventSink().send(channel, ...args);
   }
 
@@ -41,7 +59,7 @@ class PanelManager {
     // Clean up any stale running states in logs panels
     allPanels.forEach(panel => {
       if (panel.type === 'logs' && panel.state?.customState) {
-        const logsState = panel.state.customState as LogsPanelState;
+        const logsState = logsPanelState(panel);
         if (logsState.isRunning) {
           // Reset the running state since processes don't survive app restarts
           logsState.isRunning = false;
@@ -76,9 +94,9 @@ class PanelManager {
       
       // Create initial state
       // Handle both formats: { customState: {...} } and direct panel state {...}
-      const providedState = request.initialState as Record<string, unknown> | undefined;
+      const providedState = request.initialState;
       const customState = (providedState && 'customState' in providedState)
-        ? providedState.customState as Record<string, unknown>
+        ? decodeBoundary(providedState.customState, boundary.jsonObject)
         : providedState ?? {};
 
       const state: ToolPanelState = {
@@ -350,17 +368,19 @@ class PanelManager {
     const panel = databaseService.getPanel(panelId);
     if (panel) {
       // Fix any panels that have state stored as a string (defensive programming)
-      if (typeof panel.state === 'string') {
+      const serializedState = serializedPanelValue(panel.state);
+      if (serializedState !== null) {
         try {
-          panel.state = JSON.parse(panel.state);
+          panel.state = JSON.parse(serializedState);
         } catch (e) {
           console.error(`[PanelManager] Failed to parse panel state for ${panel.id}:`, e);
           panel.state = { isActive: false, hasBeenViewed: false, customState: {} };
         }
       }
-      if (typeof panel.metadata === 'string') {
+      const serializedMetadata = serializedPanelValue(panel.metadata);
+      if (serializedMetadata !== null) {
         try {
-          panel.metadata = JSON.parse(panel.metadata);
+          panel.metadata = JSON.parse(serializedMetadata);
         } catch (e) {
           console.error(`[PanelManager] Failed to parse panel metadata for ${panel.id}:`, e);
           panel.metadata = { createdAt: new Date().toISOString(), lastActiveAt: new Date().toISOString(), position: 0 };
@@ -389,17 +409,19 @@ class PanelManager {
 
     // Fix any panels that have state stored as a string (defensive programming)
     panels.forEach(panel => {
-      if (typeof panel.state === 'string') {
+      const serializedState = serializedPanelValue(panel.state);
+      if (serializedState !== null) {
         try {
-          panel.state = JSON.parse(panel.state);
+          panel.state = JSON.parse(serializedState);
         } catch (e) {
           console.error(`[PanelManager] Failed to parse panel state for ${panel.id}:`, e);
           panel.state = { isActive: false, hasBeenViewed: false, customState: {} };
         }
       }
-      if (typeof panel.metadata === 'string') {
+      const serializedMetadata = serializedPanelValue(panel.metadata);
+      if (serializedMetadata !== null) {
         try {
-          panel.metadata = JSON.parse(panel.metadata);
+          panel.metadata = JSON.parse(serializedMetadata);
         } catch (e) {
           console.error(`[PanelManager] Failed to parse panel metadata for ${panel.id}:`, e);
           panel.metadata = { createdAt: new Date().toISOString(), lastActiveAt: new Date().toISOString(), position: 0 };
@@ -419,7 +441,7 @@ class PanelManager {
     return panels.filter(p => p.type === type);
   }
   
-  async emitPanelEvent(panelId: string, eventType: PanelEventType, data: unknown): Promise<void> {
+  async emitPanelEvent(panelId: string, eventType: PanelEventType, data: PaneEventArgument): Promise<void> {
     const panel = this.getPanel(panelId);
     if (!panel) {
       console.warn(`[PanelManager] Panel ${panelId} not found for event emission`);

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -15,6 +15,12 @@ import { AbstractCliManager } from '../cli/AbstractCliManager';
 import { withLock } from '../../../utils/mutex';
 import { getAppDirectory } from '../../../utils/appDirectory';
 import { escapeForBash } from '../../../utils/wslUtils';
+import { boundary, decodeBoundary, type JsonObject } from '../../../../../shared/validation/boundaryDecoder';
+
+function getPanelManagerModule(): typeof import('../../panelManager') {
+  // SAFETY: CommonJS require returns the statically typed local panelManager module.
+  return require('../../panelManager') as typeof import('../../panelManager');
+}
 
 // Extend global object for MCP configuration storage  
 interface GlobalMcpStorage {
@@ -203,7 +209,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
       let finalPrompt = prompt;
 
       // Add system prompts for new sessions
-      const systemPromptAppend = this.buildSystemPromptAppend(dbSession ? { ...dbSession, project_id: dbSession.project_id } : { id: sessionId });
+      const systemPromptAppend = this.buildSystemPromptAppend({ project_id: dbSession?.project_id });
       if (systemPromptAppend) {
         finalPrompt = `${finalPrompt}\n\n${systemPromptAppend}`;
       }
@@ -575,10 +581,13 @@ export class ClaudeCodeManager extends AbstractCliManager {
   protected override isSpawnInProgress(panelId: string): boolean {
     // Use synchronous cache-hit path; panelManager.getPanel is sync.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { panelManager } = require('../../panelManager') as typeof import('../../panelManager');
+    const { panelManager } = getPanelManagerModule();
     const panel = panelManager.getPanel(panelId);
     if (!panel) return false;
-    const cs = (panel.state.customState || {}) as { isCliReady?: boolean; isCliPanel?: boolean };
+    const cs = decodeBoundary(panel.state.customState ?? {}, boundary.object({
+      isCliReady: boundary.optional(boundary.boolean),
+      isCliPanel: boundary.optional(boundary.boolean),
+    }));
     // Only consider "in progress" if this is a CLI panel but the CLI has not
     // reported ready yet. Non-CLI callers shouldn't hit this (Claude entries
     // are always CLI) but guard anyway.
@@ -593,8 +602,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
    * original prompt meaningfully after a mid-spawn crash.
    */
   protected override isNonInteractiveSpawn(options: import('../cli/AbstractCliManager').CliSpawnOptions): boolean {
-    const opts = options as ClaudeSpawnOptions;
-    return opts.isInteractive !== true;
+    return options.isInteractive !== true;
   }
 
   // Implementation of abstract methods from AbstractCliManager
@@ -629,7 +637,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
         let finalPrompt = prompt;
 
         // Add system prompts for new sessions
-        const systemPromptAppend = this.buildSystemPromptAppend(dbSession ? { ...dbSession, project_id: dbSession.project_id } : { id: sessionId });
+        const systemPromptAppend = this.buildSystemPromptAppend({ project_id: dbSession?.project_id });
         if (systemPromptAppend) {
           finalPrompt = `${finalPrompt}\n\n${systemPromptAppend}`;
         }
@@ -677,7 +685,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
 
       // Check if we should skip --resume flag this time (after prompt compaction)
       const skipContinueRaw = dbSession?.skip_continue_next;
-      const shouldSkipContinue = skipContinueRaw === true || (typeof skipContinueRaw === 'number' && skipContinueRaw === 1);
+      const shouldSkipContinue = skipContinueRaw === true;
 
       // Check if interactive mode is enabled
       const config = this.configManager?.getConfig();
@@ -794,8 +802,8 @@ export class ClaudeCodeManager extends AbstractCliManager {
    * When running in a worktree, Claude doesn't see MCP servers from the base project
    * because it uses the worktree path as the project key.
    */
-  private getBaseProjectMcpServers(sessionId: string): { mcpServers: Record<string, unknown>; mcpJsonPath?: string } {
-    const result: { mcpServers: Record<string, unknown>; mcpJsonPath?: string } = { mcpServers: {} };
+  private getBaseProjectMcpServers(sessionId: string): { mcpServers: JsonObject; mcpJsonPath?: string } {
+    const result: { mcpServers: JsonObject; mcpJsonPath?: string } = { mcpServers: {} };
 
     try {
       // Get the session to find the project
@@ -823,7 +831,9 @@ export class ClaudeCodeManager extends AbstractCliManager {
         // Also parse it to merge with other servers
         try {
           const mcpJsonContent = fs.readFileSync(mcpJsonFsPath, 'utf8');
-          const mcpJson = JSON.parse(mcpJsonContent) as { mcpServers?: Record<string, unknown> };
+          const mcpJson = decodeBoundary(JSON.parse(mcpJsonContent), boundary.object({
+            mcpServers: boundary.optional(boundary.jsonObject),
+          }));
           if (mcpJson.mcpServers) {
             Object.assign(result.mcpServers, mcpJson.mcpServers);
           }
@@ -837,13 +847,17 @@ export class ClaudeCodeManager extends AbstractCliManager {
       if (fs.existsSync(claudeConfigPath)) {
         try {
           const claudeConfig = fs.readFileSync(claudeConfigPath, 'utf8');
-          const config = JSON.parse(claudeConfig) as {
-            projects?: Record<string, { mcpServers?: Record<string, unknown> }>;
-            mcpServers?: Record<string, unknown>;
-          };
+          const config = decodeBoundary(JSON.parse(claudeConfig), boundary.object({
+            projects: boundary.optional(boundary.jsonObject),
+            mcpServers: boundary.optional(boundary.jsonObject),
+          }));
 
           // Get project-specific MCP servers
-          const projectConfig = config.projects?.[baseProjectPath];
+          const projectConfig = config.projects?.[baseProjectPath]
+            ? decodeBoundary(config.projects[baseProjectPath], boundary.object({
+              mcpServers: boundary.optional(boundary.jsonObject),
+            }))
+            : undefined;
           if (projectConfig?.mcpServers && Object.keys(projectConfig.mcpServers).length > 0) {
             this.logger?.verbose(`[MCP] Found ${Object.keys(projectConfig.mcpServers).length} project-specific MCP servers in ~/.claude.json`);
             Object.assign(result.mcpServers, projectConfig.mcpServers);
@@ -876,7 +890,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
     return result;
   }
 
-  private buildSystemPromptAppend(dbSession: { project_id?: number | null; [key: string]: unknown }): string | undefined {
+  private buildSystemPromptAppend(dbSession: { project_id?: number | null }): string | undefined {
     const systemPromptParts: string[] = [];
 
     // Add global system prompt first
@@ -1026,7 +1040,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
 
     // Start with base project MCP servers
     const baseProjectMcp = this.getBaseProjectMcpServers(sessionId);
-    const mcpConfig: { mcpServers: Record<string, unknown> } = {
+    const mcpConfig: { mcpServers: JsonObject } = {
       "mcpServers": {
         // Include base project MCP servers first
         ...baseProjectMcp.mcpServers,
@@ -1061,9 +1075,8 @@ export class ClaudeCodeManager extends AbstractCliManager {
     try {
       const testCmd = `"${nodePath}" "${mcpBridgePath}" --version`;
       execSync(testCmd, { encoding: 'utf8', timeout: 2000 });
-    } catch (testError: unknown) {
-      const error = testError as { code?: string; message?: string };
-      if (error.code === 'EACCES' || (error.message && error.message.includes('EACCES'))) {
+    } catch (testError) {
+      if (String(testError).includes('EACCES')) {
         this.logger?.error(`[MCP] Permission denied executing MCP bridge script`);
         throw new Error('MCP bridge script is not executable');
       }

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -685,7 +685,11 @@ export class ClaudeCodeManager extends AbstractCliManager {
 
       // Check if we should skip --resume flag this time (after prompt compaction)
       const skipContinueRaw = dbSession?.skip_continue_next;
-      const shouldSkipContinue = skipContinueRaw === true;
+      const skipContinue = decodeBoundary(
+        skipContinueRaw ?? false,
+        boundary.union(boundary.boolean, boundary.literal(0), boundary.literal(1)),
+      );
+      const shouldSkipContinue = skipContinue === true || skipContinue === 1;
 
       // Check if interactive mode is enabled
       const config = this.configManager?.getConfig();

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import * as pty from '@lydell/node-pty';
 import * as path from 'path';
 import * as os from 'os';
+import { boundary, decodeBoundary, type JsonObject, type JsonValue } from '../../../../../shared/validation/boundaryDecoder';
 import { execSync, exec } from 'child_process';
 import { promisify } from 'util';
 import type { Logger } from '../../../utils/logger';
@@ -65,7 +66,13 @@ export interface CliSpawnOptions {
   worktreePath: string;
   prompt: string;
   isResume?: boolean;
-  [key: string]: unknown; // Allow CLI-specific options
+  [key: string]: JsonValue | undefined; // Allow CLI-specific serializable options
+}
+
+const nodeFallbackTools = new Set<string>();
+
+class PtyHostUnavailableError extends Error {
+  readonly code = 'OTHER';
 }
 
 interface CliOutputEvent {
@@ -250,7 +257,7 @@ export abstract class AbstractCliManager extends EventEmitter {
       this.setupProcessHandlers(ptyProcess, panelId, sessionId);
 
       // Emit spawned event
-      this.emit('spawned', { panelId, sessionId } as CliSpawnedEvent);
+      this.emit('spawned', { panelId, sessionId });
 
       this.logger?.info(`${this.getCliToolName()} spawned successfully for panel ${panelId} (session ${sessionId})`);
     } catch (error) {
@@ -261,7 +268,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         panelId: options.panelId,
         sessionId: options.sessionId,
         error: errorMessage
-      } as CliErrorEvent);
+      });
       throw error;
     }
   }
@@ -324,7 +331,7 @@ export abstract class AbstractCliManager extends EventEmitter {
           type: 'stdout',
           data: message,
           timestamp: new Date()
-        } as CliOutputEvent);
+        });
       }
 
       if (!success) {
@@ -400,7 +407,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         this.logger?.info(`[${this.getCliToolName()}] Sent Ctrl+C to panel ${panelId} (session ${cliProcess.sessionId})`);
         count++;
       } catch (error) {
-        this.logger?.warn(`[${this.getCliToolName()}] Failed to send Ctrl+C to panel ${panelId}:`, error as Error);
+        this.logger?.warn(`[${this.getCliToolName()}] Failed to send Ctrl+C to panel ${panelId}:`, error instanceof Error ? error : new Error(String(error)));
       }
     }
     this.logger?.info(`[${this.getCliToolName()}] Gracefully signaled ${count} processes`);
@@ -526,7 +533,10 @@ export abstract class AbstractCliManager extends EventEmitter {
           const panel = await panelManager.getPanel(panelId);
           if (panel) {
             const currentState = panel.state || {};
-            const customState = (currentState.customState as Record<string, unknown>) || {};
+            let customState: JsonObject = {};
+            try {
+              customState = decodeBoundary(currentState.customState ?? {}, boundary.jsonObject);
+            } catch { /* Replace malformed persisted state with a clean object. */ }
             
             // Only update if we don't already have a session ID
             const toolSessionKey = `${this.getCliToolName().toLowerCase()}SessionId`;
@@ -552,7 +562,7 @@ export abstract class AbstractCliManager extends EventEmitter {
   /**
    * Get cached availability result or perform fresh check
    */
-  protected async getCachedAvailability(): Promise<{ available: boolean; error?: string; version?: string; path?: string }> {
+  async getCachedAvailability(): Promise<{ available: boolean; error?: string; version?: string; path?: string }> {
     if (this.availabilityCache &&
         (Date.now() - this.availabilityCache.timestamp) < this.CACHE_TTL) {
       this.logger?.verbose(`Using cached ${this.getCliToolName()} availability check`);
@@ -595,7 +605,7 @@ export abstract class AbstractCliManager extends EventEmitter {
       type: 'json',
       data: errorMessage,
       timestamp: new Date()
-    } as CliOutputEvent);
+    });
 
     // Add dedicated error output
     this.sessionManager.addSessionError(
@@ -644,10 +654,10 @@ export abstract class AbstractCliManager extends EventEmitter {
     const pathWithNode = nodeDir + pathSeparator + shellPath;
 
     return {
-      ...process.env,
+      ...Object.fromEntries(Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)),
       ...getGitAttributionEnv(this.configManager?.getConfig()),
       PATH: pathWithNode
-    } as { [key: string]: string };
+    };
   }
 
 
@@ -686,7 +696,7 @@ export abstract class AbstractCliManager extends EventEmitter {
     // 2. Even if we could execute them, they use relative paths that break when cwd differs
     if (os.platform() === 'win32') {
       this.logger?.verbose(`[${this.getCliToolName()}] Windows detected, using Node.js fallback proactively`);
-      (global as typeof global & Record<string, boolean>)[needsNodeFallbackKey] = true;
+      nodeFallbackTools.add(needsNodeFallbackKey);
     }
 
     // Try normal spawn first, then fallback to Node.js invocation if it fails
@@ -702,7 +712,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         const supervisor = getPtyHostRuntime();
         const useHost = (this.configManager?.getUsePtyHost() ?? false) && supervisor !== null;
 
-        if (spawnAttempt === 0 && !(global as typeof global & Record<string, boolean>)[needsNodeFallbackKey]) {
+        if (spawnAttempt === 0 && !nodeFallbackTools.has(needsNodeFallbackKey)) {
           // First attempt: normal spawn
           ptyProcess = useHost
             ? await this.spawnViaHost(command, args, cwd, env, 80, 30)
@@ -766,7 +776,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         lastError = spawnError;
         spawnAttempt++;
 
-        if (spawnAttempt === 1 && !(global as typeof global & Record<string, boolean>)[needsNodeFallbackKey]) {
+        if (spawnAttempt === 1 && !nodeFallbackTools.has(needsNodeFallbackKey)) {
           const errorMsg = spawnError instanceof Error ? spawnError.message : String(spawnError);
           this.logger?.error(`First ${this.getCliToolName()} spawn attempt failed: ${errorMsg}`);
 
@@ -780,7 +790,7 @@ export abstract class AbstractCliManager extends EventEmitter {
               errorMsg.includes('error code: 193') ||
               errorMsg.includes('not a valid Win32 application')) {
             this.logger?.verbose(`Error suggests shebang issue or Windows executable format error, will try Node.js fallback`);
-            (global as typeof global & Record<string, boolean>)[needsNodeFallbackKey] = true;
+            nodeFallbackTools.add(needsNodeFallbackKey);
             continue;
           }
         }
@@ -821,9 +831,7 @@ export abstract class AbstractCliManager extends EventEmitter {
     if (!supervisor) {
       // Guard: caller must have checked already; if we got here without one,
       // surface a classifier-agnostic OTHER to avoid accidental fallback.
-      const err = new Error('ptyHost supervisor not available') as Error & { code?: string };
-      err.code = 'OTHER';
-      throw err;
+      throw new PtyHostUnavailableError('ptyHost supervisor not available');
     }
 
     const { ptyId, pid } = await supervisor.spawn({
@@ -840,9 +848,7 @@ export abstract class AbstractCliManager extends EventEmitter {
     if (!handle) {
       // This shouldn't happen: supervisor.spawn() registers the handle before
       // resolving. If it does, treat as OTHER so the fallback path doesn't fire.
-      const err = new Error(`ptyHost returned ptyId ${ptyId} but no handle`) as Error & { code?: string };
-      err.code = 'OTHER';
-      throw err;
+      throw new PtyHostUnavailableError(`ptyHost returned ptyId ${ptyId} but no handle`);
     }
 
     return this.wrapPtyHandle(handle, pid);
@@ -858,12 +864,14 @@ export abstract class AbstractCliManager extends EventEmitter {
     return {
       pid,
       write(data: string | Buffer): Promise<void> {
-        return handle.write(typeof data === 'string' ? data : data.toString('utf8'));
+        return handle.write(Buffer.isBuffer(data) ? data.toString('utf8') : data);
       },
       resize(columns: number, rowsValue: number): Promise<void> {
         return handle.resize(columns, rowsValue);
       },
       kill(signal?: string): Promise<void> {
+        // SAFETY: PtyLike callers use Node signal names; this adapter merely
+        // narrows the legacy string signature for the typed ptyHost handle.
         return handle.kill(signal as NodeJS.Signals | undefined);
       },
       pause(): Promise<void> {
@@ -944,7 +952,7 @@ export abstract class AbstractCliManager extends EventEmitter {
           type: 'stderr',
           data: `\n[${this.getCliToolName()}] ptyHost restarted mid-spawn; non-interactive prompt lost. Start a new message to continue.\n`,
           timestamp: new Date()
-        } as CliOutputEvent);
+        });
         return { panelId, skipped: 'non-interactive' as const };
       }
 
@@ -1041,7 +1049,7 @@ export abstract class AbstractCliManager extends EventEmitter {
             type: 'stdout',
             data: message,
             timestamp: new Date()
-          } as CliOutputEvent);
+          });
         }
       }
 
@@ -1066,7 +1074,7 @@ export abstract class AbstractCliManager extends EventEmitter {
           type: 'stderr',
           data: crashMessage,
           timestamp: new Date()
-        } as CliOutputEvent);
+        });
       }
 
       if (exitCode !== 0) {
@@ -1092,7 +1100,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         sessionId,
         exitCode,
         signal: signal ?? null
-      } as CliExitEvent);
+      });
       this.processes.delete(panelId);
     });
   }
@@ -1129,7 +1137,7 @@ export abstract class AbstractCliManager extends EventEmitter {
       type: 'json',
       data: errorMessage,
       timestamp: new Date()
-    } as CliOutputEvent);
+    });
   }
 
   /**
@@ -1153,7 +1161,7 @@ export abstract class AbstractCliManager extends EventEmitter {
       type: 'json',
       data: errorMessage,
       timestamp: new Date()
-    } as CliOutputEvent);
+    });
   }
 
   // Process management utilities
@@ -1196,7 +1204,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         }
       }
     } catch (error) {
-      this.logger?.warn(`Error getting descendant PIDs for ${parentPid}:`, error as Error);
+      this.logger?.warn(`Error getting descendant PIDs for ${parentPid}:`, error instanceof Error ? error : new Error(String(error)));
     }
 
     return [...new Set(descendants)];
@@ -1256,7 +1264,7 @@ export abstract class AbstractCliManager extends EventEmitter {
           await this.execAsync(`taskkill /F /T /PID ${pid}`);
           this.logger?.verbose(`[${this.getCliToolName()}] Successfully killed Windows process tree ${pid}`);
         } catch (error) {
-          this.logger?.warn(`[${this.getCliToolName()}] Error killing Windows process tree: ${error as Error}`);
+          this.logger?.warn(`[${this.getCliToolName()}] Error killing Windows process tree: ${error instanceof Error ? error : new Error(String(error))}`);
           for (const childPid of descendantPids) {
             try {
               await this.execAsync(`taskkill /F /PID ${childPid}`);
@@ -1270,7 +1278,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         try {
           process.kill(pid, 'SIGTERM');
         } catch (error) {
-          this.logger?.warn(`[${this.getCliToolName()}] SIGTERM failed:`, error as Error);
+          this.logger?.warn(`[${this.getCliToolName()}] SIGTERM failed:`, error instanceof Error ? error : new Error(String(error)));
         }
 
         // Kill the entire process group
@@ -1331,10 +1339,10 @@ export abstract class AbstractCliManager extends EventEmitter {
           type: 'stderr',
           data: `\n[WARNING] Failed to terminate ${remainingPids.length} child process${remainingPids.length > 1 ? 'es' : ''}: ${processReport}\nPlease manually kill these processes.\n`,
           timestamp: new Date()
-        } as CliOutputEvent);
+        });
       }
     } catch (error) {
-      this.logger?.error(`[${this.getCliToolName()}] Error in killProcessTree:`, error as Error);
+      this.logger?.error(`[${this.getCliToolName()}] Error in killProcessTree:`, error instanceof Error ? error : new Error(String(error)));
       success = false;
     }
 

--- a/main/src/services/panels/logPanel/logsManager.ts
+++ b/main/src/services/panels/logPanel/logsManager.ts
@@ -6,7 +6,14 @@ import { panelManager } from '../../panelManager';
 import { addSessionLog, cleanupSessionLogs } from '../../../ipc/logs';
 import { getShellPath } from '../../../utils/shellPath';
 import type { AnalyticsManager } from '../../analyticsManager';
+import type { PaneEventArgument } from '../../../core/eventSink';
 import { WSLContext, buildWSLENV } from '../../../utils/wslUtils';
+
+function getLogsPanelState(panel: ToolPanel): LogsPanelState {
+  // SAFETY: This manager only creates and receives panels with type `logs`,
+  // whose custom state is owned here and always initialized as LogsPanelState.
+  return panel.state.customState as LogsPanelState;
+}
 
 class LogsManager {
   private static instance: LogsManager;
@@ -28,7 +35,7 @@ class LogsManager {
     this.analyticsManager = analyticsManager;
   }
 
-  private sendRendererEvent(channel: string, ...args: unknown[]): void {
+  private sendRendererEvent(channel: string, ...args: PaneEventArgument[]): void {
     getPaneEventSink().send(channel, ...args);
   }
 
@@ -84,7 +91,7 @@ class LogsManager {
           errorCount: 0,
           warningCount: 0,
           lastActivityTime: undefined
-        } as LogsPanelState
+        }
       }
     });
   }
@@ -122,7 +129,7 @@ class LogsManager {
           errorCount: 0,
           warningCount: 0,
           lastActivityTime: startTime
-        } as LogsPanelState
+        }
       }
     });
 
@@ -189,9 +196,9 @@ class LogsManager {
         state: {
           ...panel.state,
           customState: {
-            ...(panel.state.customState as LogsPanelState),
+            ...getLogsPanelState(panel),
             processId: childProcess.pid
-          } as LogsPanelState
+          }
         }
       });
       
@@ -409,7 +416,7 @@ class LogsManager {
     // Update panel state
     const panel = await panelManager.getPanel(panelId);
     if (panel) {
-      const currentState = panel.state.customState as LogsPanelState || {};
+      const currentState = getLogsPanelState(panel);
       const outputBuffer = currentState.outputBuffer || [];
       outputBuffer.push(content);
       
@@ -438,7 +445,7 @@ class LogsManager {
             errorCount,
             warningCount,
             lastActivityTime: new Date().toISOString()
-          } as LogsPanelState
+          }
         }
       });
     }
@@ -469,7 +476,7 @@ class LogsManager {
     // Update panel state
     const panel = await panelManager.getPanel(panelId);
     if (panel) {
-      const currentState = panel.state.customState as LogsPanelState || {};
+      const currentState = getLogsPanelState(panel);
       await panelManager.updatePanel(panelId, {
         state: {
           ...panel.state,
@@ -478,7 +485,7 @@ class LogsManager {
             isRunning: false,
             endTime: new Date().toISOString(),
             exitCode: code ?? undefined
-          } as LogsPanelState
+          }
         }
       });
     }
@@ -517,7 +524,7 @@ class LogsManager {
     
     if (!logsPanel) return false;
     
-    const state = logsPanel.state.customState as LogsPanelState;
+    const state = getLogsPanelState(logsPanel);
     return state?.isRunning || false;
   }
   

--- a/main/src/services/projectConfigDetector.ts
+++ b/main/src/services/projectConfigDetector.ts
@@ -33,6 +33,7 @@ import { posixJoin } from '../utils/wslUtils';
 import type { CommandRunner } from '../utils/commandRunner';
 import type { ProjectEnvironment } from '../utils/pathResolver';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 // Internal schema interfaces — NOT exported
 interface PaneJsonSchema {
@@ -55,6 +56,26 @@ interface DevcontainerJsonSchema {
   postCreateCommand?: string | string[];
   postStartCommand?: string | string[];
 }
+
+const paneJsonSchema = boundary.object({
+  scripts: boundary.optional(boundary.object({
+    setup: boundary.optional(boundary.string),
+    run: boundary.optional(boundary.string),
+    archive: boundary.optional(boundary.string),
+  })),
+  runScriptMode: boundary.optional(boundary.enumeration('concurrent', 'nonconcurrent')),
+});
+const gitpodYmlSchema = boundary.object({
+  tasks: boundary.optional(boundary.array(boundary.object({
+    init: boundary.optional(boundary.string),
+    command: boundary.optional(boundary.string),
+  }))),
+});
+const commandSchema = boundary.union(boundary.string, boundary.array(boundary.string));
+const devcontainerJsonSchema = boundary.object({
+  postCreateCommand: boundary.optional(commandSchema),
+  postStartCommand: boundary.optional(commandSchema),
+});
 
 function envJoin(environment: ProjectEnvironment, ...segments: string[]): string {
   if (environment === 'wsl') {
@@ -144,9 +165,7 @@ export async function detectProjectConfig(
 }
 
 function parsePaneJson(content: string, source: string): DetectedProjectConfig | null {
-  const raw = JSON.parse(content) as unknown;
-  if (!raw || typeof raw !== 'object') return null;
-  const json = raw as PaneJsonSchema;
+  const json: PaneJsonSchema = decodeBoundary(JSON.parse(content), paneJsonSchema);
   return {
     setup: json.scripts?.setup,
     run: json.scripts?.run,
@@ -161,9 +180,7 @@ function parseConductorJson(content: string, source: string): DetectedProjectCon
 }
 
 function parseGitpodYml(content: string, source: string): DetectedProjectConfig | null {
-  const raw = yaml.load(content) as unknown;
-  if (!raw || typeof raw !== 'object') return null;
-  const doc = raw as GitpodYmlSchema;
+  const doc: GitpodYmlSchema = decodeBoundary(yaml.load(content), gitpodYmlSchema);
   const firstTask = doc.tasks?.[0];
   if (!firstTask) return { source };
   return {
@@ -175,9 +192,7 @@ function parseGitpodYml(content: string, source: string): DetectedProjectConfig 
 
 function parseDevcontainerJson(content: string, source: string): DetectedProjectConfig | null {
   const stripped = stripJsonComments(content);
-  const raw = JSON.parse(stripped) as unknown;
-  if (!raw || typeof raw !== 'object') return null;
-  const json = raw as DevcontainerJsonSchema;
+  const json: DevcontainerJsonSchema = decodeBoundary(JSON.parse(stripped), devcontainerJsonSchema);
   return {
     setup: normalizeCommand(json.postCreateCommand),
     run: normalizeCommand(json.postStartCommand),
@@ -186,9 +201,8 @@ function parseDevcontainerJson(content: string, source: string): DetectedProject
 }
 
 function normalizeCommand(cmd: string | string[] | undefined): string | undefined {
-  if (typeof cmd === 'string') return cmd;
   if (Array.isArray(cmd)) return cmd.join(' && ');
-  return undefined;
+  return cmd;
 }
 
 function stripJsonComments(text: string): string {

--- a/main/src/services/remoteAnalytics.ts
+++ b/main/src/services/remoteAnalytics.ts
@@ -117,9 +117,8 @@ export function getRemoteImportProperties(
   };
 }
 
-export function getRemoteFailureCategory(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  const normalized = message.toLowerCase();
+export function getRemoteFailureCategory(message: string | null | undefined): string {
+  const normalized = (message ?? '').toLowerCase();
   if (normalized.includes('auth') || normalized.includes('token') || normalized.includes('unauthorized')) {
     return 'auth';
   }

--- a/main/src/services/resourceMonitorService.test.ts
+++ b/main/src/services/resourceMonitorService.test.ts
@@ -6,6 +6,7 @@ describe('ResourceMonitorService', () => {
     const service = new ResourceMonitorService();
     service.initialize();
 
+    // SAFETY: The assertion exposes one private pure query solely to verify the no-app initialization path.
     expect((service as { getElectronMetrics(): unknown[] }).getElectronMetrics()).toEqual([]);
   });
 });

--- a/main/src/services/resourceMonitorService.ts
+++ b/main/src/services/resourceMonitorService.ts
@@ -9,6 +9,7 @@ import type {
   SessionResourceInfo,
   ResourceSnapshot,
 } from '../../../shared/types/resourceMonitor';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const execFileAsync = promisify(execFile);
 
@@ -272,16 +273,25 @@ export class ResourceMonitorService extends EventEmitter {
         ['-NoProfile', '-Command', psCmd],
         { encoding: 'utf8', timeout: 10000 }
       );
-      const parsed: unknown = JSON.parse(stdout);
-      const items: WindowsBatchItem[] = Array.isArray(parsed) ? parsed as WindowsBatchItem[] : [parsed as WindowsBatchItem];
+      const itemSchema = boundary.object({
+        Id: boundary.number,
+        Name: boundary.string,
+        CpuSeconds: boundary.number,
+        MemoryMB: boundary.number,
+      });
+      const parsed = JSON.parse(stdout);
+      let items: WindowsBatchItem[];
+      try {
+        items = decodeBoundary(parsed, boundary.array(itemSchema));
+      } catch {
+        items = [decodeBoundary(parsed, itemSchema)];
+      }
       for (const item of items) {
-        if (item && typeof item.Id === 'number') {
-          result.set(item.Id, {
-            name: item.Name || 'unknown',
-            cpuTimeSeconds: item.CpuSeconds || 0,
-            memoryMB: item.MemoryMB || 0,
-          });
-        }
+        result.set(item.Id, {
+          name: item.Name || 'unknown',
+          cpuTimeSeconds: item.CpuSeconds || 0,
+          memoryMB: item.MemoryMB || 0,
+        });
       }
     } catch {
       // PowerShell call failed — return empty results
@@ -356,8 +366,10 @@ export class ResourceMonitorService extends EventEmitter {
 
     // Lazy imports to avoid circular dependency at module load time
     // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // SAFETY: This require targets the statically typed local module and selects its exported singleton.
     const { terminalPanelManager } = require('./terminalPanelManager') as { terminalPanelManager: { getSessionPids(): Map<string, number[]> } };
     // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // SAFETY: This require targets the statically typed local module and selects its exported registry class.
     const { CliToolRegistry } = require('./cliToolRegistry') as { CliToolRegistry: { getInstance(): { getAllManagers(): { getSessionPids(): Map<string, number[]> }[] } } };
 
     // Collect PIDs from all sources: terminal panels + CLI managers (Claude, Codex, etc.)

--- a/main/src/services/runCommandManager.ts
+++ b/main/src/services/runCommandManager.ts
@@ -58,7 +58,7 @@ class RunCommandPtyShim implements pty.IPty {
   resize(columns: number, rows: number): void {
     this.cols = columns;
     this.rows = rows;
-    this.handle.resize(columns, rows).catch((err: unknown) => {
+    this.handle.resize(columns, rows).catch((err) => {
       console.warn('[ptyHost] run-command resize failed', err);
     });
   }
@@ -68,26 +68,28 @@ class RunCommandPtyShim implements pty.IPty {
   }
 
   write(data: string | Buffer): void {
-    const str = typeof data === 'string' ? data : data.toString();
-    this.handle.write(str).catch((err: unknown) => {
+    const str = Buffer.isBuffer(data) ? data.toString() : data;
+    this.handle.write(str).catch((err) => {
       console.warn('[ptyHost] run-command write failed', err);
     });
   }
 
   kill(signal?: string): void {
-    this.handle.kill(signal as NodeJS.Signals | undefined).catch((err: unknown) => {
+    // SAFETY: IPty callers provide Node signal names; the ptyHost handle uses
+    // the narrower NodeJS.Signals contract.
+    this.handle.kill(signal as NodeJS.Signals | undefined).catch((err) => {
       console.warn('[ptyHost] run-command kill failed', err);
     });
   }
 
   pause(): void {
-    this.handle.pause().catch((err: unknown) => {
+    this.handle.pause().catch((err) => {
       console.warn('[ptyHost] run-command pause failed', err);
     });
   }
 
   resume(): void {
-    this.handle.resume().catch((err: unknown) => {
+    this.handle.resume().catch((err) => {
       console.warn('[ptyHost] run-command resume failed', err);
     });
   }
@@ -153,12 +155,12 @@ export class RunCommandManager extends EventEmitter {
             // For Linux, use current PATH to avoid slow shell detection
             const isLinux = process.platform === 'linux';
             const shellPath = isLinux ? (process.env.PATH || '') : getShellPath();
-            const env = {
-              ...process.env,
+            const env: Record<string, string> = {
+              ...Object.fromEntries(Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)),
               ...getGitAttributionEnv(getRuntimeConfigManager().getConfig()),
               WORKTREE_PATH: worktreePath,
               PATH: shellPath
-            } as { [key: string]: string };
+            };
             
             // Log environment details for debugging
             if (j === 0) {
@@ -221,7 +223,7 @@ export class RunCommandManager extends EventEmitter {
               // stays well-formed. `process.env` keys can legally be undefined.
               const envStr: Record<string, string> = {};
               for (const [key, value] of Object.entries(env)) {
-                if (typeof value === 'string') {
+                if (value !== undefined) {
                   envStr[key] = value;
                 }
               }
@@ -319,7 +321,7 @@ export class RunCommandManager extends EventEmitter {
 
           this.logger?.info(`Completed run command successfully: ${command.display_name || command.command}`);
         } catch (error) {
-          this.logger?.error(`Failed to run command: ${command.display_name || command.command}`, error as Error);
+          this.logger?.error(`Failed to run command: ${command.display_name || command.command}`, error instanceof Error ? error : new Error(String(error)));
           this.emit('error', {
             sessionId,
             commandId: command.id,
@@ -334,7 +336,7 @@ export class RunCommandManager extends EventEmitter {
 
       this.logger?.info(`Finished running commands for session ${sessionId}`);
     } catch (error) {
-      this.logger?.error(`Failed to start run commands for session ${sessionId}`, error as Error);
+      this.logger?.error(`Failed to start run commands for session ${sessionId}`, error instanceof Error ? error : new Error(String(error)));
       throw error;
     }
   }
@@ -371,7 +373,7 @@ export class RunCommandManager extends EventEmitter {
           // Process might already be dead
         }
       } catch (error) {
-        this.logger?.error(`Failed to stop run command: ${runProcess.command.display_name || runProcess.command.command}`, error as Error);
+        this.logger?.error(`Failed to stop run command: ${runProcess.command.display_name || runProcess.command.command}`, error instanceof Error ? error : new Error(String(error)));
       }
     }
 
@@ -435,7 +437,7 @@ export class RunCommandManager extends EventEmitter {
         }
       }
     } catch (error) {
-      this.logger?.warn(`Error getting descendant PIDs for ${parentPid}:`, error as Error);
+      this.logger?.warn(`Error getting descendant PIDs for ${parentPid}:`, error instanceof Error ? error : new Error(String(error)));
     }
     
     // Remove duplicates
@@ -486,7 +488,7 @@ export class RunCommandManager extends EventEmitter {
           await execAsync(`taskkill /F /T /PID ${pid}`);
           this.logger?.verbose(`Successfully killed Windows process tree ${pid}`);
         } catch (error) {
-          this.logger?.warn(`Error killing Windows process tree: ${error as Error}`);
+          this.logger?.warn(`Error killing Windows process tree: ${error instanceof Error ? error : new Error(String(error))}`);
           // Fallback: kill descendants individually
           for (const childPid of descendantPids) {
             try {
@@ -502,7 +504,7 @@ export class RunCommandManager extends EventEmitter {
         try {
           process.kill(pid, 'SIGTERM');
         } catch (error) {
-          this.logger?.warn('SIGTERM failed:', error as Error);
+          this.logger?.warn('SIGTERM failed:', error instanceof Error ? error : new Error(String(error)));
         }
         
         // Kill the entire process group using negative PID
@@ -568,7 +570,7 @@ export class RunCommandManager extends EventEmitter {
         });
       }
     } catch (error) {
-      this.logger?.error('Error in killProcessTree:', error as Error);
+      this.logger?.error('Error in killProcessTree:', error instanceof Error ? error : new Error(String(error)));
       success = false;
     }
     
@@ -637,7 +639,7 @@ export class RunCommandManager extends EventEmitter {
         });
       }
     } catch (error) {
-      this.logger?.error('Error killing escaped processes:', error as Error);
+      this.logger?.error('Error killing escaped processes:', error instanceof Error ? error : new Error(String(error)));
     }
   }
 

--- a/main/src/services/scrollbackRetention.ts
+++ b/main/src/services/scrollbackRetention.ts
@@ -1,4 +1,5 @@
 import type { DatabaseService } from '../database/database';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const RETENTION_DAYS = 21;
 
@@ -14,13 +15,13 @@ export class ScrollbackRetentionService {
   runRetentionSweep(): RetentionSweepResult {
     const sqlite = this.db.getDb();
 
-    const targetSessions = sqlite
+    const targetSessions = decodeBoundary(sqlite
       .prepare(
         `SELECT id FROM sessions
          WHERE archived = 1
            AND (last_viewed_at IS NULL OR last_viewed_at < datetime('now', ?))`
       )
-      .all(`-${RETENTION_DAYS} days`) as { id: string }[];
+      .all(`-${RETENTION_DAYS} days`), boundary.array(boundary.object({ id: boundary.string })));
 
     if (targetSessions.length === 0) {
       return { panelsCleared: 0, sessionsTouched: 0, bytesFreed: 0 };
@@ -28,7 +29,7 @@ export class ScrollbackRetentionService {
 
     const idsJson = JSON.stringify(targetSessions.map(s => s.id));
 
-    const sizeRow = sqlite
+    const sizeRow = decodeBoundary(sqlite
       .prepare(
         `SELECT COALESCE(SUM(
            COALESCE(LENGTH(json_extract(state, '$.customState.scrollbackBuffer')), 0) +
@@ -41,7 +42,7 @@ export class ScrollbackRetentionService {
              OR json_extract(state, '$.customState.serializedBuffer') IS NOT NULL
            )`
       )
-      .get(idsJson) as { bytes: number };
+      .get(idsJson), boundary.object({ bytes: boundary.number }));
 
     const result = sqlite
       .prepare(

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -19,6 +19,7 @@ import { formatForDisplay } from '../utils/timestampUtils';
 import { isCliAgentType, resolveAgentTypeFromCommand } from './agents/agentIdentity';
 import { resolveResumeId } from './agents/agentResume';
 import { scriptExecutionTracker } from './scriptExecutionTracker';
+import { boundary, decodeBoundary, type JsonValue } from '../../../shared/validation/boundaryDecoder';
 
 interface CreateSessionOptions {
   detached?: boolean;
@@ -26,34 +27,93 @@ interface CreateSessionOptions {
 }
 
 // Interface for generic JSON message data that can contain various properties
+interface MessageTextBlock { type: string; text?: string }
 interface GenericMessageData {
   type?: string;
   subtype?: string;
   session_id?: string;
   message_id?: string;
-  message?: {
-    content?: unknown;
-    [key: string]: unknown;
-  };
-  data?: Record<string, unknown>;
+  message?: string | { content?: string | MessageTextBlock[] };
+  data?: { status?: string; message?: JsonValue };
   delta?: string;
-  [key: string]: unknown;
 }
 
-// Helper function to check if data is a JSON message object with specific properties
-function isJSONMessage(data: Record<string, unknown>, requiredType?: string, requiredSubtype?: string): data is GenericMessageData {
-  if (typeof data.type !== 'string') return false;
-  if (requiredType && data.type !== requiredType) return false;
-  if (requiredSubtype && typeof data.subtype !== 'string') return false;
-  if (requiredSubtype && data.subtype !== requiredSubtype) return false;
-  return true;
+const genericMessageSchema = boundary.object({
+  type: boundary.optional(boundary.string),
+  subtype: boundary.optional(boundary.string),
+  session_id: boundary.optional(boundary.string),
+  message_id: boundary.optional(boundary.string),
+  message: boundary.optional(boundary.union(
+    boundary.string,
+    boundary.object({
+      content: boundary.optional(boundary.union(
+        boundary.string,
+        boundary.array(boundary.object({
+          type: boundary.string,
+          text: boundary.optional(boundary.string),
+        })),
+      )),
+    }),
+  )),
+  data: boundary.optional(boundary.object({
+    status: boundary.optional(boundary.string),
+    message: boundary.optional(boundary.json),
+  })),
+  delta: boundary.optional(boundary.string),
+});
+
+function parseGenericMessage(output: Omit<SessionOutput, 'sessionId'>): GenericMessageData | undefined {
+  if (output.type !== 'json') return undefined;
+  try {
+    return decodeBoundary(output.data, genericMessageSchema);
+  } catch {
+    return undefined;
+  }
 }
+
+function getMessageContent(message: GenericMessageData['message']): string | MessageTextBlock[] | undefined {
+  if (message === undefined) return undefined;
+  try {
+    return decodeBoundary(message, boundary.object({
+      content: boundary.optional(boundary.union(
+        boundary.string,
+        boundary.array(boundary.object({ type: boundary.string, text: boundary.optional(boundary.string) })),
+      )),
+    })).content;
+  } catch {
+    return undefined;
+  }
+}
+
+const terminalResumeStateSchema = boundary.object({
+  wasInterrupted: boundary.optional(boundary.boolean),
+  initialCommand: boundary.optional(boundary.string),
+  agentType: boundary.optional(boundary.enumeration('claude', 'codex', 'cursor')),
+  agentSessionId: boundary.optional(boundary.string),
+  hasClaudeSessionId: boundary.optional(boundary.boolean),
+});
+
+function parseTerminalResumeState(value: ToolPanelState['customState']): {
+  wasInterrupted?: boolean;
+  initialCommand?: string;
+  agentType?: 'claude' | 'codex' | 'cursor';
+  agentSessionId?: string;
+  hasClaudeSessionId?: boolean;
+} | undefined {
+  try {
+    return decodeBoundary(value, terminalResumeStateSchema);
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeDbOutputType(type: DbSessionOutputType): SessionOutput['type'] {
+  return type === 'system' ? 'stdout' : type;
+}
+
+type DbSessionOutputType = import('../database/models').SessionOutput['type'];
 
 // Interface for panel state with custom state that can hold any AI-specific data
-interface PanelStateWithCustomData extends ToolPanelState {
-  customState?: Record<string, unknown>;
-  [key: string]: unknown;
-}
 import { addSessionLog, cleanupSessionLogs } from '../ipc/logs';
 import { PathResolver } from '../utils/pathResolver';
 import { CommandRunner } from '../utils/commandRunner';
@@ -153,7 +213,7 @@ export class SessionManager extends EventEmitter {
   getPanelAgentSessionId(panelId: string): string | undefined {
     try {
       const panel = this.db.getPanel(panelId);
-      const customState = panel?.state?.customState as BaseAIPanelState | undefined;
+      const customState = parseTerminalResumeState(panel?.state?.customState);
       return customState?.agentSessionId;
     } catch (e) {
       return undefined;
@@ -226,7 +286,7 @@ export class SessionManager extends EventEmitter {
   }
 
   private convertDbSessionToSession(dbSession: DbSession): Session {
-    const toolTypeFromDb = (dbSession as DbSession & { tool_type?: string }).tool_type as 'claude' | 'none' | null | undefined;
+    const toolTypeFromDb = dbSession.tool_type;
     const normalizedToolType: 'claude' | 'none' = toolTypeFromDb === 'none'
         ? 'none'
         : 'claude';
@@ -602,6 +662,8 @@ export class SessionManager extends EventEmitter {
 
 
   addSessionOutput(id: string, output: Omit<SessionOutput, 'sessionId'>): void {
+    const message = parseGenericMessage(output);
+    const messageContent = getMessageContent(message?.message);
     // Check if this is the first output for this session
     const existingOutputs = this.db.getSessionOutputs(id, 1);
     const isFirstOutput = existingOutputs.length === 0;
@@ -622,21 +684,21 @@ export class SessionManager extends EventEmitter {
     this.emit('session-output-available', { sessionId: id });
     
     // Check if this is the initial system message with Claude's session ID
-    if (output.type === 'json' && isJSONMessage(output.data as Record<string, unknown>, 'system', 'init') && (output.data as GenericMessageData).session_id) {
+    if (message?.type === 'system' && message.subtype === 'init' && message.session_id) {
       // Store Claude's actual session ID
-      this.db.updateSession(id, { claude_session_id: (output.data as GenericMessageData).session_id });
+      this.db.updateSession(id, { claude_session_id: message.session_id });
     }
     
     // Check if this is a system result message — update the completion timestamp for the most recent prompt
-    if (output.type === 'json' && isJSONMessage(output.data as Record<string, unknown>, 'system', 'result')) {
+    if (message?.type === 'system' && message.subtype === 'result') {
       const completionTimestamp = output.timestamp instanceof Date ? output.timestamp.toISOString() : output.timestamp;
       this.db.updatePromptMarkerCompletion(id, completionTimestamp);
     }
     
     // Check if this is a user message in JSON format to track prompts
-    if (output.type === 'json' && (output.data as GenericMessageData).type === 'user' && (output.data as GenericMessageData).message?.content) {
+    if (message?.type === 'user' && messageContent) {
       // Extract text content from user messages
-      const content = (output.data as GenericMessageData).message?.content;
+      const content = messageContent;
       let promptText = '';
       
       if (Array.isArray(content)) {
@@ -645,7 +707,7 @@ export class SessionManager extends EventEmitter {
         if (textContent?.text) {
           promptText = textContent.text;
         }
-      } else if (typeof content === 'string') {
+      } else {
         promptText = content;
       }
       
@@ -659,9 +721,9 @@ export class SessionManager extends EventEmitter {
     }
     
     // Check if this is an assistant message to track for conversation history
-    if (output.type === 'json' && (output.data as GenericMessageData).type === 'assistant' && (output.data as GenericMessageData).message?.content) {
+    if (message?.type === 'assistant' && messageContent) {
       // Extract text content from assistant messages
-      const content = (output.data as GenericMessageData).message?.content;
+      const content = messageContent;
       let assistantText = '';
       
       if (Array.isArray(content)) {
@@ -670,7 +732,7 @@ export class SessionManager extends EventEmitter {
           .filter((item: { type: string; text?: string }) => item.type === 'text')
           .map((item: { type: string; text?: string }) => item.text || '')
           .join('\n');
-      } else if (typeof content === 'string') {
+      } else {
         assistantText = content;
       }
       
@@ -707,7 +769,7 @@ export class SessionManager extends EventEmitter {
     const dbOutputs = this.db.getSessionOutputs(id, limit);
     return dbOutputs.map(dbOutput => ({
       sessionId: dbOutput.session_id,
-      type: dbOutput.type as 'stdout' | 'stderr' | 'json' | 'error',
+      type: normalizeDbOutputType(dbOutput.type),
       data: (dbOutput.type === 'json' || dbOutput.type === 'error') ? JSON.parse(dbOutput.data) : dbOutput.data,
       timestamp: new Date(dbOutput.timestamp)
     }));
@@ -718,7 +780,7 @@ export class SessionManager extends EventEmitter {
     return dbOutputs.map(dbOutput => ({
       sessionId: dbOutput.session_id,
       panelId: dbOutput.panel_id,
-      type: dbOutput.type as 'stdout' | 'stderr' | 'json' | 'error',
+      type: normalizeDbOutputType(dbOutput.type),
       data: (dbOutput.type === 'json' || dbOutput.type === 'error') ? JSON.parse(dbOutput.data) : dbOutput.data,
       timestamp: new Date(dbOutput.timestamp)
     }));
@@ -807,6 +869,8 @@ export class SessionManager extends EventEmitter {
 
   // Panel-based methods for Claude panels (use panel_id instead of session_id)
   addPanelOutput(panelId: string, output: Omit<SessionOutput, 'sessionId'>): void {
+    const message = parseGenericMessage(output);
+    const messageContent = getMessageContent(message?.message);
     const panel = this.db.getPanel(panelId);
 
     if (this.hasAutoContextCapture(panelId)) {
@@ -828,15 +892,14 @@ export class SessionManager extends EventEmitter {
     
     const dataToStore = (output.type === 'json' || output.type === 'error') 
       ? JSON.stringify(output.data) 
-      : output.data as string;
+      : String(output.data);
     
     this.db.addPanelOutput(panelId, output.type, dataToStore);
 
     // Capture Claude's session ID from init/system messages for proper --resume handling
     try {
-      if (output.type === 'json' && output.data && typeof output.data === 'object') {
-        const data = output.data as GenericMessageData;
-        const sessionIdFromMsg = (data.type === 'system' && data.subtype === 'init' && data.session_id) || data.session_id;
+      if (message) {
+        const sessionIdFromMsg = (message.type === 'system' && message.subtype === 'init' && message.session_id) || message.session_id;
         if (sessionIdFromMsg && panel?.sessionId) {
           this.db.updateSession(panel.sessionId, { claude_session_id: sessionIdFromMsg });
         }
@@ -846,16 +909,16 @@ export class SessionManager extends EventEmitter {
     }
 
     // Check if this is a system result message indicating panel execution has completed
-    if (output.type === 'json' && isJSONMessage(output.data as Record<string, unknown>, 'system', 'result')) {
+    if (message?.type === 'system' && message.subtype === 'result') {
       // Update the completion timestamp for the most recent prompt marker for this panel
       const completionTimestamp = output.timestamp instanceof Date ? output.timestamp.toISOString() : output.timestamp;
       this.db.updatePanelPromptMarkerCompletion(panelId, completionTimestamp);
     }
 
     // Handle assistant conversation message extraction for Claude panels (same logic as sessions)
-    if (output.type === 'json' && (output.data as GenericMessageData).type === 'assistant' && (output.data as GenericMessageData).message?.content) {
+    if (message?.type === 'assistant' && messageContent) {
       // Extract text content from assistant messages
-      const content = (output.data as GenericMessageData).message?.content;
+      const content = messageContent;
       let assistantText = '';
 
       if (Array.isArray(content)) {
@@ -864,7 +927,7 @@ export class SessionManager extends EventEmitter {
           .filter((item: { type: string; text?: string }) => item.type === 'text')
           .map((item: { type: string; text?: string }) => item.text || '')
           .join('\n');
-      } else if (typeof content === 'string') {
+      } else {
         assistantText = content;
       }
 
@@ -876,25 +939,25 @@ export class SessionManager extends EventEmitter {
     }
     
     // Handle session completion message to stop prompt timing
-    if (output.type === 'json' && (output.data as GenericMessageData).type === 'session' && (output.data as GenericMessageData).data?.status === 'completed') {
+    if (message?.type === 'session' && message.data?.status === 'completed') {
       // Add a completion message to trigger panel-response-added event which stops the timer
-      const completionMessage = String((output.data as GenericMessageData).data?.message || 'Session completed');
+      const completionMessage = String(message.data.message || 'Session completed');
       this.addPanelConversationMessage(panelId, 'assistant', completionMessage);
     }
     
     // Handle agent messages (similar to Claude's assistant messages)
-    if (output.type === 'json' && ((output.data as GenericMessageData).type === 'agent_message' || (output.data as GenericMessageData).type === 'agent_message_delta')) {
-      const agentText = String((output.data as GenericMessageData).message || (output.data as GenericMessageData).delta || '');
-      if (agentText && (output.data as GenericMessageData).type === 'agent_message') {
+    if (message?.type === 'agent_message' || message?.type === 'agent_message_delta') {
+      const agentText = String(message.message || message.delta || '');
+      if (agentText && message.type === 'agent_message') {
         // Only add complete messages, not deltas
         this.addPanelConversationMessage(panelId, 'assistant', agentText);
       }
     }
     
     // Handle user conversation message extraction for Claude panels (same logic as sessions)
-    if (output.type === 'json' && (output.data as GenericMessageData).type === 'user' && (output.data as GenericMessageData).message?.content) {
+    if (message?.type === 'user' && messageContent) {
       // Extract text content from user messages
-      const content = (output.data as GenericMessageData).message?.content;
+      const content = messageContent;
       let promptText = '';
       
       if (Array.isArray(content)) {
@@ -903,7 +966,7 @@ export class SessionManager extends EventEmitter {
         if (textContent?.text) {
           promptText = textContent.text;
         }
-      } else if (typeof content === 'string') {
+      } else {
         promptText = content;
       }
       
@@ -922,13 +985,12 @@ export class SessionManager extends EventEmitter {
 
     // Capture Claude session ID per panel for proper --resume usage
     try {
-      if (output.type === 'json' && output.data && typeof output.data === 'object') {
-        const data = output.data as GenericMessageData;
-        const sessionIdFromMsg = (data.type === 'system' && data.subtype === 'init' && data.session_id) || data.session_id;
+      if (message) {
+        const sessionIdFromMsg = (message.type === 'system' && message.subtype === 'init' && message.session_id) || message.session_id;
         if (sessionIdFromMsg) {
           const panel = this.db.getPanel(panelId);
           if (panel) {
-            const currentState = panel.state as PanelStateWithCustomData || {};
+            const currentState = panel.state || {};
             const customState = currentState.customState || {};
             const updatedState = {
               ...currentState,
@@ -950,7 +1012,7 @@ export class SessionManager extends EventEmitter {
     const dbOutputs = this.db.getPanelOutputs(panelId, limit);
     return dbOutputs.map(dbOutput => ({
       sessionId: dbOutput.session_id || '', // For compatibility, though panels use panel_id
-      type: dbOutput.type as 'stdout' | 'stderr' | 'json' | 'error',
+      type: normalizeDbOutputType(dbOutput.type),
       data: (dbOutput.type === 'json' || dbOutput.type === 'error') ? JSON.parse(dbOutput.data) : dbOutput.data,
       // SQLite timestamps are in UTC but stored without timezone indicator
       // Append 'Z' to ensure proper UTC parsing as per project documentation
@@ -1291,9 +1353,16 @@ export class SessionManager extends EventEmitter {
               addSessionLog(sessionId, 'warn', line, 'Archive');
             });
           }
-        } catch (cmdError: unknown) {
+        } catch (cmdError) {
           console.error(`[SessionManager] Archive command failed: ${command}`, cmdError);
-          const error = cmdError as { stderr?: string; stdout?: string; message?: string };
+          let error: { stderr?: string; stdout?: string; message?: string } = {};
+          try {
+            error = decodeBoundary(cmdError, boundary.object({
+              stderr: boundary.optional(boundary.string),
+              stdout: boundary.optional(boundary.string),
+              message: boundary.optional(boundary.string),
+            }));
+          } catch { /* String(cmdError) remains the fallback. */ }
           const errorMessage = error.stderr || error.stdout || error.message || String(cmdError);
           allOutput += errorMessage;
 
@@ -1366,9 +1435,16 @@ export class SessionManager extends EventEmitter {
               addSessionLog(sessionId, 'warn', line, 'Build');
             });
           }
-        } catch (cmdError: unknown) {
+        } catch (cmdError) {
           console.error(`[SessionManager] Build command failed: ${command}`, cmdError);
-          const error = cmdError as { stderr?: string; stdout?: string; message?: string };
+          let error: { stderr?: string; stdout?: string; message?: string } = {};
+          try {
+            error = decodeBoundary(cmdError, boundary.object({
+              stderr: boundary.optional(boundary.string),
+              stdout: boundary.optional(boundary.string),
+              message: boundary.optional(boundary.string),
+            }));
+          } catch { /* String(cmdError) remains the fallback. */ }
           const errorMessage = error.stderr || error.stdout || error.message || String(cmdError);
           allOutput += errorMessage;
           
@@ -1668,7 +1744,8 @@ export class SessionManager extends EventEmitter {
 
   getCurrentRunningSessionId(): string | null {
     // Use shared tracker for consistency
-    return scriptExecutionTracker.getRunningScriptId('session') as string | null;
+    const runningId = scriptExecutionTracker.getRunningScriptId('session');
+    return decodeBoundary(runningId, boundary.nullable(boundary.string));
   }
 
   async cleanup(): Promise<void> {
@@ -1827,7 +1904,7 @@ export class SessionManager extends EventEmitter {
 
       for (const panel of panels) {
         if (panel.type === 'terminal') {
-          const termState = panel.state?.customState as TerminalPanelState | undefined;
+          const termState = parseTerminalResumeState(panel.state?.customState);
           if (termState?.wasInterrupted && termState?.initialCommand) {
             const agentType = termState.agentType ?? resolveAgentTypeFromCommand(termState.initialCommand);
             const resumeId = resolveResumeId(agentType, panel.id, termState);
@@ -1869,11 +1946,11 @@ export class SessionManager extends EventEmitter {
 
       for (const panel of panels) {
         if (panel.type === 'terminal') {
-          const termState = panel.state?.customState as TerminalPanelState | undefined;
+          const termState = parseTerminalResumeState(panel.state?.customState);
 
           if (termState?.wasInterrupted && termState?.initialCommand) {
             const state = panel.state;
-            const customState = (state.customState || {}) as TerminalPanelState;
+            const customState = parseTerminalResumeState(state.customState) ?? {};
             const agentType = customState.agentType ?? resolveAgentTypeFromCommand(customState.initialCommand);
 
             if (!isCliAgentType(agentType)) {

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -1950,7 +1950,7 @@ export class SessionManager extends EventEmitter {
 
           if (termState?.wasInterrupted && termState?.initialCommand) {
             const state = panel.state;
-            const customState = parseTerminalResumeState(state.customState) ?? {};
+            const customState = { ...(state.customState ?? {}), ...termState };
             const agentType = customState.agentType ?? resolveAgentTypeFromCommand(customState.initialCommand);
 
             if (!isCliAgentType(agentType)) {

--- a/main/src/services/simpleTaskQueue.ts
+++ b/main/src/services/simpleTaskQueue.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-interface Job<T, R = unknown> {
+export interface Job<T, R> {
   id: string;
   data: T;
   status: 'pending' | 'active' | 'completed' | 'failed';
@@ -94,7 +94,11 @@ export class SimpleQueue<T, R = unknown> extends EventEmitter {
     }
   }
 
-  on(event: 'active' | 'completed' | 'failed' | 'waiting' | 'error', listener: (...args: unknown[]) => void): this {
+  on(event: 'active' | 'waiting', listener: (job: Job<T, R>) => void): this;
+  on(event: 'completed', listener: (job: Job<T, R>, result: R) => void): this;
+  on(event: 'failed', listener: (job: Job<T, R>, error: Error) => void): this;
+  on(event: 'error', listener: (error: Error) => void): this;
+  on(event: string, listener: Parameters<EventEmitter['on']>[1]): this {
     return super.on(event, listener);
   }
 

--- a/main/src/services/skillCacheManager.test.ts
+++ b/main/src/services/skillCacheManager.test.ts
@@ -10,12 +10,28 @@ function normalizePathSeparators(value: string): string {
   return value.replace(/\\/g, '/');
 }
 
+function mockRequest(emitter: EventEmitter): ReturnType<typeof https.get> {
+  // SAFETY: The download code only consumes EventEmitter request behavior in
+  // these tests; no socket methods are reached.
+  return emitter as ReturnType<typeof https.get>;
+}
+
+function mockResponse(emitter: EventEmitter): IncomingMessageLike {
+  // SAFETY: Tests install statusCode, headers, and resume before delivery.
+  return emitter as IncomingMessageLike;
+}
+
+function managerDownloads(manager: SkillCacheManager): Promise<void> {
+  // SAFETY: This deliberate test seam mirrors the private fallback downloader.
+  return (manager as { downloadFallbackFiles: () => Promise<void> }).downloadFallbackFiles();
+}
+
 function mockRawDownloads(failures = new Set<string>()) {
   return vi.spyOn(https, 'get').mockImplementation((url, callback) => {
-    const request = new EventEmitter() as ReturnType<typeof https.get>;
+    const request = mockRequest(new EventEmitter());
     const pathname = new URL(String(url)).pathname;
     const relativePath = decodeURIComponent(pathname.replace('/dcouple/skills/main/', ''));
-    const response = new EventEmitter() as IncomingMessageLike;
+    const response = mockResponse(new EventEmitter());
 
     response.headers = {};
     response.resume = vi.fn();
@@ -216,7 +232,7 @@ describe('SkillCacheManager Pane Chat guide', () => {
     const httpsGet = mockRawDownloads();
 
     try {
-      await (manager as unknown as { downloadFallbackFiles: () => Promise<void> }).downloadFallbackFiles();
+      await managerDownloads(manager);
       await manager.ensurePaneChatGuide();
     } finally {
       httpsGet.mockRestore();
@@ -250,7 +266,7 @@ describe('SkillCacheManager Pane Chat guide', () => {
 
     try {
       await expect(
-        (manager as unknown as { downloadFallbackFiles: () => Promise<void> }).downloadFallbackFiles(),
+        managerDownloads(manager),
       ).rejects.toThrow(`Required download failures: ${requiredPath}`);
     } finally {
       httpsGet.mockRestore();

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { RUNPANE_CONTRACT } from '../../../shared/types/generatedRunpaneContract';
 import { getAppDirectory } from '../utils/appDirectory';
 import type { Logger } from '../utils/logger';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const execFileAsync = promisify(execFile);
 
@@ -227,7 +228,10 @@ export class SkillCacheManager {
       await execFileAsync('git', ['clone', '--depth', '1', UPSTREAM_REPO_URL, this.sourceRoot], { timeout: 180_000 });
       return true;
     } catch (error) {
-      this.logWarn('Git skill sync unavailable; falling back to raw file download', error);
+      this.logWarn(
+        'Git skill sync unavailable; falling back to raw file download',
+        error instanceof Error ? error : new Error(String(error)),
+      );
       return false;
     }
   }
@@ -261,7 +265,10 @@ export class SkillCacheManager {
         if (REQUIRED_FALLBACK_RAW_FILE_SET.has(relativePath)) {
           requiredDownloadFailures.push(`${relativePath}: ${message}`);
         }
-        this.logWarn(`Failed to download skill cache file ${relativePath}`, error);
+        this.logWarn(
+          `Failed to download skill cache file ${relativePath}`,
+          error instanceof Error ? error : new Error(String(error)),
+        );
       }
     }
 
@@ -801,7 +808,12 @@ step.
   private async readSyncState(): Promise<SkillSyncState> {
     try {
       const raw = await fs.readFile(this.syncStatePath, 'utf8');
-      return JSON.parse(raw) as SkillSyncState;
+      return decodeBoundary(JSON.parse(raw), boundary.object({
+        lastAttemptAt: boundary.optional(boundary.string),
+        lastSuccessAt: boundary.optional(boundary.string),
+        sourceCommit: boundary.optional(boundary.string),
+        lastError: boundary.optional(boundary.string),
+      }));
     } catch {
       return {};
     }
@@ -817,9 +829,8 @@ step.
     await fs.writeFile(filePath, contents, 'utf8');
   }
 
-  private logWarn(message: string, error?: unknown): void {
-    const normalized = error instanceof Error ? error : undefined;
-    this.logger?.warn(`[SkillCache] ${message}`, normalized);
+  private logWarn(message: string, error?: Error): void {
+    this.logger?.warn(`[SkillCache] ${message}`, error);
     if (!this.logger) console.warn(`[SkillCache] ${message}`, error);
   }
 }

--- a/main/src/services/spotlightManager.ts
+++ b/main/src/services/spotlightManager.ts
@@ -178,7 +178,7 @@ export class SpotlightManager extends EventEmitter {
     } catch (error) {
       this.logger?.error(
         `[SpotlightManager] Failed to restore original state for session ${sessionId}:`,
-        error as Error
+        new Error(String(error))
       );
       // Don't throw - we still want to clean up the spotlight state
     }
@@ -228,7 +228,7 @@ export class SpotlightManager extends EventEmitter {
       } catch (error) {
         this.logger?.error(
           `[SpotlightManager] Failed to restore original state for project ${projectId}:`,
-          error as Error
+          new Error(String(error))
         );
         // Continue with other spotlights
       }
@@ -243,7 +243,7 @@ export class SpotlightManager extends EventEmitter {
         unlinkSync(this.SPOTLIGHT_STATE_FILE);
       }
     } catch (error) {
-      this.logger?.error('[SpotlightManager] Failed to delete state file:', error as Error);
+      this.logger?.error('[SpotlightManager] Failed to delete state file:', new Error(String(error)));
     }
 
     this.logger?.info('[SpotlightManager] All spotlights disabled');
@@ -321,7 +321,7 @@ export class SpotlightManager extends EventEmitter {
         return; // Don't set syncInProgress to false yet
       }
 
-      this.logger?.error(`[SpotlightManager] Sync error for project ${projectId}:`, error as Error);
+      this.logger?.error(`[SpotlightManager] Sync error for project ${projectId}:`, new Error(String(error)));
 
       // Send sync error event
       const mainWindow = this.getMainWindow();
@@ -395,7 +395,7 @@ export class SpotlightManager extends EventEmitter {
       writeFileSync(this.SPOTLIGHT_STATE_FILE, JSON.stringify(persisted, null, 2));
       this.logger?.info('[SpotlightManager] State persisted successfully');
     } catch (error) {
-      this.logger?.error('[SpotlightManager] Failed to persist state:', error as Error);
+      this.logger?.error('[SpotlightManager] Failed to persist state:', new Error(String(error)));
     }
   }
 
@@ -408,7 +408,7 @@ export class SpotlightManager extends EventEmitter {
         this.logger?.info('[SpotlightManager] State file loaded successfully');
       }
     } catch (error) {
-      this.logger?.error('[SpotlightManager] Failed to load state file:', error as Error);
+      this.logger?.error('[SpotlightManager] Failed to load state file:', new Error(String(error)));
     }
   }
 
@@ -451,7 +451,7 @@ export class SpotlightManager extends EventEmitter {
         } catch (error) {
           this.logger?.error(
             `[SpotlightManager] Failed to restore spotlight for project ${projectIdStr}:`,
-            error as Error
+            new Error(String(error))
           );
           // Continue with other entries
         }
@@ -459,7 +459,7 @@ export class SpotlightManager extends EventEmitter {
 
       this.logger?.info('[SpotlightManager] Spotlight state restoration complete');
     } catch (error) {
-      this.logger?.error('[SpotlightManager] Failed to restore spotlight state:', error as Error);
+      this.logger?.error('[SpotlightManager] Failed to restore spotlight state:', new Error(String(error)));
     }
   }
 }

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -18,6 +18,7 @@ import { worktreeFileSyncService, type WorktreeFileSyncFailure } from './worktre
 import { terminalPanelManager } from './terminalPanelManager';
 import { detectProjectConfig } from './projectConfigDetector';
 import { emitFolderCreatedEvent } from './folderEvents';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 interface TaskQueueOptions {
   sessionManager: SessionManager;
@@ -41,6 +42,27 @@ interface CreateSessionJob {
   toolType?: 'claude' | 'none';
   startPinned?: boolean;
   activateOnCreate?: boolean;
+}
+
+interface SessionCreationJob {
+  id: string | number;
+  data: CreateSessionJob;
+  status?: string;
+  result?: CreateSessionQueueResult;
+  error?: Error;
+  finished?: () => Promise<CreateSessionQueueResult>;
+}
+
+interface SessionCreationQueue {
+  add(data: CreateSessionJob): Promise<SessionCreationJob>;
+  process(concurrency: number, processor: (job: SessionCreationJob) => Promise<CreateSessionQueueResult>): void;
+  on(event: 'active' | 'waiting', listener: (job: SessionCreationJob) => void): this;
+  on(event: 'completed', listener: (job: SessionCreationJob, result: CreateSessionQueueResult) => void): this;
+  on(event: 'failed', listener: (job: SessionCreationJob, error: Error) => void): this;
+  on(event: 'error', listener: (error: Error) => void): this;
+  removeListener(event: 'completed', listener: (job: SessionCreationJob, result: CreateSessionQueueResult) => void): this;
+  removeListener(event: 'failed', listener: (job: SessionCreationJob, error: Error) => void): this;
+  close(): Promise<void>;
 }
 
 interface ContinueSessionJob {
@@ -73,7 +95,7 @@ export interface CreateSessionQueueResult {
 }
 
 export class TaskQueue {
-  private sessionQueue: Bull.Queue<CreateSessionJob> | SimpleQueue<CreateSessionJob>;
+  private sessionQueue: SessionCreationQueue;
   private inputQueue: Bull.Queue<SendInputJob> | SimpleQueue<SendInputJob>;
   private continueQueue: Bull.Queue<ContinueSessionJob> | SimpleQueue<ContinueSessionJob>;
   private useSimpleQueue: boolean;
@@ -95,7 +117,7 @@ export class TaskQueue {
     if (this.useSimpleQueue) {
       console.log('[TaskQueue] Using SimpleQueue for local in-process queue');
       
-      this.sessionQueue = new SimpleQueue<CreateSessionJob>('session-creation', sessionConcurrency);
+      this.sessionQueue = new SimpleQueue<CreateSessionJob, CreateSessionQueueResult>('session-creation', sessionConcurrency);
       this.inputQueue = new SimpleQueue<SendInputJob>('session-input', 10);
       this.continueQueue = new SimpleQueue<ContinueSessionJob>('session-continue', 10);
     } else {
@@ -129,25 +151,19 @@ export class TaskQueue {
     }
     
     // Add event handlers for debugging
-    this.sessionQueue.on('active', (...args: unknown[]) => {
-      const job = args[0] as { id: string | number };
+    this.sessionQueue.on('active', (job: { id: string | number }) => {
       // Job active tracking removed - verbose debug logging
     });
     
-    this.sessionQueue.on('completed', (...args: unknown[]) => {
-      const job = args[0] as { id: string | number };
-      const result = args[1];
+    this.sessionQueue.on('completed', (job: SessionCreationJob, result: CreateSessionQueueResult) => {
       // Job completion tracking removed - verbose debug logging
     });
     
-    this.sessionQueue.on('failed', (...args: unknown[]) => {
-      const job = args[0] as { id: string | number };
-      const err = args[1] as Error;
+    this.sessionQueue.on('failed', (job: { id: string | number }, err: Error) => {
       console.error(`[TaskQueue] Job ${job.id} failed:`, err);
     });
     
-    this.sessionQueue.on('error', (...args: unknown[]) => {
-      const error = args[0] as Error;
+    this.sessionQueue.on('error', (error: Error) => {
       console.error('[TaskQueue] Queue error:', error);
     });
 
@@ -499,7 +515,7 @@ export class TaskQueue {
     });
   }
 
-  async createSession(data: CreateSessionJob): Promise<Bull.Job<CreateSessionJob> | { id: string; data: CreateSessionJob; status: string }> {
+  async createSession(data: CreateSessionJob): Promise<SessionCreationJob> {
     const job = await this.sessionQueue.add(data);
     return job;
   }
@@ -513,19 +529,18 @@ export class TaskQueue {
   }
 
   private async waitForSessionCreationJob(
-    job: Bull.Job<CreateSessionJob> | { id: string; data: CreateSessionJob; status: string; result?: unknown; error?: Error },
+    job: SessionCreationJob,
     timeoutMs: number,
   ): Promise<CreateSessionQueueResult> {
-    const bullJob = job as Bull.Job<CreateSessionJob> & { finished?: () => Promise<unknown> };
-    if (typeof bullJob.finished === 'function') {
+    if (job.finished) {
       return this.withSessionCreationTimeout(
-        bullJob.finished().then(result => this.parseSessionCreationResult(result, job.id)),
+        job.finished().then(result => this.parseSessionCreationResult(result, job.id)),
         timeoutMs,
         job.id,
       );
     }
 
-    const simpleJob = job as { id: string; status: string; result?: unknown; error?: Error };
+    const simpleJob = job;
     if (simpleJob.status === 'completed') {
       return this.parseSessionCreationResult(simpleJob.result, simpleJob.id);
     }
@@ -535,7 +550,7 @@ export class TaskQueue {
 
     let cleanup: () => void = () => {};
     return this.withSessionCreationTimeout(new Promise<CreateSessionQueueResult>((resolve, reject) => {
-      const handleCompleted = (completedJob: unknown, result: unknown) => {
+      const handleCompleted = (completedJob: SessionCreationJob, result: CreateSessionQueueResult) => {
         const completedJobId = this.getQueueJobId(completedJob);
         if (completedJobId !== String(simpleJob.id)) {
           return;
@@ -548,7 +563,7 @@ export class TaskQueue {
         }
       };
 
-      const handleFailed = (failedJob: unknown, error: unknown) => {
+      const handleFailed = (failedJob: { id: string | number }, error: Error) => {
         const failedJobId = this.getQueueJobId(failedJob);
         if (failedJobId !== String(simpleJob.id)) {
           return;
@@ -567,16 +582,12 @@ export class TaskQueue {
     }), timeoutMs, simpleJob.id, cleanup);
   }
 
-  private parseSessionCreationResult(result: unknown, jobId: string | number): CreateSessionQueueResult {
-    if (
-      typeof result === 'object' &&
-      result !== null &&
-      typeof (result as { sessionId?: unknown }).sessionId === 'string'
-    ) {
-      return { sessionId: (result as { sessionId: string }).sessionId };
+  private parseSessionCreationResult(result: CreateSessionQueueResult | undefined, jobId: string | number): CreateSessionQueueResult {
+    try {
+      return decodeBoundary(result, boundary.object({ sessionId: boundary.string }));
+    } catch {
+      throw new Error(`Session creation job ${jobId} completed without a sessionId`);
     }
-
-    throw new Error(`Session creation job ${jobId} completed without a sessionId`);
   }
 
   private withSessionCreationTimeout<T>(
@@ -600,13 +611,8 @@ export class TaskQueue {
     });
   }
 
-  private getQueueJobId(job: unknown): string | null {
-    if (typeof job !== 'object' || job === null) {
-      return null;
-    }
-
-    const id = (job as { id?: unknown }).id;
-    return typeof id === 'string' || typeof id === 'number' ? String(id) : null;
+  private getQueueJobId(job: { id: string | number }): string {
+    return String(job.id);
   }
 
   async createMultipleSessions(
@@ -620,7 +626,7 @@ export class TaskQueue {
     providedFolderId?: string,
     isMainRepo?: boolean,
     startPinned?: boolean
-  ): Promise<(Bull.Job<CreateSessionJob> | { id: string; data: CreateSessionJob; status: string })[]> {
+  ): Promise<SessionCreationJob[]> {
     let folderId: string | undefined = providedFolderId;
     let generatedBaseName: string | undefined;
     
@@ -638,11 +644,11 @@ export class TaskQueue {
     if (!providedFolderId && count > 1 && projectId) {
       try {
         const { sessionManager } = this.options;
-        const db = sessionManager.db as DatabaseService;
+        const db = sessionManager.db;
         const folderName = worktreeTemplate || generatedBaseName || 'Multi-session prompt';
         
         // Ensure projectId is a number
-        const numericProjectId = typeof projectId === 'string' ? parseInt(projectId, 10) : projectId;
+        const numericProjectId = projectId;
         if (isNaN(numericProjectId)) {
           throw new Error(`Invalid project ID: ${projectId}`);
         }

--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -3,6 +3,7 @@ import type { ConfigManager } from './configManager';
 import { resetPaneRuntimeForTests, setPaneRuntime } from '../core/runtime';
 import { createFlowControlRecord, disposeFlowControlRecord, type FlowControlRecord } from '../ptyHost/flowControl';
 import { TerminalStateEmulator } from './terminalStateEmulator';
+import type { TerminalPanelState } from '../../../shared/types/panels';
 
 vi.mock('@lydell/node-pty', () => ({}));
 
@@ -107,9 +108,9 @@ type InitialInputAccess = {
 };
 
 type LaunchCommandAccess = {
-  resolveCliLaunchCommand(panelId: string, initialCommand: string, customState: Record<string, unknown>, shellType?: string): {
+  resolveCliLaunchCommand(panelId: string, initialCommand: string, customState: TerminalPanelState, shellType?: string): {
     commandToRun: string;
-    customState: Record<string, unknown>;
+    customState: TerminalPanelState;
     isCliCommand: boolean;
   };
 };
@@ -125,6 +126,18 @@ type ShellPromptSchedulerAccess = {
     onData(listener: (data: string) => void): { dispose(): void };
   }, callback: () => void): void;
 };
+
+function testAccess<Access>(manager: TerminalPanelManager): Access {
+  // SAFETY: Each access type above mirrors the exact private members exercised
+  // by its tests; this helper keeps that deliberate test-only seam in one place.
+  return manager as Access;
+}
+
+function partialMock<Contract>(implementation: Partial<Contract>): Contract {
+  // SAFETY: Each test stub implements every ConfigManager member reached by
+  // the scenario; an unexpected call fails immediately instead of escaping.
+  return implementation as Contract;
+}
 
 function createTerminal(overrides: Partial<TerminalUnderTest> = {}): TerminalUnderTest {
   return {
@@ -168,7 +181,7 @@ describe('TerminalPanelManager terminal resize', () => {
 
   it('deduplicates ordinary same-size resizes but holds an actual redraw transition', async () => {
     vi.useFakeTimers();
-    const manager = new TerminalPanelManager() as unknown as ResizeAccess;
+    const manager = testAccess<ResizeAccess>(new TerminalPanelManager());
     const terminal = createTerminal({ outputBuffer: '' });
     manager.terminals.set(terminal.panelId, terminal);
 
@@ -212,7 +225,7 @@ describe('TerminalPanelManager shell prompt scheduling', () => {
 
   it('waits for the shell to settle after detecting its prompt', async () => {
     vi.useFakeTimers();
-    const manager = new TerminalPanelManager() as unknown as ShellPromptSchedulerAccess;
+    const manager = testAccess<ShellPromptSchedulerAccess>(new TerminalPanelManager());
     const promptPty = createPromptPty();
     const callback = vi.fn();
 
@@ -229,7 +242,7 @@ describe('TerminalPanelManager shell prompt scheduling', () => {
 
   it('invokes once when repeated prompts race the fallback', async () => {
     vi.useFakeTimers();
-    const manager = new TerminalPanelManager() as unknown as ShellPromptSchedulerAccess;
+    const manager = testAccess<ShellPromptSchedulerAccess>(new TerminalPanelManager());
     const promptPty = createPromptPty();
     const callback = vi.fn();
 
@@ -244,7 +257,7 @@ describe('TerminalPanelManager shell prompt scheduling', () => {
 
   it('falls back after five seconds when no prompt is detected', async () => {
     vi.useFakeTimers();
-    const manager = new TerminalPanelManager() as unknown as ShellPromptSchedulerAccess;
+    const manager = testAccess<ShellPromptSchedulerAccess>(new TerminalPanelManager());
     const promptPty = createPromptPty();
     const callback = vi.fn();
 
@@ -260,9 +273,9 @@ describe('TerminalPanelManager shell prompt scheduling', () => {
 });
 
 function createConfigManagerStub(): ConfigManager {
-  return {
+  return partialMock<ConfigManager>({
     getUsePtyHost: () => false,
-  } as ConfigManager;
+  });
 }
 
 async function flushPromises(): Promise<void> {
@@ -292,7 +305,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
     const manager = new TerminalPanelManager();
     const terminal = createTerminal();
 
-    (manager as unknown as FlushOutputBufferAccess).flushOutputBuffer(terminal);
+    testAccess<FlushOutputBufferAccess>(manager).flushOutputBuffer(terminal);
 
     expect(combinedSink.send).toHaveBeenCalledWith('terminal:output', {
       sessionId: 'session-1',
@@ -317,7 +330,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
     const manager = new TerminalPanelManager();
     const terminal = createTerminal({ isVisible: false });
 
-    (manager as unknown as FlushOutputBufferAccess).flushOutputBuffer(terminal);
+    testAccess<FlushOutputBufferAccess>(manager).flushOutputBuffer(terminal);
 
     expect(combinedSink.send).not.toHaveBeenCalled();
     expect(daemonSink.send).toHaveBeenCalledWith('terminal:output', {
@@ -339,7 +352,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
       getWebviewContextMap: () => new Map(),
     });
 
-    const manager = new TerminalPanelManager() as unknown as VisibilityAccess;
+    const manager = testAccess<VisibilityAccess>(new TerminalPanelManager());
     const terminal = createTerminal({
       isVisible: false,
       outputBuffer: 'hidden output',
@@ -371,7 +384,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
       getWebviewContextMap: () => new Map(),
     });
 
-    const manager = new TerminalPanelManager() as unknown as VisibilityAccess;
+    const manager = testAccess<VisibilityAccess>(new TerminalPanelManager());
     const terminal = createTerminal({
       isVisible: true,
       outputBuffer: 'visible output',
@@ -403,7 +416,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
       getWebviewContextMap: () => new Map(),
     });
 
-    const manager = new TerminalPanelManager() as unknown as VisibilityAccess;
+    const manager = testAccess<VisibilityAccess>(new TerminalPanelManager());
     const terminal = createTerminal({
       isVisible: false,
       outputBuffer: '',
@@ -423,7 +436,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('clears remote viewer visibility by prefix on disconnect', () => {
-    const manager = new TerminalPanelManager() as unknown as VisibilityAccess;
+    const manager = testAccess<VisibilityAccess>(new TerminalPanelManager());
     const terminal = createTerminal({
       isVisible: false,
       outputBuffer: '',
@@ -443,7 +456,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('returns emulated live screen and restore state for daemon and renderer reads', async () => {
-    const manager = new TerminalPanelManager() as unknown as SnapshotAccess;
+    const manager = testAccess<SnapshotAccess>(new TerminalPanelManager());
     const screenEmulator = new TerminalStateEmulator(40, 5);
     screenEmulator.write('\x1b[?1049h\x1b[Hagent screen');
     await screenEmulator.waitForIdle();
@@ -503,7 +516,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('serves normal-buffer restore content from the rendered emulator, not the raw append log', async () => {
-    const manager = new TerminalPanelManager() as unknown as SnapshotAccess;
+    const manager = testAccess<SnapshotAccess>(new TerminalPanelManager());
     const screenEmulator = new TerminalStateEmulator(40, 5);
     const frame = 'PR #363 state unchanged';
     // Live stream: the frame prints once, then forced-redraw repaints re-emit it
@@ -523,7 +536,9 @@ describe('TerminalPanelManager hidden output delivery', () => {
     manager.terminals.set(terminal.panelId, terminal);
 
     const restoreState = await manager.getTerminalState(terminal.panelId);
-    const restored = restoreState?.scrollbackBuffer as string;
+    const restored = restoreState?.scrollbackBuffer;
+    expect(restored).toBeDefined();
+    if (restored === undefined) throw new Error('Expected restored scrollback');
     expect(restored.split(frame).length - 1).toBe(1);
     expect(terminal.scrollbackBuffer.split(frame).length - 1).toBe(3);
     screenEmulator.dispose();
@@ -532,7 +547,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
 
   it('submits Codex initial input through the composer sequence', async () => {
     vi.useFakeTimers();
-    const manager = new TerminalPanelManager() as unknown as InitialInputAccess;
+    const manager = testAccess<InitialInputAccess>(new TerminalPanelManager());
     const terminal = createTerminal();
     manager.terminals.set(terminal.panelId, terminal);
     const panel = {
@@ -577,7 +592,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('does not treat input writes as output freshness', () => {
-    const manager = new TerminalPanelManager() as unknown as InitialInputAccess & TerminalPanelManager;
+    const manager = testAccess<InitialInputAccess & TerminalPanelManager>(new TerminalPanelManager());
     const terminal = createTerminal();
     manager.terminals.set(terminal.panelId, terminal);
 
@@ -591,7 +606,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
 
   it('delivers pending ready initial input with the panel submit strategy', async () => {
     vi.useFakeTimers();
-    const manager = new TerminalPanelManager() as unknown as InitialInputAccess;
+    const manager = testAccess<InitialInputAccess>(new TerminalPanelManager());
     const terminal = createTerminal();
     manager.terminals.set(terminal.panelId, terminal);
     vi.mocked(panelManager.getPanel).mockReturnValue({
@@ -628,7 +643,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('delivers after a premark clear when the cliReady path already skipped', async () => {
-    const manager = new TerminalPanelManager() as unknown as InitialInputAccess;
+    const manager = testAccess<InitialInputAccess>(new TerminalPanelManager());
     const terminal = createTerminal();
     manager.terminals.set(terminal.panelId, terminal);
     const panel = {
@@ -668,7 +683,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('delivers initial input exactly once when cliReady and explicit triggers race', async () => {
-    const manager = new TerminalPanelManager() as unknown as InitialInputAccess;
+    const manager = testAccess<InitialInputAccess>(new TerminalPanelManager());
     const terminal = createTerminal();
     manager.terminals.set(terminal.panelId, terminal);
     const panel = {
@@ -703,7 +718,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('passes fresh Codex initial input as a startup prompt argument', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand('panel-1', 'codex --yolo', {
       agentType: 'codex',
@@ -725,7 +740,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('escapes shell-sensitive startup prompt arguments without changing ordinary prompts', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
     const unsafeCommandSubstitution = manager.resolveCliLaunchCommand('panel-1', 'codex --yolo', {
       agentType: 'codex',
       initialInputMode: 'argument',
@@ -749,7 +764,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('passes fresh Claude slash input as a quoted startup argument', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand(
       '11111111-1111-4111-8111-111111111111',
@@ -772,7 +787,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('preserves multiline Claude input in the quoted startup argument', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
     const input = 'First line\nSecond line with $value';
 
     const result = manager.resolveCliLaunchCommand(
@@ -792,7 +807,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('keeps resumed Claude input composer-bound', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand(
       '11111111-1111-4111-8111-111111111111',
@@ -813,7 +828,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('launches a fresh Cursor panel through the create-chat compound', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand('panel-1', 'cursor-agent --force --trust', {
       agentType: 'cursor',
@@ -835,7 +850,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('passes fresh Cursor initial input as a startup prompt argument on both compound branches', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand('panel-1', 'cursor-agent --force --trust', {
       agentType: 'cursor',
@@ -854,7 +869,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('uses fish-compatible syntax for a fresh Cursor launch in fish', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand('panel-1', 'cursor-agent --force --trust', {
       agentType: 'cursor',
@@ -869,7 +884,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('resumes an interrupted Cursor panel with its captured chat id', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand('panel-1', 'cursor-agent --force --trust', {
       agentType: 'cursor',
@@ -888,7 +903,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('continues the latest Cursor chat when an interrupted panel has no captured id', () => {
-    const manager = new TerminalPanelManager() as unknown as LaunchCommandAccess;
+    const manager = testAccess<LaunchCommandAccess>(new TerminalPanelManager());
 
     const result = manager.resolveCliLaunchCommand('panel-1', 'cursor-agent --force --trust', {
       agentType: 'cursor',
@@ -905,7 +920,7 @@ describe('TerminalPanelManager hidden output delivery', () => {
   });
 
   it('keeps Enter as the default initial input submit strategy', async () => {
-    const manager = new TerminalPanelManager() as unknown as InitialInputAccess;
+    const manager = testAccess<InitialInputAccess>(new TerminalPanelManager());
     const terminal = createTerminal();
     manager.terminals.set(terminal.panelId, terminal);
     vi.mocked(panelManager.getPanel).mockReturnValue({
@@ -943,7 +958,7 @@ describe('TerminalPanelManager agent session capture', () => {
   });
 
   const mockPanel = (agentType: string, initialCommand: string, panelId = 'panel-1') => {
-    vi.mocked(panelManager.updatePanel).mockResolvedValue(undefined as never);
+    vi.mocked(panelManager.updatePanel).mockResolvedValue(undefined);
     vi.mocked(panelManager.getPanel).mockReturnValue({
       id: panelId,
       sessionId: 'session-1',
@@ -962,7 +977,7 @@ describe('TerminalPanelManager agent session capture', () => {
   };
 
   it('persists the Cursor chat id scraped from the marker line', () => {
-    const manager = new TerminalPanelManager() as unknown as AgentSessionCaptureAccess;
+    const manager = testAccess<AgentSessionCaptureAccess>(new TerminalPanelManager());
     const terminal = createTerminal({ agentType: 'cursor' });
     mockPanel('cursor', 'cursor-agent --force --trust');
 
@@ -978,7 +993,7 @@ describe('TerminalPanelManager agent session capture', () => {
   });
 
   it('still captures Codex resume ids from screen output', () => {
-    const manager = new TerminalPanelManager() as unknown as AgentSessionCaptureAccess;
+    const manager = testAccess<AgentSessionCaptureAccess>(new TerminalPanelManager());
     const terminal = createTerminal({ agentType: 'codex' });
     mockPanel('codex', 'codex --yolo');
 
@@ -994,7 +1009,7 @@ describe('TerminalPanelManager agent session capture', () => {
   });
 
   it('ignores marker lines when the panel is not a cursor panel', () => {
-    const manager = new TerminalPanelManager() as unknown as AgentSessionCaptureAccess;
+    const manager = testAccess<AgentSessionCaptureAccess>(new TerminalPanelManager());
     const terminal = createTerminal({ agentType: 'codex' });
     mockPanel('codex', 'codex --yolo');
 
@@ -1006,7 +1021,7 @@ describe('TerminalPanelManager agent session capture', () => {
   });
 
   it('persists the captured session id for the terminal agent on state save', async () => {
-    const manager = new TerminalPanelManager() as unknown as AgentSessionCaptureAccess;
+    const manager = testAccess<AgentSessionCaptureAccess>(new TerminalPanelManager());
     const terminal = createTerminal({ agentType: 'cursor', capturedAgentSessionId: CURSOR_CHAT_ID });
     manager.terminals.set(terminal.panelId, terminal);
     mockPanel('cursor', 'cursor-agent --force --trust');

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -22,6 +22,7 @@ import { AgentStatusMonitor } from './agentStatus/agentStatusMonitor';
 import { detectAgentState } from './agentStatus/manifestEngine';
 import { getManifestForAgent } from './agentStatus/manifests';
 import type { AgentState, PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
+import type { PaneEventArgument } from '../core/eventSink';
 
 const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI flicker
 const OUTPUT_BATCH_INTERVAL_HIDDEN = 250; // ms — background / hidden cadence to cut IPC wake-up cost
@@ -50,8 +51,14 @@ import { buildCursorLaunchCommand, createCursorReadyDetector, extractCursorChatI
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function isValidUuid(value: unknown): value is string {
-  return typeof value === 'string' && UUID_PATTERN.test(value);
+function isValidUuid(value: string | undefined): value is string {
+  return value !== undefined && UUID_PATTERN.test(value);
+}
+
+function terminalCustomState(state: ToolPanel['state']): TerminalPanelState {
+  // SAFETY: TerminalPanelManager owns terminal panels and persists this exact
+  // custom-state contract; non-terminal panel states never enter these paths.
+  return (state.customState ?? {}) as TerminalPanelState;
 }
 
 export interface TerminalPanelSnapshot {
@@ -128,7 +135,7 @@ class PtyHandleShim implements pty.IPty {
         this.cols = columns;
         this.rows = rows;
       }
-    }).catch((err: unknown) => {
+    }).catch((err) => {
       console.warn('[ptyHost] resize failed', err);
     });
   }
@@ -138,26 +145,28 @@ class PtyHandleShim implements pty.IPty {
   }
 
   write(data: string | Buffer): void {
-    const str = typeof data === 'string' ? data : data.toString();
-    this.handle.write(str).catch((err: unknown) => {
+    const str = Buffer.isBuffer(data) ? data.toString() : data;
+    this.handle.write(str).catch((err) => {
       console.warn('[ptyHost] write failed', err);
     });
   }
 
   kill(signal?: string): void {
-    this.handle.kill(signal as NodeJS.Signals | undefined).catch((err: unknown) => {
+    // SAFETY: IPty supplies Node signal names; the ptyHost handle narrows the
+    // legacy node-pty string signature to NodeJS.Signals.
+    this.handle.kill(signal as NodeJS.Signals | undefined).catch((err) => {
       console.warn('[ptyHost] kill failed', err);
     });
   }
 
   pause(): void {
-    this.handle.pause().catch((err: unknown) => {
+    this.handle.pause().catch((err) => {
       console.warn('[ptyHost] pause failed', err);
     });
   }
 
   resume(): void {
-    this.handle.resume().catch((err: unknown) => {
+    this.handle.resume().catch((err) => {
       console.warn('[ptyHost] resume failed', err);
     });
   }
@@ -404,7 +413,7 @@ export class TerminalPanelManager {
     }
 
     const state = currentPanel.state;
-    const customState = (state.customState || {}) as TerminalPanelState;
+    const customState = terminalCustomState(state);
     if (!customState.initialInput || customState.initialInputSentAt) {
       return null;
     }
@@ -418,15 +427,15 @@ export class TerminalPanelManager {
     return { input, submitStrategy };
   }
 
-  private async markInitialInputError(panelId: string, error: unknown): Promise<void> {
+  private async markInitialInputError(panelId: string, errorMessage: string): Promise<void> {
     const currentPanel = panelManager.getPanel(panelId);
     if (!currentPanel) {
       return;
     }
 
     const state = currentPanel.state;
-    const customState = (state.customState || {}) as TerminalPanelState;
-    customState.initialInputError = error instanceof Error ? error.message : String(error);
+    const customState = terminalCustomState(state);
+    customState.initialInputError = errorMessage;
     state.customState = customState;
     await panelManager.updatePanel(panelId, { state });
   }
@@ -440,7 +449,7 @@ export class TerminalPanelManager {
       this.writeInitialInput(panelId, delivery.input, delivery.submitStrategy);
     }).catch((error) => {
       console.warn(`[TerminalPanelManager] Failed to send initial input for panel ${panelId}:`, error);
-      this.markInitialInputError(panelId, error).catch(() => {});
+      this.markInitialInputError(panelId, error instanceof Error ? error.message : String(error)).catch(() => {});
     });
   }
 
@@ -449,7 +458,8 @@ export class TerminalPanelManager {
       return;
     }
     const currentPanel = panelManager.getPanel(panelId);
-    const customState = (currentPanel?.state.customState || {}) as TerminalPanelState;
+    if (!currentPanel) return;
+    const customState = terminalCustomState(currentPanel.state);
     if (customState.isCliReady !== true) {
       return;
     }
@@ -530,7 +540,7 @@ export class TerminalPanelManager {
     const panel = panelManager.getPanel(terminal.panelId);
     if (!panel) return;
 
-    const customState = (panel.state.customState || {}) as TerminalPanelState;
+    const customState = terminalCustomState(panel.state);
     const agentType = customState.agentType ?? resolveAgentTypeFromCommand(customState.initialCommand);
     if (agentType !== terminal.agentType || customState.agentSessionId === agentSessionId) return;
 
@@ -540,7 +550,7 @@ export class TerminalPanelManager {
       ...customState,
       agentType,
       agentSessionId
-    } as TerminalPanelState;
+    };
 
     void panelManager.updatePanel(terminal.panelId, { state: panel.state }).catch(error => {
       console.warn(`[TerminalPanelManager] Failed to persist ${agentType} session id for panel ${terminal.panelId}:`, error);
@@ -552,11 +562,11 @@ export class TerminalPanelManager {
     this.analyticsManager = analyticsManager;
   }
 
-  private sendRendererEvent(channel: string, ...args: unknown[]): void {
+  private sendRendererEvent(channel: string, ...args: PaneEventArgument[]): void {
     getPaneEventSink().send(channel, ...args);
   }
 
-  private sendDaemonEvent(channel: string, ...args: unknown[]): void {
+  private sendDaemonEvent(channel: string, ...args: PaneEventArgument[]): void {
     getPaneDaemonEventSink().send(channel, ...args);
   }
 
@@ -721,7 +731,7 @@ export class TerminalPanelManager {
     if (terminal.isPtyHost && terminal.ptyId) {
       const supervisor = getPtyHostRuntime();
       if (supervisor) {
-        return supervisor.pause(terminal.ptyId).catch((err: unknown) => {
+        return supervisor.pause(terminal.ptyId).catch((err) => {
           console.warn('[TerminalPanelManager] ptyHost pause failed', err);
         });
       }
@@ -737,7 +747,7 @@ export class TerminalPanelManager {
     if (terminal.isPtyHost && terminal.ptyId) {
       const supervisor = getPtyHostRuntime();
       if (supervisor) {
-        supervisor.resume(terminal.ptyId).catch((err: unknown) => {
+        supervisor.resume(terminal.ptyId).catch((err) => {
           console.warn('[TerminalPanelManager] ptyHost resume failed', err);
         });
         return;
@@ -960,7 +970,7 @@ export class TerminalPanelManager {
     // both the legacy `pty.spawn` path and the ptyHost path see the same shape.
     const baseEnv: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
-      if (typeof value === 'string') {
+      if (value !== undefined) {
         baseEnv[key] = value;
       }
     }
@@ -1055,7 +1065,7 @@ export class TerminalPanelManager {
       activityStatus: 'idle',
       idleTimer: null,
       inSyncBlock: false,
-      agentType: this.resolveTerminalAgentType(panel.state.customState as TerminalPanelState | undefined),
+      agentType: this.resolveTerminalAgentType(terminalCustomState(panel.state)),
       agentSessionScrapeBuffer: ''
     };
 
@@ -1078,7 +1088,7 @@ export class TerminalPanelManager {
     }
     
     // Get initialCommand from existing state before updating
-    const existingState = panel.state.customState as TerminalPanelState | undefined;
+    const existingState = terminalCustomState(panel.state);
     const initialCommand = existingState?.initialCommand;
     const initialInput = existingState?.initialInput;
 
@@ -1121,7 +1131,7 @@ export class TerminalPanelManager {
             const currentPanel = panelManager.getPanel(panelId);
             if (currentPanel) {
               const ps = currentPanel.state;
-              const cs2 = (ps.customState || {}) as TerminalPanelState;
+              const cs2 = terminalCustomState(ps);
               cs2.isCliReady = true;
               ps.customState = cs2;
               panelManager.updatePanel(panelId, { state: ps }); // async, not awaited
@@ -1170,7 +1180,7 @@ export class TerminalPanelManager {
       cwd: cwd,
       shellType: path.basename(shellPath),
       dimensions: { cols: initialDimensions?.cols || 80, rows: initialDimensions?.rows || 30 }
-    } as TerminalPanelState;
+    };
 
     await panelManager.updatePanel(panel.id, { state });
 
@@ -1490,7 +1500,7 @@ export class TerminalPanelManager {
       state.customState = {
         ...state.customState,
         dimensions: { cols, rows }
-      } as TerminalPanelState;
+      };
       panelManager.updatePanel(panelId, { state });
     }
   }
@@ -1550,7 +1560,7 @@ export class TerminalPanelManager {
       ...(terminal.capturedAgentSessionId && terminal.agentType
         ? { agentType: terminal.agentType, agentSessionId: terminal.capturedAgentSessionId }
         : {})
-    } as TerminalPanelState;
+    };
     
     await panelManager.updatePanel(panelId, { state });
     
@@ -1583,13 +1593,11 @@ export class TerminalPanelManager {
     if (!terminal) return;
     
     // Restore scrollback buffer (handle both string and array formats)
-    if (typeof state.scrollbackBuffer === 'string') {
-      terminal.scrollbackBuffer = state.scrollbackBuffer;
-    } else if (Array.isArray(state.scrollbackBuffer)) {
+    if (Array.isArray(state.scrollbackBuffer)) {
       // Convert legacy array format to string
       terminal.scrollbackBuffer = state.scrollbackBuffer.join('\n');
     } else {
-      terminal.scrollbackBuffer = '';
+      terminal.scrollbackBuffer = state.scrollbackBuffer;
     }
     terminal.alternateScreenBuffer = state.alternateScreenBuffer || '';
     terminal.commandHistory = state.commandHistory || [];
@@ -1602,9 +1610,9 @@ export class TerminalPanelManager {
     // `terminal:output` IPC for legacy subscribers, ptyHost port for flag-on.
     if (state.scrollbackBuffer) {
       // Cap the renderer replay at the formal ceiling; main's own buffer (set above) keeps full content.
-      const rawScrollback = typeof state.scrollbackBuffer === 'string'
-        ? state.scrollbackBuffer
-        : state.scrollbackBuffer.join('\n');
+      const rawScrollback = Array.isArray(state.scrollbackBuffer)
+        ? state.scrollbackBuffer.join('\n')
+        : state.scrollbackBuffer;
       const output = this.trimAnsiSafe(rawScrollback, MAX_RESTORE_PAYLOAD_SIZE) + restorationMsg;
       this.sendRendererEvent('terminal:output', {
         sessionId: panel.sessionId,
@@ -1663,7 +1671,7 @@ export class TerminalPanelManager {
     if (!terminal) return null;
 
     const panel = panelManager.getPanel(panelId);
-    const customState = (panel?.state.customState || {}) as TerminalPanelState;
+    const customState = panel ? terminalCustomState(panel.state) : {};
     const agentType = customState.agentType ?? resolveAgentTypeFromCommand(customState.initialCommand);
 
     return {
@@ -1698,7 +1706,7 @@ export class TerminalPanelManager {
       ...(state.customState ?? {}),
       scrollbackBuffer: '',
       serializedBuffer: undefined,
-    } as TerminalPanelState;
+    };
 
     await panelManager.updatePanel(panelId, { state });
   }
@@ -1915,7 +1923,7 @@ export class TerminalPanelManager {
 
       // Read state for respawn: cwd is persisted on panel state by
       // `initializeTerminal` (see lines 616-622). Dimensions likewise.
-      const cs = (panel.state.customState || {}) as TerminalPanelState;
+      const cs = terminalCustomState(panel.state);
       const cwd = cs.cwd || process.cwd();
       const dimensions = cs.dimensions || { cols: 80, rows: 30 };
 

--- a/main/src/services/terminalSessionManager.ts
+++ b/main/src/services/terminalSessionManager.ts
@@ -54,7 +54,7 @@ class TerminalSessionPtyShim implements pty.IPty {
   resize(columns: number, rows: number): void {
     this.cols = columns;
     this.rows = rows;
-    this.handle.resize(columns, rows).catch((err: unknown) => {
+    this.handle.resize(columns, rows).catch((err: Error) => {
       console.warn('[ptyHost] terminal-session resize failed', err);
     });
   }
@@ -64,26 +64,28 @@ class TerminalSessionPtyShim implements pty.IPty {
   }
 
   write(data: string | Buffer): void {
-    const str = typeof data === 'string' ? data : data.toString();
-    this.handle.write(str).catch((err: unknown) => {
+    const str = Buffer.isBuffer(data) ? data.toString() : data;
+    this.handle.write(str).catch((err: Error) => {
       console.warn('[ptyHost] terminal-session write failed', err);
     });
   }
 
   kill(signal?: string): void {
-    this.handle.kill(signal as NodeJS.Signals | undefined).catch((err: unknown) => {
+    // SAFETY: node-pty declares this shim method as string, while callers pass
+    // Node signal names and the host handle accepts that same finite set.
+    this.handle.kill(signal as NodeJS.Signals | undefined).catch((err: Error) => {
       console.warn('[ptyHost] terminal-session kill failed', err);
     });
   }
 
   pause(): void {
-    this.handle.pause().catch((err: unknown) => {
+    this.handle.pause().catch((err: Error) => {
       console.warn('[ptyHost] terminal-session pause failed', err);
     });
   }
 
   resume(): void {
-    this.handle.resume().catch((err: unknown) => {
+    this.handle.resume().catch((err: Error) => {
       console.warn('[ptyHost] terminal-session resume failed', err);
     });
   }
@@ -159,7 +161,7 @@ export class TerminalSessionManager extends EventEmitter {
       // RPC DTO requires `Record<string, string>`; drop undefined keys.
       const envStr: Record<string, string> = {};
       for (const [key, value] of Object.entries(rawEnv)) {
-        if (typeof value === 'string') {
+        if (value !== undefined) {
           envStr[key] = value;
         }
       }
@@ -185,7 +187,7 @@ export class TerminalSessionManager extends EventEmitter {
         cwd: worktreePath,
         cols: spawnCols,
         rows: spawnRows,
-        env: rawEnv as { [key: string]: string },
+        env: Object.fromEntries(Object.entries(rawEnv).filter((entry): entry is [string, string] => entry[1] !== undefined)),
       });
     }
 

--- a/main/src/services/uiStateManager.ts
+++ b/main/src/services/uiStateManager.ts
@@ -1,4 +1,5 @@
 import { DatabaseService } from '../database/database';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 type SidebarSection = 'pinned' | 'repositories';
 
@@ -48,8 +49,7 @@ class UIStateManager {
     const value = this.db.getUIState(SIDEBAR_SECTION_KEYS[section]);
     if (!value) return true;
     try {
-      const parsed = JSON.parse(value);
-      return typeof parsed === 'boolean' ? parsed : true;
+      return decodeBoundary(JSON.parse(value), boundary.boolean);
     } catch {
       return true;
     }

--- a/main/src/services/versionChecker.ts
+++ b/main/src/services/versionChecker.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import { ConfigManager } from './configManager';
 import { Logger } from '../utils/logger';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 export interface VersionInfo {
   current: string;
@@ -50,7 +51,19 @@ export class VersionChecker {
         throw new Error(`GitHub API returned ${response.status}: ${response.statusText}`);
       }
 
-      const release = await response.json() as GitHubRelease;
+      const release = decodeBoundary(await response.json(), boundary.object({
+        tag_name: boundary.string,
+        name: boundary.string,
+        body: boundary.string,
+        html_url: boundary.string,
+        published_at: boundary.string,
+        prerelease: boundary.boolean,
+        draft: boundary.boolean,
+        assets: boundary.optional(boundary.array(boundary.object({
+          name: boundary.string,
+          browser_download_url: boundary.string,
+        }))),
+      }));
       
       // Skip pre-releases and drafts
       if (release.prerelease || release.draft) {
@@ -74,7 +87,7 @@ export class VersionChecker {
         publishedAt: release.published_at
       };
     } catch (error) {
-      this.logger.error(`[Version Checker] Failed to check for updates:`, error as Error);
+      this.logger.error(`[Version Checker] Failed to check for updates:`, error instanceof Error ? error : new Error(String(error)));
       
       // Return current version info without update on error
       return {
@@ -92,10 +105,12 @@ export class VersionChecker {
       if (versionInfo.hasUpdate) {
         this.logger.info(`[Version Checker] Update available on startup: ${versionInfo.latest}`);
         // Emit event for UI notification
-        (process as NodeJS.Process & { emit(event: 'version-update-available', data: VersionInfo): boolean }).emit('version-update-available', versionInfo);
+        // SAFETY: Pane registers this application-owned process event and its VersionInfo payload in events.ts.
+        (process as NodeJS.Process & { emit(event: 'version-update-available', data: VersionInfo): boolean })
+          .emit('version-update-available', versionInfo);
       }
     } catch (error) {
-      this.logger.error(`[Version Checker] Startup check failed:`, error as Error);
+      this.logger.error(`[Version Checker] Startup check failed:`, error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -133,10 +148,12 @@ export class VersionChecker {
       if (versionInfo.hasUpdate) {
         this.logger.info(`[Version Checker] Update available: ${versionInfo.latest}`);
         // Emit event for UI notification
-        (process as NodeJS.Process & { emit(event: 'version-update-available', data: VersionInfo): boolean }).emit('version-update-available', versionInfo);
+        // SAFETY: Pane registers this application-owned process event and its VersionInfo payload in events.ts.
+        (process as NodeJS.Process & { emit(event: 'version-update-available', data: VersionInfo): boolean })
+          .emit('version-update-available', versionInfo);
       }
     } catch (error) {
-      this.logger.error(`[Version Checker] Periodic check failed:`, error as Error);
+      this.logger.error(`[Version Checker] Periodic check failed:`, error instanceof Error ? error : new Error(String(error)));
     }
   }
 
@@ -183,7 +200,7 @@ export class VersionChecker {
 
       return false; // Versions are equal
     } catch (error) {
-      this.logger.error(`[Version Checker] Failed to compare versions ${latest} vs ${current}:`, error as Error);
+      this.logger.error(`[Version Checker] Failed to compare versions ${latest} vs ${current}:`, error instanceof Error ? error : new Error(String(error)));
       return false;
     }
   }

--- a/main/src/services/voiceTranscriptionService.test.ts
+++ b/main/src/services/voiceTranscriptionService.test.ts
@@ -2,6 +2,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ConfigManager } from './configManager';
 import type { AnalyticsManager } from './analyticsManager';
 import { VoiceTranscriptionService } from './voiceTranscriptionService';
+import { boundary, decodeBoundary, type BoundarySchema } from '../../../shared/validation/boundaryDecoder';
+
+function requestBody<Value>(init: RequestInit | undefined, schema: BoundarySchema<Value>): Value {
+  return decodeBoundary(JSON.parse(String(init?.body)), schema);
+}
+
+function partialMock<Contract>(implementation: Partial<Contract>): Contract {
+  // SAFETY: Each test supplies every dependency method reached by its scenario;
+  // unexpected calls fail immediately instead of crossing a real boundary.
+  return implementation as Contract;
+}
 
 describe('VoiceTranscriptionService', () => {
   afterEach(() => {
@@ -12,7 +23,7 @@ describe('VoiceTranscriptionService', () => {
     const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       const urlText = String(url);
       if (urlText.includes('/storage/upload/initiate')) {
-        const body = JSON.parse(String(init?.body)) as { file_name?: string; content_type?: string };
+        const body = requestBody(init, boundary.object({ file_name: boundary.string, content_type: boundary.string }));
         expect(body.content_type).toBe('audio/webm');
         expect(body.file_name).toMatch(/^pane-voice-\d+\.webm$/);
         return new Response(JSON.stringify({
@@ -31,7 +42,7 @@ describe('VoiceTranscriptionService', () => {
       }
 
       if (urlText.includes('fal.run')) {
-        const body = JSON.parse(String(init?.body)) as { audio_url?: string };
+        const body = requestBody(init, boundary.object({ audio_url: boundary.string }));
         expect(body.audio_url).toBe('https://v3b.fal.media/files/test/pane-voice.webm');
         return new Response(JSON.stringify({
           text: 'we should use type script with open router',
@@ -45,9 +56,9 @@ describe('VoiceTranscriptionService', () => {
       }
 
       expect(urlText).toContain('openrouter.ai');
-      const body = JSON.parse(String(init?.body)) as {
-        messages?: Array<{ role: string; content: string }>;
-      };
+      const body = requestBody(init, boundary.object({
+        messages: boundary.array(boundary.object({ role: boundary.string, content: boundary.string })),
+      }));
       expect(body.messages?.[0]?.content).toContain('GPT-5.5');
       expect(body.messages?.[0]?.content).toContain('medium-high');
       return new Response(JSON.stringify({
@@ -70,17 +81,17 @@ describe('VoiceTranscriptionService', () => {
     vi.stubGlobal('fetch', fetchMock);
     const analyticsTrack = vi.fn();
 
-    const service = new VoiceTranscriptionService({
+    const service = new VoiceTranscriptionService(partialMock<ConfigManager>({
       getConfig: () => ({
         falApiKey: 'fal-test-key',
         openRouterApiKey: 'openrouter-test-key',
       }),
       isVerbose: () => false,
-    } as ConfigManager, {
+    }), partialMock<AnalyticsManager>({
       track: analyticsTrack,
       categorizeDuration: (seconds: number) => `${seconds}s`,
       categorizeNumber: (value: number) => `${value} bytes`,
-    } as unknown as AnalyticsManager);
+    }));
 
     await expect(service.transcribe({
       audioDataUrl: 'data:audio/webm;codecs=opus;base64,AAAA',
@@ -134,12 +145,12 @@ describe('VoiceTranscriptionService', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const service = new VoiceTranscriptionService({
+    const service = new VoiceTranscriptionService(partialMock<ConfigManager>({
       getConfig: () => ({
         deepgramApiKey: 'deepgram-test-key',
       }),
       isVerbose: () => false,
-    } as ConfigManager);
+    }));
 
     await expect(service.getDeepgramStreamingToken()).resolves.toMatchObject({
       accessToken: 'temporary-jwt',
@@ -150,10 +161,10 @@ describe('VoiceTranscriptionService', () => {
   });
 
   it('requires a Deepgram API key before granting streaming tokens', async () => {
-    const service = new VoiceTranscriptionService({
+    const service = new VoiceTranscriptionService(partialMock<ConfigManager>({
       getConfig: () => ({}),
       isVerbose: () => false,
-    } as ConfigManager);
+    }));
 
     await expect(service.getDeepgramStreamingToken()).rejects.toThrow('Deepgram API key is not configured');
   });
@@ -161,9 +172,9 @@ describe('VoiceTranscriptionService', () => {
   it('finalizes streaming transcripts through OpenRouter cleanup and tracks Deepgram metadata', async () => {
     const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       expect(String(url)).toContain('openrouter.ai');
-      const body = JSON.parse(String(init?.body)) as {
-        messages?: Array<{ role: string; content: string }>;
-      };
+      const body = requestBody(init, boundary.object({
+        messages: boundary.array(boundary.object({ role: boundary.string, content: boundary.string })),
+      }));
       expect(body.messages?.[0]?.content).toContain('GPT-5.5');
       expect(body.messages?.[1]?.content).toBe('i use gpt five point five medium high with claude opus');
       return new Response(JSON.stringify({
@@ -186,16 +197,16 @@ describe('VoiceTranscriptionService', () => {
     vi.stubGlobal('fetch', fetchMock);
     const analyticsTrack = vi.fn();
 
-    const service = new VoiceTranscriptionService({
+    const service = new VoiceTranscriptionService(partialMock<ConfigManager>({
       getConfig: () => ({
         openRouterApiKey: 'openrouter-test-key',
       }),
       isVerbose: () => false,
-    } as ConfigManager, {
+    }), partialMock<AnalyticsManager>({
       track: analyticsTrack,
       categorizeDuration: (seconds: number) => `${seconds}s`,
       categorizeNumber: (value: number) => `${value} bytes`,
-    } as unknown as AnalyticsManager);
+    }));
 
     await expect(service.finalizeStreaming({
       rawText: 'i use gpt five point five medium high with claude opus',

--- a/main/src/services/voiceTranscriptionService.ts
+++ b/main/src/services/voiceTranscriptionService.ts
@@ -9,6 +9,13 @@ import type {
   VoiceTranscriptionUsage,
   VoiceStreamingFinalizeRequest,
 } from '../../../shared/types/voiceTranscription';
+import {
+  boundary,
+  decodeBoundary,
+  type BoundarySchema,
+  type JsonObject,
+  type JsonValue,
+} from '../../../shared/validation/boundaryDecoder';
 
 const FAL_WIZPER_ENDPOINT = 'https://fal.run/fal-ai/wizper';
 const FAL_STORAGE_UPLOAD_INITIATE_ENDPOINT = 'https://rest.alpha.fal.ai/storage/upload/initiate?storage_type=fal-cdn-v3';
@@ -96,34 +103,56 @@ interface ValidatedStreamingFinalizeInput {
   metadata?: VoiceDeepgramStreamingMetadata;
 }
 
-interface FalWizperResponse {
-  text?: unknown;
-  chunks?: unknown;
-  languages?: unknown;
-  usage?: unknown;
-  cost?: unknown;
-  metadata?: unknown;
-  metrics?: unknown;
+const falWizperResponseSchema = boundary.object({
+  text: boundary.string,
+  chunks: boundary.optional(boundary.array(boundary.json)),
+  languages: boundary.optional(boundary.array(boundary.json)),
+  usage: boundary.optional(boundary.json),
+  cost: boundary.optional(boundary.json),
+  metadata: boundary.optional(boundary.json),
+  metrics: boundary.optional(boundary.json),
+});
+const falStorageInitiateResponseSchema = boundary.object({
+  file_url: boundary.string,
+  upload_url: boundary.string,
+});
+const openRouterResponseSchema = boundary.object({
+  choices: boundary.array(boundary.object({
+    message: boundary.object({ content: boundary.string }),
+  })),
+  usage: boundary.optional(boundary.json),
+});
+const deepgramGrantResponseSchema = boundary.object({
+  access_token: boundary.nonEmptyString,
+  expires_in: boundary.optional(boundary.number),
+});
+
+interface UsageNumbers {
+  cost?: number;
+  cost_usd?: number;
+  total_cost?: number;
+  total_cost_usd?: number;
+  upstream_inference_cost?: number;
+  upstream_inference_completions_cost?: number;
+  prompt_tokens?: number;
+  input_tokens?: number;
+  completion_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
 }
 
-interface FalStorageInitiateResponse {
-  file_url?: unknown;
-  upload_url?: unknown;
+interface ProviderUsagePayload {
+  usage?: JsonValue;
+  cost?: JsonValue;
+  metadata?: JsonValue;
+  metrics?: JsonValue;
 }
 
-interface OpenRouterResponse {
-  choices?: Array<{
-    message?: {
-      content?: unknown;
-    };
-  }>;
-  usage?: unknown;
-}
-
-interface DeepgramGrantResponse {
-  access_token?: unknown;
-  expires_in?: unknown;
-}
+const usageKeySchema = boundary.enumeration(
+  'cost', 'cost_usd', 'total_cost', 'total_cost_usd',
+  'upstream_inference_cost', 'upstream_inference_completions_cost',
+  'prompt_tokens', 'input_tokens', 'completion_tokens', 'output_tokens', 'total_tokens',
+);
 
 type ProviderUsage = VoiceTranscriptionUsage;
 
@@ -197,12 +226,8 @@ export class VoiceTranscriptionService {
         Authorization: `Token ${deepgramApiKey}`,
       },
     });
-    const payload = await readProviderJson<DeepgramGrantResponse>(response, 'Deepgram token grant failed');
-    if (typeof payload.access_token !== 'string' || payload.access_token.trim().length === 0) {
-      throw new Error('Deepgram token grant response did not include an access token.');
-    }
-
-    const expiresIn = typeof payload.expires_in === 'number' && Number.isFinite(payload.expires_in)
+    const payload = await readProviderJson(response, 'Deepgram token grant failed', deepgramGrantResponseSchema);
+    const expiresIn = payload.expires_in !== undefined && Number.isFinite(payload.expires_in)
       ? payload.expires_in
       : 30;
 
@@ -301,10 +326,7 @@ export class VoiceTranscriptionService {
       }),
     });
 
-    const payload = await readProviderJson<FalWizperResponse>(response, 'Fal Wizper transcription failed');
-    if (typeof payload.text !== 'string') {
-      throw new Error('Fal Wizper transcription response did not include text.');
-    }
+    const payload = await readProviderJson(response, 'Fal Wizper transcription failed', falWizperResponseSchema);
 
     return {
       text: payload.text,
@@ -328,13 +350,11 @@ export class VoiceTranscriptionService {
       }),
     });
 
-    const initiatePayload = await readProviderJson<FalStorageInitiateResponse>(
+    const initiatePayload = await readProviderJson(
       initiateResponse,
       'Fal audio upload initialization failed',
+      falStorageInitiateResponseSchema,
     );
-    if (typeof initiatePayload.file_url !== 'string' || typeof initiatePayload.upload_url !== 'string') {
-      throw new Error('Fal audio upload initialization response did not include upload URLs.');
-    }
 
     const uploadResponse = await fetch(initiatePayload.upload_url, {
       method: 'PUT',
@@ -376,9 +396,9 @@ export class VoiceTranscriptionService {
       }),
     });
 
-    const payload = await readProviderJson<OpenRouterResponse>(response, 'OpenRouter transcript cleanup failed');
+    const payload = await readProviderJson(response, 'OpenRouter transcript cleanup failed', openRouterResponseSchema);
     const content = payload.choices?.[0]?.message?.content;
-    if (typeof content !== 'string') {
+    if (content === undefined) {
       throw new Error('OpenRouter cleanup response did not include text.');
     }
 
@@ -409,7 +429,7 @@ export class VoiceTranscriptionService {
 
     try {
       const totalCost = sumDefinedNumbers(rawUsage?.cost, cleanupUsage?.cost);
-      const audioDurationMs = typeof requestedDurationMs === 'number' ? Math.max(0, Math.round(requestedDurationMs)) : undefined;
+      const audioDurationMs = requestedDurationMs !== undefined ? Math.max(0, Math.round(requestedDurationMs)) : undefined;
       const audioSeconds = audioDurationMs !== undefined ? Math.round(audioDurationMs / 100) / 10 : undefined;
       this.analyticsManager.track('voice_transcription_used', {
         mode: result.mode,
@@ -466,15 +486,11 @@ export class VoiceTranscriptionService {
 }
 
 function validateVoiceTranscriptionRequest(request: VoiceTranscriptionRequest): ValidatedAudioInput {
-  if (!request || typeof request !== 'object') {
-    throw new Error('Voice transcription request is invalid.');
-  }
-
-  if (typeof request.audioDataUrl !== 'string' || request.audioDataUrl.trim().length === 0) {
+  if (request.audioDataUrl.trim().length === 0) {
     throw new Error('Voice transcription audio data is required.');
   }
 
-  if (typeof request.mimeType !== 'string' || request.mimeType.trim().length === 0) {
+  if (request.mimeType.trim().length === 0) {
     throw new Error('Voice transcription audio MIME type is required.');
   }
 
@@ -516,12 +532,6 @@ function validateVoiceTranscriptionRequest(request: VoiceTranscriptionRequest): 
 }
 
 function validateVoiceStreamingFinalizeRequest(request: VoiceStreamingFinalizeRequest): ValidatedStreamingFinalizeInput {
-  if (!request || typeof request !== 'object') {
-    throw new Error('Voice streaming finalization request is invalid.');
-  }
-  if (typeof request.rawText !== 'string') {
-    throw new Error('Voice streaming finalization requires a transcript.');
-  }
   if (request.durationMs !== undefined && request.durationMs > MAX_AUDIO_DURATION_MS + 5_000) {
     throw new Error('Streaming recording is too long. Keep voice clips under 60 seconds.');
   }
@@ -531,7 +541,7 @@ function validateVoiceStreamingFinalizeRequest(request: VoiceStreamingFinalizeRe
 
   return {
     rawText: request.rawText,
-    durationMs: typeof request.durationMs === 'number'
+    durationMs: request.durationMs !== undefined
       ? Math.max(0, Math.round(request.durationMs))
       : undefined,
     language: request.language ?? 'en',
@@ -541,7 +551,7 @@ function validateVoiceStreamingFinalizeRequest(request: VoiceStreamingFinalizeRe
 }
 
 function normalizeStreamingTimings(timings: VoiceStreamingFinalizeRequest['timings']): ValidatedStreamingFinalizeInput['timings'] {
-  if (!timings || typeof timings !== 'object') {
+  if (!timings) {
     return undefined;
   }
 
@@ -554,32 +564,36 @@ function normalizeStreamingTimings(timings: VoiceStreamingFinalizeRequest['timin
     : undefined;
 }
 
-function normalizeOptionalMs(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value)
+function normalizeOptionalMs(value: number | undefined): number | undefined {
+  return value !== undefined && Number.isFinite(value)
     ? Math.max(0, Math.round(value))
     : undefined;
 }
 
 function normalizeDeepgramMetadata(metadata: VoiceStreamingFinalizeRequest['metadata']): VoiceDeepgramStreamingMetadata | undefined {
-  if (!metadata || typeof metadata !== 'object') {
+  if (!metadata) {
     return undefined;
   }
 
   return {
-    requestId: typeof metadata.requestId === 'string' ? metadata.requestId : undefined,
-    duration: typeof metadata.duration === 'number' && Number.isFinite(metadata.duration) ? metadata.duration : undefined,
-    cost: typeof metadata.cost === 'number' && Number.isFinite(metadata.cost) ? metadata.cost : undefined,
-    modelName: typeof metadata.modelName === 'string' ? metadata.modelName : undefined,
-    modelVersion: typeof metadata.modelVersion === 'string' ? metadata.modelVersion : undefined,
+    requestId: metadata.requestId,
+    duration: metadata.duration !== undefined && Number.isFinite(metadata.duration) ? metadata.duration : undefined,
+    cost: metadata.cost !== undefined && Number.isFinite(metadata.cost) ? metadata.cost : undefined,
+    modelName: metadata.modelName,
+    modelVersion: metadata.modelVersion,
   };
 }
 
-async function readProviderJson<T>(response: Response, fallbackMessage: string): Promise<T> {
-  let payload: unknown = null;
+async function readProviderJson<Value>(
+  response: Response,
+  fallbackMessage: string,
+  schema: BoundarySchema<Value>,
+): Promise<Value> {
+  let payload: JsonValue = null;
   const text = await response.text();
   if (text.trim().length > 0) {
     try {
-      payload = JSON.parse(text) as unknown;
+      payload = decodeBoundary(JSON.parse(text), boundary.json);
     } catch {
       if (!response.ok) {
         throw new Error(`${fallbackMessage}: HTTP ${response.status}`);
@@ -592,15 +606,23 @@ async function readProviderJson<T>(response: Response, fallbackMessage: string):
     throw new Error(`${fallbackMessage}: ${extractProviderMessage(payload) ?? `HTTP ${response.status}`}`);
   }
 
-  return (payload ?? {}) as T;
+  try {
+    return decodeBoundary(payload ?? {}, schema);
+  } catch {
+    throw new Error(`${fallbackMessage}: invalid response shape.`);
+  }
 }
 
-function extractProviderMessage(payload: unknown): string | null {
-  if (!payload || typeof payload !== 'object') {
+function extractProviderMessage(payload: JsonValue): string | null {
+  if (payload === null || Array.isArray(payload)) {
     return null;
   }
-
-  const record = payload as Record<string, unknown>;
+  let record: JsonObject;
+  try {
+    record = decodeBoundary(payload, boundary.jsonObject);
+  } catch {
+    return null;
+  }
   const candidates = [
     record.message,
     record.error,
@@ -608,15 +630,10 @@ function extractProviderMessage(payload: unknown): string | null {
   ];
 
   for (const candidate of candidates) {
-    if (typeof candidate === 'string' && candidate.trim()) {
-      return truncateProviderError(candidate.trim());
-    }
-    if (candidate && typeof candidate === 'object') {
-      const nested = candidate as Record<string, unknown>;
-      if (typeof nested.message === 'string' && nested.message.trim()) {
-        return truncateProviderError(nested.message.trim());
-      }
-    }
+    const message = decodeOptionalBoundary(candidate, boundary.string);
+    if (message?.trim()) return truncateProviderError(message.trim());
+    const nested = decodeOptionalBoundary(candidate, boundary.object({ message: boundary.string }));
+    if (nested?.message.trim()) return truncateProviderError(nested.message.trim());
   }
 
   return truncateProviderError(JSON.stringify(payload));
@@ -628,21 +645,15 @@ function truncateProviderError(message: string): string {
     : message;
 }
 
-function parseFalChunks(value: unknown): VoiceTranscriptionChunk[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-
+function parseFalChunks(value: JsonValue[] | undefined): VoiceTranscriptionChunk[] | undefined {
+  if (!value) return undefined;
   const chunks: VoiceTranscriptionChunk[] = [];
   for (const item of value) {
-    if (!item || typeof item !== 'object') {
-      continue;
-    }
-    const record = item as Record<string, unknown>;
-    if (typeof record.text !== 'string') {
-      continue;
-    }
-
+    const record = decodeOptionalBoundary(item, boundary.object({
+      text: boundary.string,
+      timestamp: boundary.optional(boundary.json),
+    }));
+    if (!record) continue;
     const timestamp = parseTimestamp(record.timestamp);
     chunks.push(timestamp ? { text: record.text, timestamp } : { text: record.text });
   }
@@ -650,27 +661,21 @@ function parseFalChunks(value: unknown): VoiceTranscriptionChunk[] | undefined {
   return chunks.length > 0 ? chunks : undefined;
 }
 
-function parseTimestamp(value: unknown): [number, number] | undefined {
-  if (!Array.isArray(value) || value.length !== 2) {
-    return undefined;
-  }
-
-  const [start, end] = value;
-  return typeof start === 'number' && typeof end === 'number'
-    ? [start, end]
-    : undefined;
+function parseTimestamp(value: JsonValue | undefined): [number, number] | undefined {
+  const decoded = decodeOptionalBoundary(value, boundary.array(boundary.number));
+  return decoded?.length === 2 ? [decoded[0], decoded[1]] : undefined;
 }
 
-function parseStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-
-  const values = value.filter((item): item is string => typeof item === 'string');
+function parseStringArray(value: JsonValue[] | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const values = value.flatMap((item) => {
+    const decoded = decodeOptionalBoundary(item, boundary.string);
+    return decoded === undefined ? [] : [decoded];
+  });
   return values.length > 0 ? values : undefined;
 }
 
-function parseProviderUsage(value: unknown): ProviderUsage | undefined {
+function parseProviderUsage(value: JsonValue | VoiceDeepgramStreamingMetadata | ProviderUsagePayload | undefined): ProviderUsage | undefined {
   const values = collectUsageNumbers(value);
   const usage: ProviderUsage = {
     cost: firstDefinedNumber(
@@ -704,10 +709,10 @@ function getDeepgramUsage(
     };
   }
 
-  const durationSeconds = typeof durationMs === 'number'
+  const durationSeconds = durationMs !== undefined
     ? durationMs / 1000
     : metadata?.duration;
-  if (typeof durationSeconds === 'number' && Number.isFinite(durationSeconds) && durationSeconds > 0) {
+  if (durationSeconds !== undefined && Number.isFinite(durationSeconds) && durationSeconds > 0) {
     return {
       cost: Number(((durationSeconds / 3600) * DEEPGRAM_NOVA3_STREAMING_COST_PER_HOUR_USD).toFixed(8)),
       costSource: 'estimate',
@@ -719,40 +724,52 @@ function getDeepgramUsage(
   };
 }
 
-function collectUsageNumbers(value: unknown): Record<string, number> {
-  const numbers: Record<string, number> = {};
-  const seen = new Set<unknown>();
-  const visit = (candidate: unknown) => {
-    if (!candidate || typeof candidate !== 'object' || seen.has(candidate)) {
-      return;
-    }
-    seen.add(candidate);
-
-    for (const [key, nestedValue] of Object.entries(candidate as Record<string, unknown>)) {
-      if (typeof nestedValue === 'number' && Number.isFinite(nestedValue)) {
-        numbers[key] ??= nestedValue;
-      } else if (typeof nestedValue === 'string' && nestedValue.trim() && Number.isFinite(Number(nestedValue))) {
-        numbers[key] ??= Number(nestedValue);
-      } else if (
-        nestedValue
-        && typeof nestedValue === 'object'
-        && ['usage', 'cost', 'metadata', 'metrics'].includes(key)
-      ) {
-        visit(nestedValue);
-      }
+function collectUsageNumbers(value: JsonValue | VoiceDeepgramStreamingMetadata | ProviderUsagePayload | undefined): UsageNumbers {
+  const jsonValue = value === undefined ? undefined : decodeOptionalBoundary(value, boundary.json);
+  const numbers: UsageNumbers = {};
+  if (jsonValue === undefined) return numbers;
+  const visit = (candidate: JsonValue): void => {
+    const record = decodeOptionalBoundary(candidate, boundary.jsonObject);
+    if (!record) return;
+    for (const key of Object.keys(record)) {
+      const nestedValue = record[key];
+      const numeric = decodeUsageNumber(nestedValue);
+      const usageKey = decodeOptionalBoundary(key, usageKeySchema);
+      if (usageKey !== undefined && numeric !== undefined) numbers[usageKey] ??= numeric;
+      if (['usage', 'cost', 'metadata', 'metrics'].includes(key)) visit(nestedValue);
     }
   };
-
-  visit(value);
+  visit(jsonValue);
   return numbers;
 }
 
+function decodeUsageNumber(value: JsonValue): number | undefined {
+  const numeric = decodeOptionalBoundary(value, boundary.number);
+  if (numeric !== undefined && Number.isFinite(numeric)) return numeric;
+  const text = decodeOptionalBoundary(value, boundary.string)?.trim();
+  if (!text) return undefined;
+  const parsed = Number(text);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function decodeOptionalBoundary<Value>(
+  value: JsonValue | VoiceDeepgramStreamingMetadata | ProviderUsagePayload | undefined,
+  schema: BoundarySchema<Value>,
+): Value | undefined {
+  if (value === undefined) return undefined;
+  try {
+    return decodeBoundary(value, schema);
+  } catch {
+    return undefined;
+  }
+}
+
 function firstDefinedNumber(...values: Array<number | undefined>): number | undefined {
-  return values.find((value): value is number => typeof value === 'number' && Number.isFinite(value));
+  return values.find((value): value is number => value !== undefined && Number.isFinite(value));
 }
 
 function sumDefinedNumbers(...values: Array<number | undefined>): number | undefined {
-  const numbers = values.filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+  const numbers = values.filter((value): value is number => value !== undefined && Number.isFinite(value));
   if (numbers.length === 0) {
     return undefined;
   }

--- a/main/src/services/worktreeFileSyncService.ts
+++ b/main/src/services/worktreeFileSyncService.ts
@@ -5,6 +5,7 @@ import { CommandRunner } from '../utils/commandRunner';
 import type { ProjectEnvironment } from '../utils/pathResolver';
 import { escapeForBash, posixJoin } from '../utils/wslUtils';
 import type { WorktreeFileSyncEntry } from '../../../shared/types/worktreeFileSync';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 export interface WorktreeFileSyncFailure {
   path: string;
@@ -392,9 +393,14 @@ async function execCopyCommand(
   try {
     await commandRunner.execAsync(cmd, cwd, { timeout: COPY_TIMEOUT_MS });
   } catch (err: unknown) {
-    if (environment === 'windows' && err !== null && typeof err === 'object' && 'code' in err) {
-      const code = (err as { code: unknown }).code;
-      if (typeof code === 'number' && code >= 0 && code <= 7) {
+    if (environment === 'windows') {
+      let code: number | undefined;
+      try {
+        code = decodeBoundary(err, boundary.object({ code: boundary.optional(boundary.number) })).code;
+      } catch {
+        code = undefined;
+      }
+      if (code !== undefined && code >= 0 && code <= 7) {
         // Robocopy: exit codes 0–7 are all success (0=no copy, 1=copied, 2-7=informational)
         return;
       }
@@ -474,10 +480,6 @@ async function copyRootEntry(
   await execCopyCommand(cmd, mainRepoPath, commandRunner, environment);
 }
 
-function describeError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
 /**
  * Finds all recursive matches of `entry.path` in the main repo and copies any
  * that are missing from the worktree. Returns the failures encountered so the
@@ -518,7 +520,7 @@ async function copyRecursiveMatches(
       await execCopyCommand(cmd, mainRepoPath, commandRunner, environment);
     } catch (err) {
       console.error(`[WorktreeFileSync] Failed to copy match "${matchPath}":`, err);
-      failures.push({ path: relativePath, reason: describeError(err) });
+      failures.push({ path: relativePath, reason: err instanceof Error ? err.message : String(err) });
       // Continue with remaining matches, best effort
     }
   }
@@ -653,7 +655,7 @@ export const worktreeFileSyncService = {
           }
         } catch (err) {
           console.error(`[WorktreeFileSync] Failed to sync entry "${entry.path}":`, err);
-          failures.push({ path: entry.path, reason: describeError(err) });
+          failures.push({ path: entry.path, reason: err instanceof Error ? err.message : String(err) });
           // Continue with next entry, best effort
         }
       }
@@ -662,7 +664,7 @@ export const worktreeFileSyncService = {
       return { installCommand, failures };
     } catch (err) {
       console.error('[WorktreeFileSync] syncWorktree failed:', err);
-      failures.push({ path: 'worktree files', reason: describeError(err) });
+      failures.push({ path: 'worktree files', reason: err instanceof Error ? err.message : String(err) });
       return { installCommand: null, failures };
     }
   },

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -7,6 +7,7 @@ import { PathResolver } from '../utils/pathResolver';
 import { CommandRunner } from '../utils/commandRunner';
 import { getGitAttributionEnv } from '../utils/attribution';
 import { worktreePoolManager } from './worktreePoolManager';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 type WorktreeAuditSource = 'session-delete' | 'project-delete' | 'create-cleanup';
 
@@ -16,15 +17,40 @@ export interface WorktreeAuditContext {
   projectId?: number;
 }
 
-function formatWorktreeAuditDetails(details: Record<string, unknown>): string {
+interface WorktreeAuditDetails {
+  source?: WorktreeAuditSource;
+  sessionId?: string;
+  projectId?: number;
+  projectPath?: string;
+  worktreeName?: string;
+  worktreePath?: string;
+  reason?: string;
+}
+
+function formatWorktreeAuditDetails(details: WorktreeAuditDetails): string {
   return Object.entries(details)
     .filter(([, value]) => value !== undefined && value !== null)
     .map(([key, value]) => `${key}=${JSON.stringify(String(value))}`)
     .join(' ');
 }
 
-function logWorktreeAudit(phase: string, details: Record<string, unknown>): void {
+function logWorktreeAudit(phase: string, details: WorktreeAuditDetails): void {
   console.log(`[WorktreeAudit] ${phase} ${formatWorktreeAuditDetails(details)}`);
+}
+
+const commandErrorSchema = boundary.object({
+  message: boundary.optional(boundary.string),
+  stderr: boundary.optional(boundary.string),
+  stdout: boundary.optional(boundary.string),
+});
+
+class GitOperationError extends Error {
+  gitCommand?: string;
+  gitCommands?: string[];
+  gitOutput?: string;
+  workingDirectory?: string;
+  projectPath?: string;
+  originalError?: { message?: string; stderr?: string; stdout?: string };
 }
 
 // Interface for raw commit data
@@ -415,7 +441,7 @@ export class WorktreeManager {
           });
         }
       } catch (error: unknown) {
-        const err = error as Error & { stderr?: string; stdout?: string };
+        const err = decodeBoundary(error, commandErrorSchema);
         const errorMessage = err.stderr || err.stdout || err.message || String(err);
 
         // If the worktree is not found, that's okay - it might have been manually deleted
@@ -810,7 +836,7 @@ export class WorktreeManager {
         return { hasConflicts: false, canAutoMerge: true };
 
       } catch (error: unknown) {
-        const err = error as Error & { stderr?: string; stdout?: string };
+        const err = decodeBoundary(error, commandErrorSchema);
         // If merge-tree is not available (older git), fall back to checking modified files
         console.log(`[WorktreeManager] merge-tree not available, using fallback conflict detection`);
 
@@ -890,7 +916,7 @@ export class WorktreeManager {
           });
         }
       } catch (error: unknown) {
-        const err = error as Error & { stderr?: string; stdout?: string };
+        const err = decodeBoundary(error, commandErrorSchema);
         console.error(`[WorktreeManager] Failed to rebase ${mainBranch} into worktree:`, err);
 
         // Check if conflict occurred
@@ -915,12 +941,7 @@ export class WorktreeManager {
         }
 
         // Create detailed error with git command output
-        const gitError = new Error(`Failed to rebase ${mainBranch} into worktree`) as Error & {
-          gitCommand?: string;
-          gitOutput?: string;
-          workingDirectory?: string;
-          originalError?: Error;
-        };
+        const gitError = new GitOperationError(`Failed to rebase ${mainBranch} into worktree`);
         gitError.gitCommand = executedCommands.join(' && ');
         gitError.gitOutput = err.stderr || err.stdout || lastOutput || err.message || '';
         gitError.workingDirectory = worktreePath;
@@ -945,7 +966,7 @@ export class WorktreeManager {
         throw new Error(`Failed to abort rebase: ${stderr}`);
       }
     } catch (error: unknown) {
-      const err = error as Error;
+      const err = decodeBoundary(error, commandErrorSchema);
       console.error(`[WorktreeManager] Error aborting rebase:`, err);
       throw new Error(`Failed to abort rebase: ${err.message}`);
     }
@@ -990,7 +1011,7 @@ export class WorktreeManager {
           lastOutput = rebaseWorktreeResult.stdout || rebaseWorktreeResult.stderr || '';
           console.log(`[WorktreeManager] Successfully rebased worktree onto ${mainBranch} before squashing`);
         } catch (error: unknown) {
-          const err = error as Error & { stderr?: string; stdout?: string };
+          const err = decodeBoundary(error, commandErrorSchema);
           // If rebase fails, abort it in the worktree
           try {
             await commandRunner.execAsync(`git rebase --abort`, worktreePath);
@@ -1041,7 +1062,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
           lastOutput = mergeResult.stdout || mergeResult.stderr || '';
           console.log(`[WorktreeManager] Successfully fast-forwarded ${mainBranch} to ${branchName}`);
         } catch (error: unknown) {
-          const err = error as Error & { stderr?: string; stdout?: string };
+          const err = decodeBoundary(error, commandErrorSchema);
           throw new Error(
             `Failed to fast-forward ${mainBranch} to ${branchName}.\n\n` +
             `This usually means ${mainBranch} has commits that ${branchName} doesn't have.\n` +
@@ -1066,7 +1087,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
           });
         }
       } catch (error: unknown) {
-        const err = error as Error & { stderr?: string; stdout?: string };
+        const err = decodeBoundary(error, commandErrorSchema);
         console.error(`[WorktreeManager] Failed to squash and merge worktree to ${mainBranch}:`, err);
 
         // Track failed squash
@@ -1090,13 +1111,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
         }
 
         // Create detailed error with git command output
-        const gitError = new Error(`Failed to squash and merge worktree to ${mainBranch}`) as Error & {
-          gitCommands?: string[];
-          gitOutput?: string;
-          workingDirectory?: string;
-          projectPath?: string;
-          originalError?: Error;
-        };
+        const gitError = new GitOperationError(`Failed to squash and merge worktree to ${mainBranch}`);
         gitError.gitCommands = executedCommands;
         // Prioritize actual error messages over lastOutput (which may contain unrelated data like commit counts)
         gitError.gitOutput = err.stderr || err.stdout || err.message || lastOutput || '';
@@ -1140,7 +1155,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
           lastOutput = rebaseWorktreeResult.stdout || rebaseWorktreeResult.stderr || '';
           console.log(`[WorktreeManager] Successfully rebased worktree onto ${mainBranch}`);
         } catch (error: unknown) {
-          const err = error as Error & { stderr?: string; stdout?: string };
+          const err = decodeBoundary(error, commandErrorSchema);
           // If rebase fails, abort it in the worktree
           try {
             await commandRunner.execAsync(`git rebase --abort`, worktreePath);
@@ -1169,7 +1184,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
           lastOutput = mergeResult.stdout || mergeResult.stderr || '';
           console.log(`[WorktreeManager] Successfully fast-forwarded ${mainBranch} to ${branchName}`);
         } catch (error: unknown) {
-          const err = error as Error & { stderr?: string; stdout?: string };
+          const err = decodeBoundary(error, commandErrorSchema);
           throw new Error(
             `Failed to fast-forward ${mainBranch} to ${branchName}.\n\n` +
             `This usually means ${mainBranch} has commits that ${branchName} doesn't have.\n` +
@@ -1180,17 +1195,11 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
         console.log(`[WorktreeManager] Successfully merged worktree to ${mainBranch} (without squashing)`);
       } catch (error: unknown) {
-        const err = error as Error & { stderr?: string; stdout?: string };
+        const err = decodeBoundary(error, commandErrorSchema);
         console.error(`[WorktreeManager] Failed to merge worktree to ${mainBranch}:`, err);
 
         // Create detailed error with git command output
-        const gitError = new Error(`Failed to merge worktree to ${mainBranch}`) as Error & {
-          gitCommands?: string[];
-          gitOutput?: string;
-          workingDirectory?: string;
-          projectPath?: string;
-          originalError?: Error;
-        };
+        const gitError = new GitOperationError(`Failed to merge worktree to ${mainBranch}`);
         gitError.gitCommands = executedCommands;
         // Prioritize actual error messages over lastOutput (which may contain unrelated data like commit counts)
         gitError.gitOutput = err.stderr || err.stdout || err.message || lastOutput || '';
@@ -1241,11 +1250,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return { output };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Git pull failed') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Git pull failed');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;
@@ -1271,11 +1277,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return { output };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Git push failed') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Git push failed');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;
@@ -1289,11 +1292,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return { output };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Git fetch failed') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Git fetch failed');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;
@@ -1309,11 +1309,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return { output };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Git stash failed') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Git stash failed');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;
@@ -1327,11 +1324,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return { output };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Git stash pop failed') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Git stash pop failed');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;
@@ -1387,11 +1381,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
       const output = stdout || stderr || `Tracking set to ${remoteBranch}`;
       return { output };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Failed to set upstream') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Failed to set upstream');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;
@@ -1431,11 +1422,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return { output };
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Git commit failed') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Git commit failed');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;
@@ -1491,11 +1479,8 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
 
       return commits;
     } catch (error: unknown) {
-      const err = error as Error & { stderr?: string; stdout?: string };
-      const gitError = new Error(err.message || 'Failed to get commits') as Error & {
-        gitOutput?: string;
-        workingDirectory?: string;
-      };
+      const err = decodeBoundary(error, commandErrorSchema);
+      const gitError = new GitOperationError(err.message || 'Failed to get commits');
       gitError.gitOutput = err.stderr || err.stdout || err.message || '';
       gitError.workingDirectory = worktreePath;
       throw gitError;

--- a/main/src/test-updater.ts
+++ b/main/src/test-updater.ts
@@ -16,6 +16,7 @@ export function setupTestUpdater() {
   // Log all events for debugging
   autoUpdater.logger = console;
   // Set debug level for winston-based loggers if available
+  // SAFETY: electron-updater accepts Logger but exposes the configured winston transport only at runtime.
   const logger = autoUpdater.logger as { transports?: { file?: { level: string } } };
   if (logger && logger.transports && logger.transports.file) {
     logger.transports.file.level = 'debug';

--- a/main/src/types/session.ts
+++ b/main/src/types/session.ts
@@ -100,7 +100,7 @@ interface ToolUseContent {
   type: 'tool_use';
   id: string;
   name: string;
-  input: Record<string, unknown>;
+  input: JsonObject;
 }
 
 interface ToolResultContent {
@@ -116,8 +116,7 @@ export type MessageContent = TextContent | ToolUseContent | ToolResultContent;
 interface ToolDefinition {
   name: string;
   description?: string;
-  input_schema?: Record<string, unknown>;
-  [key: string]: unknown;
+  input_schema?: JsonObject;
 }
 
 // MCP server definition interface  
@@ -126,7 +125,6 @@ interface McpServerDefinition {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
-  [key: string]: unknown;
 }
 
 // JSON message structure from Claude
@@ -137,11 +135,10 @@ export interface ClaudeJsonMessage {
   content?: string | MessageContent[];
   message?: { 
     content?: string | MessageContent[];
-    [key: string]: unknown;
   };
   timestamp: string;
   name?: string;
-  input?: Record<string, unknown>;
+  input?: JsonObject;
   tool_use_id?: string;
   parent_tool_use_id?: string;
   session_id?: string;
@@ -163,8 +160,7 @@ export interface ClaudeJsonMessage {
   num_turns?: number;
   cost_usd?: number;
   thinking?: string;
-  data?: Record<string, unknown>;
-  [key: string]: unknown;
+  data?: JsonObject;
 }
 
 export interface SessionOutput {
@@ -174,3 +170,4 @@ export interface SessionOutput {
   timestamp: Date;
   panelId?: string;
 }
+import type { JsonObject } from '../../../shared/validation/boundaryDecoder';

--- a/main/src/utils/appDirectory.ts
+++ b/main/src/utils/appDirectory.ts
@@ -1,6 +1,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { existsSync, renameSync } from 'fs';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 let customAppDir: string | undefined;
 
@@ -14,13 +15,17 @@ function getElectronApp(): ElectronAppLike | null {
     // In a plain Node process, `require('electron')` resolves to the Electron
     // binary path string rather than the runtime module. Guard that case.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electronModule = require('electron') as unknown;
-    if (!electronModule || typeof electronModule !== 'object') {
+    const electronModule = require('electron');
+    try {
+      decodeBoundary(electronModule, boundary.string);
       return null;
+    } catch {
+      // The Electron runtime exposes the module object instead of the binary path.
     }
 
+    // SAFETY: Electron's runtime module contract exposes `app`; plain Node's string case was excluded above.
     const electronApp = (electronModule as { app?: ElectronAppLike }).app;
-    if (!electronApp || typeof electronApp.getPath !== 'function') {
+    if (!electronApp) {
       return null;
     }
 

--- a/main/src/utils/attribution.test.ts
+++ b/main/src/utils/attribution.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { GIT_ATTRIBUTION_ENV, getGitAttributionEnv } from './attribution';
-import type { AppConfig } from '../types/config';
 
 describe('getGitAttributionEnv', () => {
   it('returns the attribution env when config is undefined', () => {
@@ -12,14 +11,14 @@ describe('getGitAttributionEnv', () => {
   });
 
   it('returns the attribution env when gitAttributionEnabled is absent (default enabled)', () => {
-    expect(getGitAttributionEnv({} as AppConfig)).toBe(GIT_ATTRIBUTION_ENV);
+    expect(getGitAttributionEnv({})).toBe(GIT_ATTRIBUTION_ENV);
   });
 
   it('returns the attribution env when gitAttributionEnabled is true', () => {
-    expect(getGitAttributionEnv({ gitAttributionEnabled: true } as AppConfig)).toBe(GIT_ATTRIBUTION_ENV);
+    expect(getGitAttributionEnv({ gitAttributionEnabled: true })).toBe(GIT_ATTRIBUTION_ENV);
   });
 
   it('returns an empty object when gitAttributionEnabled is false', () => {
-    expect(getGitAttributionEnv({ gitAttributionEnabled: false } as AppConfig)).toEqual({});
+    expect(getGitAttributionEnv({ gitAttributionEnabled: false })).toEqual({});
   });
 });

--- a/main/src/utils/autoStart.ts
+++ b/main/src/utils/autoStart.ts
@@ -2,6 +2,7 @@ import type { App } from 'electron';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const LINUX_AUTOSTART_FILENAME = 'com.dcouple.pane.desktop';
 
@@ -17,7 +18,13 @@ function syncLinuxAutoStart(enabled: boolean): void {
     try {
       fs.unlinkSync(desktopFilePath);
     } catch (error) {
-      if (!(error instanceof Error) || !('code' in error) || (error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      let code: string | undefined;
+      try {
+        code = decodeBoundary(error, boundary.object({ code: boundary.optional(boundary.string) })).code;
+      } catch {
+        code = undefined;
+      }
+      if (code !== 'ENOENT') {
         console.warn('[AutoStart] Failed to remove Linux autostart entry:', error);
       }
     }

--- a/main/src/utils/claudeCodeTest.ts
+++ b/main/src/utils/claudeCodeTest.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { getShellPath, findExecutableInPath } from './shellPath';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const execAsync = promisify(exec);
 
@@ -201,13 +202,25 @@ export async function testClaudeCodeInDirectory(directory: string, customClaudeP
     return { success: true, output: stdout + stderr };
   } catch (error) {
     console.error(`[ClaudeTest] Directory test failed: ${error instanceof Error ? error.message : error}`);
-    if (error instanceof Error && 'code' in error) {
-      console.error(`[ClaudeTest] Error code: ${(error as NodeJS.ErrnoException).code}`);
+    let processError: { code?: string; stdout?: string; stderr?: string } = {};
+    try {
+      processError = decodeBoundary(error, boundary.object({
+        code: boundary.optional(boundary.string),
+        stdout: boundary.optional(boundary.string),
+        stderr: boundary.optional(boundary.string),
+      }));
+    } catch {
+      processError = {};
+    }
+    if (processError.code) {
+      console.error(`[ClaudeTest] Error code: ${processError.code}`);
     }
     return { 
       success: false, 
       error: error instanceof Error ? error.message : 'Unknown error testing Claude Code in directory',
-      output: error instanceof Error && 'stdout' in error ? String((error as Error & {stdout?: string; stderr?: string}).stdout || '') + String((error as Error & {stdout?: string; stderr?: string}).stderr || '') : undefined
+      output: processError.stdout || processError.stderr
+        ? `${processError.stdout ?? ''}${processError.stderr ?? ''}`
+        : undefined
     };
   }
 }

--- a/main/src/utils/commandExecutor.ts
+++ b/main/src/utils/commandExecutor.ts
@@ -2,9 +2,18 @@ import { execSync as nodeExecSync, execFileSync as nodeExecFileSync, ExecSyncOpt
 import { promisify } from 'util';
 import { getShellPath } from './shellPath';
 import { WSLContext, getWSLExecArgs } from './wslUtils';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 const nodeExecAsync = promisify(exec);
 const nodeExecFileAsync = promisify(execFile);
+
+function decodeStringCwd(cwd: string | URL): string | undefined {
+  try {
+    return decodeBoundary(cwd, boundary.string);
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Compute env vars that differ from the current process.env.
@@ -43,7 +52,7 @@ class CommandExecutor {
     // Log the command being executed (unless silent mode requested)
     const cwd = options?.cwd || process.cwd();
 
-    const extendedOptions = options as ExtendedExecSyncOptions;
+    const extendedOptions = options;
     const silentMode = extendedOptions?.silent === true;
 
     // Get enhanced shell PATH
@@ -54,8 +63,8 @@ class CommandExecutor {
       // avoiding all cmd.exe escaping issues (%, ^, &, etc.)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { cwd: _cwd, silent: _silent, ...cleanOptions } = extendedOptions || {};
-      const wslCwd = typeof cwd === 'string' ? cwd : undefined;
-      const extraEnv = getExtraEnvVars(cleanOptions?.env as Record<string, string | undefined>);
+      const wslCwd = decodeStringCwd(cwd);
+      const extraEnv = getExtraEnvVars(cleanOptions?.env);
       const { file, args } = getWSLExecArgs(command, wslContext.distribution, wslCwd, extraEnv);
 
       if (!silentMode) {
@@ -65,7 +74,7 @@ class CommandExecutor {
       const wslOptions = {
         ...cleanOptions,
         maxBuffer: cleanOptions?.maxBuffer || 10 * 1024 * 1024,
-        encoding: (cleanOptions?.encoding || 'utf-8') as BufferEncoding,
+        encoding: cleanOptions?.encoding || 'utf-8',
         env: { ...process.env, ...cleanOptions?.env, PATH: shellPath },
       };
 
@@ -108,7 +117,7 @@ class CommandExecutor {
     };
 
     try {
-      const result = nodeExecSync(command, enhancedOptions as ExecSyncOptions);
+      const result = nodeExecSync(command, enhancedOptions);
 
       // Log success with a preview of the result (unless silent mode)
       if (result && !silentMode) {
@@ -140,8 +149,8 @@ class CommandExecutor {
       // Invoke wsl.exe directly via execFile — bypasses cmd.exe entirely
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { cwd: _cwd, silent: _silent, ...cleanOptions } = options || {};
-      const wslCwd = typeof cwd === 'string' ? cwd : undefined;
-      const extraEnv = getExtraEnvVars(cleanOptions?.env as Record<string, string | undefined>);
+      const wslCwd = decodeStringCwd(cwd);
+      const extraEnv = getExtraEnvVars(cleanOptions?.env);
       const { file, args } = getWSLExecArgs(command, wslContext.distribution, wslCwd, extraEnv);
 
       if (!silentMode) {

--- a/main/src/utils/commandRunner.ts
+++ b/main/src/utils/commandRunner.ts
@@ -9,14 +9,14 @@ export class CommandRunner {
   }
 
   /** Execute command synchronously, wrapping for WSL if needed */
-  exec(command: string, cwd: string, options?: { encoding?: string; maxBuffer?: number; silent?: boolean; env?: Record<string, string> }): string {
+  exec(command: string, cwd: string, options?: { encoding?: BufferEncoding; maxBuffer?: number; silent?: boolean; env?: Record<string, string> }): string {
     return commandExecutor.execSync(command, {
       cwd,
-      encoding: (options?.encoding || 'utf-8') as BufferEncoding,
+      encoding: options?.encoding || 'utf-8',
       maxBuffer: options?.maxBuffer,
       silent: options?.silent,
       env: options?.env ? { ...process.env, ...options.env } : undefined,
-    }, this.wslContext) as string;
+    }, this.wslContext);
   }
 
   /** Execute command asynchronously, wrapping for WSL if needed */

--- a/main/src/utils/consoleWrapper.test.ts
+++ b/main/src/utils/consoleWrapper.test.ts
@@ -2,6 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const savedConsole = { ...console };
 
+function throwingConsoleMethod(error: Error): typeof console.log {
+  return vi.fn(() => {
+    throw error;
+  });
+}
+
 async function loadConsoleWrapperWithOriginals(originals: Partial<Console>) {
   vi.resetModules();
   Object.assign(console, originals);
@@ -17,12 +23,8 @@ describe('setupConsoleWrapper', () => {
   it('ignores EPIPE from closed stdout or stderr streams', async () => {
     const epipe = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
     const { setupConsoleWrapper } = await loadConsoleWrapperWithOriginals({
-      log: vi.fn(() => {
-        throw epipe;
-      }) as unknown as typeof console.log,
-      error: vi.fn(() => {
-        throw epipe;
-      }) as unknown as typeof console.error,
+      log: throwingConsoleMethod(epipe),
+      error: throwingConsoleMethod(epipe),
     });
 
     setupConsoleWrapper();
@@ -33,9 +35,7 @@ describe('setupConsoleWrapper', () => {
 
   it('preserves unexpected console write failures', async () => {
     const { setupConsoleWrapper } = await loadConsoleWrapperWithOriginals({
-      log: vi.fn(() => {
-        throw new Error('unexpected console failure');
-      }) as unknown as typeof console.log,
+      log: throwingConsoleMethod(new Error('unexpected console failure')),
     });
 
     setupConsoleWrapper();

--- a/main/src/utils/consoleWrapper.ts
+++ b/main/src/utils/consoleWrapper.ts
@@ -1,7 +1,11 @@
 // Simple console wrapper to reduce logging in production
 // This follows the existing pattern in the codebase
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
-const isDevelopment = process.env.NODE_ENV !== 'production' && !((global as { isPackaged?: boolean }).isPackaged);
+const runtimeGlobal = decodeBoundary(global, boundary.object({
+  isPackaged: boundary.optional(boundary.boolean),
+}));
+const isDevelopment = process.env.NODE_ENV !== 'production' && !runtimeGlobal.isPackaged;
 
 // Store original console methods
 const originalConsole = {
@@ -12,15 +16,17 @@ const originalConsole = {
   debug: console.debug
 };
 
-function isBrokenPipeError(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException | undefined)?.code === 'EPIPE';
-}
-
 function writeOriginalConsole(method: (...args: unknown[]) => void, args: unknown[]): void {
   try {
     method(...args);
   } catch (error) {
-    if (!isBrokenPipeError(error)) {
+    let code: string | undefined;
+    try {
+      code = decodeBoundary(error, boundary.object({ code: boundary.optional(boundary.string) })).code;
+    } catch {
+      code = undefined;
+    }
+    if (code !== 'EPIPE') {
       throw error;
     }
   }
@@ -30,29 +36,35 @@ function writeOriginalConsole(method: (...args: unknown[]) => void, args: unknow
 function shouldLog(level: 'log' | 'info' | 'debug', args: unknown[]): boolean {
   if (args.length === 0) return false;
   const firstArg = args[0];
-  if (typeof firstArg === 'string') {
+  let message: string | undefined;
+  try {
+    message = decodeBoundary(firstArg, boundary.string);
+  } catch {
+    message = undefined;
+  }
+  if (message !== undefined) {
     // Always log [Main] messages as they're important startup info
-    if (firstArg.includes('[Main]')) return true;
+    if (message.includes('[Main]')) return true;
     // Always log errors from any component
-    if (firstArg.includes('Error') || firstArg.includes('Failed')) return true;
+    if (message.includes('Error') || message.includes('Failed')) return true;
     
     // Skip verbose logging from these components in both dev and production
-    if (firstArg.includes('[CommandExecutor]')) return false;
-    if (firstArg.includes('[ShellPath]')) return false;
-    if (firstArg.includes('[Database] Getting folders')) return false;
-    if (firstArg.includes('[WorktreeManager]') && firstArg.includes('called with')) return false;
+    if (message.includes('[CommandExecutor]')) return false;
+    if (message.includes('[ShellPath]')) return false;
+    if (message.includes('[Database] Getting folders')) return false;
+    if (message.includes('[WorktreeManager]') && message.includes('called with')) return false;
     // Skip git status polling logs
-    if (firstArg.includes('[GitStatus]') && !firstArg.includes('error') && !firstArg.includes('failed')) return false;
-    if (firstArg.includes('[Git]') && firstArg.includes('Refreshing git status')) return false;
+    if (message.includes('[GitStatus]') && !message.includes('error') && !message.includes('failed')) return false;
+    if (message.includes('[Git]') && message.includes('Refreshing git status')) return false;
     // Skip individual git status updates from frontend
-    if (firstArg.includes('Git status updated:')) return false;
-    if (firstArg.includes('Git status:') && firstArg.includes('→')) return false;
+    if (message.includes('Git status updated:')) return false;
+    if (message.includes('Git status:') && message.includes('→')) return false;
     // Skip verbose git status manager logs
-    if (firstArg.includes('Polling git status for')) return false;
-    if (firstArg.includes('Using cached status for')) return false;
-    if (firstArg.includes('[IPC:git] Getting commits')) return false;
-    if (firstArg.includes('[IPC:git] Project path:')) return false;
-    if (firstArg.includes('[IPC:git] Using main branch:')) return false;
+    if (message.includes('Polling git status for')) return false;
+    if (message.includes('Using cached status for')) return false;
+    if (message.includes('[IPC:git] Getting commits')) return false;
+    if (message.includes('[IPC:git] Project path:')) return false;
+    if (message.includes('[IPC:git] Using main branch:')) return false;
     
     // In development, log everything else
     if (isDevelopment) {

--- a/main/src/utils/contextCompactor.ts
+++ b/main/src/utils/contextCompactor.ts
@@ -2,6 +2,7 @@ import type { DatabaseService } from '../database/database';
 import type { Session, ConversationMessage, PromptMarker, ExecutionDiff } from '../database/models';
 import type { SessionOutput } from '../types/session';
 import { formatDuration, getTimeDifference, parseTimestamp } from './timestampUtils';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 interface CompactionData {
   session: Session;
@@ -36,6 +37,30 @@ interface Todo {
   id: string;
   content: string;
   status: 'pending' | 'in_progress' | 'completed';
+}
+
+const compactionMessageSchema = boundary.object({
+  type: boundary.optional(boundary.string),
+  message: boundary.optional(boundary.object({
+    content: boundary.optional(boundary.array(boundary.object({
+      type: boundary.optional(boundary.string),
+      name: boundary.optional(boundary.string),
+      input: boundary.optional(boundary.object({
+        file_path: boundary.optional(boundary.string),
+        todos: boundary.optional(boundary.array(boundary.object({
+          id: boundary.string,
+          content: boundary.string,
+          status: boundary.enumeration('pending', 'in_progress', 'completed'),
+        }))),
+        edits: boundary.optional(boundary.array(boundary.json)),
+      })),
+      text: boundary.optional(boundary.string),
+    }))),
+  })),
+});
+
+function decodeSessionOutputData(value: SessionOutput['data']) {
+  return decodeBoundary(value, compactionMessageSchema);
 }
 
 interface GitStatus {
@@ -123,25 +148,15 @@ export class ProgrammaticCompactor {
       if (output.type === 'json') {
         try {
           // output.data is already parsed by sessionManager.getSessionOutputs
-          const message = output.data as {
-            type?: string;
-            message?: {
-              content?: Array<{
-                type?: string;
-                name?: string;
-                input?: { file_path?: string; todos?: Todo[]; edits?: unknown[] };
-                text?: string;
-              }>;
-            };
-          };
+          const message = decodeSessionOutputData(output.data);
           if (message.type === 'assistant' && message.message?.content) {
             message.message.content.forEach((content) => {
               if (content.type === 'tool_use') {
                 const path = content.input?.file_path;
                 if (path && content.name && ['Edit', 'Write', 'MultiEdit'].includes(content.name)) {
-                  const existing = fileMap.get(path) || {
+                  const existing: FileModification = fileMap.get(path) || {
                     path,
-                    operations: [] as Array<'create' | 'edit'>,
+                    operations: [],
                     changeCount: 0
                   };
                   
@@ -175,17 +190,7 @@ export class ProgrammaticCompactor {
       if (output.type === 'json') {
         try {
           // output.data is already parsed by sessionManager.getSessionOutputs
-          const message = output.data as {
-            type?: string;
-            message?: {
-              content?: Array<{
-                type?: string;
-                name?: string;
-                input?: { file_path?: string; todos?: Todo[]; edits?: unknown[] };
-                text?: string;
-              }>;
-            };
-          };
+          const message = decodeSessionOutputData(output.data);
           if (message.type === 'assistant' && message.message?.content) {
             message.message.content.forEach((content) => {
               if (content.type === 'tool_use' && content.input?.file_path) {
@@ -211,17 +216,7 @@ export class ProgrammaticCompactor {
       if (output.type === 'json') {
         try {
           // output.data is already parsed by sessionManager.getSessionOutputs
-          const message = output.data as {
-            type?: string;
-            message?: {
-              content?: Array<{
-                type?: string;
-                name?: string;
-                input?: { file_path?: string; todos?: Todo[]; edits?: unknown[] };
-                text?: string;
-              }>;
-            };
-          };
+          const message = decodeSessionOutputData(output.data);
           if (message.type === 'assistant' && message.message?.content) {
             message.message.content.forEach((content) => {
               if (content.type === 'tool_use' && content.name === 'TodoWrite' && content.input?.todos) {
@@ -275,17 +270,7 @@ export class ProgrammaticCompactor {
       if (output.type === 'json') {
         try {
           // output.data is already parsed by sessionManager.getSessionOutputs
-          const message = output.data as {
-            type?: string;
-            message?: {
-              content?: Array<{
-                type?: string;
-                name?: string;
-                input?: { file_path?: string; todos?: Todo[]; edits?: unknown[] };
-                text?: string;
-              }>;
-            };
-          };
+          const message = decodeSessionOutputData(output.data);
           if (message.type === 'assistant' && message.message?.content && Array.isArray(message.message.content)) {
             // Look for text content
             for (const content of message.message.content) {

--- a/main/src/utils/formatters.ts
+++ b/main/src/utils/formatters.ts
@@ -1,5 +1,15 @@
 import { formatForDisplay, isValidTimestamp } from './timestampUtils';
 import type { ClaudeJsonMessage, MessageContent } from '../types/session';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+
+function isStringContent(item: MessageContent | string): item is string {
+  try {
+    decodeBoundary(item, boundary.string);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export function formatJsonForOutput(jsonMessage: ClaudeJsonMessage): string {
   // Safely parse timestamp
@@ -39,7 +49,7 @@ export function formatJsonForOutput(jsonMessage: ClaudeJsonMessage): string {
       if (Array.isArray(jsonMessage.message.content)) {
         content = jsonMessage.message.content
           .map((item: MessageContent | string) => {
-            if (typeof item === 'string') return item;
+            if (isStringContent(item)) return item;
             if (item.type === 'text') return item.text;
             if (item.type === 'tool_result') {
               // Limit tool results to 10 lines
@@ -54,7 +64,7 @@ export function formatJsonForOutput(jsonMessage: ClaudeJsonMessage): string {
             return JSON.stringify(item);
           })
           .join(' ');
-      } else if (typeof jsonMessage.message.content === 'string') {
+      } else {
         content = jsonMessage.message.content;
       }
     }
@@ -73,7 +83,7 @@ export function formatJsonForOutput(jsonMessage: ClaudeJsonMessage): string {
       if (Array.isArray(jsonMessage.message.content)) {
         content = jsonMessage.message.content
           .map((item: MessageContent | string) => {
-            if (typeof item === 'string') return item;
+            if (isStringContent(item)) return item;
             if (item.type === 'text') {
               // Don't truncate text content
               return item.text;
@@ -91,7 +101,7 @@ export function formatJsonForOutput(jsonMessage: ClaudeJsonMessage): string {
             return JSON.stringify(item);
           })
           .join('\n\n');
-      } else if (typeof jsonMessage.message.content === 'string') {
+      } else {
         content = jsonMessage.message.content;
       }
     }

--- a/main/src/utils/logger.ts
+++ b/main/src/utils/logger.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { getAppSubdirectory } from './appDirectory';
 import { formatForDatabase } from './timestampUtils';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 // Capture the ORIGINAL console methods immediately when this module loads
 // This must happen before any other code can override them
@@ -290,14 +291,23 @@ export class Logger {
       // Always log to console using the original console method to avoid recursion
       this.originalConsole.log(consoleMessage);
     } catch (consoleError: unknown) {
+      let decodedError: { code?: string; message?: string } = {};
+      try {
+        decodedError = decodeBoundary(consoleError, boundary.object({
+          code: boundary.optional(boundary.string),
+          message: boundary.optional(boundary.string),
+        }));
+      } catch {
+        decodedError = {};
+      }
       // If console logging fails (e.g., EPIPE), just write to file
-      if ((consoleError as NodeJS.ErrnoException)?.code !== 'EPIPE' && !this.isInErrorHandler) {
+      if (decodedError.code !== 'EPIPE' && !this.isInErrorHandler) {
         // Prevent recursion by setting flag
         this.isInErrorHandler = true;
         try {
           // For non-EPIPE errors, try to at least write the error to file
           // Use a direct write to avoid potential recursion through writeToFile
-          const errorMessage = `[${timestamp}] ERROR: Failed to write to console: ${(consoleError as Error)?.message || 'Unknown error'}`;
+          const errorMessage = `[${timestamp}] ERROR: Failed to write to console: ${decodedError.message || 'Unknown error'}`;
           if (this.logStream && !this.logStream.destroyed) {
             this.logStream.write(`${this.truncateForFile(errorMessage)}\n`);
           }

--- a/main/src/utils/sessionValidation.ts
+++ b/main/src/utils/sessionValidation.ts
@@ -110,7 +110,12 @@ export function validateSessionIsActive(sessionId: string): ValidationResult {
 /**
  * Validates that an event matches the expected session context
  */
-export function validateEventContext(eventData: Record<string, unknown>, expectedSessionId?: string): ValidationResult {
+interface SessionEventContext {
+  readonly sessionId?: string;
+  readonly panelId?: string;
+}
+
+export function validateEventContext(eventData: SessionEventContext, expectedSessionId?: string): ValidationResult {
   if (!eventData) {
     return { valid: false, error: 'Event data is required' };
   }
@@ -120,7 +125,7 @@ export function validateEventContext(eventData: Record<string, unknown>, expecte
     if (!eventData.sessionId) {
       return { valid: false, error: 'Event must contain sessionId' };
     }
-    return validateSessionExists(String(eventData.sessionId));
+    return validateSessionExists(eventData.sessionId);
   }
 
   // Validate event session matches expected session
@@ -148,7 +153,7 @@ export function validateEventContext(eventData: Record<string, unknown>, expecte
  * Validates that a panel event matches the expected context
  */
 export function validatePanelEventContext(
-  eventData: Record<string, unknown>, 
+  eventData: SessionEventContext,
   expectedPanelId?: string, 
   expectedSessionId?: string
 ): ValidationResult {

--- a/main/src/utils/timestampUtils.ts
+++ b/main/src/utils/timestampUtils.ts
@@ -11,13 +11,17 @@ export function formatForDatabase(date: Date = new Date()): string {
   return date.toISOString();
 }
 
+function toDate(timestamp: string | Date): Date {
+  return timestamp instanceof Date ? timestamp : new Date(timestamp);
+}
+
 /**
  * Formats a timestamp for display to users
  * @param timestamp - The timestamp string from database or Date object
  * @returns Localized time string
  */
 export function formatForDisplay(timestamp: string | Date): string {
-  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const date = toDate(timestamp);
   return date.toLocaleTimeString();
 }
 
@@ -27,7 +31,7 @@ export function formatForDisplay(timestamp: string | Date): string {
  * @returns Localized date and time string
  */
 function formatFullDateTime(timestamp: string | Date): string {
-  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const date = toDate(timestamp);
   return date.toLocaleString();
 }
 
@@ -55,7 +59,7 @@ function getCurrentTimestamp(): string {
  */
 export function isValidTimestamp(timestamp: string | Date | null | undefined): boolean {
   if (!timestamp) return false;
-  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const date = toDate(timestamp);
   return !isNaN(date.getTime());
 }
 
@@ -65,7 +69,7 @@ export function isValidTimestamp(timestamp: string | Date | null | undefined): b
  * @returns UTC ISO string
  */
 function toUTC(timestamp: string | Date): string {
-  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const date = toDate(timestamp);
   return date.toISOString();
 }
 
@@ -76,8 +80,8 @@ function toUTC(timestamp: string | Date): string {
  * @returns Duration in milliseconds
  */
 export function getTimeDifference(start: string | Date, end: string | Date = new Date()): number {
-  const startDate = typeof start === 'string' ? new Date(start) : start;
-  const endDate = typeof end === 'string' ? new Date(end) : end;
+  const startDate = toDate(start);
+  const endDate = toDate(end);
   return endDate.getTime() - startDate.getTime();
 }
 

--- a/main/src/utils/toolFormatter.ts
+++ b/main/src/utils/toolFormatter.ts
@@ -1,12 +1,13 @@
 import * as path from 'path';
 import { formatJsonForOutput } from './formatters';
 import type { ClaudeJsonMessage } from '../types/session';
+import { boundary, decodeBoundary, type JsonObject, type JsonValue } from '../../../shared/validation/boundaryDecoder';
 
 interface ToolCall {
   type: 'tool_use';
   id: string;
   name: string;
-  input: Record<string, unknown>;
+  input: JsonObject;
 }
 
 interface ToolResult {
@@ -37,13 +38,36 @@ interface TextItem {
 
 type ContentItem = ThinkingItem | TextItem | ToolCall | ToolResult;
 
+const contentItemSchema = boundary.union(
+  boundary.object({ type: boundary.literal('thinking'), thinking: boundary.optional(boundary.string) }),
+  boundary.object({ type: boundary.literal('text'), text: boundary.optional(boundary.string) }),
+  boundary.object({
+    type: boundary.literal('tool_use'), id: boundary.string, name: boundary.string, input: boundary.jsonObject,
+  }),
+  boundary.object({
+    type: boundary.literal('tool_result'), tool_use_id: boundary.string, content: boundary.string,
+  }),
+);
+
+function readString(record: JsonObject, key: string): string | undefined {
+  return decodeOptional(record[key], boundary.string);
+}
+
+function readNumber(record: JsonObject, key: string): number | undefined {
+  return decodeOptional(record[key], boundary.number);
+}
+
+function readObject(record: JsonObject, key: string): JsonObject | undefined {
+  return decodeOptional(record[key], boundary.jsonObject);
+}
+
 // Store pending tool calls to match with their results
 const pendingToolCalls = new Map<string, PendingToolCall>();
 
 /**
  * Recursively filter out base64 data from any object structure
  */
-function filterBase64Data(obj: unknown): unknown {
+function filterBase64Data(obj: JsonValue): JsonValue {
   if (obj === null || obj === undefined) {
     return obj;
   }
@@ -54,18 +78,22 @@ function filterBase64Data(obj: unknown): unknown {
   }
 
   // Handle objects
-  if (typeof obj === 'object') {
-    const filtered: Record<string, unknown> = {};
-    const objRecord = obj as Record<string, unknown>;
+  try {
+    const objRecord = decodeBoundary(obj, boundary.jsonObject);
+    const filtered: JsonObject = {};
     
     for (const key in objRecord) {
       if (Object.prototype.hasOwnProperty.call(objRecord, key)) {
         // Check if this is a base64 source object
-        const sourceObj = objRecord[key] as Record<string, unknown>;
-        if (key === 'source' && sourceObj?.type === 'base64' && sourceObj?.data) {
+        const sourceRecord = decodeOptional(objRecord[key], boundary.jsonObject);
+        const sourceObj = decodeOptional(objRecord[key], boundary.object({
+          type: boundary.optional(boundary.string),
+          data: boundary.optional(boundary.string),
+        }));
+        if (key === 'source' && sourceObj?.type === 'base64' && sourceObj.data) {
           // Replace base64 data with placeholder
           filtered[key] = {
-            ...sourceObj,
+            ...sourceRecord,
             data: '[Base64 data filtered]'
           };
         } else {
@@ -76,26 +104,35 @@ function filterBase64Data(obj: unknown): unknown {
     }
     
     return filtered;
-  }
+  } catch { /* Primitive JSON values pass through unchanged. */ }
 
   // Return primitive values as-is
   return obj;
 }
 
+function decodeOptional<Value>(value: JsonValue | undefined, schema: import('../../../shared/validation/boundaryDecoder').BoundarySchema<Value>): Value | undefined {
+  if (value === undefined) return undefined;
+  try {
+    return decodeBoundary(value, schema);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Convert absolute file paths to relative paths based on the git repository root
  */
-function makePathsRelative(content: unknown, gitRepoPath?: string): string {
+function makePathsRelative(content: JsonValue, gitRepoPath?: string): string {
   // Handle non-string content
   let stringContent: string;
-  if (typeof content !== 'string') {
-    if (content === null || content === undefined) {
+  const decodedString = decodeOptional(content, boundary.string);
+  if (decodedString === undefined) {
+    if (content === null) {
       return '';
     }
-    // Convert to string if it's an object or array
-    stringContent = typeof content === 'object' ? JSON.stringify(content, null, 2) : String(content);
+    stringContent = JSON.stringify(content, null, 2);
   } else {
-    stringContent = content;
+    stringContent = decodedString;
   }
   
   if (!gitRepoPath) return stringContent;
@@ -174,9 +211,10 @@ function formatToolInteraction(
       }
     } else if (toolCall.name === 'Read' && toolCall.input.file_path) {
       output += `\x1b[90m│  File: ${makePathsRelative(toolCall.input.file_path, gitRepoPath)}\x1b[0m\r\n`;
-      if (toolCall.input.offset && typeof toolCall.input.offset === 'number') {
-        const limit = typeof toolCall.input.limit === 'number' ? toolCall.input.limit : 2000;
-        output += `\x1b[90m│  Lines: ${toolCall.input.offset}-${toolCall.input.offset + limit}\x1b[0m\r\n`;
+      const offset = decodeOptional(toolCall.input.offset, boundary.number);
+      if (offset) {
+        const limit = decodeOptional(toolCall.input.limit, boundary.number) ?? 2000;
+        output += `\x1b[90m│  Lines: ${offset}-${offset + limit}\x1b[0m\r\n`;
       }
     } else if (toolCall.name === 'Edit' && toolCall.input.file_path) {
       output += `\x1b[90m│  File: ${makePathsRelative(toolCall.input.file_path, gitRepoPath)}\x1b[0m\r\n`;
@@ -185,14 +223,18 @@ function formatToolInteraction(
       output += `\x1b[90m│  $ ${toolCall.input.command}\x1b[0m\r\n`;
     } else if (toolCall.name === 'TodoWrite' && toolCall.input.todos) {
       output += `\x1b[90m│  Tasks updated:\x1b[0m\r\n`;
-      (toolCall.input.todos as Array<{status: string; content: string}>).forEach((todo) => {
+      const todos = decodeOptional(toolCall.input.todos, boundary.array(boundary.object({
+        status: boundary.string,
+        content: boundary.string,
+      }))) ?? [];
+      todos.forEach((todo) => {
         const status = todo.status === 'completed' ? '✓' : todo.status === 'in_progress' ? '→' : '○';
         const statusColor = todo.status === 'completed' ? '\x1b[32m' : todo.status === 'in_progress' ? '\x1b[33m' : '\x1b[90m';
         output += `\x1b[90m│    ${statusColor}${status}\x1b[0m ${todo.content}\x1b[0m\r\n`;
       });
     } else if (toolCall.name === 'Write' && toolCall.input.file_path) {
       output += `\x1b[90m│  File: ${makePathsRelative(toolCall.input.file_path, gitRepoPath)}\x1b[0m\r\n`;
-      const content = typeof toolCall.input.content === 'string' ? toolCall.input.content : '';
+      const content = decodeOptional(toolCall.input.content, boundary.string) ?? '';
       const lines = content.split('\n');
       output += `\x1b[90m│  Size: ${lines.length} lines\x1b[0m\r\n`;
     } else if (toolCall.name === 'Glob' && toolCall.input.pattern) {
@@ -412,24 +454,26 @@ function formatToolInteraction(
 /**
  * Enhanced JSON to output formatter that unifies tool calls and responses
  */
-export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>, gitRepoPath?: string): string {
+export function formatJsonForOutputEnhanced(jsonMessage: JsonObject, gitRepoPath?: string): string {
   // CODEX COMPATIBILITY: Unwrap old Codex format {"id":"0","msg":{...}}
   let unwrappedMessage = jsonMessage;
-  if (jsonMessage.id !== undefined && jsonMessage.msg && typeof jsonMessage.msg === 'object') {
+  const wrappedMessage = readObject(jsonMessage, 'msg');
+  if (jsonMessage.id !== undefined && wrappedMessage) {
     console.log('[Codex] Detected old Codex format, unwrapping msg property');
-    unwrappedMessage = { ...jsonMessage.msg as Record<string, unknown>, timestamp: jsonMessage.timestamp };
+    unwrappedMessage = { ...wrappedMessage, timestamp: jsonMessage.timestamp };
   }
 
   // Ensure we have a valid timestamp
   let timestamp: string;
   try {
-    if (unwrappedMessage.timestamp && typeof unwrappedMessage.timestamp === 'string') {
+    const providedTimestamp = readString(unwrappedMessage, 'timestamp');
+    if (providedTimestamp) {
       // Validate the provided timestamp
-      const date = new Date(unwrappedMessage.timestamp);
+      const date = new Date(providedTimestamp);
       if (isNaN(date.getTime())) {
         throw new Error('Invalid timestamp');
       }
-      timestamp = unwrappedMessage.timestamp;
+      timestamp = providedTimestamp;
     } else {
       // Use current time if no timestamp provided
       timestamp = new Date().toISOString();
@@ -440,7 +484,7 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
   }
 
   // CODEX COMPATIBILITY: Handle new Codex protocol message types
-  const messageType = unwrappedMessage.type as string;
+  const messageType = readString(unwrappedMessage, 'type');
 
   // Handle thread lifecycle messages
   if (messageType === 'thread.started' || messageType === 'turn.started') {
@@ -450,22 +494,22 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
 
   // Handle item messages (reasoning, command execution, etc.)
   if (messageType === 'item.started' || messageType === 'item.completed') {
-    const item = unwrappedMessage.item as Record<string, unknown> | undefined;
+    const item = readObject(unwrappedMessage, 'item');
     if (!item) return '';
 
-    const itemType = item.type as string;
+    const itemType = readString(item, 'type');
     const time = new Date(timestamp).toLocaleTimeString();
 
     if (itemType === 'reasoning') {
-      const reasoningText = item.text as string || '';
+      const reasoningText = readString(item, 'text') || '';
       return `\r\n\x1b[36m[${time}]\x1b[0m \x1b[1m\x1b[96m🧠 ${reasoningText}\x1b[0m\r\n`;
     }
 
     if (itemType === 'command_execution') {
-      const command = item.command as string || '';
-      const status = item.status as string || '';
-      const exitCode = item.exit_code as number | undefined;
-      const aggregatedOutput = item.aggregated_output as string || '';
+      const command = readString(item, 'command') || '';
+      const status = readString(item, 'status') || '';
+      const exitCode = readNumber(item, 'exit_code');
+      const aggregatedOutput = readString(item, 'aggregated_output') || '';
 
       if (messageType === 'item.started') {
         return `\r\n\x1b[36m[${time}]\x1b[0m \x1b[1m\x1b[33m🔧 Executing: ${command}\x1b[0m\r\n`;
@@ -497,14 +541,14 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
     }
 
     if (itemType === 'text_delta') {
-      const text = item.text as string || '';
+      const text = readString(item, 'text') || '';
       if (!text.trim()) return '';
 
       return `\x1b[37m${text}\x1b[0m`;
     }
 
     if (itemType === 'message') {
-      const text = item.text as string || '';
+      const text = readString(item, 'text') || '';
       if (!text.trim()) return '';
 
       const time = new Date(timestamp).toLocaleTimeString();
@@ -518,13 +562,13 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
   }
 
   if (messageType === 'agent_reasoning') {
-    const reasoningText = unwrappedMessage.text as string || '';
+    const reasoningText = readString(unwrappedMessage, 'text') || '';
     const time = new Date(timestamp).toLocaleTimeString();
     return `\r\n\x1b[36m[${time}]\x1b[0m \x1b[1m\x1b[96m🧠 ${reasoningText}\x1b[0m\r\n`;
   }
 
   if (messageType === 'agent_message') {
-    const messageText = unwrappedMessage.message as string || '';
+    const messageText = readString(unwrappedMessage, 'message') || '';
     const time = new Date(timestamp).toLocaleTimeString();
     return `\r\n\x1b[36m[${time}]\x1b[0m \x1b[1m\x1b[35m🤖 ${messageText}\x1b[0m\r\n\r\n`;
   }
@@ -540,8 +584,8 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
 
   // Handle messages from assistant (Claude Code format)
   if (unwrappedMessage.type === 'assistant') {
-    const messageObj = unwrappedMessage.message as {content?: unknown} | undefined;
-    const content = messageObj?.content;
+    const messageObj = readObject(unwrappedMessage, 'message');
+    const content: ContentItem[] | undefined = decodeOptional(messageObj?.content, boundary.array(contentItemSchema));
     
     if (Array.isArray(content)) {
       let output = '';
@@ -619,8 +663,8 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
 
   // Handle tool results from user
   if (unwrappedMessage.type === 'user') {
-    const messageObj = unwrappedMessage.message as {content?: unknown} | undefined;
-    const content = messageObj?.content;
+    const messageObj = readObject(unwrappedMessage, 'message');
+    const content: ContentItem[] | undefined = decodeOptional(messageObj?.content, boundary.array(contentItemSchema));
     
     if (Array.isArray(content)) {
       const toolResults = content.filter((item: ContentItem): item is ToolResult => item.type === 'tool_result');
@@ -659,9 +703,10 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
             const filteredContent = filterBase64Data(content);
             
             // Then convert to string for display
-            if (typeof filteredContent === 'string') {
-              content = makePathsRelative(filteredContent, gitRepoPath);
-            } else if (filteredContent !== null && filteredContent !== undefined) {
+            const filteredText = decodeOptional(filteredContent, boundary.string);
+            if (filteredText !== undefined) {
+              content = makePathsRelative(filteredText, gitRepoPath);
+            } else if (filteredContent !== null) {
               // Convert filtered object/array to string
               content = JSON.stringify(filteredContent, null, 2);
               content = makePathsRelative(content, gitRepoPath);
@@ -699,7 +744,11 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
 
   // Handle session messages (like errors)
   if (unwrappedMessage.type === 'session') {
-    const data = (unwrappedMessage.data as {status?: string; message?: string; details?: string}) || {};
+    const data: { status?: string; message?: string; details?: string } = decodeOptional(unwrappedMessage.data, boundary.object({
+      status: boundary.optional(boundary.string),
+      message: boundary.optional(boundary.string),
+      details: boundary.optional(boundary.string),
+    })) || {};
     const time = (() => {
       try {
         const date = new Date(timestamp);
@@ -719,7 +768,10 @@ export function formatJsonForOutputEnhanced(jsonMessage: Record<string, unknown>
   }
   
   // Fall back to original formatter for other message types
-  return formatJsonForOutput(unwrappedMessage as ClaudeJsonMessage);
+  const legacyMessage = { ...unwrappedMessage, type: unwrappedMessage.type, timestamp };
+  // SAFETY: The legacy formatter reads the same finite Claude message fields
+  // decoded above; unrecognized protocol fields are ignored by that formatter.
+  return formatJsonForOutput(legacyMessage as ClaudeJsonMessage);
 }
 
 // Re-export the original formatter for backwards compatibility

--- a/shared/types/daemon.ts
+++ b/shared/types/daemon.ts
@@ -1,5 +1,11 @@
 import { boundary, decodeBoundary } from '../validation/boundaryDecoder';
-import type { BoundarySchema, JsonObject, JsonValue } from '../validation/boundaryDecoder';
+import type { BoundarySchema, JsonValue } from '../validation/boundaryDecoder';
+export type {
+  PanePermissionInput,
+  PanePermissionRequest,
+  PanePermissionResponse,
+  PanePermissionResolvedEvent,
+} from './permissions';
 
 export interface PaneDaemonRequestFrame {
   type: 'request';
@@ -31,27 +37,6 @@ export interface PaneDaemonEventFrame {
   type: 'event';
   channel: string;
   args: JsonValue[];
-}
-
-export type PanePermissionInput = JsonObject;
-
-export interface PanePermissionRequest {
-  id: string;
-  sessionId: string;
-  toolName: string;
-  input: PanePermissionInput;
-  timestamp: number;
-}
-
-export interface PanePermissionResponse {
-  behavior: 'allow' | 'deny';
-  updatedInput?: PanePermissionInput;
-  message?: string;
-}
-
-export interface PanePermissionResolvedEvent {
-  request: PanePermissionRequest;
-  response: PanePermissionResponse;
 }
 
 export type PaneDaemonResponseFrame =

--- a/shared/types/permissions.ts
+++ b/shared/types/permissions.ts
@@ -1,0 +1,22 @@
+import type { JsonObject } from '../validation/boundaryDecoder';
+
+export type PanePermissionInput = JsonObject;
+
+export interface PanePermissionRequest {
+  id: string;
+  sessionId: string;
+  toolName: string;
+  input: PanePermissionInput;
+  timestamp: number;
+}
+
+export interface PanePermissionResponse {
+  behavior: 'allow' | 'deny';
+  updatedInput?: PanePermissionInput;
+  message?: string;
+}
+
+export interface PanePermissionResolvedEvent {
+  request: PanePermissionRequest;
+  response: PanePermissionResponse;
+}

--- a/shared/types/remoteDaemon.ts
+++ b/shared/types/remoteDaemon.ts
@@ -268,7 +268,7 @@ export interface RemoteDaemonHeartbeatPayload {
 
 export interface RemoteDaemonEventEnvelope {
   channel: string;
-  args: unknown[];
+  args: Array<JsonValue | object>;
   timestamp: string;
 }
 


### PR DESCRIPTION
## Summary
- parse PTY, process, persisted JSON, and service payloads at their owning boundaries
- replace downstream unknown dictionaries, runtime representation checks, and scattered assertions with finite contracts
- move shared permission event contracts to a neutral shared module
- reduce the Phase 2c inventory from 849 findings to 0

Closes #403 (partial: Phase 2c)

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter main exec vitest run` (61 files, 593 tests)
- `pnpm build`
- exact Phase 2c advisory inventory: 0 findings