### PR TITLE
Eliminate script and test boundary findings

### DIFF
--- a/scripts/generate-notices.js
+++ b/scripts/generate-notices.js
@@ -283,19 +283,23 @@ function collectAllLicenses() {
   return licenses;
 }
 
+function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
 function formatLicenseEntry(info) {
   let entry = `Package: ${info.name}\n`;
   entry += `Version: ${info.version}\n`;
   
   if (info.author) {
-    const author = typeof info.author === 'object' ? info.author.name : info.author;
+    const author = isPlainObject(info.author) ? info.author.name : info.author;
     if (author) entry += `Author: ${author}\n`;
   }
   
   if (info.homepage) {
     entry += `Homepage: ${info.homepage}\n`;
   } else if (info.repository) {
-    const repo = typeof info.repository === 'object' ? info.repository.url : info.repository;
+    const repo = isPlainObject(info.repository) ? info.repository.url : info.repository;
     if (repo) entry += `Repository: ${repo}\n`;
   }
   
@@ -352,7 +356,7 @@ function generateNotices() {
       for (const { info } of packages) {
         notices += `  - ${info.name} (${info.version})`;
         if (info.author) {
-          const author = typeof info.author === 'object' ? info.author.name : info.author;
+          const author = isPlainObject(info.author) ? info.author.name : info.author;
           if (author) notices += ` - ${author}`;
         }
         notices += '\n';

--- a/scripts/generate-runpane-contract.js
+++ b/scripts/generate-runpane-contract.js
@@ -42,7 +42,13 @@ function assertUnique(items, label) {
 }
 
 function isObject(value) {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function runtimeType(value) {
+  if (Array.isArray(value)) return 'array';
+  if (isObject(value)) return 'object';
+  return Object.prototype.toString.call(value).slice(8, -1).toLowerCase();
 }
 
 function pointerSegment(segment) {
@@ -73,7 +79,7 @@ function typeMatches(value, type) {
   if (type === 'object') {
     return isObject(value);
   }
-  return typeof value === type;
+  return runtimeType(value) === type;
 }
 
 function validateJsonSchema(value, schemaNode, label, rootSchema) {
@@ -181,7 +187,7 @@ function validateContract(contract, schema) {
     if (!template) {
       throw new Error(`agentTemplates.${agent} is required`);
     }
-    if (typeof template.title !== 'string' || typeof template.command !== 'string') {
+    if (runtimeType(template.title) !== 'string' || runtimeType(template.command) !== 'string') {
       throw new Error(`agentTemplates.${agent} must include title and command`);
     }
   }

--- a/scripts/merge-windows-latest.js
+++ b/scripts/merge-windows-latest.js
@@ -19,6 +19,14 @@ function getErrorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function isNonEmptyString(value) {
+  return Object.prototype.toString.call(value) === '[object String]' && value.trim().length > 0;
+}
+
 function readUpdateInfo(filePath, expectedArch) {
   if (!filePath) {
     fail(`Missing ${expectedArch} latest.yml path`);
@@ -36,11 +44,11 @@ function readUpdateInfo(filePath, expectedArch) {
     fail(`Failed to parse ${absolutePath}: ${getErrorMessage(error)}`);
   }
 
-  if (!info || typeof info !== 'object') {
+  if (!isObject(info)) {
     fail(`${absolutePath} did not contain a YAML object`);
   }
 
-  if (typeof info.version !== 'string' || !info.version.trim()) {
+  if (!isNonEmptyString(info.version)) {
     fail(`${absolutePath} is missing version`);
   }
 
@@ -49,7 +57,7 @@ function readUpdateInfo(filePath, expectedArch) {
   }
 
   const matchingFiles = info.files.filter(file => {
-    return file && typeof file.url === 'string' && file.url.endsWith(`Windows-${expectedArch}.exe`);
+    return isObject(file) && isNonEmptyString(file.url) && file.url.endsWith(`Windows-${expectedArch}.exe`);
   });
 
   if (matchingFiles.length !== 1) {
@@ -57,11 +65,11 @@ function readUpdateInfo(filePath, expectedArch) {
   }
 
   const file = matchingFiles[0];
-  if (typeof file.sha512 !== 'string' || !file.sha512.trim()) {
+  if (!isNonEmptyString(file.sha512)) {
     fail(`${absolutePath} ${file.url} is missing sha512`);
   }
 
-  if (typeof file.size !== 'number' || file.size <= 0) {
+  if (!Number.isFinite(file.size) || file.size <= 0) {
     fail(`${absolutePath} ${file.url} is missing a positive size`);
   }
 
@@ -70,7 +78,7 @@ function readUpdateInfo(filePath, expectedArch) {
 
 function ensureNoUnexpectedWindowsInstaller(info, sourcePath) {
   const windowsInstallers = info.files.filter(file => {
-    return file && typeof file.url === 'string' && WINDOWS_EXE_PATTERN.test(file.url);
+    return isObject(file) && isNonEmptyString(file.url) && WINDOWS_EXE_PATTERN.test(file.url);
   });
 
   if (windowsInstallers.length !== 1) {
@@ -96,7 +104,7 @@ function main() {
   }
 
   const releaseDate = x64.info.releaseDate || arm64.info.releaseDate;
-  if (releaseDate && typeof releaseDate !== 'string') {
+  if (releaseDate && !isNonEmptyString(releaseDate)) {
     fail('releaseDate must be a string when present');
   }
 

--- a/scripts/pane-remote-setup.js
+++ b/scripts/pane-remote-setup.js
@@ -19,7 +19,7 @@ function run(command, args) {
     process.exit(1);
   }
 
-  if (typeof result.status === 'number' && result.status !== 0) {
+  if (Number.isInteger(result.status) && result.status !== 0) {
     process.exit(result.status);
   }
 }

--- a/scripts/test-runpane-contract.js
+++ b/scripts/test-runpane-contract.js
@@ -572,7 +572,7 @@ async function checkNodeReleaseTimeout() {
 
 function assertNoSensitiveTelemetryValues(properties) {
   for (const [key, value] of Object.entries(properties)) {
-    if (typeof value !== 'string') {
+    if (Object.prototype.toString.call(value) !== '[object String]') {
       continue;
     }
     assert.strictEqual(value.includes('/Users/'), false, `Telemetry property ${key} leaked a POSIX path`);

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -175,6 +175,7 @@ async function openConnectedRemote(page: Page): Promise<void> {
       return;
     }
 
+    // SAFETY: the test route receives the remote invoke envelope emitted by this fixture.
     const body = JSON.parse(request.postData() ?? '{}') as { channel?: string };
     let result: unknown = null;
     switch (body.channel) {
@@ -231,6 +232,7 @@ test('Home and About are axe-clean and the modal contains and restores focus', a
 
   const dialog = page.getByRole('dialog', { name: 'About Pane' });
   await expect(dialog).toBeVisible();
+  // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
   await expect.poll(() => page.evaluate(() => (
     document.activeElement?.closest('[role="dialog"]') !== null
   ))).toBe(true);
@@ -303,6 +305,7 @@ test('seeded pane exposes separate compound actions and arrow-keyed panel tabs',
   await expect(pinButton).toBeAttached();
   await expect(paneButton.locator('button, a, [role="button"]')).toHaveCount(0);
   await archiveButton.click();
+  // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
   await expect.poll(() => page.evaluate(() => (
     window as typeof window & {
       __paneTestElectronMock: { getSessionDeleteCalls: () => string[] };
@@ -310,6 +313,7 @@ test('seeded pane exposes separate compound actions and arrow-keyed panel tabs',
   ).__paneTestElectronMock.getSessionDeleteCalls())).toEqual([session.id]);
   await expect(paneButton).not.toHaveAttribute('aria-current', 'page');
   await pinButton.click();
+  // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
   await expect.poll(() => page.evaluate(() => (
     window as typeof window & {
       __paneTestElectronMock: { getSessionFavoriteToggleCalls: () => string[] };

--- a/tests/agent-usage.spec.ts
+++ b/tests/agent-usage.spec.ts
@@ -277,6 +277,7 @@ test('latest main-repository lookup wins across A to delayed B to A', async ({ p
   const detailPanel = page.locator('.pane-detail-panel-vertical');
   await expect(detailPanel.getByText('main-a', { exact: true })).toBeVisible();
   await page.evaluate(() => {
+    // SAFETY: these properties are created and consumed within this page-evaluate fixture.
     const testWindow = window as typeof window & {
       __noSessionSelectedSeen: boolean;
       __noSessionSelectedObserver?: MutationObserver;
@@ -302,6 +303,7 @@ test('latest main-repository lookup wins across A to delayed B to A', async ({ p
   await page.waitForTimeout(700);
 
   const noSessionSelectedSeen = await page.evaluate(() => {
+    // SAFETY: these properties are created and consumed within this page-evaluate fixture.
     const testWindow = window as typeof window & {
       __noSessionSelectedSeen?: boolean;
       __noSessionSelectedObserver?: MutationObserver;

--- a/tests/analytics-consent.spec.ts
+++ b/tests/analytics-consent.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import type { JsonObject } from '../shared/validation/boundaryDecoder';
 import { installElectronApiMock } from './electronApiMock';
 
 type CapturedPostHogRequest = {
@@ -8,7 +9,7 @@ type CapturedPostHogRequest = {
 
 type CapturedPostHogEvent = {
   event?: string;
-  properties?: Record<string, unknown>;
+  properties?: JsonObject;
 };
 
 function parseCapturedEvents(requests: CapturedPostHogRequest[]): CapturedPostHogEvent[] {
@@ -27,9 +28,11 @@ function parseCapturedEvents(requests: CapturedPostHogRequest[]): CapturedPostHo
 
 function parsePostHogBody(bodyText: string): CapturedPostHogEvent & { batch?: CapturedPostHogEvent[] } {
   try {
+    // SAFETY: captured PostHog requests are decoded into the fixture's constrained event shape.
     return JSON.parse(bodyText) as CapturedPostHogEvent & { batch?: CapturedPostHogEvent[] };
   } catch {
     const data = new URLSearchParams(bodyText).get('data');
+    // SAFETY: captured PostHog requests are decoded into the fixture's constrained event shape.
     return data
       ? JSON.parse(data) as CapturedPostHogEvent & { batch?: CapturedPostHogEvent[] }
       : {};
@@ -86,7 +89,7 @@ test('declining analytics sends identified consent events and discards queued us
 
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 
-  await expect(page.getByText('Help Improve Pane')).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole('dialog', { name: 'Help Improve Pane' })).toBeVisible({ timeout: 10000 });
   await expect.poll(() => parseCapturedEvents(requests).map((event) => event.event)).toEqual(
     expect.arrayContaining(['consent_dialog_shown', 'app_first_opened'])
   );
@@ -125,8 +128,8 @@ test('declining analytics sends identified consent events and discards queued us
     is_first_launch: true,
   });
   expect(alias?.properties).toMatchObject({
-    distinct_id: identity.distinctId,
-    alias: identity.webDistinctId,
+    distinct_id: identity.webDistinctId,
+    alias: identity.distinctId,
     install_id: identity.installId,
   });
   expect(events.some((event) => event.event === 'app_opened')).toBe(false);
@@ -181,7 +184,7 @@ test('accepting analytics captures opt-in before any queued usage event can flus
 
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30000 });
 
-  await expect(page.getByText('Help Improve Pane')).toBeVisible({ timeout: 10000 });
+  await expect(page.getByRole('dialog', { name: 'Help Improve Pane' })).toBeVisible({ timeout: 10000 });
   await page.getByRole('button', { name: 'Enable analytics' }).click();
 
   await expect.poll(() => parseCapturedEvents(requests).map((event) => event.event)).toContain('analytics_opted_in');

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -1,15 +1,28 @@
 import type { Page } from '@playwright/test';
+import type { CloudVmState } from '../shared/types/cloud';
 import type { PaneChatAgent } from '../shared/types/paneChat';
+import type { PanePermissionRequest, PanePermissionResponse } from '../shared/types/permissions';
+import type {
+  RemoteDaemonClientRecord,
+  RemoteDaemonConfig,
+  RemoteDaemonHostConfig,
+  RemotePaneConnectionProfile,
+  RemotePaneConnectionState,
+} from '../shared/types/remoteDaemon';
+import type { JsonObject, JsonValue } from '../shared/validation/boundaryDecoder';
+
+type MockEventValue = JsonValue | object | undefined;
+type MockEventCallback = (...args: MockEventValue[]) => void;
 
 type AnalyticsMainEvent = {
   eventName: string;
-  properties?: Record<string, unknown>;
+  properties?: JsonObject;
 };
 
 type ElectronApiMockOptions = {
   analyticsConsentShown?: boolean;
-  analyticsIdentity?: Record<string, unknown>;
-  initialConfig?: Record<string, unknown>;
+  analyticsIdentity?: JsonObject;
+  initialConfig?: JsonObject;
   initialPreferences?: Record<string, string>;
   platform?: 'darwin' | 'linux' | 'win32';
   availableShells?: Array<Record<string, string>>;
@@ -17,9 +30,9 @@ type ElectronApiMockOptions = {
   configGetFailures?: number;
   notificationsSupported?: boolean;
   mainAnalyticsEvents?: AnalyticsMainEvent[];
-  initialProjects?: Array<Record<string, unknown>>;
-  initialSessions?: Array<Record<string, unknown>>;
-  initialPanels?: Array<Record<string, unknown>>;
+  initialProjects?: JsonObject[];
+  initialSessions?: JsonObject[];
+  initialPanels?: JsonObject[];
   initialUiState?: Partial<{
     expandedProjects: number[];
     expandedFolders: string[];
@@ -27,10 +40,10 @@ type ElectronApiMockOptions = {
     pinnedSectionExpanded: boolean;
     repositoriesSectionExpanded: boolean;
   }>;
-  initialExecutions?: Array<Record<string, unknown>>;
-  initialCombinedDiff?: Record<string, unknown> | null;
-  initialTerminalStates?: Record<string, Record<string, unknown>>;
-  initialAgentUsage?: Record<string, unknown>;
+  initialExecutions?: JsonObject[];
+  initialCombinedDiff?: JsonObject | null;
+  initialTerminalStates?: Record<string, JsonObject>;
+  initialAgentUsage?: JsonObject;
   forcedAgentUsageError?: string;
   detectedBranch?: string | null;
   detectedBranchByPath?: Record<string, string | null>;
@@ -45,11 +58,15 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     if (mockOptions.notificationsSupported === false) {
       Reflect.deleteProperty(window, 'Notification');
     }
-    const success = (data: unknown = null) => Promise.resolve({ success: true, data });
+    function success(): Promise<{ success: true; data: null }>;
+    function success<Value>(data: Value): Promise<{ success: true; data: Value }>;
+    function success<Value>(data?: Value) {
+      return Promise.resolve({ success: true, data: data ?? null });
+    }
     const unsubscribe = () => undefined;
-    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
-    const pendingPermissions: Array<Record<string, unknown>> = [];
-    const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+    const listeners = new Map<string, Set<MockEventCallback>>();
+    const pendingPermissions: PanePermissionRequest[] = [];
+    const clone = <T>(value: T): T => structuredClone(value);
     const preferences: Record<string, string> = {
       analytics_consent_shown: mockOptions.analyticsConsentShown === false ? 'false' : 'true',
       ...clone(mockOptions.initialPreferences ?? {}),
@@ -66,7 +83,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       previousVersion: 'test',
     };
     let nextRemoteConnectionId = 1;
-    const remoteDaemonConfig = {
+    const remoteDaemonConfig: RemoteDaemonConfig = {
       host: {
         config: {
           enabled: false,
@@ -75,49 +92,50 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           pairingRequired: true,
           allowInsecureHttpOnLoopback: true,
         },
-        clients: [] as Array<Record<string, unknown>>,
+        clients: [],
       },
       client: {
-        profiles: [] as Array<Record<string, unknown>>,
-        activeProfileId: null as string | null,
-        mode: 'local' as 'local' | 'remote',
+        profiles: [],
+        activeProfileId: null,
+        mode: 'local',
       },
     };
-    const remoteConnectionState = {
-      mode: 'local' as 'local' | 'remote',
-      status: 'local' as 'local' | 'connecting' | 'connected' | 'reconnecting' | 'error',
-      activeProfileId: null as string | null,
-      activeProfileLabel: null as string | null,
-      activeBaseUrl: null as string | null,
-      lastError: null as string | null,
+    const remoteConnectionState: RemotePaneConnectionState = {
+      mode: 'local',
+      status: 'local',
+      activeProfileId: null,
+      activeProfileLabel: null,
+      activeBaseUrl: null,
+      lastError: null,
+      lastSeenAt: null,
     };
     const remoteHostState = {
       enabled: false,
-      status: 'inactive' as 'inactive' | 'live' | 'error',
-      listenHost: null as string | null,
-      listenPort: null as number | null,
-      lastError: null as string | null,
-      connectedClients: [] as Array<Record<string, unknown>>,
+      status: 'inactive' as const,
+      listenHost: null,
+      listenPort: null,
+      lastError: null,
+      connectedClients: [],
       updatedAt: '1970-01-01T00:00:00.000Z',
     };
-    const cloudState = {
-      status: 'not_provisioned' as const,
-      ip: null as string | null,
-      noVncUrl: null as string | null,
-      provider: null as 'gcp' | null,
-      serverId: null as string | null,
-      lastChecked: null as string | null,
-      error: null as string | null,
-      tunnelStatus: 'off' as const,
-      daemonStatus: 'unknown' as const,
-      daemonBaseUrl: null as string | null,
-      linkedRemoteProfileId: null as string | null,
-      linkedRemoteProfileLabel: null as string | null,
-      remoteConnectionStatus: 'unlinked' as const,
-      preferredAccess: 'daemon' as const,
+    const cloudState: CloudVmState = {
+      status: 'not_provisioned',
+      ip: null,
+      noVncUrl: null,
+      provider: null,
+      serverId: null,
+      lastChecked: null,
+      error: null,
+      tunnelStatus: 'off',
+      daemonStatus: 'unknown',
+      daemonBaseUrl: null,
+      linkedRemoteProfileId: null,
+      linkedRemoteProfileLabel: null,
+      remoteConnectionStatus: 'unlinked',
+      preferredAccess: 'daemon',
       allowNoVncFallback: true,
     };
-    const configState: Record<string, unknown> = {
+    const configState: JsonObject = {
       remoteDaemon: clone(remoteDaemonConfig),
       defaultOrchestratorAgent: 'claude',
       ...clone(mockOptions.initialConfig ?? {}),
@@ -186,29 +204,29 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     let mockSessions = clone(mockOptions.initialSessions ?? []);
     let mockPanels = clone(mockOptions.initialPanels ?? []);
     const uiState = {
-      expandedProjects: [] as number[],
-      expandedFolders: [] as string[],
+      expandedProjects: [] satisfies number[],
+      expandedFolders: [] satisfies string[],
       sessionSortAscending: true,
       pinnedSectionExpanded: true,
       repositoriesSectionExpanded: true,
       ...clone(mockOptions.initialUiState ?? {}),
     };
     let mockActiveProjectId = mockOptions.activeProjectId === undefined
-      ? (mockProjects.find((project) => project.active === true)?.id as number | undefined) ?? null
+      ? Number(mockProjects.find((project) => project.active === true)?.id ?? null) || null
       : mockOptions.activeProjectId;
     let cloudDisconnectError: string | null = null;
     let configGetCount = 0;
     let nextConfigUpdateError: string | null = null;
     let nextPreferenceSetError: string | null = null;
     let remainingConfigGetFailures = mockOptions.configGetFailures ?? 0;
-    const configUpdates: Array<Record<string, unknown>> = [];
+    const configUpdates: JsonObject[] = [];
     const preferenceWrites: Array<{ key: string; value: string }> = [];
     const sessionDeleteCalls: string[] = [];
     const sessionFavoriteToggleCalls: string[] = [];
     let sessionsGetCount = 0;
 
-    const subscribe = (channel: string, callback: (...args: unknown[]) => void) => {
-      const callbacks = listeners.get(channel) ?? new Set<(...args: unknown[]) => void>();
+    const subscribe = (channel: string, callback: MockEventCallback) => {
+      const callbacks = listeners.get(channel) ?? new Set<MockEventCallback>();
       callbacks.add(callback);
       listeners.set(channel, callbacks);
       return () => {
@@ -219,7 +237,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       };
     };
 
-    const emit = (channel: string, ...args: unknown[]) => {
+    const emit = (channel: string, ...args: MockEventValue[]) => {
       const callbacks = listeners.get(channel);
       if (!callbacks) {
         return;
@@ -244,11 +262,11 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       emit('remote-daemon:host-state-changed', clone(remoteHostState));
     };
 
-    const namespace = (overrides: Record<string, unknown> = {}) =>
+    const namespace = <Overrides extends object>(overrides: Overrides) =>
       new Proxy(overrides, {
         get(target, prop: string | symbol) {
           if (prop in target) {
-            return target[prop as keyof typeof target];
+            return Reflect.get(target, prop);
           }
           return () => success();
         },
@@ -257,16 +275,16 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     const events = new Proxy({}, {
       get: (_target, prop: string | symbol) => {
         if (prop === 'onPermissionRequest') {
-          return (callback: (request: unknown) => void) => subscribe('permission:request', callback);
+          return (callback: MockEventCallback) => subscribe('permission:request', callback);
         }
         if (prop === 'onPermissionResolved') {
-          return (callback: (event: unknown) => void) => subscribe('permission:resolved', callback);
+          return (callback: MockEventCallback) => subscribe('permission:resolved', callback);
         }
         if (prop === 'onRemoteDaemonResyncRequested') {
           return (callback: () => void) => subscribe('remote-daemon:resync-required', callback);
         }
         if (prop === 'onGitStatusUpdated') {
-          return (callback: (data: unknown) => void) => subscribe('git-status-updated', callback);
+          return (callback: MockEventCallback) => subscribe('git-status-updated', callback);
         }
         return () => unsubscribe;
       },
@@ -321,8 +339,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       openExternal: () => undefined,
       analytics: namespace({
         getIdentity: () => success(clone(mockOptions.analyticsIdentity ?? defaultAnalyticsIdentity)),
-        onMainEvent: (callback: (event: AnalyticsMainEvent) => void) => {
-          const remove = subscribe('analytics:main-event', callback as (...args: unknown[]) => void);
+        onMainEvent: (callback: MockEventCallback) => {
+          const remove = subscribe('analytics:main-event', callback);
           for (const event of mockOptions.mainAnalyticsEvents ?? []) {
             callback(clone(event));
           }
@@ -353,7 +371,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       }),
       cloud: namespace({
         getState: () => success(clone(cloudState)),
-        onStateChanged: (callback: (state: unknown) => void) => subscribe('cloud:state-changed', callback),
+        onStateChanged: (callback: MockEventCallback) => subscribe('cloud:state-changed', callback),
         connectWorkspace: () => {
           if (!cloudState.linkedRemoteProfileId) {
             return Promise.resolve({ success: false, error: 'Hosted cloud workspace does not have a linked remote profile' });
@@ -415,7 +433,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           }
           return success(clone(configState));
         },
-        update: (updates: Record<string, unknown>) => {
+        update: (updates: JsonObject) => {
           if (nextConfigUpdateError) {
             const error = nextConfigUpdateError;
             nextConfigUpdateError = null;
@@ -440,8 +458,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         writeGitHubAuthTerminal: () => success(),
         resizeGitHubAuthTerminal: () => success(),
         killGitHubAuthTerminal: () => success(),
-        onGitHubAuthTerminalOutput: (callback: (...args: unknown[]) => void) => subscribe('onboarding:github-auth-pty-output', callback),
-        onGitHubAuthTerminalExit: (callback: (...args: unknown[]) => void) => subscribe('onboarding:github-auth-pty-exit', callback),
+        onGitHubAuthTerminalOutput: (callback: MockEventCallback) => subscribe('onboarding:github-auth-pty-output', callback),
+        onGitHubAuthTerminalExit: (callback: MockEventCallback) => subscribe('onboarding:github-auth-pty-exit', callback),
         setupDefaultRepo: () => success({}),
         supportProject: () => success({}),
       }),
@@ -463,7 +481,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       }),
       permissions: namespace({
         getPending: () => success([...pendingPermissions]),
-        respond: (requestId: string, response: Record<string, unknown>) => {
+        respond: (requestId: string, response: PanePermissionResponse) => {
           const index = pendingPermissions.findIndex((request) => request.id === requestId);
           if (index >= 0) {
             const [request] = pendingPermissions.splice(index, 1);
@@ -629,7 +647,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           syncRemoteDaemonConfig();
           return success({ client, profile, token });
         },
-        updateHostConfig: (updates: Record<string, unknown>) => {
+        updateHostConfig: (updates: Partial<RemoteDaemonHostConfig>) => {
           remoteDaemonConfig.host.config = {
             ...remoteDaemonConfig.host.config,
             ...updates,
@@ -645,7 +663,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           });
           return success(clone(remoteDaemonConfig.host.config));
         },
-        upsertClientRecord: (record: Record<string, unknown>) => {
+        upsertClientRecord: (record: RemoteDaemonClientRecord) => {
           const existingIndex = remoteDaemonConfig.host.clients.findIndex((client) => client.id === record.id);
           if (existingIndex >= 0) {
             remoteDaemonConfig.host.clients[existingIndex] = record;
@@ -660,7 +678,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           syncRemoteDaemonConfig();
           return success(clone(remoteDaemonConfig.host.clients));
         },
-        upsertConnectionProfile: (profile: Record<string, unknown>) => {
+        upsertConnectionProfile: (profile: RemotePaneConnectionProfile) => {
           const existingIndex = remoteDaemonConfig.client.profiles.findIndex((existing) => existing.id === profile.id);
           if (existingIndex >= 0) {
             remoteDaemonConfig.client.profiles[existingIndex] = profile;
@@ -721,9 +739,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           syncRemoteDaemonConfig();
           return success(clone(remoteDaemonConfig.client));
         },
-        onConnectionStateChanged: (callback: (state: unknown) => void) =>
+        onConnectionStateChanged: (callback: MockEventCallback) =>
           subscribe('remote-daemon:connection-state-changed', callback),
-        onHostStateChanged: (callback: (state: unknown) => void) =>
+        onHostStateChanged: (callback: MockEventCallback) =>
           subscribe('remote-daemon:host-state-changed', callback),
       }),
       uiState: namespace({
@@ -755,7 +773,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       configurable: true,
       value: {
         invoke,
-        on: (channel: string, callback: (...args: unknown[]) => void) => {
+        on: (channel: string, callback: MockEventCallback) => {
           subscribe(channel, callback);
         },
         off: () => undefined,
@@ -786,11 +804,11 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         setConfigGetFailures(count: number) {
           remainingConfigGetFailures = count;
         },
-        emitPermissionRequest(request: Record<string, unknown>) {
+        emitPermissionRequest(request: PanePermissionRequest) {
           pendingPermissions.push(request);
           emit('permission:request', request);
         },
-        setCloudState(updates: Record<string, unknown>) {
+        setCloudState(updates: Partial<CloudVmState>) {
           Object.assign(cloudState, updates);
           emit('cloud:state-changed', clone(cloudState));
         },
@@ -803,17 +821,17 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         getConfigReadCount() {
           return configGetCount;
         },
-        setSessions(sessions: Array<Record<string, unknown>>) {
+        setSessions(sessions: JsonObject[]) {
           mockSessions = clone(sessions);
         },
-        setProjects(projects: Array<Record<string, unknown>>, activeProjectId: number | null = null) {
+        setProjects(projects: JsonObject[], activeProjectId: number | null = null) {
           mockProjects = clone(projects);
           mockActiveProjectId = activeProjectId;
         },
-        setPanels(panels: Array<Record<string, unknown>>) {
+        setPanels(panels: JsonObject[]) {
           mockPanels = clone(panels);
         },
-        emitGitStatusUpdated(sessionId: string, gitStatus: Record<string, unknown>) {
+        emitGitStatusUpdated(sessionId: string, gitStatus: JsonObject) {
           emit('git-status-updated', { sessionId, gitStatus: clone(gitStatus) });
         },
         getSessionsReadCount() {

--- a/tests/review-availability.spec.ts
+++ b/tests/review-availability.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import type { JsonObject } from '../shared/validation/boundaryDecoder';
 import { installElectronApiMock } from './electronApiMock';
 
 const project = {
@@ -117,8 +118,8 @@ async function openSession(
   gitStatus: ReviewGitStatus = baseGitStatus,
   options: {
     withLocalChanges?: boolean;
-    initialPanels?: Array<Record<string, unknown>>;
-    initialConfig?: Record<string, unknown>;
+    initialPanels?: JsonObject[];
+    initialConfig?: JsonObject;
   } = { withLocalChanges: true },
 ): Promise<void> {
   await installElectronApiMock(page, {
@@ -283,9 +284,10 @@ test('Review stays local until a newly discovered pull request is explicitly ope
   await capture(page, testInfo, '01-local-review-before-pr.png');
 
   await page.evaluate((gitStatus) => {
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     const mock = (window as typeof window & {
       __paneTestElectronMock: {
-        emitGitStatusUpdated: (sessionId: string, status: Record<string, unknown>) => void;
+        emitGitStatusUpdated: (sessionId: string, status: JsonObject) => void;
       };
     }).__paneTestElectronMock;
     mock.emitGitStatusUpdated('review-session', gitStatus);

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, type Page } from '@playwright/test';
+import type { JsonObject } from '../shared/validation/boundaryDecoder';
 import { installElectronApiMock } from './electronApiMock';
 
 type SettingsMock = {
-  getConfig: () => Record<string, unknown>;
-  getConfigUpdates: () => Array<Record<string, unknown>>;
+  getConfig: () => JsonObject;
+  getConfigUpdates: () => JsonObject[];
   getPreferenceWrites: () => Array<{ key: string; value: string }>;
   failNextConfigUpdate: (error: string) => void;
   failNextPreferenceSet: (error: string) => void;
@@ -114,6 +115,7 @@ test.describe('Settings', () => {
     await toggle.click();
     await expect(page.getByText('Saved', { exact: true })).toBeVisible();
 
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     const updates = await page.evaluate(() => (
       window as typeof window & { __paneTestElectronMock: SettingsMock }
     ).__paneTestElectronMock.getConfigUpdates());
@@ -131,6 +133,7 @@ test.describe('Settings', () => {
     await expect(paletteToggle).toHaveAttribute('aria-checked', 'true');
     await paletteToggle.click();
 
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     const updates = await page.evaluate(() => (
       window as typeof window & { __paneTestElectronMock: SettingsMock }
     ).__paneTestElectronMock.getConfigUpdates());
@@ -169,6 +172,7 @@ test.describe('Settings', () => {
     await expect(page.getByRole('radio', { name: 'Two rows' })).toHaveAttribute('aria-checked', 'true');
 
     const writes = await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & { __paneTestElectronMock: SettingsMock }).__paneTestElectronMock;
       return { config: mock.getConfigUpdates(), preferences: mock.getPreferenceWrites() };
     });
@@ -182,6 +186,7 @@ test.describe('Settings', () => {
     await page.getByRole('switch', { name: 'Keep computer awake while sessions are active' }).click();
     await expect(page.getByText('Saved', { exact: true })).toBeVisible();
 
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     const updates = await page.evaluate(() => (
       window as typeof window & { __paneTestElectronMock: SettingsMock }
     ).__paneTestElectronMock.getConfigUpdates());
@@ -191,6 +196,7 @@ test.describe('Settings', () => {
   test('announces a failed save and restores the authoritative value', async ({ page }) => {
     await bootSettings(page, { initialConfig: { autoCheckUpdates: true } });
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & { __paneTestElectronMock: SettingsMock }).__paneTestElectronMock;
       mock.failNextConfigUpdate('Disk is read-only');
     });
@@ -200,6 +206,7 @@ test.describe('Settings', () => {
 
     await expect(page.getByRole('alert')).toContainText('Disk is read-only');
     await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     const config = await page.evaluate(() => (
       window as typeof window & { __paneTestElectronMock: SettingsMock }
     ).__paneTestElectronMock.getConfig());
@@ -210,6 +217,7 @@ test.describe('Settings', () => {
     await bootSettings(page, { configGetFailures: 100 });
     await expect(page.getByRole('alert')).toContainText('Mock config read failed');
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & { __paneTestElectronMock: SettingsMock }).__paneTestElectronMock;
       mock.setConfigGetFailures(0);
     });
@@ -218,6 +226,7 @@ test.describe('Settings', () => {
 
     await page.getByRole('button', { name: 'Appearance', exact: true }).click();
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & { __paneTestElectronMock: SettingsMock }).__paneTestElectronMock;
       mock.failNextPreferenceSet('Preference database is read-only');
     });
@@ -235,6 +244,7 @@ test.describe('Settings', () => {
     await expect(page.getByText('Saved', { exact: true })).toBeVisible();
     await expect(page.getByRole('dialog', { name: 'Pane Settings' })).toBeVisible();
 
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     const updates = await page.evaluate(() => (
       window as typeof window & { __paneTestElectronMock: SettingsMock }
     ).__paneTestElectronMock.getConfigUpdates());

--- a/tests/sidebar-compact.spec.ts
+++ b/tests/sidebar-compact.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import type { JsonObject } from '../shared/validation/boundaryDecoder';
 import { installElectronApiMock } from './electronApiMock';
 
 const projects = [
@@ -24,7 +25,7 @@ function session(
   id: string,
   name: string,
   projectId: number,
-  overrides: Record<string, unknown> = {},
+  overrides: JsonObject = {},
 ) {
   return {
     id,
@@ -152,6 +153,7 @@ test.describe('compact sidebar', () => {
     await expect(menu.getByRole('menuitem').nth(1)).toHaveText('Pin');
     await menu.getByRole('menuitem', { name: 'Archive' }).click();
 
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     await expect.poll(() => page.evaluate(() => (
       window as typeof window & {
         __paneTestElectronMock: { getSessionDeleteCalls: () => string[] };
@@ -168,6 +170,7 @@ test.describe('compact sidebar', () => {
     await expect(menu.getByRole('menuitem').nth(0)).toHaveText('Archive');
     await menu.getByRole('menuitem', { name: 'Unpin', exact: true }).click();
 
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
     await expect.poll(() => page.evaluate(() => (
       window as typeof window & {
         __paneTestElectronMock: { getSessionFavoriteToggleCalls: () => string[] };

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import type { JsonObject } from '../shared/validation/boundaryDecoder';
 import { installElectronApiMock } from './electronApiMock';
 
 test.beforeEach(async ({ page }) => {
@@ -29,7 +30,10 @@ async function clickDomNode(locator: ReturnType<Page['locator']>) {
 
 async function setInputValue(locator: ReturnType<Page['locator']>, value: string) {
   await locator.evaluate((node: HTMLElement, nextValue) => {
-    const input = node as HTMLInputElement | HTMLTextAreaElement;
+    if (!(node instanceof HTMLInputElement) && !(node instanceof HTMLTextAreaElement)) {
+      throw new Error('Expected an input or textarea element');
+    }
+    const input = node;
     const prototype = input instanceof HTMLTextAreaElement
       ? HTMLTextAreaElement.prototype
       : HTMLInputElement.prototype;
@@ -204,8 +208,9 @@ test.describe('Smoke Tests', () => {
     await dismissStartupDialogs(page);
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { emitPermissionRequest: (request: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { emitPermissionRequest: (request: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.emitPermissionRequest({
@@ -235,6 +240,7 @@ test.describe('Smoke Tests', () => {
     await page.waitForTimeout(250);
 
     const beforeCount = await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
         __paneTestElectronMock?: {
           emitRemoteDaemonResyncRequested: () => void;
@@ -248,6 +254,7 @@ test.describe('Smoke Tests', () => {
     });
 
     await expect.poll(async () => page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
         __paneTestElectronMock?: { getConfigReadCount: () => number };
       }).__paneTestElectronMock;
@@ -264,10 +271,11 @@ test.describe('Smoke Tests', () => {
     const staleSessionName = 'Remote stale pane';
 
     await page.evaluate((sessionName) => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
         __paneTestElectronMock?: {
           emitRemoteDaemonResyncRequested: () => void;
-          setSessions: (sessions: Array<Record<string, unknown>>) => void;
+          setSessions: (sessions: JsonObject[]) => void;
         };
       }).__paneTestElectronMock;
 
@@ -288,10 +296,11 @@ test.describe('Smoke Tests', () => {
     await expect(page.getByText(staleSessionName)).toBeVisible({ timeout: 5000 });
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
         __paneTestElectronMock?: {
           emitRemoteDaemonResyncRequested: () => void;
-          setSessions: (sessions: Array<Record<string, unknown>>) => void;
+          setSessions: (sessions: JsonObject[]) => void;
         };
       }).__paneTestElectronMock;
 
@@ -318,8 +327,9 @@ test.describe('Smoke Tests', () => {
     });
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { setCloudState: (updates: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.setCloudState({
@@ -346,8 +356,9 @@ test.describe('Smoke Tests', () => {
     await dismissStartupDialogs(page);
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { setCloudState: (updates: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.setCloudState({
@@ -374,8 +385,9 @@ test.describe('Smoke Tests', () => {
     await dismissStartupDialogs(page);
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { setCloudState: (updates: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.setCloudState({
@@ -406,8 +418,9 @@ test.describe('Smoke Tests', () => {
     await dismissStartupDialogs(page);
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { setCloudState: (updates: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.setCloudState({
@@ -431,8 +444,9 @@ test.describe('Smoke Tests', () => {
     await dismissStartupDialogs(page);
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { setCloudState: (updates: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.setCloudState({
@@ -468,8 +482,9 @@ test.describe('Smoke Tests', () => {
     });
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { setCloudState: (updates: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.setCloudState({
@@ -500,8 +515,9 @@ test.describe('Smoke Tests', () => {
     await dismissStartupDialogs(page);
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
-        __paneTestElectronMock?: { setCloudState: (updates: Record<string, unknown>) => void };
+        __paneTestElectronMock?: { setCloudState: (updates: JsonObject) => void };
       }).__paneTestElectronMock;
 
       mock?.setCloudState({
@@ -527,9 +543,10 @@ test.describe('Smoke Tests', () => {
     await dismissStartupDialogs(page);
 
     await page.evaluate(() => {
+      // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
       const mock = (window as typeof window & {
         __paneTestElectronMock?: {
-          setCloudState: (updates: Record<string, unknown>) => void;
+          setCloudState: (updates: JsonObject) => void;
           setCloudDisconnectError: (error: string | null) => void;
         };
       }).__paneTestElectronMock;

--- a/tests/terminal-selection-popover.spec.ts
+++ b/tests/terminal-selection-popover.spec.ts
@@ -61,6 +61,7 @@ async function installClipboardMock(page: Page): Promise<void> {
 
 async function clipboardWrites(page: Page): Promise<string[]> {
   return page.evaluate(() => (
+    // SAFETY: installClipboardMock initializes this property to a string array before navigation.
     Reflect.get(window, '__terminalClipboardWrites') as string[] | undefined
   ) ?? []);
 }
@@ -88,16 +89,19 @@ async function selectFirstLine(page: Page, terminal: Locator): Promise<void> {
     while (reactElement) {
       const fiberKey = Object.keys(reactElement).find((key) => key.startsWith('__reactFiber$'));
       if (fiberKey) {
+        // SAFETY: React's private fiber key points to the linked fiber shape traversed below.
         let fiber = Reflect.get(reactElement, fiberKey) as FiberNode | null;
         while (fiber) {
           let hook = fiber.memoizedState;
           while (hook) {
             const ref = hook.memoizedState;
-            if (ref && typeof ref === 'object') {
+            if (ref instanceof Object) {
+              // SAFETY: React ref objects expose their current value through this property.
               const candidate = Reflect.get(ref, 'current') as unknown;
-              if (candidate && typeof candidate === 'object') {
+              if (candidate instanceof Object) {
+                // SAFETY: the xterm ref exposes its public select method on the terminal instance.
                 const select = Reflect.get(candidate, 'select') as unknown;
-                if (typeof select === 'function') {
+                if (select instanceof Function) {
                   select.call(candidate, 0, 0, 11);
                   return true;
                 }


### PR DESCRIPTION
## Summary
- replace runtime representation checks in repository scripts with explicit value-contract helpers
- type the Playwright Electron mock with shared domain and JSON boundary contracts
- document unavoidable test-only assertions and correct stale analytics expectations
- clear all Phase 2e findings across scripts and Playwright tests (139 to 0)

## Validation
- `pnpm lint`
- `pnpm typecheck`
- frontend unit tests: 161/161
- main unit tests: 595/595
- focused Playwright tests: 67/67 (65 in combined run, 2 analytics rerun after expectation correction)
- `pnpm build` (including signed macOS universal package)
- `pnpm --filter runpane build`
- `node scripts/generate-runpane-contract.js --check`
- `node scripts/test-runpane-contract.js`
- Phase 2e advisory scan: 0 assigned findings

Part of #403.