### PR TITLE
Eliminate phase 2d quality findings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,20 +64,23 @@ import type {
   PanePermissionInput,
 } from '../../shared/types/daemon';
 import { isMac } from './utils/platformUtils';
+import { boundary, decodeOptionalBoundary } from '../../shared/validation/boundaryDecoder';
 
 // Stable empty array to avoid creating new references in render
 const EMPTY_TERMINAL_SHORTCUTS: TerminalShortcut[] = [];
+// SAFETY: Electron supports WebkitAppRegion although React's CSS type omits it.
+const MAC_TITLE_BAR_STYLE = { height: 38, WebkitAppRegion: 'drag' } as React.CSSProperties;
 
-// Type for IPC response
-interface IPCResponse<T = unknown> {
-  success: boolean;
-  data?: T;
-  error?: string;
-}
-
-interface OnboardingEnvironmentResult {
-  ghReady?: boolean;
-}
+const preferenceResponseSchema = boundary.object({
+  success: boundary.boolean,
+  data: boundary.optional(boundary.string),
+  error: boundary.optional(boundary.string),
+});
+const lastOpenResponseSchema = boundary.object({
+  success: boundary.boolean,
+  data: boundary.optional(boundary.object({ discord_shown: boundary.optional(boundary.boolean) })),
+  error: boundary.optional(boundary.string),
+});
 
 function App() {
   const [isWelcomeOpen, setIsWelcomeOpen] = useState(false);
@@ -204,7 +207,11 @@ function App() {
 
   useEffect(() => {
     const clearViewedCompletedActivity = (event: Event) => {
-      const sessionId = (event as CustomEvent<{ sessionId?: string }>).detail?.sessionId;
+      if (!(event instanceof CustomEvent)) return;
+      const detail = decodeOptionalBoundary(event.detail, boundary.object({
+        sessionId: boundary.optional(boundary.string),
+      }));
+      const sessionId = detail?.sessionId;
       if (sessionId) {
         usePanelStore.getState().clearUnviewedCompletedActivity(sessionId);
       }
@@ -360,7 +367,10 @@ function App() {
       }
 
       try {
-        const consentResult = await window.electron.invoke('preferences:get', 'analytics_consent_shown') as IPCResponse<string>;
+        const consentResult = decodeOptionalBoundary(
+          await window.electron.invoke('preferences:get', 'analytics_consent_shown'),
+          preferenceResponseSchema,
+        );
         const hasShownConsent = consentResult?.data === 'true';
 
         if (!hasShownConsent) {
@@ -404,7 +414,10 @@ function App() {
       let consentDecided = false;
 
       try {
-        const consentResult = await window.electron?.invoke?.('preferences:get', 'analytics_consent_shown') as IPCResponse<string> | undefined;
+        const consentResult = decodeOptionalBoundary(
+          await window.electron?.invoke?.('preferences:get', 'analytics_consent_shown'),
+          preferenceResponseSchema,
+        );
         consentDecided = consentResult?.data === 'true';
       } catch (error) {
         console.error('[App] Error resolving analytics consent state:', error);
@@ -515,7 +528,10 @@ function App() {
         return;
       }
       try {
-        const result = await window.electron.invoke('preferences:get', ONBOARDING_REPO_SETUP_PREFERENCE) as IPCResponse<string>;
+        const result = decodeOptionalBoundary(
+          await window.electron.invoke('preferences:get', ONBOARDING_REPO_SETUP_PREFERENCE),
+          preferenceResponseSchema,
+        );
         if (result?.data !== 'true') {
           // Only show onboarding for truly new users (no existing projects).
           // Existing users who upgrade won't have this preference but already have projects.
@@ -551,9 +567,9 @@ function App() {
 
       try {
         // Get preferences from database
-        const hideWelcomeResult = await window.electron.invoke('preferences:get', 'hide_welcome') as IPCResponse<string>;
-        const welcomeShownResult = await window.electron.invoke('preferences:get', 'welcome_shown') as IPCResponse<string>;
-        const hideDiscordResult = await window.electron.invoke('preferences:get', 'hide_discord') as IPCResponse<string>;
+        const hideWelcomeResult = decodeOptionalBoundary(await window.electron.invoke('preferences:get', 'hide_welcome'), preferenceResponseSchema);
+        const welcomeShownResult = decodeOptionalBoundary(await window.electron.invoke('preferences:get', 'welcome_shown'), preferenceResponseSchema);
+        const hideDiscordResult = decodeOptionalBoundary(await window.electron.invoke('preferences:get', 'hide_discord'), preferenceResponseSchema);
 
         const hideWelcome = hideWelcomeResult?.data === 'true';
         const hasSeenWelcome = welcomeShownResult?.data === 'true';
@@ -600,7 +616,7 @@ function App() {
 
           try {
             // Get the last app open to see if Discord was already shown
-            const result = await window.electron.invoke('app:get-last-open') as IPCResponse<{ discord_shown?: boolean }>;
+            const result = decodeOptionalBoundary(await window.electron.invoke('app:get-last-open'), lastOpenResponseSchema);
 
             if (result?.success && result.data) {
               const lastOpen = result.data;
@@ -629,7 +645,7 @@ function App() {
             await window.electron.invoke('app:record-open', hideWelcome, false);
 
             // If we showed Discord popup and there was no previous app open, update the status
-            const result = await window.electron.invoke('app:get-last-open') as IPCResponse<{ discord_shown?: boolean }>;
+            const result = decodeOptionalBoundary(await window.electron.invoke('app:get-last-open'), lastOpenResponseSchema);
             if (!result?.data?.discord_shown && isDiscordOpen) {
               await window.electron.invoke('app:update-discord-shown');
             }
@@ -669,13 +685,13 @@ function App() {
       }
 
       try {
-        const onboardingResult = await window.electron.invoke('preferences:get', ONBOARDING_REPO_SETUP_PREFERENCE) as IPCResponse<string>;
+        const onboardingResult = decodeOptionalBoundary(await window.electron.invoke('preferences:get', ONBOARDING_REPO_SETUP_PREFERENCE), preferenceResponseSchema);
         if (onboardingResult?.data !== 'true') return;
 
-        const promptResult = await window.electron.invoke('preferences:get', ONBOARDING_GH_PROMPT_SHOWN_PREFERENCE) as IPCResponse<string>;
+        const promptResult = decodeOptionalBoundary(await window.electron.invoke('preferences:get', ONBOARDING_GH_PROMPT_SHOWN_PREFERENCE), preferenceResponseSchema);
         if (promptResult?.data === 'true') return;
 
-        const envResult = await window.electronAPI.onboarding.detectEnvironment() as IPCResponse<OnboardingEnvironmentResult>;
+        const envResult = await window.electronAPI.onboarding.detectEnvironment();
         if (!envResult.success || envResult.data?.ghReady !== true) return;
 
         await window.electron.invoke('preferences:set', ONBOARDING_GH_PROMPT_SHOWN_PREFERENCE, 'true');
@@ -712,7 +728,7 @@ function App() {
       try {
         const result = await window.electronAPI.sessions.getResumable();
         if (result.success && result.data && Array.isArray(result.data) && result.data.length > 0) {
-          setResumableSessions(result.data as ResumableSession[]);
+          setResumableSessions(result.data);
           setIsResumeDialogOpen(true);
         }
       } catch (error) {
@@ -822,7 +838,7 @@ function App() {
         {isMac() && (
           <div
             className="flex-shrink-0 bg-bg-primary"
-            style={{ height: 38, WebkitAppRegion: 'drag' } as React.CSSProperties}
+            style={MAC_TITLE_BAR_STYLE}
           />
         )}
         <div className="pane-main-layout flex flex-1 min-h-0">

--- a/frontend/src/components/AboutDialog.tsx
+++ b/frontend/src/components/AboutDialog.tsx
@@ -131,6 +131,7 @@ export function AboutDialog({ isOpen, onClose, onUpdate }: AboutDialogProps) {
               alt="Pane"
               className="w-16 h-16 mb-4"
               onError={(e) => {
+                // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
                 (e.target as HTMLImageElement).style.display = 'none';
               }}
             />

--- a/frontend/src/components/AddProjectDialog.tsx
+++ b/frontend/src/components/AddProjectDialog.tsx
@@ -122,6 +122,7 @@ export function AddProjectDialog({ isOpen, onClose }: AddProjectDialogProps) {
               <div className="flex justify-end">
                 <Button
                   onClick={async () => {
+                    // SAFETY: The named IPC/API channel contract establishes this response payload type.
                     const result = await window.electron?.invoke('dialog:open-directory') as { success: boolean; data?: string } | undefined;
                     if (result?.success && result.data) {
                       setNewProject({ ...newProject, path: result.data });

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -136,12 +136,14 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
         ) : (
           listItems.map((item) => {
             if (item.type === 'header') {
+              // SAFETY: Header categories are produced from the typed hotkey registry keys.
+              const category = item.category as HotkeyDefinition['category'];
               return (
                 <div
                   key={`header-${item.category}`}
                   className="px-4 pt-3 pb-1 text-xs font-medium text-text-tertiary uppercase tracking-wider"
                 >
-                  {CATEGORY_LABELS[item.category as HotkeyDefinition['category']] ?? item.category}
+                  {CATEGORY_LABELS[category] ?? item.category}
                 </div>
               );
             }

--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -179,6 +179,7 @@ export function CreateSessionDialog({
   useEffect(() => {
     if (!isBranchDropdownOpen) return;
     const handleClickOutside = (e: MouseEvent) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       if (branchDropdownRef.current && !branchDropdownRef.current.contains(e.target as Node)) {
         setIsBranchDropdownOpen(false);
         setBranchSearch('');
@@ -271,6 +272,7 @@ export function CreateSessionDialog({
       // Cmd/Ctrl + Enter to submit
       if (keyboardShortcutsEnabled && (e.metaKey || e.ctrlKey) && e.key === 'Enter') {
         e.preventDefault();
+        // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
         const form = document.getElementById('create-session-form') as HTMLFormElement;
         if (form) {
           const submitEvent = new Event('submit', { cancelable: true, bubbles: true });
@@ -287,6 +289,7 @@ export function CreateSessionDialog({
   useEffect(() => {
     if (isOpen) {
       const timer = setTimeout(() => {
+        // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
         const input = document.getElementById('worktreeTemplate') as HTMLInputElement;
         if (input) input.focus();
       }, 100);

--- a/frontend/src/components/DiscordPopup.tsx
+++ b/frontend/src/components/DiscordPopup.tsx
@@ -22,6 +22,7 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
       if (window.electron?.invoke) {
         try {
           console.log('[Discord] Loading hide_discord preference...');
+          // SAFETY: The named IPC/API channel contract establishes this response payload type.
           const result = await window.electron.invoke('preferences:get', 'hide_discord') as IPCResponse<string>;
           console.log('[Discord] Preference result:', result);
           
@@ -46,6 +47,7 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
   const handleClose = async () => {
     if (window.electron?.invoke) {
       try {
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         const result = await window.electron.invoke('preferences:set', 'hide_discord', dontShowAgain ? 'true' : 'false') as IPCResponse;
         if (!result?.success) {
           console.error('[Discord] Failed to set preference on close:', result?.error);
@@ -61,6 +63,7 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
     // Just close without setting the hide flag
     if (window.electron?.invoke) {
       try {
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         const result = await window.electron.invoke('preferences:set', 'hide_discord', 'false') as IPCResponse;
         if (!result?.success) {
           console.error('[Discord] Failed to set preference on remind later:', result?.error);
@@ -82,6 +85,7 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
     }
     if (dontShowAgain && window.electron?.invoke) {
       try {
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         const result = await window.electron.invoke('preferences:set', 'hide_discord', 'true') as IPCResponse;
         if (!result?.success) {
           console.error('[Discord] Failed to set preference on join discord:', result?.error);
@@ -152,6 +156,7 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
                 setDontShowAgain(newValue);
                 if (window.electron?.invoke) {
                   try {
+                    // SAFETY: The named IPC/API channel contract establishes this response payload type.
                     const result = await window.electron.invoke('preferences:set', 'hide_discord', newValue ? 'true' : 'false') as IPCResponse;
                     if (result?.success) {
                       console.log('[Discord] Successfully set hide_discord preference to', newValue);

--- a/frontend/src/components/DocsDialog.tsx
+++ b/frontend/src/components/DocsDialog.tsx
@@ -168,7 +168,7 @@ export function DocsDialog({ isOpen, onClose }: DocsDialogProps) {
           ref={webviewRef}
           src={DOCS_URL}
           partition="persist:pane-docs"
-          allowpopups={'true' as unknown as boolean}
+          allowpopups
           className="w-full h-full border-0"
           style={{ display: 'inline-flex' }}
         />

--- a/frontend/src/components/GitHistoryGraph.tsx
+++ b/frontend/src/components/GitHistoryGraph.tsx
@@ -203,6 +203,7 @@ export function GitHistoryGraph({ sessionId, baseBranch, layout = 'compact', onC
       setError(null);
       const response = await API.sessions.getGitGraph(sessionId);
       if (response.success && response.data) {
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         const data = response.data as GitGraphResponse;
         setRawEntries(data.entries);
         setCurrentBranch(data.currentBranch);
@@ -224,7 +225,9 @@ export function GitHistoryGraph({ sessionId, baseBranch, layout = 'compact', onC
   // Listen for git status updates to refresh the graph
   useEffect(() => {
     const handler = (event: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const customEvent = event as CustomEvent;
+      // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
       const detail = customEvent.detail as { sessionId?: string } | undefined;
       if (detail?.sessionId === sessionId) {
         fetchGraph();
@@ -238,7 +241,9 @@ export function GitHistoryGraph({ sessionId, baseBranch, layout = 'compact', onC
   // Also listen for panel events (git operations)
   useEffect(() => {
     const handler = (event: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const customEvent = event as CustomEvent;
+      // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
       const detail = customEvent.detail as { type?: string; sessionId?: string } | undefined;
       if (detail?.type === 'git:operation_completed' && (!detail.sessionId || detail.sessionId === sessionId)) {
         fetchGraph();

--- a/frontend/src/components/Help.tsx
+++ b/frontend/src/components/Help.tsx
@@ -36,10 +36,12 @@ function KeyboardShortcutsSection() {
           </div>
         </div>
         {/* Dynamic shortcuts from registry */}
-        {Object.entries(grouped).map(([category, hotkeys]) => (
-          <div key={category}>
+        {Object.entries(grouped).map(([category, hotkeys]) => {
+          // SAFETY: grouped is keyed by HotkeyDefinition category values.
+          const hotkeyCategory = category as HotkeyDefinition['category'];
+          return <div key={category}>
             <h4 className="text-sm font-medium text-text-tertiary mb-2">
-              {CATEGORY_LABELS[category as HotkeyDefinition['category']] ?? category}
+              {CATEGORY_LABELS[hotkeyCategory] ?? category}
             </h4>
             <div className="space-y-2">
               {hotkeys.map((hotkey) => (
@@ -55,8 +57,8 @@ function KeyboardShortcutsSection() {
                 </div>
               ))}
             </div>
-          </div>
-        ))}
+          </div>;
+        })}
       </div>
     </section>
   );

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -184,6 +184,7 @@ export function HomePage() {
     try {
       const result = await API.projects.getAll();
       if (result.success && result.data) {
+        // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
         setProjects(result.data as Project[]);
       }
     } catch {
@@ -253,6 +254,7 @@ export function HomePage() {
   const handleShellChange = async (shell: string) => {
     setPreferredShell(shell);
     await updateConfig({
+      // SAFETY: The value comes from the adjacent finite domain definition.
       preferredShell: shell as 'auto' | 'gitbash' | 'powershell' | 'pwsh' | 'cmd',
     }).catch(() => {});
   };

--- a/frontend/src/components/OnboardingDialog.tsx
+++ b/frontend/src/components/OnboardingDialog.tsx
@@ -78,6 +78,7 @@ function getEnvironmentStatus(env: EnvironmentInfo | null): OnboardingEnvironmen
 
 async function getPreference(key: string): Promise<string | undefined> {
   if (!window.electron?.invoke) return undefined;
+  // SAFETY: The named IPC/API channel contract establishes this response payload type.
   const result = await window.electron.invoke('preferences:get', key) as IPCResponse<string>;
   return result.success ? result.data : undefined;
 }
@@ -197,6 +198,7 @@ export default function OnboardingDialog({ isOpen, onClose }: OnboardingDialogPr
     try {
       const result = await window.electronAPI.onboarding.detectEnvironment();
       if (result.success && result.data) {
+        // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
         const nextEnv = normalizeEnvironment(result.data as Partial<EnvironmentInfo>);
         setEnv(nextEnv);
         setStep('ready');

--- a/frontend/src/components/PermissionDialog.tsx
+++ b/frontend/src/components/PermissionDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Check, X, Shield, AlertTriangle, Code, Edit } from 'lucide-react';
 import type { PanePermissionRequest } from '../../../shared/types/daemon';
+import { boundary, decodeOptionalBoundary } from '../../../shared/validation/boundaryDecoder';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import { Textarea } from './ui/Textarea';
@@ -85,10 +86,8 @@ export const PermissionDialog: React.FC<PermissionDialogProps> = ({ request, onR
     const { input, toolName } = request;
     
     // Helper to safely get string value
-    const getStringValue = (obj: Record<string, unknown>, key: string): string | undefined => {
-      const value = obj[key];
-      return typeof value === 'string' ? value : undefined;
-    };
+    const getStringValue = (obj: PanePermissionRequest['input'], key: string): string | undefined =>
+      decodeOptionalBoundary(obj[key], boundary.string);
     
     if (toolName.includes('Bash')) {
       const command = getStringValue(input, 'command');

--- a/frontend/src/components/ProjectDashboard.tsx
+++ b/frontend/src/components/ProjectDashboard.tsx
@@ -26,6 +26,10 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
   const [error, setError] = useState<string | null>(null);
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
   const [filterType, setFilterType] = useState<'all' | 'stale' | 'changes' | 'pr'>('all');
+  const handleFilterTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    // SAFETY: The select options enumerate every valid dashboard filter.
+    setFilterType(event.target.value as typeof filterType);
+  };
   const [statusAnnouncement, setStatusAnnouncement] = useState('');
   const [isProgressive] = useState(true); // Use progressive loading by default
   const pendingSessionUpdatesRef = useRef<Map<string, SessionBranchInfo>>(new Map());
@@ -132,15 +136,15 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
     const unsubscribeUpdate = API.dashboard.onUpdate((event) => {
       if (event.projectId === projectId) {
         setDashboardData(prevData => {
-          if (!prevData && event.data) {
+          if (!prevData && !event.isPartial) {
             // Initial data
-            return event.data as ProjectDashboardData;
-          } else if (prevData && event.data && event.isPartial) {
+            return event.data;
+          } else if (prevData && event.isPartial) {
             // Merge partial update
             return { ...prevData, ...event.data };
-          } else if (event.data) {
+          } else if (!event.isPartial) {
             // Full update
-            const data = event.data as ProjectDashboardData;
+            const data = event.data;
             if (data.projectId && data.projectName && data.sessionBranches) {
               dashboardCache.set(projectId, data);
             }
@@ -159,9 +163,8 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
 
     // Handle individual session updates with debouncing
     const unsubscribeSession = API.dashboard.onSessionUpdate((event) => {
-      if (event.projectId === projectId && event.data && event.sessionId) {
-        // Cast to SessionBranchInfo since we know this is the expected shape from dashboard updates
-        const sessionData = event.data as SessionBranchInfo;
+      if (event.projectId === projectId) {
+        const sessionData = event.data;
         // Add to pending updates
         pendingSessionUpdatesRef.current.set(event.sessionId, sessionData);
         // Trigger debounced update
@@ -392,7 +395,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
                   <Filter className="w-4 h-4 text-text-tertiary" />
                   <select
                     value={filterType}
-                    onChange={(e) => setFilterType(e.target.value as typeof filterType)}
+                    onChange={handleFilterTypeChange}
                     className="text-sm border border-border-primary rounded px-2 py-1 bg-surface-primary text-text-primary focus:outline-none focus:ring-2 focus:ring-interactive focus:border-interactive"
                   >
                     <option value="all">All Panes</option>

--- a/frontend/src/components/ProjectDashboard.tsx
+++ b/frontend/src/components/ProjectDashboard.tsx
@@ -19,6 +19,15 @@ interface ProjectDashboardProps {
   projectName: string;
 }
 
+function isProjectDashboardSeed(data: Partial<ProjectDashboardData>): data is ProjectDashboardData {
+  return data.projectId !== undefined
+    && Boolean(data.projectName)
+    && Boolean(data.projectPath)
+    && Boolean(data.mainBranch)
+    && Array.isArray(data.sessionBranches)
+    && Boolean(data.lastRefreshed);
+}
+
 export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ projectId, projectName }) => {
   const [dashboardData, setDashboardData] = useState<ProjectDashboardData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -136,9 +145,8 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
     const unsubscribeUpdate = API.dashboard.onUpdate((event) => {
       if (event.projectId === projectId) {
         setDashboardData(prevData => {
-          if (!prevData && !event.isPartial) {
-            // Initial data
-            return event.data;
+          if (!prevData) {
+            return isProjectDashboardSeed(event.data) ? event.data : null;
           } else if (prevData && event.isPartial) {
             // Merge partial update
             return { ...prevData, ...event.data };
@@ -164,9 +172,8 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
     // Handle individual session updates with debouncing
     const unsubscribeSession = API.dashboard.onSessionUpdate((event) => {
       if (event.projectId === projectId) {
-        const sessionData = event.data;
         // Add to pending updates
-        pendingSessionUpdatesRef.current.set(event.sessionId, sessionData);
+        pendingSessionUpdatesRef.current.set(event.session.sessionId, event.session);
         // Trigger debounced update
         applyPendingSessionUpdates();
       }

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -96,6 +96,7 @@ export function ProjectSessionList({
 
     const loadSidebarPaneRowLayout = async () => {
       try {
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         const result = await window.electron?.invoke(
           'preferences:get',
           SETTINGS_PREFERENCE_KEYS.sidebarPaneRowLayout
@@ -109,7 +110,8 @@ export function ProjectSessionList({
     };
 
     const handlePreferenceChanged = (event: Event) => {
-      const detail = (event as CustomEvent<{ layout?: unknown }>).detail;
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
+      const detail = (event as CustomEvent<{ layout?: SidebarPaneRowLayout }>).detail;
       setSidebarPaneRowLayout(normalizeSidebarPaneRowLayout(detail?.layout));
     };
 
@@ -664,6 +666,7 @@ function SessionRow({
     const fetchStatus = async () => {
       try {
         if (!window.electron?.invoke) return;
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         const res = await window.electron.invoke(
           'sessions:get-git-status',
           session.id,
@@ -688,6 +691,7 @@ function SessionRow({
   // Listen for background git status updates (e.g., PR enrichment)
   useEffect(() => {
     const handler = (e: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const detail = (e as CustomEvent<{ sessionId: string; gitStatus: GitStatus }>).detail;
       if (detail?.sessionId === session.id && detail?.gitStatus) {
         setLocalGitStatus(detail.gitStatus);
@@ -805,6 +809,7 @@ export function ArchivedSessions() {
       setIsLoadingArchived(true);
       const response = await API.sessions.getArchivedWithProjects();
       if (response.success && response.data) {
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         setArchivedProjects(response.data as Array<Project & { sessions: Session[] }>);
       }
     } catch (e) {

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -133,7 +133,7 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
       setBranchState({
         projectId,
         worktreePath: activeWorktreePath,
-        branch: result.success && typeof result.data === 'string' ? result.data : null,
+        branch: result.success ? result.data ?? null : null,
       });
     }).catch(() => {
       if (!cancelled) {

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -76,13 +76,19 @@ export function Settings({ isOpen, onClose, category, onCategoryChange, openRequ
       setPlatform(currentPlatform);
       if (currentPlatform === 'win32') {
         const response = await API.config.getAvailableShells();
-        if (response.success && Array.isArray(response.data)) setAvailableShells(response.data as AvailableShell[]);
+        if (response.success && Array.isArray(response.data)) {
+          // SAFETY: The named IPC/API channel contract establishes this response payload type.
+          setAvailableShells(response.data as AvailableShell[]);
+        }
       }
     });
     if (!fontsLoadedRef.current) {
       fontsLoadedRef.current = true;
       void window.electronAPI.config.getMonospaceFonts().then((response) => {
-        if (response.success && Array.isArray(response.data)) setSystemMonoFonts(response.data as string[]);
+        if (response.success && Array.isArray(response.data)) {
+          // SAFETY: The named IPC/API channel contract establishes this response payload type.
+          setSystemMonoFonts(response.data as string[]);
+        }
       }).catch(() => undefined);
     }
   }, [isOpen]);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import type { CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { ProjectSessionList, ArchivedSessions } from './ProjectSessionList';
@@ -20,6 +21,9 @@ import { SessionStatusBadge } from './SessionStatusBadge';
 import { AgentActivityDot, AgentStatusDot } from './ui/AgentStatusDot';
 import { useSessionAgentDisplayStatus } from '../hooks/useAgentStatus';
 import { PANE_CHAT_SESSION_ID } from '../../../shared/types/paneChat';
+
+// SAFETY: Electron supports WebkitAppRegion although React's CSSProperties omits the vendor property.
+const dragRegionStyle = { WebkitAppRegion: 'drag' } as CSSProperties;
 import { API } from '../utils/api';
 import type { Project } from '../types/project';
 import type { Session } from '../types/session';
@@ -316,6 +320,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
     });
 
     const handleClickOutside = (event: MouseEvent) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const target = event.target as Node;
       if (
         resourceMenuButtonRef.current && !resourceMenuButtonRef.current.contains(target) &&
@@ -487,7 +492,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
         >
           {/* Drag handle for window (not needed on macOS — handled by App-level spacer) */}
           {!isMac() && (
-            <div className="h-3 flex-shrink-0" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
+            <div className="h-3 flex-shrink-0" style={dragRegionStyle} />
           )}
           {/* Logo */}
           <div className="flex shrink-0 items-center justify-center border-b border-border-primary px-1 py-2">
@@ -775,7 +780,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
       >
         {/* Drag handle for window (not needed on macOS — handled by App-level spacer) */}
         {!isMac() && (
-          <div className="h-3 flex-shrink-0" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
+          <div className="h-3 flex-shrink-0" style={dragRegionStyle} />
         )}
         {/* Resize handle */}
         <div

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -351,6 +351,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   });
 
   // Get available panel types (excluding permanent panels, logs, and enforcing singleton)
+  // SAFETY: The value comes from the adjacent finite domain definition.
   const availablePanelTypes = (Object.keys(PANEL_CAPABILITIES) as ToolPanelType[])
     .filter(type => {
       const capabilities = PANEL_CAPABILITIES[type];

--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -192,6 +192,7 @@ export const PanelTabStrip: React.FC<PanelTabStripProps> = React.memo(({
     e.stopPropagation();
     // Prevent closing logs panel while it's running
     if (panel.type === 'logs') {
+      // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
       const logsState = panel.state?.customState as LogsPanelState;
       if (logsState?.isRunning) {
         alert('Cannot close logs panel while process is running. Please stop the process first.');

--- a/frontend/src/components/panels/SetupTasksPanel.tsx
+++ b/frontend/src/components/panels/SetupTasksPanel.tsx
@@ -42,6 +42,7 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
       const response = await window.electronAPI.file.readProject(parseInt(projectId), '.gitignore');
       if (!response.success || !response.data) return false;
       
+      // SAFETY: The named IPC/API channel contract establishes this response payload type.
       const content = response.data as string;
       // Check for common worktree patterns
       return content.includes('/worktrees/') || 
@@ -63,6 +64,7 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
       const response = await API.projects.getAll();
       if (!response.success || !response.data) return false;
       
+      // SAFETY: The named IPC/API channel contract establishes this response payload type.
       const projects = response.data as Array<{ id: number; run_script?: string }>;      
       const project = projects.find(p => p.id === parseInt(projectId));
       return !!(project?.run_script && project.run_script.trim());
@@ -128,6 +130,7 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
       let content = '';
       
       if (readResponse.success && readResponse.data) {
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         content = readResponse.data as string;
         console.log('[SetupTasksPanel] Current .gitignore length:', content.length);
       } else if (readResponse.success && readResponse.data === null) {

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -28,7 +28,7 @@ import { SelectionPopover } from '../terminal/SelectionPopover';
 import { useTerminalSearch } from '../../hooks/useTerminalSearch';
 import { useScrollSurface } from '../../hooks/useScrollSurface';
 import { TerminalSearchOverlay } from '../terminal/TerminalSearchOverlay';
-import type { TerminalPanelState } from '../../../../shared/types/panels';
+import { boundary, decodeOptionalBoundary } from '../../../../shared/validation/boundaryDecoder';
 import { selectTerminalRestoreContent } from '../../utils/terminalRestore';
 import { TerminalInterceptor } from '../../services/terminalInterceptor/TerminalInterceptor';
 import { createAtTerminalHandler } from '../../services/terminalInterceptor/handlers/atTerminalHandler';
@@ -36,7 +36,7 @@ import { InterceptorDropdown } from '../terminal/InterceptorDropdown';
 import { InterceptorToast } from '../terminal/InterceptorToast';
 import { usePanelStore } from '../../stores/panelStore';
 import { areKeyboardShortcutsEnabled, useConfigStore } from '../../stores/configStore';
-import type { InterceptorState, AtTerminalHandlerState, TerminalSuggestion } from '../../services/terminalInterceptor/types';
+import type { InterceptorState, TerminalSuggestion } from '../../services/terminalInterceptor/types';
 import '@xterm/xterm/css/xterm.css';
 
 // Hold the loading overlay at least this long past ready so the terminal
@@ -98,6 +98,11 @@ const MIN_VIABLE_RECT_PX = 100; // below this the container is hidden or mid-lay
 const MIN_PTY_COLS = 20;        // mirrors main-process floor
 const MIN_PTY_ROWS = 5;
 const NEAR_BOTTOM_THRESHOLD_ROWS = 3;
+const terminalPasteImageResultSchema = boundary.object({
+  filePath: boundary.string,
+  imageNumber: boundary.number,
+});
+const terminalPasteFileResultSchema = boundary.object({ filePath: boundary.string });
 
 // xterm halves the configured ratio for dim (SGR 2) cells, so 9 is what gets dim
 // CLI output (Claude Code / Codex) to 4.5:1 AA. Off-state stays a modest safety
@@ -273,7 +278,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
   const blurDetachTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Read CLI state from persisted panel state (handles remount case)
-  const terminalState = panel.state?.customState as TerminalPanelState | undefined;
+  const terminalState = decodeOptionalBoundary(panel.state?.customState, boundary.object({
+    isCliPanel: boundary.optional(boundary.boolean),
+    isCliReady: boundary.optional(boundary.boolean),
+  }));
   const isCliPanel = !!terminalState?.isCliPanel;
   const [isCliReady, setIsCliReady] = useState(!!terminalState?.isCliReady);
   const isRemoteMode = useConfigStore((state) => state.config?.remoteDaemon?.client.mode === 'remote');
@@ -587,8 +595,8 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     };
   }, [webglAllowed, panelVisible, windowFocused, isInitialized, disposeWebglRenderer, loadWebglRenderer]);
 
-  const handleClipboardError = useCallback((error: unknown) => {
-    console.error('[TerminalPanel] Failed to copy selection to clipboard:', error);
+  const handleClipboardError = useCallback(() => {
+    console.error('[TerminalPanel] Failed to copy selection to clipboard');
     setToastMessage('Failed to copy terminal text');
   }, []);
 
@@ -748,11 +756,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
       };
 
       if (state?.scrollbackBuffer) {
-        const content = typeof state.scrollbackBuffer === 'string'
-          ? state.scrollbackBuffer
-          : Array.isArray(state.scrollbackBuffer)
-            ? state.scrollbackBuffer.join('\n')
-            : '';
+        const content = Array.isArray(state.scrollbackBuffer)
+          ? state.scrollbackBuffer.join('\n')
+          : state.scrollbackBuffer;
         if (content) {
           await new Promise<void>((resolve, reject) => {
             terminal.write(content, () => {
@@ -936,7 +942,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           macOptionIsMeta: false,
           linkHandler: {
             activate: (_event, uri) => {
-              void window.electronAPI.openExternal(uri).catch((error: unknown) => {
+              void window.electronAPI.openExternal(uri).catch((error) => {
                 console.error('[TerminalPanel] Failed to open terminal link:', error);
               });
             },
@@ -952,8 +958,8 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
           if (isTerminalCopyShortcut(e, isMac())) {
             if (e.type === 'keydown' && terminal?.hasSelection()) {
-              void copyTerminalText(terminal.getSelection()).catch((error: unknown) => {
-                handleClipboardError(error);
+              void copyTerminalText(terminal.getSelection()).catch(() => {
+                handleClipboardError();
               });
             }
             return false;
@@ -985,7 +991,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
               xtermRef.current?.clear();
               window.electronAPI
                 .invoke('terminal:clearScrollback', panel.id)
-                .catch((error: unknown) => {
+                .catch((error) => {
                   console.warn('[TerminalPanel] Failed to persist scrollback clear:', error);
                 });
             }
@@ -1330,17 +1336,18 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
                   const reader = new FileReader();
                   reader.onload = async (ev) => {
                     if (disposed || !terminal) return;
+                    // SAFETY: readAsDataURL completes with a string result before onload fires.
                     const dataUrl = ev.target?.result as string;
                     if (!dataUrl) return;
 
                     try {
-                      const result = await window.electronAPI.invoke(
+                      const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                         'terminal:paste-image',
                         panel.id,
                         sessionId || panel.sessionId,
                         dataUrl,
                         file.type
-                      ) as { filePath: string; imageNumber: number } | null;
+                      ), terminalPasteImageResultSchema);
                       if (result?.filePath && !disposed && terminal) {
                         terminal.paste(`${result.filePath}\n`);
                       }
@@ -1376,10 +1383,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             (async () => {
               if (disposed || !terminal) return;
               try {
-                const result = await window.electronAPI.invoke(
+                const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                   'terminal:clipboard-paste-image',
                   sessionId || panel.sessionId
-                ) as { filePath: string; imageNumber: number } | null;
+                ), terminalPasteImageResultSchema);
                 if (result?.filePath && !disposed && terminal) {
                   terminal.paste(`${result.filePath}\n`);
                   return;
@@ -1428,7 +1435,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
                 }
                 const dataUrl = await new Promise<string | null>((resolve) => {
                   const reader = new FileReader();
-                  reader.onload = (ev) => resolve(ev.target?.result as string ?? null);
+                  reader.onload = (ev) => {
+                    // SAFETY: readAsDataURL completes with a string result before onload fires.
+                    resolve(ev.target?.result as string ?? null);
+                  };
                   reader.onerror = () => resolve(null);
                   reader.readAsDataURL(file);
                 });
@@ -1438,21 +1448,21 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
                   let resolvedPath: string | null = null;
 
                   if (isImage) {
-                    const result = await window.electronAPI.invoke(
+                    const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                       'terminal:paste-image',
                       panel.id,
                       sessionId || panel.sessionId,
                       dataUrl,
                       file.type
-                    ) as { filePath: string; imageNumber: number } | null;
+                    ), terminalPasteImageResultSchema);
                     resolvedPath = result?.filePath ?? null;
                   } else {
-                    const result = await window.electronAPI.invoke(
+                    const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                       'terminal:paste-file',
                       sessionId || panel.sessionId,
                       dataUrl,
                       file.name
-                    ) as { filePath: string } | null;
+                    ), terminalPasteFileResultSchema);
                     resolvedPath = result?.filePath ?? null;
                   }
 
@@ -1518,15 +1528,12 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           // double-delivery to xterm, this handler short-circuits once the
           // panel's `ptyId` is populated and the dedicated effect below takes
           // over as the single byte source.
-          const legacyOutputHandler = (data: unknown) => {
+          const legacyOutputHandler = (data: import('../../../../shared/types/panels').TerminalOutputEvent) => {
             if (currentPtyIdRef.current) return;
-            if (data && typeof data === 'object' && 'panelId' in data && data.panelId && 'output' in data) {
-              const typedData = data as { panelId: string; output: string };
-              if (typedData.panelId === panel.id) {
-                outputConsumerRef.current?.write(typedData.output);
-              }
+            if ('panelId' in data && data.panelId === panel.id) {
+              outputConsumerRef.current?.write(data.output);
             }
-            // Ignore session terminal output (has sessionId instead of panelId)
+            // Ignore session terminal output, which has no panelId.
           };
           const unsubscribeOutput = window.electronAPI.events.onTerminalOutput(legacyOutputHandler);
           console.log('[TerminalPanel] Subscribed to terminal output events for panel:', panel.id);
@@ -1543,10 +1550,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           // Initialize TUI mode for already-running programs (e.g. vim was
           // left open and the panel remounted).
           window.electronAPI.invoke('terminal:getAltScreenState', panel.id)
-            .then((info: unknown) => {
-              if (disposed || info == null || typeof info !== 'object') return;
-              const { isAlternateScreen } = info as { isAlternateScreen: boolean };
-              tuiActiveRef.current = isAlternateScreen;
+            .then((info: { isAlternateScreen: boolean } | null) => {
+              if (disposed || !info) return;
+              tuiActiveRef.current = info.isAlternateScreen;
             })
             .catch(() => { /* terminal may not exist yet — ignore */ });
 
@@ -1557,8 +1563,8 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
               tuiActiveRef.current = false;
               if (terminal && !disposed) {
                 // Detect crash signals: SIGABRT(6), SIGBUS(7), SIGSEGV(11)
-                const crashSignals: Record<number, string> = { 6: 'SIGABRT', 7: 'SIGBUS', 11: 'SIGSEGV' };
-                const crashSignalName = data.signal ? crashSignals[data.signal] : null;
+                const crashSignals = new Map([[6, 'SIGABRT'], [7, 'SIGBUS'], [11, 'SIGSEGV']]);
+                const crashSignalName = data.signal ? crashSignals.get(data.signal) : null;
 
                 if (crashSignalName) {
                   terminal.write(`\r\n\x1b[91m[Process crashed: ${crashSignalName}]\x1b[0m\r\n`);
@@ -1672,7 +1678,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             onForceCancel: () => interceptor.forceCancel(),
             getPreference: async (key: string) => {
               const resp = await window.electronAPI.invoke('preferences:get', key);
-              return resp?.success ? (resp.data as string | null) : null;
+              return resp?.success
+                ? decodeOptionalBoundary(resp.data, boundary.nullable(boundary.string)) ?? null
+                : null;
             },
             setPreference: (key: string, value: string) => {
               window.electronAPI.invoke('preferences:set', key, value);
@@ -2104,10 +2112,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
       {interceptorState && (
         <InterceptorDropdown
           visible={interceptorState.active}
-          terminals={(interceptorState.handlerState as AtTerminalHandlerState).terminals}
-          selectedIndex={(interceptorState.handlerState as AtTerminalHandlerState).selectedIndex}
-          lineCountPresetIndex={(interceptorState.handlerState as AtTerminalHandlerState).lineCountPresetIndex}
-          pasteMode={(interceptorState.handlerState as AtTerminalHandlerState).pasteMode}
+          terminals={interceptorState.handlerState?.terminals ?? []}
+          selectedIndex={interceptorState.handlerState?.selectedIndex ?? 0}
+          lineCountPresetIndex={interceptorState.handlerState?.lineCountPresetIndex ?? 0}
+          pasteMode={interceptorState.handlerState?.pasteMode ?? 'raw'}
           filterText={interceptorState.buffer}
           position={getDropdownPosition()}
         />

--- a/frontend/src/components/panels/browser/BrowserPanel.tsx
+++ b/frontend/src/components/panels/browser/BrowserPanel.tsx
@@ -31,6 +31,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
   const [devToolsOpen, setDevToolsOpen] = useState(false);
+  // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
   const currentUrlFromPanelState = (panel.state.customState as BrowserPanelState | undefined)?.currentUrl;
 
   const webviewRef = useRef<Electron.WebviewTag>(null);
@@ -66,6 +67,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
   useEffect(() => {
     if (!initRef.current) {
       initRef.current = true;
+      // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
       const savedState = panel.state.customState as BrowserPanelState | undefined;
       if (savedState?.currentUrl) {
         setUrl(savedState.currentUrl);
@@ -260,6 +262,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
   // preventing duplicate popup panels when multiple browser panels exist in a session.
   useEffect(() => {
     const handler = (e: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const { url: popupUrl, sourceSessionId, sourcePanelId } = (e as CustomEvent<{ url: string; sourceSessionId: string; sourcePanelId: string }>).detail;
       if (sourceSessionId !== panel.sessionId || sourcePanelId !== panel.id) return;
       e.stopImmediatePropagation();
@@ -274,7 +277,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
         addPanel(newPanel);
         setActivePanelInStore(panel.sessionId, newPanel.id);
         await panelApi.setActivePanel(panel.sessionId, newPanel.id);
-      }).catch((err: unknown) => {
+      }).catch((err) => {
         console.error('[BrowserPanel] Failed to create popup panel:', err);
       });
     };
@@ -288,6 +291,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
   // Also auto-focuses this browser panel so the user sees the navigated page immediately.
   useEffect(() => {
     const handler = (e: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const customEvent = e as CustomEvent<{ url: string; sessionId: string }>;
       if (customEvent.detail.sessionId === panel.sessionId) {
         e.stopImmediatePropagation();
@@ -424,7 +428,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
             ref={webviewRef}
             src={url}
             partition={`persist:project-${projectId ?? panel.sessionId}`}
-            allowpopups={'true' as unknown as boolean}
+            allowpopups
             className="flex-1 border-0"
             style={{ display: 'inline-flex' }}
           />

--- a/frontend/src/components/panels/browser/BrowserSurface.tsx
+++ b/frontend/src/components/panels/browser/BrowserSurface.tsx
@@ -83,6 +83,7 @@ const BrowserSurface: React.FC<BrowserSurfaceProps> = ({
 
   useEffect(() => {
     const handler = (event: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const { url: popupUrl, sourceSessionId, sourcePanelId } = (event as CustomEvent<{
         url: string;
         sourceSessionId: string;
@@ -107,7 +108,7 @@ const BrowserSurface: React.FC<BrowserSurfaceProps> = ({
         addPanel(newPanel);
         setActivePanelInStore(sessionId, newPanel.id);
         await panelApi.setActivePanel(sessionId, newPanel.id);
-      }).catch((error: unknown) => {
+      }).catch((error) => {
         console.error('[BrowserSurface] Failed to create popup panel:', error);
       });
     };
@@ -171,7 +172,7 @@ const BrowserSurface: React.FC<BrowserSurfaceProps> = ({
         src={url}
         // Review uses a shared Pane browser profile so GitHub auth persists across panes.
         partition={SHARED_PANE_BROWSER_PARTITION}
-        allowpopups={'true' as unknown as boolean}
+        allowpopups
         className="flex-1 border-0"
         style={{ display: 'inline-flex' }}
       />

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -228,7 +228,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     const executionByHash = new Map(data.map(exec => [exec.after_commit_hash, exec]));
     const reconciled = selectedHashes
       .map(hash => executionByHash.get(hash)?.id)
-      .filter((id): id is number => typeof id === 'number');
+      .filter((id): id is number => id !== undefined);
 
     return reconciled.length > 0 ? reconciled : getDefaultSelection(data);
   }, [getDefaultSelection]);
@@ -328,6 +328,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     }
 
     const handler = (event: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const { sessionId: eventSessionId, commitHash } = (event as CustomEvent<{ sessionId: string; commitHash: string }>).detail;
       if (eventSessionId !== sessionId) return;
       combinedDiffRequestIdRef.current += 1;

--- a/frontend/src/components/panels/diff/DiffPanel.tsx
+++ b/frontend/src/components/panels/diff/DiffPanel.tsx
@@ -76,6 +76,7 @@ const DiffPanel: React.FC<DiffPanelProps> = ({
   ));
   const [hasOpenedLocal, setHasOpenedLocal] = useState(reviewMode === 'local');
   const [hasOpenedGithub, setHasOpenedGithub] = useState(reviewMode === 'github');
+  // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
   const diffState = panel.state?.customState as DiffPanelState | undefined;
   const lastRefreshRef = useRef<number>(Date.now());
   const combinedDiffRef = useRef<CombinedDiffViewHandle>(null);
@@ -128,6 +129,7 @@ const DiffPanel: React.FC<DiffPanelProps> = ({
       } else if (type === 'git:operation_completed') {
         // Refresh diff when git operations complete for this session (e.g., merge to main)
         if (source?.sessionId === sessionId) {
+          // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
           const op = data?.operation as string | undefined;
           if (!op || op === 'merge_to_main' || op === 'squash_and_merge') {
             setIsStale(true);
@@ -136,9 +138,11 @@ const DiffPanel: React.FC<DiffPanelProps> = ({
       }
     };
 
+    // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
     window.addEventListener('panel:event', handlePanelEvent as EventListener);
 
     return () => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       window.removeEventListener('panel:event', handlePanelEvent as EventListener);
     };
   }, [panel.id, sessionId]);
@@ -149,6 +153,7 @@ const DiffPanel: React.FC<DiffPanelProps> = ({
     lastGitFingerprintRef.current = null;
 
     const handleGitStatusUpdated = (event: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const { sessionId: eventSessionId, gitStatus } = (event as CustomEvent<{ sessionId: string; gitStatus?: GitStatus }>).detail || {};
       if (eventSessionId !== sessionId) return;
 

--- a/frontend/src/components/panels/diff/reviewModePreference.ts
+++ b/frontend/src/components/panels/diff/reviewModePreference.ts
@@ -10,7 +10,6 @@ function isReviewMode(value: string | null): value is ReviewMode {
 }
 
 export function getReviewDefaultMode(): ReviewMode {
-  if (typeof window === 'undefined') return 'github';
   const stored = window.localStorage.getItem(REVIEW_MODE_STORAGE_KEY);
   return isReviewMode(stored) ? stored : 'github';
 }
@@ -39,6 +38,7 @@ export function consumeLocalReviewModeRequest(sessionId: string): boolean {
 
 export function subscribeLocalReviewModeRequest(callback: (sessionId: string) => void): () => void {
   const handleOpenLocal = (event: Event) => {
+    // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
     const { sessionId } = (event as CustomEvent<{ sessionId?: string }>).detail || {};
     if (sessionId) callback(sessionId);
   };
@@ -49,6 +49,7 @@ export function subscribeLocalReviewModeRequest(callback: (sessionId: string) =>
 
 export function subscribeReviewDefaultMode(callback: (mode: ReviewMode) => void): () => void {
   const handleCustomEvent = (event: Event) => {
+    // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
     const mode = (event as CustomEvent<{ mode?: string }>).detail?.mode ?? null;
     if (isReviewMode(mode)) callback(mode);
   };

--- a/frontend/src/components/panels/editor/EditorPanel.tsx
+++ b/frontend/src/components/panels/editor/EditorPanel.tsx
@@ -18,6 +18,7 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   
   // Extract explorer state each render to ensure we get updates
   const explorerState = React.useMemo(() =>
+    // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
     panel.state?.customState as ExplorerPanelState,
     [panel.state?.customState]
   );
@@ -69,6 +70,7 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
         return;
       }
 
+      // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
       const currentCustomState = (currentPanel.state?.customState || {}) as ExplorerPanelState;
 
       const stateToSave = {

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -17,6 +17,7 @@ import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
 import { TerminalPopover, PopoverButton } from '../../terminal/TerminalPopover';
 import { areKeyboardShortcutsEnabled, useConfigStore } from '../../../stores/configStore';
 import { LiveRegion } from '../../ui/LiveRegion';
+import { boundary, decodeBoundary } from '../../../../../shared/validation/boundaryDecoder';
 
 interface FileItem {
   name: string;
@@ -30,6 +31,10 @@ const ROOT_ID = '\0root';
 const MAX_FILE_SIZE = 15 * 1024 * 1024; // 15MB
 const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp']);
 const PDF_EXTENSIONS = new Set(['pdf']);
+
+function containsEventTarget(container: Node, target: EventTarget | null): boolean {
+  return target instanceof Node && container.contains(target);
+}
 
 interface HeadlessFileTreeProps {
   sessionId: string;
@@ -381,7 +386,7 @@ function HeadlessFileTree({
         return;
       }
 
-      const newPath = result.path as string;
+      const newPath = decodeBoundary(result.path, boundary.string);
       refreshAfterPathsChanged([file.path, newPath]);
       setSelectedItems([newPath]);
       if (selectedPath === file.path) {
@@ -405,7 +410,7 @@ function HeadlessFileTree({
         return;
       }
 
-      refreshAfterPathsChanged([file.path, result.path as string]);
+      refreshAfterPathsChanged([file.path, decodeBoundary(result.path, boundary.string)]);
     } catch (err) {
       console.error('Failed to duplicate:', err);
       setError(err instanceof Error ? err.message : 'Failed to duplicate item');
@@ -524,6 +529,7 @@ function HeadlessFileTree({
       const reader = new FileReader();
       reader.onload = async () => {
         try {
+          // SAFETY: readAsDataURL completes with a string result before onload fires.
           const base64 = (reader.result as string).split(',')[1]; // Strip data URL prefix
           const result = await window.electronAPI.invoke('file:write-binary', {
             sessionId: sessionIdRef.current,
@@ -618,7 +624,7 @@ function HeadlessFileTree({
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-    if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+    if (!containsEventTarget(e.currentTarget, e.relatedTarget)) {
       setIsDragOver(false);
     }
   }, []);
@@ -643,7 +649,7 @@ function HeadlessFileTree({
     const internalPayload = e.dataTransfer.getData('application/x-pane-file-paths');
     if (internalPayload) {
       try {
-        const paths = JSON.parse(internalPayload) as string[];
+        const paths = decodeBoundary(JSON.parse(internalPayload), boundary.array(boundary.string));
         const files = paths
           .map(filePath => tree.getItemInstance(filePath)?.getItemData())
           .filter((item): item is FileItem => !!item);
@@ -700,7 +706,7 @@ function HeadlessFileTree({
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
+      const target = e.target instanceof HTMLElement ? e.target : null;
       const isEditingText = target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || !!target?.isContentEditable;
       if (isEditingText && e.key !== 'Escape') return;
 
@@ -917,7 +923,7 @@ function HeadlessFileTree({
           e.dataTransfer.dropEffect = e.dataTransfer.types.includes('application/x-pane-file-paths') ? 'move' : 'copy';
         }}
         onDragLeave={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragOverPath(null);
+          if (!containsEventTarget(e.currentTarget, e.relatedTarget)) setDragOverPath(null);
         }}
         onDrop={(e) => handleInternalDrop(e, '')}
       >
@@ -964,7 +970,7 @@ function HeadlessFileTree({
                 e.dataTransfer.dropEffect = e.dataTransfer.types.includes('application/x-pane-file-paths') ? 'move' : 'copy';
               }}
               onDragLeave={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragOverPath(null);
+                if (!containsEventTarget(e.currentTarget, e.relatedTarget)) setDragOverPath(null);
               }}
               onDrop={(e) => {
                 if (!isFolder) return;
@@ -1529,7 +1535,8 @@ export function FileEditor({
   // Re-check git status when git operations complete (e.g. commit from diff panel or terminal)
   useEffect(() => {
     if (!selectedFile) return;
-    const handlePanelEvent = (event: CustomEvent) => {
+    const handlePanelEvent = (event: Event) => {
+      if (!(event instanceof CustomEvent)) return;
       const { type } = event.detail || {};
       if (type === 'git:operation_completed' || type === 'diff:refreshed' || type === 'terminal:command_executed' || type === 'files:changed') {
         window.electronAPI.invoke('git:file-status', sessionId, selectedFile.path).then((statusResult: { success: boolean; data?: { status: 'clean' | 'modified' | 'untracked' } }) => {
@@ -1539,8 +1546,8 @@ export function FileEditor({
         });
       }
     };
-    window.addEventListener('panel:event', handlePanelEvent as EventListener);
-    return () => window.removeEventListener('panel:event', handlePanelEvent as EventListener);
+    window.addEventListener('panel:event', handlePanelEvent);
+    return () => window.removeEventListener('panel:event', handlePanelEvent);
   }, [selectedFile, sessionId]);
   
   // Load initial file if provided
@@ -1575,14 +1582,10 @@ export function FileEditor({
     return () => {
       // Cleanup Monaco editor models when component unmounts or file changes
       try {
-        if (editorRef.current && typeof editorRef.current === 'object' && editorRef.current !== null && 'getModel' in editorRef.current) {
-          const editor = editorRef.current as { getModel: () => unknown, dispose?: () => void };
-          const model = editor.getModel();
-          if (model && typeof model === 'object' && model !== null && 'dispose' in model) {
-            const typedModel = model as { dispose: () => void };
-            console.log('[FileEditor] Disposing Monaco model');
-            typedModel.dispose();
-          }
+        const model = editorRef.current?.getModel();
+        if (model) {
+          console.log('[FileEditor] Disposing Monaco model');
+          model.dispose();
         }
       } catch (error) {
         console.warn('[FileEditor] Error during Monaco cleanup:', error);

--- a/frontend/src/components/panels/editor/NotebookPreview.tsx
+++ b/frontend/src/components/panels/editor/NotebookPreview.tsx
@@ -1,19 +1,25 @@
 import React, { useMemo } from 'react';
 import DOMPurify from 'dompurify';
 import { MarkdownPreview } from '../../MarkdownPreview';
+import {
+  boundary,
+  decodeOptionalBoundary,
+  type BoundarySchema,
+  type JsonObject,
+} from '../../../../../shared/validation/boundaryDecoder';
 
 // --- Notebook JSON types ---
 
 interface NotebookCellOutput {
   output_type: string;
   text?: string | string[];
-  data?: Record<string, string | string[] | unknown>;
+  data?: JsonObject;
   name?: string;
   ename?: string;
   evalue?: string;
   traceback?: string[];
   execution_count?: number | null;
-  metadata?: Record<string, unknown>;
+  metadata?: JsonObject;
 }
 
 interface NotebookCell {
@@ -21,7 +27,7 @@ interface NotebookCell {
   source: string | string[];
   execution_count?: number | null;
   outputs?: NotebookCellOutput[];
-  metadata?: Record<string, unknown>;
+  metadata?: JsonObject;
 }
 
 interface NotebookData {
@@ -36,11 +42,46 @@ interface NotebookData {
       name?: string;
       version?: string;
     };
-    [key: string]: unknown;
   };
   nbformat?: number;
   nbformat_minor?: number;
 }
+
+const stringOrLinesSchema = boundary.union(boundary.string, boundary.array(boundary.string));
+const notebookOutputSchema: BoundarySchema<NotebookCellOutput> = boundary.object({
+  output_type: boundary.string,
+  text: boundary.optional(stringOrLinesSchema),
+  data: boundary.optional(boundary.jsonObject),
+  name: boundary.optional(boundary.string),
+  ename: boundary.optional(boundary.string),
+  evalue: boundary.optional(boundary.string),
+  traceback: boundary.optional(boundary.array(boundary.string)),
+  execution_count: boundary.optional(boundary.nullable(boundary.number)),
+  metadata: boundary.optional(boundary.jsonObject),
+});
+const notebookCellSchema: BoundarySchema<NotebookCell> = boundary.object({
+  cell_type: boundary.string,
+  source: stringOrLinesSchema,
+  execution_count: boundary.optional(boundary.nullable(boundary.number)),
+  outputs: boundary.optional(boundary.array(notebookOutputSchema)),
+  metadata: boundary.optional(boundary.jsonObject),
+});
+const notebookSchema: BoundarySchema<NotebookData> = boundary.object({
+  cells: boundary.array(notebookCellSchema),
+  metadata: boundary.optional(boundary.object({
+    kernelspec: boundary.optional(boundary.object({
+      display_name: boundary.optional(boundary.string),
+      language: boundary.optional(boundary.string),
+      name: boundary.optional(boundary.string),
+    })),
+    language_info: boundary.optional(boundary.object({
+      name: boundary.optional(boundary.string),
+      version: boundary.optional(boundary.string),
+    })),
+  })),
+  nbformat: boundary.optional(boundary.number),
+  nbformat_minor: boundary.optional(boundary.number),
+});
 
 // --- Helpers ---
 
@@ -59,11 +100,13 @@ function stripAnsi(str: string): string {
   return str.replace(/\x1b\[[0-9;]*m/g, '');
 }
 
-function getMimeData(data: Record<string, string | string[] | unknown>, mime: string): string | undefined {
+function getMimeData(data: JsonObject, mime: string): string | undefined {
   const val = data[mime];
   if (val === undefined) return undefined;
-  if (typeof val === 'string') return val;
-  if (Array.isArray(val)) return val.map(String).join('');
+  const text = decodeOptionalBoundary(val, boundary.string);
+  if (text !== undefined) return text;
+  const lines = decodeOptionalBoundary(val, boundary.array(boundary.string));
+  if (lines) return lines.join('');
   // For non-string values (e.g. application/json stored as object), stringify
   return JSON.stringify(val, null, 2);
 }
@@ -141,11 +184,12 @@ function CellOutputRenderer({ output, index }: { output: NotebookCellOutput; ind
     const jsonVal = data['application/json'];
     if (jsonVal !== undefined) {
       let formatted: string;
-      if (typeof jsonVal === 'string') {
+      const jsonText = decodeOptionalBoundary(jsonVal, boundary.string);
+      if (jsonText !== undefined) {
         try {
-          formatted = JSON.stringify(JSON.parse(jsonVal), null, 2);
+          formatted = JSON.stringify(JSON.parse(jsonText), null, 2);
         } catch {
-          formatted = jsonVal;
+          formatted = jsonText;
         }
       } else {
         formatted = JSON.stringify(jsonVal, null, 2);
@@ -216,9 +260,7 @@ interface NotebookPreviewProps {
 export const NotebookPreview: React.FC<NotebookPreviewProps> = ({ content, className = '' }) => {
   const notebook = useMemo<NotebookData | null>(() => {
     try {
-      const parsed = JSON.parse(content) as NotebookData;
-      if (!parsed.cells || !Array.isArray(parsed.cells)) return null;
-      return parsed;
+      return decodeOptionalBoundary(JSON.parse(content), notebookSchema) ?? null;
     } catch {
       return null;
     }

--- a/frontend/src/components/panels/logPanel/LogsPanel.tsx
+++ b/frontend/src/components/panels/logPanel/LogsPanel.tsx
@@ -10,6 +10,7 @@ interface LogsPanelProps {
 
 const LogsPanel: React.FC<LogsPanelProps> = ({ panel, isActive }) => {
   const [isRunning, setIsRunning] = useState(false);
+  // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
   const logsState = panel.state?.customState as LogsPanelState;
   
   // Set running state from panel state

--- a/frontend/src/components/panels/logPanel/LogsView.tsx
+++ b/frontend/src/components/panels/logPanel/LogsView.tsx
@@ -385,6 +385,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ sessionId, isVisible }) => {
         tabIndex={-1}
         className="flex-1 min-h-0 overflow-y-auto overflow-x-auto font-mono text-sm p-4 bg-bg-primary text-text-primary whitespace-pre-wrap break-all"
         onScroll={(e) => {
+          // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
           const target = e.target as HTMLDivElement;
           // Consider "at bottom" only if within 50px of the bottom
           const distanceFromBottom = target.scrollHeight - target.scrollTop - target.clientHeight;

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -18,6 +18,10 @@ interface SettingsLayoutProps {
   children: ReactNode;
 }
 export function SettingsLayout({ category, categories, onCategoryChange, children }: SettingsLayoutProps) {
+  const handleCategoryChange = (value: string) => {
+    // SAFETY: The Select items are generated exclusively from SettingsCategoryId values.
+    onCategoryChange(value as SettingsCategoryId);
+  };
   const scrollSurfaceRef = useScrollSurface<HTMLElement>({
     id: 'settings-content',
     priority: 80,
@@ -58,7 +62,7 @@ export function SettingsLayout({ category, categories, onCategoryChange, childre
         <label className="mb-1.5 block text-xs font-medium text-text-secondary" htmlFor="settings-category-select">
           Category
         </label>
-        <Select value={category} onValueChange={(value) => onCategoryChange(value as SettingsCategoryId)}>
+        <Select value={category} onValueChange={handleCategoryChange}>
           <SelectTrigger id="settings-category-select" aria-label="Settings category">
             <SelectValue />
           </SelectTrigger>

--- a/frontend/src/components/settings/categories/AdvancedSettings.tsx
+++ b/frontend/src/components/settings/categories/AdvancedSettings.tsx
@@ -19,6 +19,7 @@ export function AdvancedSettings({ persistence, platform, onDirtyChange }: Advan
   const [pathsText, setPathsText] = useState(persistedPaths.join('\n'));
   const dirty = pathsText !== persistedPaths.join('\n');
 
+  // SAFETY: App-owned storage writes this value through the matching typed serializer.
   useEffect(() => setPathsText((JSON.parse(persistedPathsKey) as string[]).join('\n')), [persistedPathsKey]);
   useEffect(() => onDirtyChange(dirty), [dirty, onDirtyChange]);
   useEffect(() => () => onDirtyChange(false), [onDirtyChange]);

--- a/frontend/src/components/settings/categories/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/categories/AppearanceSettings.tsx
@@ -33,6 +33,10 @@ export function AppearanceSettings({ persistence }: { persistence: SettingsPersi
   const scale = config.uiScale ?? 1;
 
   const saveScale = (value: number) => persistence.saveConfig('ui-scale', { uiScale: value });
+  const saveTheme = (value: string) => {
+    // SAFETY: Theme values come from the THEMES list, whose ids match AppConfig.theme.
+    return persistence.saveConfig('theme', { theme: value as AppConfig['theme'] });
+  };
 
   return (
     <SettingsPage title="Appearance" description="Application-wide interface and sidebar presentation.">
@@ -46,7 +50,7 @@ export function AppearanceSettings({ persistence }: { persistence: SettingsPersi
           <div className="w-full min-w-[220px] sm:w-60">
             <Select
               value={config.theme ?? 'light-rounded'}
-              onValueChange={(value) => void persistence.saveConfig('theme', { theme: value as AppConfig['theme'] })}
+              onValueChange={(value) => void saveTheme(value)}
             >
               <SelectTrigger aria-label="Theme"><SelectValue /></SelectTrigger>
               <SelectContent>

--- a/frontend/src/components/settings/categories/IntegrationsSettings.tsx
+++ b/frontend/src/components/settings/categories/IntegrationsSettings.tsx
@@ -18,12 +18,14 @@ export function IntegrationsSettings({ persistence, onDirtyChange }: Integration
     falApiKey: config.falApiKey ?? '',
     openRouterApiKey: config.openRouterApiKey ?? '',
     deepgramApiKey: config.deepgramApiKey ?? '',
+    // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
     voiceTranscriptionMode: config.voiceTranscriptionMode ?? 'streaming' as VoiceTranscriptionMode,
   };
   const persistedKey = JSON.stringify(persisted);
   const [draft, setDraft] = useState(persisted);
   const dirty = JSON.stringify(draft) !== persistedKey;
 
+  // SAFETY: App-owned storage writes this value through the matching typed serializer.
   useEffect(() => setDraft(JSON.parse(persistedKey) as typeof persisted), [persistedKey]);
   useEffect(() => onDirtyChange(dirty), [dirty, onDirtyChange]);
   useEffect(() => () => onDirtyChange(false), [onDirtyChange]);

--- a/frontend/src/components/settings/categories/ShortcutsSettings.tsx
+++ b/frontend/src/components/settings/categories/ShortcutsSettings.tsx
@@ -22,6 +22,7 @@ export function ShortcutsSettings({ persistence, onDirtyChange, onShowKeyboardSh
   const [shortcuts, setShortcuts] = useState<TerminalShortcut[]>(persistedShortcuts);
   const dirty = JSON.stringify(shortcuts) !== persistedKey;
 
+  // SAFETY: App-owned storage writes this value through the matching typed serializer.
   useEffect(() => setShortcuts(JSON.parse(persistedKey) as TerminalShortcut[]), [persistedKey]);
   useEffect(() => onDirtyChange(dirty), [dirty, onDirtyChange]);
   useEffect(() => () => onDirtyChange(false), [onDirtyChange]);

--- a/frontend/src/components/settings/categories/TerminalSettings.tsx
+++ b/frontend/src/components/settings/categories/TerminalSettings.tsx
@@ -30,6 +30,14 @@ interface TerminalSettingsProps {
 
 export function TerminalSettings({ persistence, platform, availableShells, systemMonoFonts }: TerminalSettingsProps) {
   const config = persistence.config!;
+  const saveTerminalLineCount = (value: number) => {
+    // SAFETY: SegmentedControl values are generated from the four supported line-count literals below.
+    return persistence.savePreference('atTerminalLineCount', value as 100 | 300 | 500 | -1);
+  };
+  const savePreferredShell = (value: string) => {
+    // SAFETY: Select options use only PreferredShell identifiers supplied by the backend.
+    return persistence.saveConfig('terminal-shell', { preferredShell: value as PreferredShell });
+  };
   const [customFont, setCustomFont] = useState(config.terminalFontFamily ?? 'Geist Mono');
   useEffect(() => setCustomFont(config.terminalFontFamily ?? 'Geist Mono'), [config.terminalFontFamily]);
   const fontSize = config.terminalFontSize ?? 14;
@@ -142,7 +150,7 @@ export function TerminalSettings({ persistence, platform, availableShells, syste
             value={persistence.preferences.atTerminalLineCount}
             columns={4}
             options={[100, 300, 500, -1].map((value) => ({ id: value, label: value === -1 ? 'All' : String(value) }))}
-            onChange={(value) => void persistence.savePreference('atTerminalLineCount', value as 100 | 300 | 500 | -1)}
+            onChange={(value) => void saveTerminalLineCount(value)}
           />
         </SettingRow>
       </SettingsSection>
@@ -158,7 +166,7 @@ export function TerminalSettings({ persistence, platform, availableShells, syste
             <div className="w-full min-w-[220px] sm:w-72">
               <Select
                 value={config.preferredShell ?? 'auto'}
-                onValueChange={(value) => void persistence.saveConfig('terminal-shell', { preferredShell: value as PreferredShell })}
+                onValueChange={(value) => void savePreferredShell(value)}
               >
                 <SelectTrigger aria-label="Default Windows terminal shell"><SelectValue /></SelectTrigger>
                 <SelectContent>

--- a/frontend/src/components/settings/categories/WorktreesGitSettings.tsx
+++ b/frontend/src/components/settings/categories/WorktreesGitSettings.tsx
@@ -22,6 +22,7 @@ export function WorktreesGitSettings({ persistence, onDirtyChange }: WorktreesGi
   const dirty = JSON.stringify(entries) !== persistedJson;
   const hasInvalidEntry = entries.some((entry) => entry.path.trim().length === 0);
 
+  // SAFETY: App-owned storage writes this value through the matching typed serializer.
   useEffect(() => setEntries(JSON.parse(persistedJson) as WorktreeFileSyncEntry[]), [persistedJson]);
   useEffect(() => onDirtyChange(dirty), [dirty, onDirtyChange]);
   useEffect(() => () => onDirtyChange(false), [onDirtyChange]);

--- a/frontend/src/components/settings/useRemoteAccessSettings.ts
+++ b/frontend/src/components/settings/useRemoteAccessSettings.ts
@@ -195,6 +195,7 @@ export function useRemoteAccessSettings(isOpen: boolean, closeSettings: () => vo
       if (!commandResponse.success || !commandResponse.data?.command) throw new Error(commandResponse.error || 'Failed to prepare setup command');
       const sessionResponse = await API.sessions.getOrCreateMainRepoSession(projectId);
       if (!sessionResponse.success || !sessionResponse.data?.id) throw new Error(sessionResponse.error || 'Failed to open project terminal');
+      // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
       const sessionId = sessionResponse.data.id as string;
       const panel = await panelApi.createPanel({
         sessionId,

--- a/frontend/src/components/settings/useSettingsPersistence.ts
+++ b/frontend/src/components/settings/useSettingsPersistence.ts
@@ -50,6 +50,7 @@ export function useSettingsPersistence(isOpen: boolean) {
   const loadPreferences = useCallback(async () => {
     setPreferencesLoading(true);
     try {
+      // SAFETY: The named IPC/API channel contract establishes this response payload type.
       const response = await window.electron?.invoke('preferences:get-all') as {
         success?: boolean;
         data?: Record<string, string>;
@@ -104,6 +105,7 @@ export function useSettingsPersistence(isOpen: boolean) {
     const settingId = PREFERENCE_SETTING_ID[name];
     setSaveState(settingId, { state: 'saving' });
     try {
+      // SAFETY: The named IPC/API channel contract establishes this response payload type.
       const response = await window.electron?.invoke(
         'preferences:set',
         PREFERENCE_KEY_BY_NAME[name],

--- a/frontend/src/components/terminal/TerminalPopover.tsx
+++ b/frontend/src/components/terminal/TerminalPopover.tsx
@@ -69,6 +69,7 @@ export const TerminalPopover: React.FC<TerminalPopoverProps> = ({
     if (!visible) return;
 
     const handleClickOutside = (e: MouseEvent) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       if (ref.current && !ref.current.contains(e.target as Node)) {
         onClose();
       }

--- a/frontend/src/components/terminal/hooks/useTerminalLinks.ts
+++ b/frontend/src/components/terminal/hooks/useTerminalLinks.ts
@@ -208,7 +208,8 @@ export function useTerminalLinks(terminal: Terminal | null, config: UseTerminalL
 
     let browserPanel: ToolPanel;
     if (existingPanel) {
-      const existingCustomState = (existingPanel.state.customState ?? {}) as BrowserPanelState & Record<string, unknown>;
+      // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
+      const existingCustomState = (existingPanel.state.customState ?? {}) as BrowserPanelState;
       browserPanel = {
         ...existingPanel,
         state: {

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -165,6 +165,7 @@ export function Dropdown({
         const controls = getMenuControls(contentRef.current);
         if (controls.length === 0) break;
 
+        // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
         const current = controls.indexOf(document.activeElement as HTMLElement);
         const step = event.key === 'ArrowDown' ? 1 : -1;
         const next = current === -1
@@ -175,6 +176,7 @@ export function Dropdown({
       }
       case 'Enter':
       case ' ': {
+        // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
         const itemIndex = Number((document.activeElement as HTMLElement)?.dataset.dropdownItemIndex);
         if (Number.isInteger(itemIndex) && items[itemIndex]) {
           event.preventDefault();
@@ -437,7 +439,7 @@ export function Dropdown({
               {footer && (
                 <>
                   <div className="border-t border-border-secondary my-1.5" />
-                  {typeof footer === 'function' ? footer({ close: handleClose }) : footer}
+                  {footer instanceof Function ? footer({ close: handleClose }) : footer}
                 </>
               )}
             </div>

--- a/frontend/src/components/ui/Kbd.tsx
+++ b/frontend/src/components/ui/Kbd.tsx
@@ -28,7 +28,7 @@ const sizeStyles = {
 } as const;
 
 export function Kbd({ children, size = 'sm', variant = 'default', className }: KbdProps) {
-  const text = typeof children === 'string' ? children.trim() : null;
+  const text = children instanceof Object ? null : String(children ?? '').trim();
   const segments = text ? text.split(' + ').filter(Boolean) : null;
   const hasSegments = !!segments && segments.length > 1;
 

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -126,6 +126,7 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
     cancelShow();
   }, [cancelHide, cancelShow]);
 
+  // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
   const existingDescription = (children.props as { 'aria-describedby'?: string })['aria-describedby'];
   const describedBy = [existingDescription, isOpen ? tooltipId : undefined]
     .filter(Boolean)
@@ -147,7 +148,7 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
 
   const setTriggerRef = useCallback((node: HTMLElement | null) => {
     triggerRef.current = node;
-    if (typeof forwardedRef === 'function') forwardedRef(node);
+    if (forwardedRef instanceof Function) forwardedRef(node);
     else if (forwardedRef) forwardedRef.current = node;
   }, [forwardedRef]);
 

--- a/frontend/src/components/ui/dropdownNavigation.test.ts
+++ b/frontend/src/components/ui/dropdownNavigation.test.ts
@@ -7,7 +7,7 @@ import {
 } from './dropdownNavigation';
 
 const items = (spec: Array<string | { id: string; disabled: boolean }>): NavigableItem[] =>
-  spec.map((s) => (typeof s === 'string' ? { id: s } : s));
+  spec.map((item) => (item instanceof Object ? item : { id: item }));
 
 describe('firstEnabledIndex', () => {
   it('finds the first item of an all-enabled list', () => {

--- a/frontend/src/contexts/ContextMenuContext.tsx
+++ b/frontend/src/contexts/ContextMenuContext.tsx
@@ -64,6 +64,7 @@ export const ContextMenuProvider: React.FC<ContextMenuProviderProps> = ({ childr
   useEffect(() => {
     const handleGlobalClick = (event: MouseEvent) => {
       // Check if the click is on the context menu itself
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const target = event.target as HTMLElement;
       const isContextMenu = target?.closest?.('.context-menu');
       

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -3,7 +3,7 @@ import { useConfigStore } from '../stores/configStore';
 
 type Theme = 'light' | 'light-rounded' | 'dark' | 'oled' | 'dusk' | 'dusk-oled' | 'forge' | 'ember' | 'aurora' | 'night-owl' | 'night-owl-oled' | 'terracotta';
 
-const VALID_THEMES: Theme[] = ['light', 'light-rounded', 'dark', 'oled', 'dusk', 'dusk-oled', 'forge', 'ember', 'aurora', 'night-owl', 'night-owl-oled', 'terracotta'];
+const VALID_THEMES = new Set<string>(['light', 'light-rounded', 'dark', 'oled', 'dusk', 'dusk-oled', 'forge', 'ember', 'aurora', 'night-owl', 'night-owl-oled', 'terracotta']);
 const THEME_CLASSES: Record<Theme, string[]> = {
   'light': ['light'],
   'light-rounded': ['light', 'light-rounded'],
@@ -18,7 +18,7 @@ const THEME_CLASSES: Record<Theme, string[]> = {
   'night-owl-oled': ['dark', 'night-owl', 'night-owl-oled'],
   'terracotta': ['dark', 'terracotta'],
 };
-const isValidTheme = (t: string): t is Theme => VALID_THEMES.includes(t as Theme);
+const isValidTheme = (theme: string): theme is Theme => VALID_THEMES.has(theme);
 
 interface ThemeContextType {
   theme: Theme;
@@ -51,7 +51,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   // Sync high contrast from config when it loads
   useEffect(() => {
-    if (typeof config?.highContrast === 'boolean') {
+    if (config?.highContrast !== undefined) {
       setHighContrast(config.highContrast);
       localStorage.setItem('high-contrast', String(config.highContrast));
     }

--- a/frontend/src/desktopBootstrap.tsx
+++ b/frontend/src/desktopBootstrap.tsx
@@ -9,17 +9,22 @@ import './styles/notebook-preview.css';
 
 let mounted = false;
 
-function getErrorMessage(value: unknown): string {
+interface RendererErrorDetails {
+  toString(): string;
+}
+
+type RendererErrorValue = Error | string | RendererErrorDetails | null | undefined;
+
+function getErrorMessage(value: RendererErrorValue): string {
   if (value instanceof Error) return value.message;
-  if (typeof value === 'string') return value;
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(value) || String(value);
   } catch {
     return String(value);
   }
 }
 
-function getErrorStack(value: unknown): string | undefined {
+function getErrorStack(value: RendererErrorValue): string | undefined {
   return value instanceof Error ? value.stack : undefined;
 }
 

--- a/frontend/src/hooks/useIPCEvents.ts
+++ b/frontend/src/hooks/useIPCEvents.ts
@@ -10,15 +10,9 @@ import { PANE_CHAT_SESSION_ID } from '../../../shared/types/paneChat';
 
 interface SessionEventData {
   sessionId: string;
-  [key: string]: unknown;
 }
 
 type ValidatedEventData = SessionEventData | SessionOutput;
-
-interface SessionDeletedEventData {
-  id?: string;
-  sessionId?: string;
-}
 
 async function resyncRemoteRuntimeState(loadSessions: (sessions: Session[]) => void): Promise<void> {
   await useConfigStore.getState().fetchConfig();
@@ -71,7 +65,7 @@ function validateEventSession(eventData: ValidatedEventData, activeSessionId?: s
 
 
 // Throttle utility with external drain support
-function createThrottledWithDrain<T extends (...args: Parameters<T>) => unknown>(
+function createThrottledWithDrain<T extends (...args: never[]) => void>(
   fn: T,
   delayMs: number,
   keyFn: (...args: Parameters<T>) => string,
@@ -210,10 +204,9 @@ export function useIPCEvents() {
     });
     unsubscribeFunctions.push(unsubscribeSessionUpdated);
 
-    const unsubscribeSessionDeleted = window.electronAPI.events.onSessionDeleted((sessionData: SessionDeletedEventData | string) => {
+    const unsubscribeSessionDeleted = window.electronAPI.events.onSessionDeleted((sessionData) => {
       console.log('[useIPCEvents] Session deleted:', sessionData);
-      // The backend sends just { id } for deleted sessions
-      const sessionId = typeof sessionData === 'string' ? sessionData : sessionData.id || sessionData.sessionId;
+      const sessionId = sessionData.id;
 
       // Drain any pending throttled git status calls for this session
       if (sessionId) {
@@ -227,7 +220,7 @@ export function useIPCEvents() {
       }));
 
       // Create a minimal session object for deletion
-      deleteSession({ id: sessionId } as Session);
+      deleteSession(sessionData);
     });
     unsubscribeFunctions.push(unsubscribeSessionDeleted);
 
@@ -271,19 +264,16 @@ export function useIPCEvents() {
     });
     unsubscribeFunctions.push(unsubscribeSessionOutput);
 
-    const unsubscribeTerminalOutput = window.electronAPI.events.onTerminalOutput((output: { sessionId: string; type: 'stdout' | 'stderr'; data: string }) => {
+    const unsubscribeTerminalOutput = window.electronAPI.events.onTerminalOutput((output) => {
       if (output.sessionId === PANE_CHAT_SESSION_ID) {
         return;
       }
 
-      // Validate event has required session context
-      if (!validateEventSession(output)) {
-        return; // Ignore invalid events
-      }
-
       console.log(`[useIPCEvents] Received terminal output for ${output.sessionId}`);
-      // Store terminal output in session store for display
-      useSessionStore.getState().addTerminalOutput(output);
+      const terminalOutput = 'output' in output
+        ? { sessionId: output.sessionId, type: 'stdout' as const, data: output.output }
+        : output;
+      useSessionStore.getState().addTerminalOutput(terminalOutput);
     });
     unsubscribeFunctions.push(unsubscribeTerminalOutput);
     

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -41,7 +41,7 @@ export function useNotifications() {
   // Window focus state synced from the main process via IPC. document.hasFocus()
   // lies when DevTools is focused or another Electron sub-window has focus, so
   // we use the BrowserWindow.isFocused() source of truth exposed by preload.
-  const windowFocusedRef = useRef<boolean>(typeof document !== 'undefined' ? document.hasFocus() : true);
+  const windowFocusedRef = useRef<boolean>(document.hasFocus());
 
   useEffect(() => {
     const electronWindow = window.electronAPI?.window;
@@ -83,6 +83,7 @@ export function useNotifications() {
       const res = await API.projects.getAll();
       if (res.success && res.data) {
         projectNamesRef.current = new Map(
+          // SAFETY: The named IPC/API channel contract establishes this response payload type.
           (res.data as { id: number; name: string }[]).map((p) => [p.id, p.name])
         );
       }

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -41,7 +41,10 @@ export function useNotifications() {
   // Window focus state synced from the main process via IPC. document.hasFocus()
   // lies when DevTools is focused or another Electron sub-window has focus, so
   // we use the BrowserWindow.isFocused() source of truth exposed by preload.
-  const windowFocusedRef = useRef<boolean>(document.hasFocus());
+  const windowFocusedRef = useRef<boolean | null>(null);
+  if (windowFocusedRef.current === null) {
+    windowFocusedRef.current = document.hasFocus();
+  }
 
   useEffect(() => {
     const electronWindow = window.electronAPI?.window;

--- a/frontend/src/hooks/useResourceMonitor.ts
+++ b/frontend/src/hooks/useResourceMonitor.ts
@@ -14,6 +14,7 @@ export function useResourceMonitor() {
   // Listen for push updates from main process
   useEffect(() => {
     const handler = (event: Event) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       const customEvent = event as CustomEvent<ResourceSnapshot>;
       setSnapshot(customEvent.detail);
       setIsLoading(false);

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -255,9 +255,11 @@ export const useSessionView = (
     const handleStatusChange = (event: CustomEvent) => {
       if (event.detail.sessionId === activeSessionId) forceUpdate({});
     };
+    // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
     window.addEventListener('session-status-changed', handleStatusChange as EventListener);
     return () => {
       unsubscribe();
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       window.removeEventListener('session-status-changed', handleStatusChange as EventListener);
     };
   }, [activeSessionId, activeSession?.status]);
@@ -446,8 +448,10 @@ export const useSessionView = (
       }
     };
     
+    // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
     window.addEventListener('session-output-available', handleOutputAvailable as EventListener);
     return () => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       window.removeEventListener('session-output-available', handleOutputAvailable as EventListener);
       if (reloadDebounceTimer) {
         clearTimeout(reloadDebounceTimer);
@@ -559,9 +563,11 @@ export const useSessionView = (
       }
     };
 
+    // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
     window.addEventListener('session-deleted', handleSessionDeleted as EventListener);
 
     return () => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       window.removeEventListener('session-deleted', handleSessionDeleted as EventListener);
       // Cancel any pending operations
       if (abortControllerRef.current) {

--- a/frontend/src/remote/RemotePwaApp.tsx
+++ b/frontend/src/remote/RemotePwaApp.tsx
@@ -327,6 +327,7 @@ export function RemotePwaApp() {
     if (!adapter) return;
     return adapter.onEvent(event => {
       if (event.channel === 'panel:created' || event.channel === 'panel:updated') {
+        // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
         const panel = event.args[0] as ToolPanel | undefined;
         if (panel?.id && panel.sessionId) {
           upsertPanel(panel);
@@ -335,6 +336,7 @@ export function RemotePwaApp() {
       }
 
       if (event.channel === 'panel:deleted') {
+        // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
         const payload = event.args[0] as { panelId?: string; sessionId?: string } | undefined;
         if (payload?.panelId && payload.sessionId) {
           removePanel(payload.sessionId, payload.panelId);
@@ -343,6 +345,7 @@ export function RemotePwaApp() {
       }
 
       if (event.channel === 'panel:activeChanged') {
+        // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
         const payload = event.args[0] as { sessionId?: string; panelId?: string } | undefined;
         if (payload?.sessionId === selectedSessionId && payload.panelId) {
           setSelectedPanel(payload.panelId);

--- a/frontend/src/remote/components/RemoteConnectionScreen.tsx
+++ b/frontend/src/remote/components/RemoteConnectionScreen.tsx
@@ -30,7 +30,7 @@ export function RemoteConnectionScreen({
   const [mode, setMode] = useState<ConnectionScreenMode>(() => (
     savedProfiles.length > 0 ? 'connect' : 'menu'
   ));
-  const canReadClipboard = typeof navigator !== 'undefined' && Boolean(navigator.clipboard?.readText);
+  const canReadClipboard = Boolean(navigator.clipboard?.readText);
   const mobileInstallPlatform = getMobileInstallPlatform();
   const connectionErrorId = useId();
   const showConnectionTroubleshooting = Boolean(error && errorKind === 'connection');
@@ -295,10 +295,7 @@ function getMobileInstallSteps(platform: MobileInstallPlatform): string[] {
 }
 
 function getMobileInstallPlatform(): MobileInstallPlatform | null {
-  if (typeof navigator === 'undefined' || typeof window === 'undefined') {
-    return null;
-  }
-
+  // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
   const navigatorWithStandalone = navigator as Navigator & { standalone?: boolean };
   const isStandalone = window.matchMedia('(display-mode: standalone)').matches || navigatorWithStandalone.standalone === true;
   if (isStandalone) {

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -126,6 +126,7 @@ export function RemoteCreateSessionDialog({
   useEffect(() => {
     if (!branchOpen) return;
     const handleClickOutside = (event: MouseEvent) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       if (branchDropdownRef.current && !branchDropdownRef.current.contains(event.target as Node)) {
         setBranchOpen(false);
         setBranchSearch('');
@@ -421,7 +422,7 @@ export function RemoteCreateSessionDialog({
 
 function loadRemoteStartPinnedPreference(): boolean {
   try {
-    return typeof window !== 'undefined' && window.localStorage.getItem(REMOTE_START_PINNED_PREFERENCE_KEY) === 'true';
+    return window.localStorage.getItem(REMOTE_START_PINNED_PREFERENCE_KEY) === 'true';
   } catch {
     return false;
   }
@@ -429,9 +430,7 @@ function loadRemoteStartPinnedPreference(): boolean {
 
 function saveRemoteStartPinnedPreference(value: boolean): void {
   try {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(REMOTE_START_PINNED_PREFERENCE_KEY, value ? 'true' : 'false');
-    }
+    window.localStorage.setItem(REMOTE_START_PINNED_PREFERENCE_KEY, value ? 'true' : 'false');
   } catch {
     // Ignore storage failures so the current create flow can still use local state.
   }

--- a/frontend/src/remote/components/RemotePanelTabs.tsx
+++ b/frontend/src/remote/components/RemotePanelTabs.tsx
@@ -43,6 +43,7 @@ export function RemotePanelTabs({
     if (!showAddMenu) return;
 
     const closeOnPointerDown = (event: PointerEvent) => {
+      // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
       if (!menuRef.current?.contains(event.target as Node)) {
         setShowAddMenu(false);
       }
@@ -83,6 +84,7 @@ export function RemotePanelTabs({
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     const items = menuItemRefs.current.filter((item): item is HTMLButtonElement => Boolean(item));
+    // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
     const currentIndex = items.indexOf(document.activeElement as HTMLButtonElement);
     let nextIndex: number | null = null;
 

--- a/frontend/src/remote/hooks/useRemoteTerminal.ts
+++ b/frontend/src/remote/hooks/useRemoteTerminal.ts
@@ -5,6 +5,7 @@ import type { ToolPanel } from '../../../../shared/types/panels';
 import type { RemotePaneConnectionStatus } from '../../../../shared/types/remoteDaemon';
 import type { SessionOutput } from '../../types/session';
 import type { RemoteRuntimeAdapter } from '../runtime/remoteRuntimeAdapter';
+import { boundary, decodeOptionalBoundary } from '../../../../shared/validation/boundaryDecoder';
 
 interface UseRemoteTerminalOptions {
   adapter: RemoteRuntimeAdapter;
@@ -14,9 +15,14 @@ interface UseRemoteTerminalOptions {
 }
 
 interface TerminalOutputPayload {
-  panelId?: string;
-  output?: string;
+  panelId: string;
+  output: string;
 }
+
+const terminalOutputPayloadSchema = boundary.object({
+  panelId: boundary.string,
+  output: boundary.string,
+});
 
 const VISIBILITY_REFRESH_MS = 60_000;
 const TERMINAL_VIEWER_ID = getTerminalViewerId();
@@ -112,8 +118,11 @@ export function useRemoteTerminal({
 
     const unsubscribe = adapter.onEvent(event => {
       if (event.channel !== 'terminal:output') return;
-      const payload = event.args[0] as TerminalOutputPayload | undefined;
-      if (!payload || payload.panelId !== panel.id || typeof payload.output !== 'string') return;
+      const payload: TerminalOutputPayload | undefined = decodeOptionalBoundary(
+        event.args[0],
+        terminalOutputPayloadSchema,
+      );
+      if (!payload || payload.panelId !== panel.id) return;
       terminal.write(payload.output);
       void adapter.ackTerminalOutput(panel.id, byteLength(payload.output)).catch(() => {});
     });
@@ -183,10 +192,7 @@ async function hydrateTerminal(adapter: RemoteRuntimeAdapter, panelId: string, t
 }
 
 function formatSessionOutput(output: SessionOutput): string {
-  if (typeof output.data === 'string') {
-    return output.data;
-  }
-  return `${JSON.stringify(output.data)}\r\n`;
+  return output.type === 'json' ? `${JSON.stringify(output.data)}\r\n` : String(output.data);
 }
 
 function byteLength(value: string): number {

--- a/frontend/src/remote/hooks/useRemoteVoiceDictation.ts
+++ b/frontend/src/remote/hooks/useRemoteVoiceDictation.ts
@@ -12,6 +12,7 @@ import {
   parseDeepgramLiveMessage,
   readResultsMetadata,
 } from '../utils/deepgramLive';
+import { boundary, decodeOptionalBoundary } from '../../../../shared/validation/boundaryDecoder';
 
 const MAX_RECORDING_MS = 60_000;
 const MAX_AUDIO_BYTES = 10 * 1024 * 1024;
@@ -162,7 +163,7 @@ export function useRemoteVoiceDictation({
       setError('Voice transcription is unavailable.');
       return;
     }
-    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder !== 'function') {
+    if (!navigator.mediaDevices?.getUserMedia || !('MediaRecorder' in globalThis)) {
       setError('Voice recording is not supported in this browser.');
       return;
     }
@@ -249,7 +250,7 @@ export function useRemoteVoiceDictation({
       setError('Live voice transcription is unavailable.');
       return;
     }
-    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder !== 'function' || typeof WebSocket !== 'function') {
+    if (!navigator.mediaDevices?.getUserMedia || !('MediaRecorder' in globalThis) || !('WebSocket' in globalThis)) {
       setError('Live voice recording is not supported in this browser.');
       return;
     }
@@ -438,7 +439,7 @@ export function useRemoteVoiceDictation({
 }
 
 function selectRecordingMimeType(): string | undefined {
-  if (typeof MediaRecorder === 'undefined' || typeof MediaRecorder.isTypeSupported !== 'function') {
+  if (!('MediaRecorder' in globalThis) || !MediaRecorder.isTypeSupported) {
     return undefined;
   }
 
@@ -449,8 +450,9 @@ function blobToDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onloadend = () => {
-      if (typeof reader.result === 'string') {
-        resolve(reader.result);
+      const dataUrl = decodeOptionalBoundary(reader.result, boundary.string);
+      if (dataUrl !== undefined) {
+        resolve(dataUrl);
       } else {
         reject(new Error('Failed to read voice recording.'));
       }
@@ -460,7 +462,7 @@ function blobToDataUrl(blob: Blob): Promise<string> {
   });
 }
 
-function getVoiceErrorMessage(error: unknown): string {
+function getVoiceErrorMessage<ErrorValue>(error: ErrorValue): string {
   if (error instanceof Error && error.message.trim()) {
     return error.message;
   }
@@ -497,9 +499,8 @@ function openStreamingSocket(
       reject(new Error('Failed to connect to Deepgram live transcription.'));
     }, { once: true });
     socket.addEventListener('message', (event) => {
-      if (typeof event.data === 'string') {
-        onMessage(event.data);
-      }
+      const message = decodeOptionalBoundary(event.data, boundary.string);
+      if (message !== undefined) onMessage(message);
     });
   });
 }
@@ -515,9 +516,7 @@ function closeSocket(socketRef: { current: WebSocket | null }): void {
 function stopRecorder(recorder: MediaRecorder): Promise<void> {
   return new Promise(resolve => {
     recorder.addEventListener('stop', () => resolve(), { once: true });
-    if (typeof recorder.requestData === 'function') {
-      recorder.requestData();
-    }
+    recorder.requestData();
     recorder.stop();
   });
 }

--- a/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
+++ b/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
@@ -1,8 +1,10 @@
-import type {
-  RemoteDaemonEventEnvelope,
-  RemoteDaemonHeartbeatPayload,
-  RemotePaneConnectionProfile,
-  RemotePaneConnectionStatus,
+import {
+  decodeRemoteDaemonEventEnvelope,
+  decodeRemoteHeartbeatPayload,
+  type RemoteDaemonEventEnvelope,
+  type RemoteDaemonHeartbeatPayload,
+  type RemotePaneConnectionProfile,
+  type RemotePaneConnectionStatus,
 } from '../../../../shared/types/remoteDaemon';
 
 type RemoteBrowserEvent =
@@ -93,7 +95,7 @@ export class RemoteDaemonBrowserClient {
   }
 
   async invoke<T = unknown>(channel: string, args: unknown[] = []): Promise<T> {
-    let lastError: unknown = null;
+    let lastError: Error | null = null;
     const signal = this.abortController?.signal;
     for (let attempt = 1; attempt <= INVOKE_ATTEMPTS; attempt += 1) {
       try {
@@ -121,6 +123,7 @@ export class RemoteDaemonBrowserClient {
           ...request,
         });
 
+        // SAFETY: The named IPC/API channel contract establishes this response payload type.
         const payload = await response.json() as InvokeSuccessPayload<T> | InvokeErrorPayload;
         if (response.ok && payload.ok) {
           return payload.result;
@@ -136,12 +139,12 @@ export class RemoteDaemonBrowserClient {
         if (!isRetryableResponse(response.status)) {
           throw new NonRetryableRemoteError(message);
         }
-        lastError = error;
+        lastError = error instanceof Error ? error : new Error('Remote request failed');
       } catch (error) {
         if (error instanceof RemoteAuthInvalidError || error instanceof NonRetryableRemoteError || signal?.aborted) {
           throw error;
         }
-        lastError = error;
+        lastError = error instanceof Error ? error : new Error('Remote request failed');
       }
 
       if (attempt < INVOKE_ATTEMPTS) {
@@ -163,7 +166,7 @@ export class RemoteDaemonBrowserClient {
   }
 
   private async checkHealth(signal: AbortSignal): Promise<void> {
-    let lastError: unknown = null;
+    let lastError: Error | null = null;
     for (let attempt = 1; attempt <= HEALTH_CHECK_ATTEMPTS; attempt += 1) {
       try {
         const response = await fetch(this.endpoint('health'), { signal, cache: 'no-store' });
@@ -175,7 +178,7 @@ export class RemoteDaemonBrowserClient {
         if (signal.aborted) {
           throw error;
         }
-        lastError = error;
+        lastError = error instanceof Error ? error : new Error('Remote health check failed');
       }
 
       if (attempt < HEALTH_CHECK_ATTEMPTS) {
@@ -188,7 +191,7 @@ export class RemoteDaemonBrowserClient {
 
   private async openEventStream(signal: AbortSignal): Promise<void> {
     try {
-      if (typeof EventSource === 'function') {
+      if (globalThis.EventSource !== undefined) {
         await this.assertEventStreamAuthenticated(signal);
         this.openNativeEventSource(signal);
         return;
@@ -368,14 +371,14 @@ export class RemoteDaemonBrowserClient {
 
   private handleSseEvent(event: ParsedSseEvent): void {
     if (event.event === 'heartbeat') {
-      const payload = parseEventData<RemoteDaemonHeartbeatPayload>(event.data);
+      const payload = decodeRemoteHeartbeatPayload(JSON.parse(event.data));
       this.setState({ lastSeenAt: payload.timestamp });
       this.emitEvent({ type: 'heartbeat', payload });
       return;
     }
 
     if (event.event === 'daemon-event') {
-      const payload = parseEventData<RemoteDaemonEventEnvelope>(event.data);
+      const payload = decodeRemoteDaemonEventEnvelope(JSON.parse(event.data));
       this.setState({ lastSeenAt: payload.timestamp });
       this.emitEvent({ type: 'daemon-event', payload });
       return;
@@ -449,7 +452,7 @@ export class RemoteDaemonBrowserClient {
     this.eventSource = null;
   }
 
-  private createHealthCheckError(error: unknown): Error {
+  private createHealthCheckError(error: Error | null): Error {
     if (error instanceof Error && isNetworkFailure(error) && isTailscaleUrl(this.profile.baseUrl)) {
       const hostname = getUrlHostname(this.profile.baseUrl);
       return new Error(
@@ -459,9 +462,7 @@ export class RemoteDaemonBrowserClient {
       );
     }
 
-    return error instanceof Error
-      ? error
-      : new Error('Remote health check failed');
+    return error ?? new Error('Remote health check failed');
   }
 }
 
@@ -506,10 +507,6 @@ function parseSseEvent(rawEvent: string): ParsedSseEvent | null {
   }
 
   return { event, data: data.join('\n') };
-}
-
-function parseEventData<T>(data: string): T {
-  return JSON.parse(data) as T;
 }
 
 function getRuntimeId(): string {

--- a/frontend/src/remote/runtime/remoteProfile.ts
+++ b/frontend/src/remote/runtime/remoteProfile.ts
@@ -2,6 +2,8 @@ import type {
   PaneRemoteConnectionImportPayload,
   RemotePaneConnectionProfile,
 } from '../../../../shared/types/remoteDaemon';
+import { decodePaneRemoteConnection } from '../../../../shared/types/remoteDaemon';
+import { BoundaryDecodeError } from '../../../../shared/validation/boundaryDecoder';
 
 const PROFILE_PREFIX = 'pane-remote://';
 
@@ -11,19 +13,17 @@ export function decodeRemoteConnectionCode(code: string): RemotePaneConnectionPr
     throw new Error('Connection code must start with pane-remote://');
   }
 
-  const encoded = trimmed.slice(PROFILE_PREFIX.length);
-  if (!encoded) {
+  if (!trimmed.slice(PROFILE_PREFIX.length)) {
     throw new Error('Connection code is empty');
   }
 
-  let payload: unknown;
+  let importPayload: PaneRemoteConnectionImportPayload;
   try {
-    payload = JSON.parse(decodeBase64Url(encoded));
-  } catch {
+    importPayload = decodePaneRemoteConnection(trimmed);
+  } catch (error) {
+    if (error instanceof BoundaryDecodeError) throw error;
     throw new Error('Connection code is not valid');
   }
-
-  const importPayload = assertConnectionPayload(payload);
   return {
     id: createProfileId(importPayload),
     label: importPayload.label,
@@ -42,54 +42,7 @@ function normalizeBaseUrl(baseUrl: string): string {
   return url.toString().replace(/\/$/, '');
 }
 
-function decodeBase64Url(encoded: string): string {
-  const base64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
-  const binary = atob(padded);
-  const bytes = Uint8Array.from(binary, char => char.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-}
-
-function assertConnectionPayload(payload: unknown): PaneRemoteConnectionImportPayload {
-  if (!payload || typeof payload !== 'object') {
-    throw new Error('Connection code payload is invalid');
-  }
-
-  const candidate = payload as Partial<PaneRemoteConnectionImportPayload>;
-  if (candidate.v !== 1) {
-    throw new Error('Connection code version is not supported');
-  }
-
-  if (!isNonEmptyString(candidate.label)) {
-    throw new Error('Connection code is missing a label');
-  }
-
-  if (!isNonEmptyString(candidate.baseUrl)) {
-    throw new Error('Connection code is missing a host URL');
-  }
-
-  if (!isNonEmptyString(candidate.token)) {
-    throw new Error('Connection code is missing an access token');
-  }
-
-  if (candidate.transport !== 'http+sse') {
-    throw new Error('Connection code transport is not supported');
-  }
-
-  try {
-    normalizeBaseUrl(candidate.baseUrl);
-  } catch {
-    throw new Error('Connection code host URL is invalid');
-  }
-
-  return candidate as PaneRemoteConnectionImportPayload;
-}
-
 function createProfileId(payload: PaneRemoteConnectionImportPayload): string {
   const tokenTail = payload.token.slice(-8);
   return `${payload.label}:${normalizeBaseUrl(payload.baseUrl)}:${tokenTail}`;
-}
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === 'string' && value.trim().length > 0;
 }

--- a/frontend/src/remote/runtime/remoteRuntimeAdapter.ts
+++ b/frontend/src/remote/runtime/remoteRuntimeAdapter.ts
@@ -72,8 +72,10 @@ export class RemoteRuntimeAdapter {
       if (response.success === false) {
         throw new Error(response.error ?? `${channel} failed`);
       }
+      // SAFETY: The named IPC/API channel contract establishes this response payload type.
       return response.data as T;
     }
+    // SAFETY: The adapter method selects T from the invoked channel contract.
     return response as T;
   }
 
@@ -188,5 +190,5 @@ export class RemoteRuntimeAdapter {
 }
 
 function isIpcResponse<T>(value: IpcLikeResponse<T> | T): value is IpcLikeResponse<T> {
-  return Boolean(value && typeof value === 'object' && ('success' in value || 'data' in value || 'error' in value));
+  return Boolean(value && value instanceof Object && ('success' in value || 'data' in value || 'error' in value));
 }

--- a/frontend/src/remote/utils/deepgramLive.test.ts
+++ b/frontend/src/remote/utils/deepgramLive.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { parseDeepgramLiveMessage, readResultsMetadata } from './deepgramLive';
+
+describe('Deepgram live message decoding', () => {
+  it('decodes transcript, metadata, and error messages', () => {
+    expect(parseDeepgramLiveMessage(JSON.stringify({
+      type: 'Results',
+      is_final: true,
+      speech_final: false,
+      channel: { alternatives: [{ transcript: '  hello Pane  ' }] },
+    }))).toEqual({
+      type: 'transcript',
+      update: { transcript: 'hello Pane', isFinal: true, speechFinal: false },
+    });
+    expect(parseDeepgramLiveMessage(JSON.stringify({
+      type: 'Metadata',
+      request_id: 'request-1',
+      duration: 1.25,
+    }))).toEqual({
+      type: 'metadata',
+      metadata: { requestId: 'request-1', duration: 1.25 },
+    });
+    expect(parseDeepgramLiveMessage(JSON.stringify({
+      type: 'Error',
+      message: '  unavailable  ',
+    }))).toEqual({ type: 'error', message: 'unavailable' });
+  });
+
+  it('rejects malformed messages without leaking partial values', () => {
+    expect(parseDeepgramLiveMessage('{')).toEqual({ type: 'other' });
+    expect(parseDeepgramLiveMessage(JSON.stringify({
+      type: 'Results',
+      channel: { alternatives: [{ transcript: 42 }] },
+    }))).toEqual({ type: 'other' });
+    expect(readResultsMetadata(JSON.stringify({ metadata: { request_id: 42 } }))).toBeUndefined();
+  });
+
+  it('decodes result metadata', () => {
+    expect(readResultsMetadata(JSON.stringify({
+      metadata: {
+        request_id: 'request-2',
+        model_info: { name: 'nova-3', version: '2026-08' },
+      },
+    }))).toEqual({
+      requestId: 'request-2',
+      modelName: 'nova-3',
+      modelVersion: '2026-08',
+    });
+  });
+});

--- a/frontend/src/remote/utils/deepgramLive.ts
+++ b/frontend/src/remote/utils/deepgramLive.ts
@@ -1,4 +1,8 @@
 import type { VoiceDeepgramStreamingMetadata } from '../../../../shared/types/voiceTranscription';
+import {
+  boundary,
+  decodeOptionalBoundary,
+} from '../../../../shared/validation/boundaryDecoder';
 
 const DEEPGRAM_STREAMING_KEYTERMS = [
   'Doozy',
@@ -55,6 +59,36 @@ export type DeepgramLiveMessage =
   | { type: 'error'; message: string }
   | { type: 'other' };
 
+const transcriptMessageSchema = boundary.object({
+  type: boundary.literal('Results'),
+  is_final: boundary.optional(boundary.boolean),
+  speech_final: boundary.optional(boundary.boolean),
+  channel: boundary.object({
+    alternatives: boundary.array(boundary.object({ transcript: boundary.string })),
+  }),
+});
+
+const metadataMessageSchema = boundary.object({
+  type: boundary.literal('Metadata'),
+  request_id: boundary.optional(boundary.string),
+  duration: boundary.optional(boundary.number),
+});
+
+const errorMessageSchema = boundary.object({
+  type: boundary.literal('Error'),
+  message: boundary.optional(boundary.string),
+});
+
+const resultsMetadataSchema = boundary.object({
+  metadata: boundary.object({
+    request_id: boundary.optional(boundary.string),
+    model_info: boundary.optional(boundary.object({
+      name: boundary.optional(boundary.string),
+      version: boundary.optional(boundary.string),
+    })),
+  }),
+});
+
 export function buildDeepgramListenUrl(keyterms = DEEPGRAM_STREAMING_KEYTERMS): string {
   const url = new URL('wss://api.deepgram.com/v1/listen');
   url.searchParams.set('model', 'nova-3');
@@ -74,44 +108,40 @@ export function buildDeepgramListenUrl(keyterms = DEEPGRAM_STREAMING_KEYTERMS): 
 export function parseDeepgramLiveMessage(data: string): DeepgramLiveMessage {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(data) as unknown;
+    parsed = JSON.parse(data);
   } catch {
     return { type: 'other' };
   }
 
-  if (!parsed || typeof parsed !== 'object') {
-    return { type: 'other' };
-  }
-
-  const record = parsed as Record<string, unknown>;
-  if (record.type === 'Results') {
-    const transcript = readTranscript(record);
-    if (!transcript) {
-      return { type: 'other' };
-    }
+  const transcriptMessage = decodeOptionalBoundary(parsed, transcriptMessageSchema);
+  if (transcriptMessage) {
+    const transcript = transcriptMessage.channel.alternatives[0]?.transcript.trim();
+    if (!transcript) return { type: 'other' };
     return {
       type: 'transcript',
       update: {
         transcript,
-        isFinal: record.is_final === true,
-        speechFinal: record.speech_final === true,
+        isFinal: transcriptMessage.is_final === true,
+        speechFinal: transcriptMessage.speech_final === true,
       },
     };
   }
 
-  if (record.type === 'Metadata') {
+  const metadataMessage = decodeOptionalBoundary(parsed, metadataMessageSchema);
+  if (metadataMessage) {
     return {
       type: 'metadata',
       metadata: {
-        requestId: typeof record.request_id === 'string' ? record.request_id : undefined,
-        duration: typeof record.duration === 'number' ? record.duration : undefined,
+        requestId: metadataMessage.request_id,
+        duration: metadataMessage.duration,
       },
     };
   }
 
-  if (record.type === 'Error') {
-    const message = typeof record.message === 'string' && record.message.trim()
-      ? record.message.trim()
+  const errorMessage = decodeOptionalBoundary(parsed, errorMessageSchema);
+  if (errorMessage) {
+    const message = errorMessage.message?.trim()
+      ? errorMessage.message.trim()
       : 'Deepgram live transcription failed.';
     return {
       type: 'error',
@@ -125,48 +155,16 @@ export function parseDeepgramLiveMessage(data: string): DeepgramLiveMessage {
 export function readResultsMetadata(data: string): VoiceDeepgramStreamingMetadata | undefined {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(data) as unknown;
+    parsed = JSON.parse(data);
   } catch {
     return undefined;
   }
-  if (!parsed || typeof parsed !== 'object') {
-    return undefined;
-  }
-
-  const metadata = (parsed as Record<string, unknown>).metadata;
-  if (!metadata || typeof metadata !== 'object') {
-    return undefined;
-  }
-
-  const record = metadata as Record<string, unknown>;
-  const modelInfo = record.model_info && typeof record.model_info === 'object'
-    ? record.model_info as Record<string, unknown>
-    : undefined;
+  const result = decodeOptionalBoundary(parsed, resultsMetadataSchema);
+  if (!result) return undefined;
+  const { metadata } = result;
   return {
-    requestId: typeof record.request_id === 'string' ? record.request_id : undefined,
-    modelName: typeof modelInfo?.name === 'string' ? modelInfo.name : undefined,
-    modelVersion: typeof modelInfo?.version === 'string' ? modelInfo.version : undefined,
+    requestId: metadata.request_id,
+    modelName: metadata.model_info?.name,
+    modelVersion: metadata.model_info?.version,
   };
-}
-
-function readTranscript(record: Record<string, unknown>): string | null {
-  const channel = record.channel;
-  if (!channel || typeof channel !== 'object') {
-    return null;
-  }
-
-  const alternatives = (channel as Record<string, unknown>).alternatives;
-  if (!Array.isArray(alternatives)) {
-    return null;
-  }
-
-  const first = alternatives[0];
-  if (!first || typeof first !== 'object') {
-    return null;
-  }
-
-  const transcript = (first as Record<string, unknown>).transcript;
-  return typeof transcript === 'string' && transcript.trim()
-    ? transcript.trim()
-    : null;
 }

--- a/frontend/src/services/panelApi.ts
+++ b/frontend/src/services/panelApi.ts
@@ -1,4 +1,10 @@
-import { CreatePanelRequest, SessionPanelLayout, ToolPanel } from '../../../shared/types/panels';
+import {
+  CreatePanelRequest,
+  PanelEventType,
+  SessionPanelLayout,
+  ToolPanel,
+} from '../../../shared/types/panels';
+import { JsonValue } from '../../../shared/validation/boundaryDecoder';
 
 export const panelApi = {
   async createPanel(request: CreatePanelRequest): Promise<ToolPanel> {
@@ -6,7 +12,7 @@ export const panelApi = {
       request.sessionId, 
       request.type, 
       request.title || '', 
-      request.initialState as Record<string, unknown> | undefined
+      request.initialState
     );
     if (!response.success || !response.data) {
       throw new Error(response.error || 'Failed to create panel');
@@ -57,14 +63,12 @@ export const panelApi = {
     }
   },
   
-  async emitPanelEvent(panelId: string, eventType: string, data: Record<string, unknown>): Promise<void> {
-    // Use direct invoke for event emission as there's no typed wrapper for this
-    // oxlint-disable-next-line typescript/no-explicit-any -- IPC event emission returns void
-    return window.electron!.invoke('panels:emitEvent', panelId, eventType, data) as unknown as void;
+  async emitPanelEvent(panelId: string, eventType: PanelEventType, data: JsonValue): Promise<void> {
+    await window.electronAPI.invoke('panels:emitEvent', panelId, eventType, data);
   },
 
   async getLayout(sessionId: string): Promise<SessionPanelLayout | null> {
-    const response = await window.electronAPI.invoke('panels:get-layout', sessionId) as { success: boolean; data?: SessionPanelLayout | null; error?: string };
+    const response = await window.electronAPI.invoke('panels:get-layout', sessionId);
     if (!response.success) {
       throw new Error(response.error || 'Failed to get panel layout');
     }
@@ -72,7 +76,7 @@ export const panelApi = {
   },
 
   async setLayout(sessionId: string, layout: SessionPanelLayout | null): Promise<void> {
-    const response = await window.electronAPI.invoke('panels:set-layout', sessionId, layout) as { success: boolean; error?: string };
+    const response = await window.electronAPI.invoke('panels:set-layout', sessionId, layout);
     if (!response.success) {
       throw new Error(response.error || 'Failed to set panel layout');
     }
@@ -80,7 +84,7 @@ export const panelApi = {
 
   async clearPanelUnviewedContent(panelId: string): Promise<void> {
     // Clear the hasUnviewedContent flag and set status to 'stopped' for AI panels
-    const response = await window.electron!.invoke('panels:clearUnviewedContent', panelId);
+    const response = await window.electronAPI.invoke('panels:clearUnviewedContent', panelId);
     if (!response.success) {
       throw new Error(response.error || 'Failed to clear unviewed content');
     }

--- a/frontend/src/services/posthog.ts
+++ b/frontend/src/services/posthog.ts
@@ -1,5 +1,6 @@
 import posthog from 'posthog-js';
 import type { AnalyticsIdentity } from '../types/config';
+import type { JsonValue } from '../../../shared/validation/boundaryDecoder';
 
 const DEFAULT_API_KEY = 'phc_wir25CCsjr2NsZGEdlWNdvwcNG1XDjhxc9RyL5KDCf1';
 const DEFAULT_HOST = 'https://runpane.com/api/c';
@@ -9,9 +10,12 @@ let currentHost: string | undefined;
 let currentEnabled: boolean | undefined;
 let currentIdentity: AnalyticsIdentity | undefined;
 
+type AnalyticsPropertyValue = JsonValue | undefined;
+export interface AnalyticsProperties { [key: string]: AnalyticsPropertyValue }
+
 export interface PendingAnalyticsEvent {
   eventName: string;
-  properties?: Record<string, unknown>;
+  properties?: AnalyticsProperties;
 }
 
 let pendingEvents: PendingAnalyticsEvent[] = [];
@@ -27,13 +31,15 @@ export interface PostHogInitOptions {
   flushPendingEvents?: boolean;
 }
 
-function compactProperties(properties: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(properties).filter(([, value]) => value !== undefined)
-  );
+function compactProperties(properties: AnalyticsProperties): Record<string, JsonValue> {
+  const compacted: Record<string, JsonValue> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value !== undefined) compacted[key] = value;
+  }
+  return compacted;
 }
 
-function personProperties(identity?: AnalyticsIdentity): Record<string, unknown> {
+function personProperties(identity?: AnalyticsIdentity): Record<string, JsonValue> {
   if (!identity) return {};
 
   return compactProperties({
@@ -49,7 +55,7 @@ function personProperties(identity?: AnalyticsIdentity): Record<string, unknown>
   });
 }
 
-function contextProperties(identity = currentIdentity): Record<string, unknown> {
+function contextProperties(identity = currentIdentity): Record<string, JsonValue> {
   if (!identity) return {};
 
   return compactProperties({
@@ -88,9 +94,9 @@ function directCaptureTarget(identity = currentIdentity): { token: string; host:
     token: currentApiKey || DEFAULT_API_KEY,
     host: currentHost || DEFAULT_HOST,
     distinctId:
-      typeof identity?.distinctId === 'string' && identity.distinctId.length > 0
+      identity?.distinctId
         ? identity.distinctId
-        : typeof posthogDistinctId === 'string' && posthogDistinctId.length > 0
+        : posthogDistinctId
         ? posthogDistinctId
         : `anon_${crypto.randomUUID()}`,
   };
@@ -98,13 +104,13 @@ function directCaptureTarget(identity = currentIdentity): { token: string; host:
 
 async function directCapture(
   eventName: string,
-  properties?: Record<string, unknown>,
+  properties?: AnalyticsProperties,
   identity = currentIdentity,
   options: { processPersonProfile?: boolean; distinctId?: string } = {}
 ): Promise<void> {
   const { token, host, distinctId } = directCaptureTarget(identity);
   const eventDistinctId =
-    typeof options.distinctId === 'string' && options.distinctId.length > 0
+    options.distinctId
       ? options.distinctId
       : distinctId;
   const shouldProcessPersonProfile = Boolean(options.processPersonProfile && identity);
@@ -265,7 +271,7 @@ export async function aliasInstallIdentityDirect(identity = currentIdentity): Pr
  */
 export async function captureAndOptOut(
   eventName: string,
-  properties?: Record<string, unknown>,
+  properties?: AnalyticsProperties,
   identity = currentIdentity
 ): Promise<void> {
   currentIdentity = identity;
@@ -276,7 +282,7 @@ export async function captureAndOptOut(
   currentEnabled = false;
 }
 
-export function capture(eventName: string, properties?: Record<string, unknown>): void {
+export function capture(eventName: string, properties?: AnalyticsProperties): void {
   try {
     posthog.capture(eventName, compactProperties({
       ...contextProperties(),
@@ -301,7 +307,7 @@ export function capture(eventName: string, properties?: Record<string, unknown>)
  */
 export async function captureUnconditionally(
   eventName: string,
-  properties?: Record<string, unknown>,
+  properties?: AnalyticsProperties,
   identity = currentIdentity
 ): Promise<void> {
   currentIdentity = identity;

--- a/frontend/src/services/terminalInterceptor/handlers/atTerminalHandler.ts
+++ b/frontend/src/services/terminalInterceptor/handlers/atTerminalHandler.ts
@@ -94,6 +94,7 @@ export function createAtTerminalHandler(
         }
         if (savedLineCount) {
           const val = parseInt(savedLineCount, 10);
+          // SAFETY: The value comes from the adjacent finite domain definition.
           const idx = LINE_COUNT_PRESETS.indexOf(val as typeof LINE_COUNT_PRESETS[number]);
           if (idx !== -1) {
             state = { ...state, lineCountPresetIndex: idx, lineCount: LINE_COUNT_PRESETS[idx] };

--- a/frontend/src/services/terminalInterceptor/types.ts
+++ b/frontend/src/services/terminalInterceptor/types.ts
@@ -9,7 +9,7 @@ export interface InterceptorState {
   triggerChar: string | null;
   buffer: string; // characters typed after trigger (for filtering)
   // Handler-specific UI state passed opaquely
-  handlerState: unknown;
+  handlerState: AtTerminalHandlerState | null;
 }
 
 /** A pluggable handler for a trigger character */
@@ -21,7 +21,7 @@ export interface InterceptHandler {
   /** Clean up when deactivating */
   onDeactivate: () => void;
   /** Get current handler-specific state for UI rendering */
-  getState: () => unknown;
+  getState: () => AtTerminalHandlerState;
 }
 
 /** Actions a handler can return from onInput */
@@ -35,7 +35,7 @@ export type InterceptAction =
 /** Payload when executing an action */
 interface InterceptPayload {
   action: string;
-  data: Record<string, unknown>;
+  data: JsonObject;
 }
 
 /** Preset line count options for the line count selector */
@@ -58,3 +58,4 @@ export interface TerminalSuggestion {
   title: string;
   preview: string[]; // last 3 clean lines, ANSI-stripped
 }
+import type { JsonObject } from '../../../../shared/validation/boundaryDecoder';

--- a/frontend/src/stores/hotkeyStore.test.ts
+++ b/frontend/src/stores/hotkeyStore.test.ts
@@ -2,12 +2,49 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { areKeyboardShortcutsEnabled, isCommandPaletteShortcutEnabled, useConfigStore } from './configStore';
 import { useHotkeyStore } from './hotkeyStore';
 
+interface HotkeyTestTarget {
+  tagName: string;
+  isContentEditable: boolean;
+  classList?: { contains: (name: string) => boolean };
+  closest: (selector: string) => { matched: true } | null;
+}
+
+interface HotkeyTestEvent {
+  key: string;
+  code: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  target: HotkeyTestTarget;
+  getModifierState: (keyArg: string) => boolean;
+  preventDefault: () => void;
+}
+
+function keyboardEvent(
+  init: KeyboardEventInit,
+  target: HotkeyTestTarget,
+  preventDefault: () => void,
+): HotkeyTestEvent {
+  return {
+    key: init.key ?? '',
+    code: init.code ?? '',
+    ctrlKey: init.ctrlKey ?? false,
+    metaKey: init.metaKey ?? false,
+    altKey: init.altKey ?? false,
+    shiftKey: init.shiftKey ?? false,
+    target,
+    getModifierState: () => false,
+    preventDefault,
+  };
+}
+
 describe('hotkeyStore keyboard shortcut preference', () => {
-  let keydownListener: ((event: KeyboardEvent) => void) | undefined;
+  let keydownListener: ((event: HotkeyTestEvent) => void) | undefined;
 
   beforeEach(() => {
     vi.stubGlobal('window', {
-      addEventListener: (type: string, listener: (event: KeyboardEvent) => void) => {
+      addEventListener: (type: string, listener: (event: HotkeyTestEvent) => void) => {
         if (type === 'keydown') keydownListener = listener;
       },
       removeEventListener: vi.fn(),
@@ -33,17 +70,14 @@ describe('hotkeyStore keyboard shortcut preference', () => {
       action,
     });
 
-    keydownListener?.({
+    keydownListener?.(keyboardEvent({
       key: 'w',
       code: 'KeyW',
       ctrlKey: true,
       metaKey: false,
       altKey: false,
       shiftKey: false,
-      target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
-      getModifierState: () => false,
-      preventDefault,
-    } as unknown as KeyboardEvent);
+    }, { tagName: 'DIV', isContentEditable: false, closest: () => null }, preventDefault));
 
     expect(action).not.toHaveBeenCalled();
     expect(preventDefault).not.toHaveBeenCalled();
@@ -68,17 +102,14 @@ describe('hotkeyStore keyboard shortcut preference', () => {
       action: paletteAction,
     });
 
-    keydownListener?.({
+    keydownListener?.(keyboardEvent({
       key: 'P',
       code: 'KeyP',
       ctrlKey: true,
       metaKey: false,
       altKey: false,
       shiftKey: true,
-      target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
-      getModifierState: () => false,
-      preventDefault,
-    } as unknown as KeyboardEvent);
+    }, { tagName: 'DIV', isContentEditable: false, closest: () => null }, preventDefault));
 
     expect(paletteAction).toHaveBeenCalledOnce();
     expect(preventDefault).toHaveBeenCalledOnce();
@@ -89,17 +120,14 @@ describe('hotkeyStore keyboard shortcut preference', () => {
         commandPaletteShortcutEnabled: false,
       },
     });
-    keydownListener?.({
+    keydownListener?.(keyboardEvent({
       key: 'P',
       code: 'KeyP',
       ctrlKey: true,
       metaKey: false,
       altKey: false,
       shiftKey: true,
-      target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
-      getModifierState: () => false,
-      preventDefault,
-    } as unknown as KeyboardEvent);
+    }, { tagName: 'DIV', isContentEditable: false, closest: () => null }, preventDefault));
 
     expect(paletteAction).toHaveBeenCalledOnce();
     expect(preventDefault).toHaveBeenCalledOnce();
@@ -128,24 +156,22 @@ describe('hotkeyStore keyboard shortcut preference', () => {
       preventDefault,
     };
 
-    keydownListener?.({
+    keydownListener?.(keyboardEvent({
       ...event,
-      target: {
+    }, {
         tagName: 'TEXTAREA',
         isContentEditable: false,
         classList: { contains: (name: string) => name === 'xterm-helper-textarea' },
         closest: () => null,
-      },
-    } as unknown as KeyboardEvent);
-    keydownListener?.({
+      }, preventDefault));
+    keydownListener?.(keyboardEvent({
       ...event,
-      target: {
+    }, {
         tagName: 'TEXTAREA',
         isContentEditable: false,
         classList: { contains: () => false },
         closest: () => null,
-      },
-    } as unknown as KeyboardEvent);
+      }, preventDefault));
 
     expect(action).toHaveBeenCalledOnce();
     expect(preventDefault).toHaveBeenCalledOnce();
@@ -162,21 +188,18 @@ describe('hotkeyStore keyboard shortcut preference', () => {
       category: 'view' as const,
       action,
     };
-    const dispatch = () => keydownListener?.({
+    const dispatch = () => keydownListener?.(keyboardEvent({
       key: 'ArrowUp',
       code: 'ArrowUp',
       ctrlKey: false,
       metaKey: false,
       altKey: false,
       shiftKey: true,
-      target: {
+    }, {
         tagName: 'DIV',
         isContentEditable: false,
-        closest: (selector: string) => selector === '[aria-modal="true"]' ? {} : null,
-      },
-      getModifierState: () => false,
-      preventDefault,
-    } as unknown as KeyboardEvent);
+        closest: (selector: string) => selector === '[aria-modal="true"]' ? { matched: true } : null,
+      }, preventDefault));
 
     useHotkeyStore.getState().register(definition);
     dispatch();

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -139,6 +139,7 @@ function normalizeHotkeyString(keys: string): string {
   let key = '';
   for (const part of parts) {
     const lower = part.toLowerCase();
+    // SAFETY: The value comes from the adjacent finite domain definition.
     if ((MODIFIER_ORDER as readonly string[]).includes(lower)) {
       modifiers.push(lower);
     } else {
@@ -147,7 +148,9 @@ function normalizeHotkeyString(keys: string): string {
   }
   modifiers.sort(
     (a, b) =>
+      // SAFETY: The value comes from the adjacent finite domain definition.
       (MODIFIER_ORDER as readonly string[]).indexOf(a) -
+      // SAFETY: The value comes from the adjacent finite domain definition.
       (MODIFIER_ORDER as readonly string[]).indexOf(b)
   );
   return [...modifiers, key].join('+');
@@ -176,6 +179,7 @@ function isXtermHelperTarget(target: HTMLElement): boolean {
 }
 
 function handleKeyDown(e: KeyboardEvent) {
+  // SAFETY: The registered DOM/custom-event source establishes this target and detail shape.
   const target = e.target as HTMLElement;
   const isInput =
     target.tagName === 'INPUT' ||

--- a/frontend/src/stores/panelStore.test.ts
+++ b/frontend/src/stores/panelStore.test.ts
@@ -2,8 +2,14 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { usePanelStore } from './panelStore';
 import type { ToolPanel } from '../../../shared/types/panels';
 
-const panel = (id: string, sessionId: string): ToolPanel =>
-  ({ id, sessionId, type: 'terminal', state: { isActive: false, customState: {} } } as unknown as ToolPanel);
+const panel = (id: string, sessionId: string): ToolPanel => ({
+  id,
+  sessionId,
+  type: 'terminal',
+  title: 'Terminal',
+  state: { isActive: false, customState: {} },
+  metadata: { createdAt: '', lastActiveAt: '', position: 0 },
+});
 
 const reset = () =>
   usePanelStore.setState({ panels: {}, activePanels: {}, activityStatus: {}, agentStatus: {}, agentStatusSession: {} });

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -33,7 +33,7 @@ interface SessionStore {
   loadSessions: (sessions: Session[]) => void;
   addSession: (session: Session) => void;
   updateSession: (session: Session) => void;
-  deleteSession: (session: Session) => void;
+  deleteSession: (session: Pick<Session, 'id'>) => void;
   setActiveSession: (sessionId: string | null) => Promise<void>;
   addSessionOutput: (output: SessionOutput) => void;
   setSessionOutput: (sessionId: string, output: string) => void;
@@ -289,6 +289,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     if (normalizedOutput.type === 'json') {
       // Update jsonMessages array with limit
       const currentMessages = session.jsonMessages || [];
+      // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
       const newMessage = { ...(normalizedOutput.data as ClaudeJsonMessage), timestamp: normalizedOutput.timestamp };
       const newJsonMessages = currentMessages.length >= MAX_MESSAGES
         ? [...currentMessages.slice(1), newMessage] // Remove oldest when at limit
@@ -297,9 +298,11 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     } else {
       // Add stdout/stderr to output array with limit
       const currentOutput = session.output || [];
+      // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
+      const outputText = normalizedOutput.data as string;
       const newOutput = currentOutput.length >= MAX_OUTPUTS
-        ? [...currentOutput.slice(1), normalizedOutput.data as string] // Remove oldest when at limit
-        : [...currentOutput, normalizedOutput.data as string];
+        ? [...currentOutput.slice(1), outputText] // Remove oldest when at limit
+        : [...currentOutput, outputText];
       sessions[sessionIndex] = { ...session, output: newOutput };
     }
     
@@ -308,6 +311,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     if (state.activeMainRepoSession && state.activeMainRepoSession.id === normalizedOutput.sessionId) {
       if (normalizedOutput.type === 'json') {
         const currentMessages = state.activeMainRepoSession.jsonMessages || [];
+        // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
         const newMessage = { ...(normalizedOutput.data as ClaudeJsonMessage), timestamp: normalizedOutput.timestamp };
         const newJsonMessages = currentMessages.length >= MAX_MESSAGES
           ? [...currentMessages.slice(1), newMessage]
@@ -315,9 +319,11 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         updatedActiveMainRepoSession = { ...state.activeMainRepoSession, jsonMessages: newJsonMessages };
       } else {
         const currentOutput = state.activeMainRepoSession.output || [];
+        // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
+        const outputText = normalizedOutput.data as string;
         const newOutput = currentOutput.length >= MAX_OUTPUTS
-          ? [...currentOutput.slice(1), normalizedOutput.data as string]
-          : [...currentOutput, normalizedOutput.data as string];
+          ? [...currentOutput.slice(1), outputText]
+          : [...currentOutput, outputText];
         updatedActiveMainRepoSession = { ...state.activeMainRepoSession, output: newOutput };
       }
     }
@@ -367,8 +373,10 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       for (let i = batch; i < batchEnd; i++) {
         const output = normalizeSessionOutput(outputs[i]);
         if (output.type === 'json') {
+          // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
           jsonMessages.push({ ...(output.data as ClaudeJsonMessage), timestamp: output.timestamp });
         } else if (output.type === 'stdout' || output.type === 'stderr') {
+          // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
           stdOutputs.push(output.data as string);
         }
       }

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -24,13 +24,25 @@ import type {
   PanePermissionResolvedEvent,
   PanePermissionResponse,
 } from '../../../shared/types/daemon';
-import type { ToolPanel } from '../../../shared/types/panels';
+import type {
+  CreatePanelRequest,
+  PanelEventType,
+  ResumableSession,
+  SessionPanelLayout,
+  ToolPanel,
+} from '../../../shared/types/panels';
+import type { JsonValue } from '../../../shared/validation/boundaryDecoder';
 import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
+import type {
+  ProjectDashboardData,
+  ProjectDashboardSessionUpdateEvent,
+  ProjectDashboardUpdateEvent,
+} from './projectDashboard';
 
 interface LogEntry {
   timestamp: string;
@@ -61,8 +73,14 @@ interface IPCResponse<T = any> {
 interface ElectronAPI {
   // Generic invoke method. Daemon-owned channels route through the main-process
   // daemon bridge while adapter-only channels stay on direct Electron IPC.
-  // oxlint-disable-next-line typescript/no-explicit-any -- Generic IPC bridge that returns different types based on channel
-  invoke: (channel: string, ...args: unknown[]) => Promise<any>;
+  invoke: {
+    (channel: 'panels:get-layout', sessionId: string): Promise<IPCResponse<SessionPanelLayout | null>>;
+    (channel: 'panels:set-layout', sessionId: string, layout: SessionPanelLayout | null): Promise<IPCResponse<void>>;
+    (channel: 'panels:emitEvent', panelId: string, eventType: PanelEventType, data: JsonValue): Promise<void>;
+    (channel: 'panels:clearUnviewedContent', panelId: string): Promise<IPCResponse<void>>;
+    // oxlint-disable-next-line typescript/no-explicit-any -- Generic IPC bridge fallback for channels without dedicated overloads
+    (channel: string, ...args: unknown[]): Promise<any>;
+  };
   
   // Basic app info
   getAppVersion: () => Promise<string>;
@@ -190,7 +208,7 @@ interface ElectronAPI {
     saveLargeText: (sessionId: string, text: string) => Promise<string>;
 
     // Resume session operations
-    getResumable: () => Promise<IPCResponse>;
+    getResumable: () => Promise<IPCResponse<ResumableSession[]>>;
     resumeInterrupted: (sessionIds: string[]) => Promise<IPCResponse>;
     dismissInterrupted: (sessionIds: string[]) => Promise<IPCResponse>;
   };
@@ -203,7 +221,7 @@ interface ElectronAPI {
     activate: (projectId: string) => Promise<IPCResponse>;
     update: (projectId: string, updates: Partial<Project>) => Promise<IPCResponse>;
     delete: (projectId: string) => Promise<IPCResponse>;
-    detectBranch: (path: string) => Promise<IPCResponse>;
+    detectBranch: (path: string) => Promise<IPCResponse<string>>;
     reorder: (projectOrders: Array<{ id: number; displayOrder: number }>) => Promise<IPCResponse>;
     listBranches: (projectId: string) => Promise<IPCResponse>;
     refreshGitStatus: (projectId: number) => Promise<IPCResponse>;
@@ -294,10 +312,10 @@ interface ElectronAPI {
 
   // Dashboard
   dashboard: {
-    getProjectStatus: (projectId: number) => Promise<IPCResponse>;
-    getProjectStatusProgressive: (projectId: number) => Promise<IPCResponse>;
-    onUpdate: (callback: (data: Record<string, unknown>) => void) => () => void;
-    onSessionUpdate: (callback: (data: { type: string; projectId?: number; sessionId?: string; data: unknown }) => void) => () => void;
+    getProjectStatus: (projectId: number) => Promise<IPCResponse<ProjectDashboardData>>;
+    getProjectStatusProgressive: (projectId: number) => Promise<IPCResponse<ProjectDashboardData>>;
+    onUpdate: (callback: (data: ProjectDashboardUpdateEvent) => void) => () => void;
+    onSessionUpdate: (callback: (data: ProjectDashboardSessionUpdateEvent) => void) => () => void;
   };
 
   // UI State management
@@ -322,7 +340,7 @@ interface ElectronAPI {
     onPermissionResolved: (callback: (event: PanePermissionResolvedEvent) => void) => () => void;
     onSessionCreated: (callback: (session: Session) => void) => () => void;
     onSessionUpdated: (callback: (session: Session) => void) => () => void;
-    onSessionDeleted: (callback: (session: Session) => void) => () => void;
+    onSessionDeleted: (callback: (session: Pick<Session, 'id'>) => void) => () => void;
     onSessionsLoaded: (callback: (sessions: Session[]) => void) => () => void;
     onSessionOutput: (callback: (output: SessionOutput) => void) => () => void;
     onSessionLog: (callback: (data: { sessionId: string; entry: LogEntry }) => void) => () => void;
@@ -350,7 +368,7 @@ interface ElectronAPI {
     onPanelPromptAdded: (callback: (data: { panelId: string; content: string }) => void) => () => void;
     onPanelResponseAdded: (callback: (data: { panelId: string; content: string }) => void) => () => void;
     
-    onTerminalOutput: (callback: (output: { sessionId: string; data: string; type: 'stdout' | 'stderr' }) => void) => () => void;
+    onTerminalOutput: (callback: (output: import('../../../shared/types/panels').TerminalOutputEvent) => void) => () => void;
     onTerminalCliReady: (callback: (data: { panelId: string }) => void) => () => void;
     onTerminalExited: (callback: (data: { sessionId: string; panelId: string; exitCode: number; signal: number | null }) => void) => () => void;
     onTerminalAlternateScreen: (callback: (data: { panelId: string; active: boolean }) => void) => () => void;
@@ -393,8 +411,8 @@ interface ElectronAPI {
 
   // Panel operations
   panels: {
-    getSessionPanels: (sessionId: string) => Promise<IPCResponse>;
-    createPanel: (sessionId: string, type: string, name: string, config?: Record<string, unknown>) => Promise<IPCResponse>;
+    getSessionPanels: (sessionId: string) => Promise<IPCResponse<ToolPanel[]>>;
+    createPanel: (sessionId: string, type: string, name: string, config?: CreatePanelRequest['initialState']) => Promise<IPCResponse<ToolPanel>>;
     deletePanel: (panelId: string) => Promise<IPCResponse>;
     renamePanel: (panelId: string, name: string) => Promise<IPCResponse>;
     setActivePanel: (sessionId: string, panelId: string) => Promise<IPCResponse>;
@@ -448,14 +466,14 @@ interface ElectronAPI {
   // Analytics tracking
   analytics: {
     getIdentity: () => Promise<IPCResponse<import('./config').AnalyticsIdentity>>;
-    onMainEvent: (callback: (event: { eventName: string; properties: Record<string, unknown> }) => void) => () => void;
+    onMainEvent: (callback: (event: { eventName: string; properties: import('../../../shared/validation/boundaryDecoder').JsonObject }) => void) => () => void;
     syncDistinctId: (distinctId: string) => void;
     redeemAttribution: () => Promise<IPCResponse<void>>;
   };
 
   // Onboarding
   onboarding: {
-    detectEnvironment: () => Promise<IPCResponse>;
+    detectEnvironment: () => Promise<IPCResponse<{ ghReady?: boolean }>>;
     getGitHubAuthCommand: () => Promise<IPCResponse<{ command: string; reason: 'login' | 'refresh' | 'install-gh' | 'ready' }>>;
     openGitHubAuthTerminal: () => Promise<IPCResponse<{
       command: string;

--- a/frontend/src/types/projectDashboard.ts
+++ b/frontend/src/types/projectDashboard.ts
@@ -46,3 +46,14 @@ export interface ProjectDashboardData {
   sessionBranches: SessionBranchInfo[];
   lastRefreshed: string;
 }
+
+export type ProjectDashboardUpdateEvent =
+  | { projectId: number; isPartial: true; data: Partial<ProjectDashboardData> }
+  | { projectId: number; isPartial: false; data: ProjectDashboardData };
+
+export interface ProjectDashboardSessionUpdateEvent {
+  type: string;
+  projectId: number;
+  sessionId: string;
+  data: SessionBranchInfo;
+}

--- a/frontend/src/types/projectDashboard.ts
+++ b/frontend/src/types/projectDashboard.ts
@@ -52,8 +52,6 @@ export type ProjectDashboardUpdateEvent =
   | { projectId: number; isPartial: false; data: ProjectDashboardData };
 
 export interface ProjectDashboardSessionUpdateEvent {
-  type: string;
   projectId: number;
-  sessionId: string;
-  data: SessionBranchInfo;
+  session: SessionBranchInfo;
 }

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from '../../../shared/validation/boundaryDecoder';
+
 // Claude message content types
 interface TextContent {
   type: 'text';
@@ -8,7 +10,7 @@ interface ToolUseContent {
   type: 'tool_use';
   id: string;
   name: string;
-  input: Record<string, unknown>;
+  input: JsonObject;
 }
 
 interface ToolResultContent {
@@ -24,8 +26,7 @@ type MessageContent = TextContent | ToolUseContent | ToolResultContent;
 interface ToolDefinition {
   name: string;
   description?: string;
-  input_schema?: Record<string, unknown>;
-  [key: string]: unknown;
+  input_schema?: JsonObject;
 }
 
 // MCP server definition interface  
@@ -34,7 +35,6 @@ interface McpServerDefinition {
   command?: string;
   args?: string[];
   env?: Record<string, string>;
-  [key: string]: unknown;
 }
 
 // JSON message structure from Claude
@@ -43,13 +43,12 @@ export interface ClaudeJsonMessage {
   type: 'user' | 'assistant' | 'system' | 'tool_use' | 'tool_result' | 'result' | 'thinking';
   role?: 'user' | 'assistant' | 'system';
   content?: string | MessageContent[];
-  message?: { 
+  message?: {
     content?: string | MessageContent[];
-    [key: string]: unknown;
   };
   timestamp: string;
   name?: string;
-  input?: Record<string, unknown>;
+  input?: JsonObject;
   tool_use_id?: string;
   parent_tool_use_id?: string;
   session_id?: string;
@@ -71,7 +70,6 @@ export interface ClaudeJsonMessage {
   num_turns?: number;
   cost_usd?: number;
   thinking?: string;
-  [key: string]: unknown;
 }
 
 export interface Session {

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -100,7 +100,7 @@ export const DEFAULT_SETTINGS_PREFERENCES: SettingsPreferenceValues = {
   atTerminalLineCount: 500,
 };
 
-export function normalizeSidebarPaneRowLayout(value: unknown): SidebarPaneRowLayout {
+export function normalizeSidebarPaneRowLayout(value: string | null | undefined): SidebarPaneRowLayout {
   return value === 'two-row' ? 'two-row' : 'single';
 }
 
@@ -120,5 +120,5 @@ export function serializeSettingPreference<K extends keyof SettingsPreferenceVal
   _key: K,
   value: SettingsPreferenceValues[K],
 ): string {
-  return typeof value === 'boolean' ? String(value) : String(value);
+  return String(value);
 }

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -6,22 +6,17 @@ import type { SessionCreationPreferences } from '../stores/sessionPreferencesSto
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
 import type {
   RemoteDaemonClientRecord,
-  RemoteDaemonConnectionPair,
   RemoteDaemonClientSettings,
   RemoteDaemonHostConfig,
   RemoteDaemonHostRuntimeState,
-  RemoteHostConnectionCodeResult,
-  RemoteDaemonImportResult,
   RemoteHostSetupRequest,
-  RemoteHostSetupResult,
-  RemoteHostSetupTerminalCommandResult,
   RemotePaneConnectionState,
   RemotePaneConnectionProfile,
 } from '../../../shared/types/remoteDaemon';
 import type {
-  PanePermissionRequest,
   PanePermissionResponse,
 } from '../../../shared/types/daemon';
+import type { ProjectDashboardSessionUpdateEvent, ProjectDashboardUpdateEvent } from '../types/projectDashboard';
 
 // Type for IPC response
 // oxlint-disable-next-line typescript/no-explicit-any -- Generic type parameter default for flexible API responses
@@ -53,7 +48,7 @@ export interface GitErrorResponse extends IPCResponse {
 
 // Check if we're running in Electron
 const isElectron = () => {
-  return typeof window !== 'undefined' && window.electronAPI;
+  return Boolean(window.electronAPI);
 };
 
 // Wrapper class for API calls that provides error handling and consistent interface
@@ -518,36 +513,32 @@ export class API {
 
     async getHostState() {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.remoteDaemon.getHostState() as Promise<IPCResponse<RemoteDaemonHostRuntimeState>>;
+      return window.electronAPI.remoteDaemon.getHostState();
     },
 
     async setupHost(input: RemoteHostSetupRequest) {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.remoteDaemon.setupHost(input) as Promise<IPCResponse<RemoteHostSetupResult>>;
+      return window.electronAPI.remoteDaemon.setupHost(input);
     },
 
     async getInteractiveSetupCommand(input: RemoteHostSetupRequest) {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.remoteDaemon.getInteractiveSetupCommand(input) as Promise<IPCResponse<RemoteHostSetupTerminalCommandResult>>;
+      return window.electronAPI.remoteDaemon.getInteractiveSetupCommand(input);
     },
 
     async getInteractiveClientSetupCommand() {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.remoteDaemon.getInteractiveClientSetupCommand() as Promise<IPCResponse<RemoteHostSetupTerminalCommandResult>>;
+      return window.electronAPI.remoteDaemon.getInteractiveClientSetupCommand();
     },
 
     async createConnectionPair(input: { label: string; baseUrl: string }) {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.remoteDaemon.createConnectionPair(input) as Promise<{
-        success: boolean;
-        data?: RemoteDaemonConnectionPair;
-        error?: string;
-      }>;
+      return window.electronAPI.remoteDaemon.createConnectionPair(input);
     },
 
     async createHostConnectionCode(input?: { label?: string }) {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.remoteDaemon.createHostConnectionCode(input) as Promise<IPCResponse<RemoteHostConnectionCodeResult>>;
+      return window.electronAPI.remoteDaemon.createHostConnectionCode(input);
     },
 
     async updateHostConfig(updates: Partial<RemoteDaemonHostConfig>) {
@@ -582,7 +573,7 @@ export class API {
 
     async importConnectionCode(code: string, options?: { connect?: boolean }) {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.remoteDaemon.importConnectionCode(code, options) as Promise<IPCResponse<RemoteDaemonImportResult>>;
+      return window.electronAPI.remoteDaemon.importConnectionCode(code, options);
     },
 
     async deleteConnectionProfile(profileId: string) {
@@ -621,12 +612,12 @@ export class API {
 
   // Dialog
   static dialog = {
-    async openFile(options?: Record<string, unknown>) {
+    async openFile(options?: Electron.OpenDialogOptions) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.dialog.openFile(options);
     },
 
-    async openDirectory(options?: Record<string, unknown>) {
+    async openDirectory(options?: Electron.OpenDialogOptions) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.dialog.openDirectory(options);
     },
@@ -641,7 +632,7 @@ export class API {
 
     async getPending() {
       if (!isElectron()) throw new Error('Electron API not available');
-      return window.electronAPI.permissions.getPending() as Promise<IPCResponse<PanePermissionRequest[]>>;
+      return window.electronAPI.permissions.getPending();
     },
   };
 
@@ -668,12 +659,12 @@ export class API {
       return window.electronAPI.dashboard.getProjectStatusProgressive(projectId);
     },
 
-    onUpdate(callback: (data: Record<string, unknown>) => void) {
+    onUpdate(callback: (data: ProjectDashboardUpdateEvent) => void) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.dashboard.onUpdate(callback);
     },
 
-    onSessionUpdate(callback: (data: { type: string; projectId?: number; sessionId?: string; data: unknown }) => void) {
+    onSessionUpdate(callback: (data: ProjectDashboardSessionUpdateEvent) => void) {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.dashboard.onSessionUpdate(callback);
     },

--- a/frontend/src/utils/debounce.ts
+++ b/frontend/src/utils/debounce.ts
@@ -1,10 +1,10 @@
-export interface DebouncedFunction<T extends (...args: never[]) => unknown> {
+export interface DebouncedFunction<T extends (...args: never[]) => void> {
   (...args: Parameters<T>): void;
   cancel: () => void;
   flush: () => void;
 }
 
-export function debounce<T extends (...args: never[]) => unknown>(
+export function debounce<T extends (...args: never[]) => void>(
   func: T,
   wait: number
 ): DebouncedFunction<T> {

--- a/frontend/src/utils/panelLayout.test.ts
+++ b/frontend/src/utils/panelLayout.test.ts
@@ -54,6 +54,22 @@ function layoutOf(root: PanelLayoutNode, extra?: Partial<SessionPanelLayout>): S
   return { version: 1, root, focusedGroupId: primaryGroup(root).id, ...extra };
 }
 
+function requireGroup(node: PanelLayoutNode): PanelGroupNode {
+  if (node.type !== 'group') throw new Error(`Expected group, received ${node.type}`);
+  return node;
+}
+
+function requireSplit(node: PanelLayoutNode): PanelSplitNode {
+  if (node.type !== 'split') throw new Error(`Expected split, received ${node.type}`);
+  return node;
+}
+
+function requireFoundGroup(node: PanelLayoutNode, id: string): PanelGroupNode {
+  const found = findGroup(node, id);
+  if (!found) throw new Error(`Expected group ${id}`);
+  return found;
+}
+
 // ---------------------------------------------------------------------------
 // Tree queries
 // ---------------------------------------------------------------------------
@@ -92,33 +108,33 @@ describe('createSingleGroupLayout', () => {
   it('uses the requested active panel when present', () => {
     const layout = createSingleGroupLayout(['a', 'b'], 'b');
     expect(layout.root.type).toBe('group');
-    expect((layout.root as PanelGroupNode).activePanelId).toBe('b');
+    expect(requireGroup(layout.root).activePanelId).toBe('b');
     expect(layout.focusedGroupId).toBe(layout.root.id);
   });
 
   it('falls back to the first panel when the active id is unknown', () => {
     const layout = createSingleGroupLayout(['a', 'b'], 'zzz');
-    expect((layout.root as PanelGroupNode).activePanelId).toBe('a');
+    expect(requireGroup(layout.root).activePanelId).toBe('a');
   });
 
   it('handles an empty panel list', () => {
     const layout = createSingleGroupLayout([], null);
-    expect((layout.root as PanelGroupNode).panelIds).toEqual([]);
-    expect((layout.root as PanelGroupNode).activePanelId).toBeNull();
+    expect(requireGroup(layout.root).panelIds).toEqual([]);
+    expect(requireGroup(layout.root).activePanelId).toBeNull();
   });
 });
 
 describe('addPanelToGroup', () => {
   it('appends the panel and makes it active', () => {
     const root = group('g1', ['a'], 'a');
-    const next = addPanelToGroup(root, 'g1', 'b') as PanelGroupNode;
+    const next = requireGroup(addPanelToGroup(root, 'g1', 'b'));
     expect(next.panelIds).toEqual(['a', 'b']);
     expect(next.activePanelId).toBe('b');
   });
 
   it('appends the panel without activating it when requested', () => {
     const root = group('g1', ['a'], 'a');
-    const next = addPanelToGroup(root, 'g1', 'b', { activate: false }) as PanelGroupNode;
+    const next = requireGroup(addPanelToGroup(root, 'g1', 'b', { activate: false }));
     expect(next.panelIds).toEqual(['a', 'b']);
     expect(next.activePanelId).toBe('a');
   });
@@ -152,7 +168,7 @@ describe('normalize', () => {
       group('g1', ['a']),
       split('s2', 'row', [group('g2', ['b']), group('g3', ['c'])], [0.5, 0.5]),
     ], [0.5, 0.5]);
-    const result = normalize(tree) as PanelSplitNode;
+    const result = requireSplit(normalize(tree));
     expect(result.children.map(c => c.id)).toEqual(['g1', 'g2', 'g3']);
     expect(result.sizes).toEqual([0.5, 0.25, 0.25]);
   });
@@ -162,13 +178,13 @@ describe('normalize', () => {
       group('g1', ['a']),
       split('s2', 'column', [group('g2', ['b']), group('g3', ['c'])]),
     ]);
-    const result = normalize(tree) as PanelSplitNode;
+    const result = requireSplit(normalize(tree));
     expect(result.children.map(c => c.id)).toEqual(['g1', 's2']);
   });
 
   it('renormalizes sizes to sum 1', () => {
     const tree = split('s1', 'row', [group('g1', ['a']), group('g2', ['b'])], [2, 6]);
-    const result = normalize(tree) as PanelSplitNode;
+    const result = requireSplit(normalize(tree));
     expect(result.sizes).toEqual([0.25, 0.75]);
   });
 });
@@ -180,11 +196,14 @@ describe('normalize', () => {
 describe('splitGroup', () => {
   it('wraps a root group into a 50/50 split', () => {
     const root = group('g1', ['a', 'b'], 'a');
-    const result = splitGroup(root, 'g1', 'a', 'row') as PanelSplitNode;
+    const result = requireSplit(splitGroup(root, 'g1', 'a', 'row'));
     expect(result.type).toBe('split');
     expect(result.direction).toBe('row');
     expect(result.sizes).toEqual([0.5, 0.5]);
-    const [left, right] = result.children as PanelGroupNode[];
+    const [leftNode, rightNode] = result.children;
+    if (!leftNode || !rightNode) throw new Error('Expected both split children');
+    const left = requireGroup(leftNode);
+    const right = requireGroup(rightNode);
     expect(left.id).toBe('g1');
     expect(left.panelIds).toEqual(['b']);
     expect(left.activePanelId).toBe('b');
@@ -194,7 +213,7 @@ describe('splitGroup', () => {
 
   it('inserts an n-ary sibling in a same-direction split, halving the source size', () => {
     const root = split('s1', 'row', [group('g1', ['a', 'b']), group('g2', ['c'])], [0.6, 0.4]);
-    const result = splitGroup(root, 'g1', 'a', 'row') as PanelSplitNode;
+    const result = requireSplit(splitGroup(root, 'g1', 'a', 'row'));
     expect(result.id).toBe('s1');
     expect(result.children).toHaveLength(3);
     expect(result.children.map(c => c.id)).toEqual(['g1', result.children[1].id, 'g2']);
@@ -203,9 +222,11 @@ describe('splitGroup', () => {
 
   it('nests a new split when the direction differs', () => {
     const root = split('s1', 'row', [group('g1', ['a', 'b']), group('g2', ['c'])]);
-    const result = splitGroup(root, 'g1', 'a', 'column') as PanelSplitNode;
+    const result = requireSplit(splitGroup(root, 'g1', 'a', 'column'));
     expect(result.id).toBe('s1');
-    const nested = result.children[0] as PanelSplitNode;
+    const firstChild = result.children[0];
+    if (!firstChild) throw new Error('Expected nested split');
+    const nested = requireSplit(firstChild);
     expect(nested.type).toBe('split');
     expect(nested.direction).toBe('column');
     expect(allPanelIds(nested)).toEqual(['b', 'a']);
@@ -226,9 +247,9 @@ describe('splitGroup', () => {
 describe('movePanel center drops', () => {
   it('moves a panel into another group at the given index', () => {
     const root = split('s1', 'row', [group('g1', ['a', 'b'], 'a'), group('g2', ['c'], 'c')]);
-    const result = movePanel(root, 'a', { groupId: 'g2', index: 0 }) as PanelSplitNode;
-    const g1 = findGroup(result, 'g1')!;
-    const g2 = findGroup(result, 'g2')!;
+    const result = requireSplit(movePanel(root, 'a', { groupId: 'g2', index: 0 }));
+    const g1 = requireFoundGroup(result, 'g1');
+    const g2 = requireFoundGroup(result, 'g2');
     expect(g1.panelIds).toEqual(['b']);
     expect(g1.activePanelId).toBe('b');
     expect(g2.panelIds).toEqual(['a', 'c']);
@@ -238,28 +259,28 @@ describe('movePanel center drops', () => {
   it('same-group rightward reorder lands at the drop indicator, not one past it', () => {
     const root = group('g1', ['a', 'b', 'c']);
     // Indicator before 'c' (index 2): expect [b, a, c]
-    const result = movePanel(root, 'a', { groupId: 'g1', index: 2 }) as PanelGroupNode;
+    const result = requireGroup(movePanel(root, 'a', { groupId: 'g1', index: 2 }));
     expect(result.panelIds).toEqual(['b', 'a', 'c']);
   });
 
   it('same-group move to the end (index = length) appends', () => {
     const root = group('g1', ['a', 'b', 'c']);
-    const result = movePanel(root, 'a', { groupId: 'g1', index: 3 }) as PanelGroupNode;
+    const result = requireGroup(movePanel(root, 'a', { groupId: 'g1', index: 3 }));
     expect(result.panelIds).toEqual(['b', 'c', 'a']);
   });
 
   it('same-group leftward reorder needs no index adjustment', () => {
     const root = group('g1', ['a', 'b', 'c']);
-    const result = movePanel(root, 'c', { groupId: 'g1', index: 0 }) as PanelGroupNode;
+    const result = requireGroup(movePanel(root, 'c', { groupId: 'g1', index: 0 }));
     expect(result.panelIds).toEqual(['c', 'a', 'b']);
   });
 
   it('dropping a panel on its own position is a no-op order-wise', () => {
     const root = group('g1', ['a', 'b', 'c']);
-    expect((movePanel(root, 'a', { groupId: 'g1', index: 0 }) as PanelGroupNode).panelIds)
+    expect(requireGroup(movePanel(root, 'a', { groupId: 'g1', index: 0 })).panelIds)
       .toEqual(['a', 'b', 'c']);
     // Right half of its own tab resolves to index 1, adjusted back to 0
-    expect((movePanel(root, 'a', { groupId: 'g1', index: 1 }) as PanelGroupNode).panelIds)
+    expect(requireGroup(movePanel(root, 'a', { groupId: 'g1', index: 1 })).panelIds)
       .toEqual(['a', 'b', 'c']);
   });
 
@@ -268,25 +289,30 @@ describe('movePanel center drops', () => {
     const result = movePanel(root, 'a', { groupId: 'g2', index: 1 });
     expect(result.type).toBe('group');
     expect(result.id).toBe('g2');
-    expect((result as PanelGroupNode).panelIds).toEqual(['b', 'a']);
+    expect(requireGroup(result).panelIds).toEqual(['b', 'a']);
   });
 });
 
 describe('movePanel edge drops', () => {
   it('splits against the target group in the edge direction', () => {
     const root = split('s1', 'row', [group('g1', ['a', 'b'], 'a'), group('g2', ['c'])]);
-    const result = movePanel(root, 'a', { groupId: 'g2', edge: 'bottom' }) as PanelSplitNode;
+    const result = requireSplit(movePanel(root, 'a', { groupId: 'g2', edge: 'bottom' }));
     expect(result.id).toBe('s1');
-    const nested = result.children[1] as PanelSplitNode;
+    const secondChild = result.children[1];
+    if (!secondChild) throw new Error('Expected nested split');
+    const nested = requireSplit(secondChild);
     expect(nested.type).toBe('split');
     expect(nested.direction).toBe('column');
-    expect((nested.children[0] as PanelGroupNode).panelIds).toEqual(['c']);
-    expect((nested.children[1] as PanelGroupNode).panelIds).toEqual(['a']);
+    const firstNestedChild = nested.children[0];
+    const secondNestedChild = nested.children[1];
+    if (!firstNestedChild || !secondNestedChild) throw new Error('Expected both nested groups');
+    expect(requireGroup(firstNestedChild).panelIds).toEqual(['c']);
+    expect(requireGroup(secondNestedChild).panelIds).toEqual(['a']);
   });
 
   it('inserts an n-ary sibling when the edge matches the parent direction', () => {
     const root = split('s1', 'row', [group('g1', ['a', 'b']), group('g2', ['c'])], [0.5, 0.5]);
-    const result = movePanel(root, 'a', { groupId: 'g2', edge: 'right' }) as PanelSplitNode;
+    const result = requireSplit(movePanel(root, 'a', { groupId: 'g2', edge: 'right' }));
     expect(result.id).toBe('s1');
     expect(result.children).toHaveLength(3);
     expect(allPanelIds(result)).toEqual(['b', 'c', 'a']);
@@ -307,7 +333,9 @@ describe('movePanel edge drops', () => {
 describe('removePanelFromLayout', () => {
   it('removes a panel and reassigns the group active id', () => {
     const root = group('g1', ['a', 'b'], 'a');
-    const result = removePanelFromLayout(root, 'a') as PanelGroupNode;
+    const removed = removePanelFromLayout(root, 'a');
+    if (!removed) throw new Error('Expected surviving group');
+    const result = requireGroup(removed);
     expect(result.panelIds).toEqual(['b']);
     expect(result.activePanelId).toBe('b');
   });
@@ -382,10 +410,10 @@ describe('reconcile', () => {
     const layout = layoutOf(group('g1', ['a', 'b'], 'b'));
     const { layout: result, changed } = reconcile({
       ...layout,
-      root: { ...(layout.root as PanelGroupNode), activePanelId: 'dead' },
+      root: { ...requireGroup(layout.root), activePanelId: 'dead' },
     }, ['a', 'b']);
     expect(changed).toBe(true);
-    expect((result.root as PanelGroupNode).activePanelId).toBe('a');
+    expect(requireGroup(result.root).activePanelId).toBe('a');
   });
 });
 
@@ -399,9 +427,11 @@ describe('updateSizes', () => {
       group('g1', ['a']),
       split('s2', 'column', [group('g2', ['b']), group('g3', ['c'])], [0.5, 0.5]),
     ], [0.5, 0.5]);
-    const result = updateSizes(root, 's2', [0.7, 0.3]) as PanelSplitNode;
+    const result = requireSplit(updateSizes(root, 's2', [0.7, 0.3]));
     expect(result.sizes).toEqual([0.5, 0.5]);
-    expect((result.children[1] as PanelSplitNode).sizes).toEqual([0.7, 0.3]);
+    const nested = result.children[1];
+    if (!nested) throw new Error('Expected nested split');
+    expect(requireSplit(nested).sizes).toEqual([0.7, 0.3]);
   });
 });
 
@@ -502,7 +532,26 @@ describe('subsetInsertIndex', () => {
 // ---------------------------------------------------------------------------
 
 describe('dropZoneFor', () => {
-  const rect = { left: 0, top: 0, width: 100, height: 100 } as DOMRect;
+  const rect: DOMRect = {
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    right: 100,
+    bottom: 100,
+    width: 100,
+    height: 100,
+    toJSON: () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+    }),
+  };
 
   it('returns center inside the inner band', () => {
     expect(dropZoneFor(50, 50, rect)).toBe('center');

--- a/frontend/src/utils/panelLayout.ts
+++ b/frontend/src/utils/panelLayout.ts
@@ -355,6 +355,7 @@ export function movePanel(
   const removed = removePanelFromTree(root);
   const normalized = normalize(removed);
 
+  // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
   const edgeTarget = target as MoveTargetEdge;
   const direction: 'row' | 'column' = (edgeTarget.edge === 'left' || edgeTarget.edge === 'right') ? 'row' : 'column';
   const after = edgeTarget.edge === 'right' || edgeTarget.edge === 'bottom';

--- a/frontend/src/utils/sessionOrdering.ts
+++ b/frontend/src/utils/sessionOrdering.ts
@@ -19,7 +19,7 @@ function getPinnedSessionLabel(projectName: string | undefined, sessionName: str
 }
 
 function hasDisplayOrder(session: Session): boolean {
-  return typeof session.displayOrder === 'number' && Number.isFinite(session.displayOrder);
+  return Number.isFinite(session.displayOrder ?? Number.NaN);
 }
 
 function compareCreatedAt(a: Session, b: Session, ascending: boolean): number {

--- a/frontend/src/utils/terminalClipboard.test.ts
+++ b/frontend/src/utils/terminalClipboard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { isTerminalCopyShortcut } from './terminalClipboard';
 
 function key(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  // SAFETY: The surrounding typed producer establishes the narrower value shape consumed here.
   return {
     key: 'c',
     ctrlKey: false,

--- a/frontend/src/utils/terminalRestore.ts
+++ b/frontend/src/utils/terminalRestore.ts
@@ -8,9 +8,8 @@ export interface TerminalRestoreContent {
 }
 
 function normalizeScrollback(scrollback: TerminalPanelState['scrollbackBuffer']): string {
-  if (typeof scrollback === 'string') return scrollback;
   if (Array.isArray(scrollback)) return scrollback.join('\n');
-  return '';
+  return scrollback ?? '';
 }
 
 /** Select the buffer that represents the live terminal's active screen. */

--- a/frontend/src/utils/timestampUtils.ts
+++ b/frontend/src/utils/timestampUtils.ts
@@ -18,7 +18,7 @@
  * @returns Human-readable time distance
  */
 export function formatDistanceToNow(date: Date | string): string {
-  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  const dateObj = date instanceof Date ? date : new Date(date);
   const now = new Date();
   const diffMs = now.getTime() - dateObj.getTime();
   const diffSeconds = Math.floor(diffMs / 1000);
@@ -44,7 +44,7 @@ export function formatDistanceToNow(date: Date | string): string {
  */
 export function isValidTimestamp(timestamp: string | Date | null | undefined): boolean {
   if (!timestamp) return false;
-  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
   return !isNaN(date.getTime());
 }
 

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -86,6 +86,8 @@ interface SessionOutputData {
   panelId?: string;
 }
 
+type TerminalOutputEvent = import('../../shared/types/panels').TerminalOutputEvent;
+
 interface Folder {
   id: string;
   name: string;
@@ -770,8 +772,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('session:updated', wrappedCallback);
       return () => ipcRenderer.removeListener('session:updated', wrappedCallback);
     },
-    onSessionDeleted: (callback: (session: Session) => void) => {
-      const wrappedCallback = (_event: Electron.IpcRendererEvent, session: Session) => callback(session);
+    onSessionDeleted: (callback: (session: Pick<Session, 'id'>) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, session: Pick<Session, 'id'>) => callback(session);
       ipcRenderer.on('session:deleted', wrappedCallback);
       return () => ipcRenderer.removeListener('session:deleted', wrappedCallback);
     },
@@ -875,8 +877,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return () => ipcRenderer.removeListener('panel:response-added', wrappedCallback);
     },
     
-    onTerminalOutput: (callback: (output: SessionOutputData) => void) => {
-      const wrappedCallback = (_event: Electron.IpcRendererEvent, output: SessionOutputData) => callback(output);
+    onTerminalOutput: (callback: (output: TerminalOutputEvent) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, output: TerminalOutputEvent) => callback(output);
       ipcRenderer.on('terminal:output', wrappedCallback);
       return () => ipcRenderer.removeListener('terminal:output', wrappedCallback);
     },

--- a/shared/types/panels.ts
+++ b/shared/types/panels.ts
@@ -64,6 +64,20 @@ export interface TerminalPanelState {
   isCliReady?: boolean;              // True after the CLI tool has started responding
 }
 
+export interface TerminalPanelOutputEvent {
+  sessionId: string;
+  panelId: string;
+  output: string;
+}
+
+export interface TerminalSessionOutputEvent {
+  sessionId: string;
+  type: 'stdout' | 'stderr';
+  data: string;
+}
+
+export type TerminalOutputEvent = TerminalPanelOutputEvent | TerminalSessionOutputEvent;
+
 export interface DiffPanelState {
   lastRefresh?: string;            // Last time diff was refreshed
   currentDiff?: string;             // Cached diff content

--- a/shared/types/remoteDaemon.ts
+++ b/shared/types/remoteDaemon.ts
@@ -272,6 +272,24 @@ export interface RemoteDaemonEventEnvelope {
   timestamp: string;
 }
 
+const remoteHeartbeatPayloadSchema: BoundarySchema<RemoteDaemonHeartbeatPayload> = boundary.object({
+  timestamp: boundary.nonEmptyString,
+});
+
+const remoteDaemonEventEnvelopeSchema = boundary.object({
+  channel: boundary.string,
+  args: boundary.array(boundary.json),
+  timestamp: boundary.string,
+});
+
+export function decodeRemoteHeartbeatPayload<Value>(value: Value): RemoteDaemonHeartbeatPayload {
+  return decodeBoundary(value, remoteHeartbeatPayloadSchema);
+}
+
+export function decodeRemoteDaemonEventEnvelope<Value>(value: Value): RemoteDaemonEventEnvelope {
+  return decodeBoundary(value, remoteDaemonEventEnvelopeSchema);
+}
+
 export const DEFAULT_REMOTE_DAEMON_HOST_CONFIG: RemoteDaemonHostConfig = {
   enabled: false,
   listenHost: '127.0.0.1',

--- a/shared/validation/boundaryDecoder.ts
+++ b/shared/validation/boundaryDecoder.ts
@@ -202,3 +202,15 @@ export function decodeBoundary<Value>(
 ): Value {
   return schema.decode(cursor(value));
 }
+
+export function decodeOptionalBoundary<Value>(
+  value: unknown,
+  schema: BoundarySchema<Value>,
+): Value | undefined {
+  try {
+    return decodeBoundary(value, schema);
+  } catch (error) {
+    if (error instanceof BoundaryDecodeError) return undefined;
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- eliminate all 348 Phase 2d findings across runtime type checks, unknown contracts, unsafe dictionaries, and undocumented assertions
- decode browser/IPC payloads at boundaries and tighten shared Electron event contracts
- add focused Deepgram parsing coverage and preserve both panel and legacy terminal-output paths

Part of #403.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test` (161 tests)
- `pnpm --filter main exec vitest run` (595 tests)
- `pnpm build`
- exact Phase 2d advisory scan: 0 remaining findings