### PR TITLE
Phase 3a: tighten finite internal contracts

### DIFF
--- a/main/src/core/runtime.test.ts
+++ b/main/src/core/runtime.test.ts
@@ -25,7 +25,7 @@ describe('pane runtime', () => {
 
   it('returns the installed runtime and helper accessors', () => {
     // SAFETY: This test only verifies ConfigManager reference identity; none of its methods are invoked.
-    const configManager = { source: 'test' } as unknown as ConfigManager;
+    const configManager = Object.assign(Object.create(null), { source: 'test' }) as ConfigManager;
     const webviewContextMap = new Map([[1, { panelId: 'panel-1', sessionId: 'session-1' }]]);
     const daemonEventSink = {
       send: () => undefined,

--- a/main/src/daemon/client/remotePaneClient.test.ts
+++ b/main/src/daemon/client/remotePaneClient.test.ts
@@ -23,8 +23,12 @@ interface TestRemoteServer {
   setEventsReady(ready: boolean): void;
 }
 
+interface RemoteConfigSnapshot {
+  remoteDaemon: RemoteDaemonConfig;
+}
+
 interface ConfigManagerStub extends EventEmitter {
-  getConfig(): { remoteDaemon: RemoteDaemonConfig };
+  getConfig(): RemoteConfigSnapshot;
   setRemoteConfig(remoteDaemon: RemoteDaemonConfig): void;
 }
 
@@ -605,7 +609,7 @@ function createConfigManagerStub(initialConfig: RemoteDaemonConfig): ConfigManag
   class Stub extends EventEmitter implements ConfigManagerStub {
     private remoteDaemon = initialConfig;
 
-    getConfig(): { remoteDaemon: RemoteDaemonConfig } {
+    getConfig(): RemoteConfigSnapshot {
       return { remoteDaemon: this.remoteDaemon };
     }
 

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -388,11 +388,14 @@ export class RemotePaneClient {
 
   private buildRequestOptions(endpoint: URL, options: RequestOptions): RemoteRequestOptions {
     const lookup = createTailscaleFallbackLookup(this.profile, endpoint);
-    return {
-      ...options,
-      ...(lookup ? { lookup } : {}),
-      ...(endpoint.protocol === 'https:' ? { servername: endpoint.hostname } : {}),
-    };
+    const requestOptions: RemoteRequestOptions = { ...options };
+    if (lookup) {
+      requestOptions.lookup = lookup;
+    }
+    if (endpoint.protocol === 'https:') {
+      requestOptions.servername = endpoint.hostname;
+    }
+    return requestOptions;
   }
 
   private handleInitialConnectionFailure(): void {

--- a/main/src/daemon/httpApiServer.test.ts
+++ b/main/src/daemon/httpApiServer.test.ts
@@ -23,6 +23,10 @@ interface TestEventStream {
   nextEvent(timeoutMs?: number): Promise<{ event: string | null; data: string[] }>;
 }
 
+interface RequestHeaders {
+  [name: string]: string;
+}
+
 const activeServers: PaneRemoteHttpApiServer[] = [];
 const activeRequests = new Set<http.ClientRequest>();
 
@@ -79,16 +83,19 @@ async function requestJson(
   }
 
   return new Promise((resolve, reject) => {
+    const requestHeaders: RequestHeaders = { ...extraHeaders };
+    if (token) {
+      requestHeaders.Authorization = `Bearer ${token}`;
+    }
+    if (body !== undefined) {
+      requestHeaders['Content-Type'] = 'application/json';
+    }
     const request = http.request({
       host: address.host,
       port: address.port,
       path,
       method,
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
-        ...extraHeaders,
-      },
+      headers: requestHeaders,
     }, (response) => {
       const chunks: Buffer[] = [];
       response.on('data', (chunk) => {
@@ -162,15 +169,16 @@ async function openEventStream(
   }
 
   return new Promise((resolve, reject) => {
+    const requestHeaders: RequestHeaders = { ...headers };
+    if (token) {
+      requestHeaders.Authorization = `Bearer ${token}`;
+    }
     const request = http.request({
       host: address.host,
       port: address.port,
       path,
       method: 'GET',
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        ...headers,
-      },
+      headers: requestHeaders,
     });
 
     activeRequests.add(request);

--- a/main/src/daemon/httpApiServer.test.ts
+++ b/main/src/daemon/httpApiServer.test.ts
@@ -83,13 +83,14 @@ async function requestJson(
   }
 
   return new Promise((resolve, reject) => {
-    const requestHeaders: RequestHeaders = { ...extraHeaders };
+    const requestHeaders: RequestHeaders = {};
     if (token) {
       requestHeaders.Authorization = `Bearer ${token}`;
     }
     if (body !== undefined) {
       requestHeaders['Content-Type'] = 'application/json';
     }
+    Object.assign(requestHeaders, extraHeaders);
     const request = http.request({
       host: address.host,
       port: address.port,

--- a/main/src/daemon/pwaStaticAssets.ts
+++ b/main/src/daemon/pwaStaticAssets.ts
@@ -13,9 +13,13 @@ interface RemotePwaAssetOptions {
   distRoot?: string;
 }
 
+interface ContentTypeByExtension {
+  [extension: string]: string;
+}
+
 const REMOTE_PWA_PREFIX = '/app';
 
-const CONTENT_TYPES: Record<string, string> = {
+const CONTENT_TYPES: ContentTypeByExtension = {
   '.css': 'text/css; charset=utf-8',
   '.html': 'text/html; charset=utf-8',
   '.ico': 'image/x-icon',

--- a/main/src/daemon/remotePairing.ts
+++ b/main/src/daemon/remotePairing.ts
@@ -56,12 +56,13 @@ export function createPaneRemoteConnectionImportPayload(
   pair: RemoteDaemonConnectionPair,
   tunnel?: PaneRemoteConnectionImportPayload['tunnel'],
 ): PaneRemoteConnectionImportPayload {
-  return {
+  const payload: PaneRemoteConnectionImportPayload = {
     v: 1,
     label: pair.profile.label,
     baseUrl: pair.profile.baseUrl,
     token: pair.token,
     transport: pair.profile.transport,
-    ...(tunnel ? { tunnel } : {}),
   };
+  if (tunnel) payload.tunnel = tunnel;
+  return payload;
 }

--- a/main/src/daemon/remoteTransportController.test.ts
+++ b/main/src/daemon/remoteTransportController.test.ts
@@ -20,6 +20,10 @@ interface TestEventStream {
   nextEvent(timeoutMs?: number): Promise<{ event: string | null; data: string[] }>;
 }
 
+interface RemoteConfigSnapshot {
+  remoteDaemon: RemoteDaemonConfig;
+}
+
 class ConfigManagerStub extends EventEmitter {
   private remoteDaemon: RemoteDaemonConfig;
 
@@ -28,7 +32,7 @@ class ConfigManagerStub extends EventEmitter {
     this.remoteDaemon = initialConfig;
   }
 
-  getConfig(): { remoteDaemon: RemoteDaemonConfig } {
+  getConfig(): RemoteConfigSnapshot {
     return { remoteDaemon: this.remoteDaemon };
   }
 

--- a/main/src/daemon/setupRemoteHost.ts
+++ b/main/src/daemon/setupRemoteHost.ts
@@ -128,13 +128,12 @@ export async function setupRemoteHost(options: SetupRemoteHostOptions = {}): Pro
       } satisfies RemoteHostSetupServiceResult
     : await installRemoteDaemonService(paneDir, options.serviceDependencies);
 
-  return {
+  const result: SetupRemoteHostResult = {
     paneDir,
     configPath,
     label,
     listenPort,
     channel,
-    ...(options.repoRef ? { repoRef: options.repoRef } : {}),
     connectionCode,
     tunnel: tunnelSelection.tunnel,
     fallbackTunnelCommands: tunnelSelection.fallbackCommands,
@@ -142,6 +141,10 @@ export async function setupRemoteHost(options: SetupRemoteHostOptions = {}): Pro
     manualDaemonCommand,
     wroteConfig,
   };
+  if (options.repoRef) {
+    result.repoRef = options.repoRef;
+  }
+  return result;
 }
 
 export function formatSetupRemoteHostResult(result: SetupRemoteHostResult): string {
@@ -192,11 +195,14 @@ function createRemoteHostAccess(
   baseUrl: string,
   tunnel?: PaneRemoteConnectionImportPayload['tunnel'],
 ): RemoteDaemonHostAccess {
-  return {
+  const access: RemoteDaemonHostAccess = {
     baseUrl,
-    ...(tunnel ? { tunnel } : {}),
     updatedAt: new Date().toISOString(),
   };
+  if (tunnel) {
+    access.tunnel = tunnel;
+  }
+  return access;
 }
 
 export function readConfiguredTailscaleServeAccess(listenPort: number): RemoteDaemonHostAccess | null {
@@ -218,13 +224,16 @@ export function readConfiguredTailscaleServeAccess(listenPort: number): RemoteDa
   const tailscaleCommand = buildTailscaleServeCommand(tailscaleCli, listenPort);
   const tailscaleIp = readTailscaleIpv4(tailscaleCli);
 
-  return createRemoteHostAccess(serveUrl, {
+  const tunnel: NonNullable<PaneRemoteConnectionImportPayload['tunnel']> = {
     kind: 'tailscale',
     selected: true,
     command: tailscaleCommand,
     note: 'Tailscale Serve is configured for this tailnet. Keep Pane running on this host when using current data mode. If another device cannot connect immediately, wait a few minutes for Tailscale Serve to finish provisioning, then retry.',
-    ...(tailscaleIp ? { tailscaleIp } : {}),
-  });
+  };
+  if (tailscaleIp) {
+    tunnel.tailscaleIp = tailscaleIp;
+  }
+  return createRemoteHostAccess(serveUrl, tunnel);
 }
 
 function buildNextRemoteDaemonConfig<Value>(
@@ -383,18 +392,22 @@ function selectTailscaleTunnel(options: {
 
   const tailscaleIp = readTailscaleIpv4(tailscaleCli);
 
+  const tunnel: NonNullable<TunnelSelection['tunnel']> = {
+    kind: 'tailscale',
+    selected: true,
+    command: tailscaleCommand,
+    note: 'Tailscale Serve is configured for this tailnet. Keep Pane running on this host when using current data mode. If another device cannot connect immediately, wait a few minutes for Tailscale Serve to finish provisioning, then retry.',
+  };
+  if (tailscaleIp) {
+    tunnel.tailscaleIp = tailscaleIp;
+  }
+
   return {
     baseUrl: serveUrl,
     fallbackCommands: options.fallbackCommands.includes(tailscaleCommand)
       ? options.fallbackCommands
       : [options.fallbackCommands[0], tailscaleCommand],
-    tunnel: {
-      kind: 'tailscale',
-      selected: true,
-      command: tailscaleCommand,
-      note: 'Tailscale Serve is configured for this tailnet. Keep Pane running on this host when using current data mode. If another device cannot connect immediately, wait a few minutes for Tailscale Serve to finish provisioning, then retry.',
-      ...(tailscaleIp ? { tailscaleIp } : {}),
-    },
+    tunnel,
   };
 }
 

--- a/main/src/database/database.hidden-sessions.test.ts
+++ b/main/src/database/database.hidden-sessions.test.ts
@@ -6,7 +6,12 @@ import { DatabaseService } from './database';
 
 const tempDirs: string[] = [];
 
-function createTestDatabase(): { db: DatabaseService; tempDir: string } {
+interface TestDatabase {
+  db: DatabaseService;
+  tempDir: string;
+}
+
+function createTestDatabase(): TestDatabase {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-hidden-sessions-'));
   tempDirs.push(tempDir);
   const db = new DatabaseService(path.join(tempDir, 'sessions.db'));

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -83,6 +83,65 @@ interface PanelStateLogSummary {
   readonly hasBeenViewed?: boolean;
 }
 
+interface TableStructure {
+  columns: Array<{
+    cid: number;
+    name: string;
+    type: string;
+    notnull: number;
+    dflt_value: unknown;
+    pk: number;
+  }>;
+  foreignKeys: Array<{
+    id: number;
+    seq: number;
+    table: string;
+    from: string;
+    to: string;
+    on_update: string;
+    on_delete: string;
+    match: string;
+  }>;
+  indexes: Array<{ name: string; tbl_name: string; sql: string }>;
+}
+
+interface UserPreferences {
+  [key: string]: string;
+}
+
+interface SessionTokenUsage {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  totalCacheCreationTokens: number;
+  messageCount: number;
+}
+
+interface SessionOutputCounts {
+  json: number;
+  stdout: number;
+  stderr: number;
+}
+
+interface SessionToolUsage {
+  tools: Array<{
+    name: string;
+    count: number;
+    totalDuration: number;
+    avgDuration: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+  }>;
+  totalToolCalls: number;
+}
+
+const ESTIMATED_TOOL_DURATIONS = new Map<string, number>([
+  ["Read", 150], ["Write", 200], ["Edit", 250], ["MultiEdit", 400],
+  ["Grep", 100], ["Glob", 80], ["LS", 50], ["Bash", 500],
+  ["BashOutput", 30], ["KillBash", 50], ["Task", 1000],
+  ["TodoWrite", 100], ["WebSearch", 2000], ["WebFetch", 1500],
+]);
+
 function sanitizePanelStateForLog(value: Partial<ToolPanelState>): PanelStateLogSummary {
   return {
     serializedLength: JSON.stringify(value).length,
@@ -4037,31 +4096,7 @@ export class DatabaseService {
   }
 
   // Debug method to check table structure
-  getTableStructure(tableName: "folders" | "sessions"): {
-    columns: Array<{
-      cid: number;
-      name: string;
-      type: string;
-      notnull: number;
-      dflt_value: unknown;
-      pk: number;
-    }>;
-    foreignKeys: Array<{
-      id: number;
-      seq: number;
-      table: string;
-      from: string;
-      to: string;
-      on_update: string;
-      on_delete: string;
-      match: string;
-    }>;
-    indexes: Array<{
-      name: string;
-      tbl_name: string;
-      sql: string;
-    }>;
-  } {
+  getTableStructure(tableName: "folders" | "sessions"): TableStructure {
     console.log(`[Database] Getting structure for table: ${tableName}`);
 
     // Get column information
@@ -4253,7 +4288,7 @@ export class DatabaseService {
       .run(key, value);
   }
 
-  getUserPreferences(): Record<string, string> {
+  getUserPreferences(): UserPreferences {
     // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
@@ -4263,7 +4298,7 @@ export class DatabaseService {
       )
       .all() as Array<{ key: string; value: string }>;
 
-    const preferences: Record<string, string> = {};
+    const preferences: UserPreferences = {};
     for (const row of rows) {
       preferences[row.key] = row.value;
     }
@@ -4863,13 +4898,7 @@ export class DatabaseService {
   }
 
   // Session statistics methods
-  getSessionTokenUsage(sessionId: string): {
-    totalInputTokens: number;
-    totalOutputTokens: number;
-    totalCacheReadTokens: number;
-    totalCacheCreationTokens: number;
-    messageCount: number;
-  } {
+  getSessionTokenUsage(sessionId: string): SessionTokenUsage {
     // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const rows = this.db
       .prepare(
@@ -4918,11 +4947,7 @@ export class DatabaseService {
     };
   }
 
-  getSessionOutputCounts(sessionId: string): {
-    json: number;
-    stdout: number;
-    stderr: number;
-  } {
+  getSessionOutputCounts(sessionId: string): SessionOutputCounts {
     // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const result = this.db
       .prepare(
@@ -4937,17 +4962,16 @@ export class DatabaseService {
       )
       .all(sessionId) as { type: string; count: number }[];
 
-    const counts: { json: number; stdout: number; stderr: number } = {
+    const counts: SessionOutputCounts = {
       json: 0,
       stdout: 0,
       stderr: 0,
     };
 
     result.forEach((row: { type: string; count: number }) => {
-      if (row.type in counts) {
-        // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
-        counts[row.type as keyof typeof counts] = row.count;
-      }
+      if (row.type === "json") counts.json = row.count;
+      if (row.type === "stdout") counts.stdout = row.count;
+      if (row.type === "stderr") counts.stderr = row.count;
     });
 
     return counts;
@@ -4983,17 +5007,7 @@ export class DatabaseService {
     return result?.count || 0;
   }
 
-  getSessionToolUsage(sessionId: string): {
-    tools: Array<{
-      name: string;
-      count: number;
-      totalDuration: number;
-      avgDuration: number;
-      totalInputTokens: number;
-      totalOutputTokens: number;
-    }>;
-    totalToolCalls: number;
-  } {
+  getSessionToolUsage(sessionId: string): SessionToolUsage {
     // Get all tool_use messages for this session
     // SAFETY: This fixed SQLite query projection matches the declared row type at this database boundary.
     const toolUseRows = this.db
@@ -5081,23 +5095,7 @@ export class DatabaseService {
                     // If duration is 0 (same second), estimate based on tool type
                     // These are typical execution times in milliseconds
                     if (duration === 0) {
-                      const estimatedDurations: Record<string, number> = {
-                        Read: 150,
-                        Write: 200,
-                        Edit: 250,
-                        MultiEdit: 400,
-                        Grep: 100,
-                        Glob: 80,
-                        LS: 50,
-                        Bash: 500,
-                        BashOutput: 30,
-                        KillBash: 50,
-                        Task: 1000,
-                        TodoWrite: 100,
-                        WebSearch: 2000,
-                        WebFetch: 1500,
-                      };
-                      duration = estimatedDurations[toolName] || 100; // Default 100ms for unknown tools
+                      duration = ESTIMATED_TOOL_DURATIONS.get(toolName) ?? 100;
                     }
 
                     if (duration >= 0 && duration < 3600000) {

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -60,7 +60,7 @@ if (process.platform === 'win32') {
 }
 
 // Now import the rest of electron
-import { BrowserWindow, Menu, ipcMain, shell, dialog, IpcMainInvokeEvent, session, WebContents, webContents, WebContentsView } from 'electron';
+import { BrowserWindow, Menu, ipcMain, shell, dialog, IpcMainInvokeEvent, session, WebContents, webContents, WebContentsView, type BrowserWindowConstructorOptions } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
 import type { SessionManager } from './services/sessionManager';
@@ -112,11 +112,13 @@ const registeredPartitions = new Set<string>();
 
 // Module-level shutdown guard to prevent multiple shutdown attempts
 let shutdownInProgress = false;
-let analyticsLaunchContext: {
+interface AnalyticsLaunchContext {
   appVersion?: string;
   previousVersion?: string | null;
   isFirstLaunch?: boolean;
-} = {};
+}
+
+let analyticsLaunchContext: AnalyticsLaunchContext = {};
 
 type RendererDiagnosticPayload = {
   kind?: string;
@@ -300,7 +302,7 @@ async function createWindow() {
     Menu.setApplicationMenu(null);
   }
 
-  mainWindow = new BrowserWindow({
+  const mainWindowOptions: BrowserWindowConstructorOptions = {
     width: 1400,
     height: 900,
     icon: path.join(__dirname, '../assets/icon.png'),
@@ -310,11 +312,12 @@ async function createWindow() {
       nodeIntegration: false,
       webviewTag: true
     },
-    ...(process.platform === 'darwin' ? {
-      titleBarStyle: 'hiddenInset',
-      trafficLightPosition: { x: 10, y: 10 }
-    } : {})
-  });
+  };
+  if (process.platform === 'darwin') {
+    mainWindowOptions.titleBarStyle = 'hiddenInset';
+    mainWindowOptions.trafficLightPosition = { x: 10, y: 10 };
+  }
+  mainWindow = new BrowserWindow(mainWindowOptions);
 
   // Set main window on analytics manager for IPC forwarding
   if (analyticsManager) {

--- a/main/src/ipc/agentUsage.test.ts
+++ b/main/src/ipc/agentUsage.test.ts
@@ -26,7 +26,7 @@ describe('registerAgentUsageHandlers', () => {
   // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
   const services = {
     databaseService: { getAllProjects: vi.fn(() => projects) },
-  } as unknown as AppServices;
+  } as AppServices;
   const unavailable = {
     providers: [{ id: 'codex', name: 'Codex', status: 'unavailable', plan: null, limits: [], fetchedAt: '2026-08-14T12:00:00.000Z', error: 'codex not found' }],
     fetchedAt: '2026-08-14T12:00:00.000Z',

--- a/main/src/ipc/cloud.test.ts
+++ b/main/src/ipc/cloud.test.ts
@@ -59,7 +59,7 @@ describe('cloud IPC', () => {
       connectWorkspace,
       disconnectWorkspace,
       on: vi.fn(),
-    }) as unknown as CloudVmManager);
+    }) as CloudVmManager);
   });
 
   it('requests renderer state resync after hosted workspace mode changes', async () => {

--- a/main/src/ipc/config.test.ts
+++ b/main/src/ipc/config.test.ts
@@ -114,7 +114,7 @@ describe('config IPC handlers', () => {
     const ipcMain = createIpcMainStub();
     registerConfigHandlers(
       // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
-      ipcMain as unknown as IpcMain,
+      ipcMain as IpcMain,
       createServicesStub([activeProject, inactiveProject]),
     );
 

--- a/main/src/ipc/onboarding.ts
+++ b/main/src/ipc/onboarding.ts
@@ -225,7 +225,16 @@ function buildWindowsInteractiveCommand(command: string): string {
   return `${command} & echo. & echo GitHub setup finished. You can return to Pane. & pause`;
 }
 
-function normalizeTerminalDimensions(cols: PaneCommandValue, rows: PaneCommandValue): { cols: number; rows: number } {
+interface TerminalDimensions {
+  cols: number;
+  rows: number;
+}
+
+interface PtyEnvironment {
+  [name: string]: string;
+}
+
+function normalizeTerminalDimensions(cols: PaneCommandValue, rows: PaneCommandValue): TerminalDimensions {
   const parseDimension = (value: PaneCommandValue, fallback: number): number => {
     try {
       const decoded = decodeBoundary(value, boundary.number);
@@ -243,8 +252,8 @@ function normalizeTerminalDimensions(cols: PaneCommandValue, rows: PaneCommandVa
   };
 }
 
-function buildGitHubAuthPtyEnv(): Record<string, string> {
-  const env: Record<string, string> = {};
+function buildGitHubAuthPtyEnv(): PtyEnvironment {
+  const env: PtyEnvironment = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (value !== undefined) {
       env[key] = value;

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -184,7 +184,11 @@ async function saveFileForSession(
 export const sessionImageCounters = new Map<string, number>();
 
 // MIME type to file extension mapping
-const MIME_EXTENSIONS: Record<string, string> = {
+interface MimeExtensionLookup {
+  [mimeType: string]: string;
+}
+
+const MIME_EXTENSIONS: MimeExtensionLookup = {
   'image/png': 'png',
   'image/jpeg': 'jpg',
   'image/gif': 'gif',

--- a/main/src/ipc/remoteDaemon.ts
+++ b/main/src/ipc/remoteDaemon.ts
@@ -46,6 +46,7 @@ import {
   getRemoteSetupProperties,
   getRemoteSetupResultProperties,
   trackRemotePaneEvent,
+  type RemotePaneAnalyticsProperties,
 } from '../services/remoteAnalytics';
 
 interface IpcMainHandleLike {
@@ -368,25 +369,22 @@ export function registerRemoteDaemonHandlers(
         };
       });
 
-      trackRemotePaneEvent(analyticsManager, 'remote_pane_connection_code_imported', {
+      const importEventProperties: RemotePaneAnalyticsProperties = {
         ...getRemoteImportProperties(payload),
         result: connectionError ? 'failed' : 'succeeded',
         connected,
-        ...(connectionError
-          ? {
-              failure_stage: 'connect_imported_profile',
-              failure_category: getRemoteFailureCategory(connectionError),
-            }
-          : {}),
-      });
+      };
+      if (connectionError) {
+        importEventProperties.failure_stage = 'connect_imported_profile';
+        importEventProperties.failure_category = getRemoteFailureCategory(connectionError);
+      }
+      trackRemotePaneEvent(analyticsManager, 'remote_pane_connection_code_imported', importEventProperties);
 
+      const importResult: RemoteDaemonImportResult = { profile, connected };
+      if (connectionError) importResult.connectionError = connectionError;
       return {
         success: true,
-        data: {
-          profile,
-          connected,
-          ...(connectionError ? { connectionError } : {}),
-        } satisfies RemoteDaemonImportResult,
+        data: importResult,
       };
     } catch (error) {
       trackRemotePaneEvent(analyticsManager, 'remote_pane_connection_code_import_failed', {

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -177,7 +177,7 @@ function createServices(overrides: Partial<AppServices> = {}): AppServices {
       })),
     },
     ...overrides,
-  } as unknown as AppServices;
+  } as AppServices;
 }
 
 const tempDirs: string[] = [];
@@ -2228,6 +2228,10 @@ describe('runpane IPC handlers', () => {
           vi.mocked(panelManager.createPanel).mockImplementation(async (request) => {
             createRequest = request;
             const initialState = request.initialState ?? {};
+            const customState: TerminalPanelState = { ...initialState };
+            if (initialState.initialInputMode === 'argument') {
+              customState.initialInputSentAt = '2026-01-01T00:02:00.000Z';
+            }
             createdPanel = {
               id: 'panel-1',
               sessionId: session.id,
@@ -2235,12 +2239,7 @@ describe('runpane IPC handlers', () => {
               title: request.title,
               state: {
                 isActive: false,
-                customState: {
-                  ...initialState,
-                  ...(initialState.initialInputMode === 'argument'
-                    ? { initialInputSentAt: '2026-01-01T00:02:00.000Z' }
-                    : {}),
-                },
+                customState,
               },
               metadata: {},
             };

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -725,16 +725,18 @@ async function createTerminalPanelForSession(
   const initialState: TerminalPanelState = {
     initialCommand: tool.command,
     initialInput: tool.initialInput,
-    ...(useArgumentDelivery ? { initialInputMode: 'argument' as const } : {}),
     initialInputSubmitStrategy: tool.agent === 'codex' && !useArgumentDelivery
       ? 'codex-ctrl-enter'
       : 'enter',
-    ...(shouldCreateSubmitInitialInput ? {
-      initialInputSentAt: new Date().toISOString(),
-    } : {}),
     agentType: tool.agent,
     isCliPanel: Boolean(tool.agent),
   };
+  if (useArgumentDelivery) {
+    initialState.initialInputMode = 'argument';
+  }
+  if (shouldCreateSubmitInitialInput) {
+    initialState.initialInputSentAt = new Date().toISOString();
+  }
 
   const createRequest: CreatePanelRequest = {
     sessionId: session.id,
@@ -785,7 +787,7 @@ async function submitCreateInitialInput(
     const sentAt = optionalString(customState.initialInputSentAt);
     const deliveryError = optionalString(customState.initialInputError);
     const delivered = Boolean(sentAt) && !deliveryError;
-    return {
+    const result: RunpaneInitialInputDeliveryResult = {
       delivered,
       submitted: delivered,
       inputBytes: Buffer.byteLength(tool.initialInput, 'utf8'),
@@ -793,13 +795,14 @@ async function submitCreateInitialInput(
       sequenceName: 'argument',
       verifiedSubmitted: delivered,
       sentAt,
-      ...(delivered ? {} : {
-        error: {
-          message: deliveryError ?? 'Initial input was not attached to the agent launch command.',
-        },
-      }),
       nextCommand: readiness?.nextCommand ?? panelWaitCommand(panel.id),
     };
+    if (!delivered) {
+      result.error = {
+        message: deliveryError ?? 'Initial input was not attached to the agent launch command.',
+      };
+    }
+    return result;
   }
 
   if (!tool.agent || !readiness) {
@@ -1093,10 +1096,15 @@ async function buildPanelScreenResult(panel: ToolPanel, limit: number): Promise<
   };
 }
 
+interface PanelScreenText {
+  source: RunpanePanelScreenSource;
+  rawText: string;
+}
+
 function selectPanelScreenText(
   snapshot: TerminalPanelSnapshot | null,
   customState: TerminalPanelState,
-): { source: RunpanePanelScreenSource; rawText: string } {
+): PanelScreenText {
   if (snapshot) {
     if (snapshot.screenText !== undefined) {
       return {
@@ -1170,7 +1178,13 @@ function normalizeScrollbackBuffer(value: TerminalPanelState['scrollbackBuffer']
   return '';
 }
 
-function boundSanitizedLines(rawText: string, limit: number): { text: string; hasMore: boolean; returnedLineCount: number } {
+interface BoundedSanitizedLines {
+  text: string;
+  hasMore: boolean;
+  returnedLineCount: number;
+}
+
+function boundSanitizedLines(rawText: string, limit: number): BoundedSanitizedLines {
   const stripped = sanitizeTerminalOutput(rawText);
   if (!stripped) {
     return { text: '', hasMore: false, returnedLineCount: 0 };
@@ -1306,14 +1320,16 @@ function ensureSubmitEnter(input: string): string {
   return `${input}\r`;
 }
 
-function resolveComposerSubmit(
-  strategy: RunpanePanelSubmitComposerStrategy | undefined,
-  agentType: RunpaneAgentId | undefined,
-): {
+interface ComposerSubmit {
   strategy: 'codex-ctrl-enter' | 'enter';
   sequenceName: RunpanePanelSubmitComposerResult['sequenceName'];
   input: string;
-} {
+}
+
+function resolveComposerSubmit(
+  strategy: RunpanePanelSubmitComposerStrategy | undefined,
+  agentType: RunpaneAgentId | undefined,
+): ComposerSubmit {
   if (strategy === 'codex-ctrl-enter' || ((!strategy || strategy === 'auto') && agentType === 'codex')) {
     return {
       strategy: 'codex-ctrl-enter',
@@ -1403,9 +1419,9 @@ function looksLikePendingComposer(text: string): boolean {
 }
 
 // GUI-launched Electron PATHs typically miss ~/.local/bin, cursor-agent's install target.
-const AGENT_FALLBACK_BIN_PATHS: Partial<Record<RunpaneAgentId, readonly string[]>> = {
+const AGENT_FALLBACK_BIN_PATHS = {
   cursor: ['$HOME/.local/bin/cursor-agent'],
-};
+} satisfies Partial<Record<RunpaneAgentId, readonly string[]>>;
 
 async function runAgentDoctor(
   services: AppServices,
@@ -1481,7 +1497,8 @@ async function runAgentDoctor(
   }
 
   if (!executablePath && environment !== 'windows') {
-    for (const fallback of AGENT_FALLBACK_BIN_PATHS[agent] ?? []) {
+    const fallbackPaths = agent === 'cursor' ? AGENT_FALLBACK_BIN_PATHS.cursor : [];
+    for (const fallback of fallbackPaths) {
       try {
         const result = await context.commandRunner.execAsync(`command -v "${fallback}"`, repo.path, {
           timeout: 5_000,
@@ -2269,7 +2286,9 @@ function resolveToolSpec(tool: RunpaneToolSpec, environment?: ProjectEnvironment
   };
 }
 
-function describeTool(tool: RunpaneResolvedTool): { title: string; command: string; agent?: RunpaneAgentId } {
+type DescribedTool = Pick<RunpaneResolvedTool, 'title' | 'command' | 'agent'>;
+
+function describeTool(tool: RunpaneResolvedTool): DescribedTool {
   return {
     title: tool.title,
     command: tool.command,
@@ -2348,11 +2367,14 @@ async function withRunpaneAction<T extends { ok: boolean }>(
   try {
     const result = await handler();
     const commandOk = result.ok;
-    trackRunpaneAction(services, action, 'success', Date.now() - startedAt, {
+    const actionMetadata: RunpaneActionMetadata = {
       ...metadata,
       ok: commandOk,
-      ...(resultMetadata ? resultMetadata(result) : {}),
-    });
+    };
+    if (resultMetadata) {
+      Object.assign(actionMetadata, resultMetadata(result));
+    }
+    trackRunpaneAction(services, action, 'success', Date.now() - startedAt, actionMetadata);
     return result;
   } catch (error) {
     trackRunpaneAction(services, action, 'failure', Date.now() - startedAt, {

--- a/main/src/ipc/script.ts
+++ b/main/src/ipc/script.ts
@@ -224,7 +224,11 @@ export function registerScriptHandlers(
   });
 
   // Allowlist of known IDE commands keyed by identifier
-  const IDE_COMMANDS: Record<string, string> = {
+  interface IdeCommandLookup {
+    [ide: string]: string;
+  }
+
+  const IDE_COMMANDS: IdeCommandLookup = {
     vscode: 'code .',
     cursor: 'cursor .',
   };

--- a/main/src/ipc/updater.ts
+++ b/main/src/ipc/updater.ts
@@ -86,7 +86,7 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
         console.log('[Version Debug] Worktree name:', worktreeName);
       }
 
-      const responseData: {
+      interface VersionResponseData {
         current: string;
         name: string;
         workingDirectory: string;
@@ -95,7 +95,9 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
         gitCommit?: string;
         buildTimestamp?: number;
         worktreeName?: string;
-      } = {
+      }
+
+      const responseData: VersionResponseData = {
         current: app.getVersion(),
         name: app.getName(),
         workingDirectory: process.cwd(),

--- a/main/src/ptyHost/ptyHostMain.ts
+++ b/main/src/ptyHost/ptyHostMain.ts
@@ -141,9 +141,9 @@ const ptyMap = new Map<string, HostPty>();
 function bootstrap(): void {
   // SAFETY: Electron UtilityProcess injects a MessagePort-compatible
   // `process.parentPort`; the fallback exposes the same documented surface.
-  const parent = (
-    (process as unknown as { parentPort?: unknown }).parentPort ?? electron.parentPort
-  ) as (HostPort & { once: HostPort['on'] }) | undefined;
+  const injectedParentPort: unknown = Reflect.get(process, 'parentPort');
+  const parent = (injectedParentPort ?? electron.parentPort) as
+    (HostPort & { once: HostPort['on'] }) | undefined;
   if (!parent) {
     console.error('[ptyHost] parentPort is not available; exiting');
     process.exit(1);

--- a/main/src/ptyHost/ptyHostSupervisor.ts
+++ b/main/src/ptyHost/ptyHostSupervisor.ts
@@ -100,6 +100,10 @@ function decodeFrame<Value>(frame: JsonValue, schema: BoundarySchema<Value>): Va
 type DataListener = (data: string) => void;
 type ExitListener = (exitCode: number | null, signal: number | null) => void;
 
+interface DisposableListener {
+  dispose(): void;
+}
+
 /**
  * Thin `IPty`-compatible shim.
  *
@@ -131,7 +135,7 @@ export class PtyHandle {
    * Subscribe to PTY byte output. Returns an `IDisposable`-shaped object so
    * callers that previously used `pty.onData(...).dispose()` keep working.
    */
-  onData(listener: DataListener): { dispose(): void } {
+  onData(listener: DataListener): DisposableListener {
     this.dataListeners.add(listener);
     return {
       dispose: () => {
@@ -145,7 +149,7 @@ export class PtyHandle {
    * from the host; `signal` is the raw number so SIGSEGV/SIGABRT/SIGBUS
    * detection at `AbstractCliManager.ts:781-795` keeps working.
    */
-  onExit(listener: ExitListener): { dispose(): void } {
+  onExit(listener: ExitListener): DisposableListener {
     this.exitListeners.add(listener);
     return {
       dispose: () => {

--- a/main/src/services/agentStatus/manifests.ts
+++ b/main/src/services/agentStatus/manifests.ts
@@ -337,7 +337,11 @@ export const CURSOR_MANIFEST: AgentManifest = {
   ],
 };
 
-const MANIFESTS_BY_AGENT: Record<string, AgentManifest> = {
+interface AgentManifestLookup {
+  [agent: string]: AgentManifest;
+}
+
+const MANIFESTS_BY_AGENT: AgentManifestLookup = {
   claude: CLAUDE_MANIFEST,
   codex: CODEX_MANIFEST,
   cursor: CURSOR_MANIFEST,

--- a/main/src/services/agentUsageService.test.ts
+++ b/main/src/services/agentUsageService.test.ts
@@ -54,7 +54,7 @@ function createFakeChild(stdin: Writable): ChildProcessWithoutNullStreams {
     exitCode: null,
     signalCode: null,
     kill: vi.fn(() => true),
-  }) as unknown as ChildProcessWithoutNullStreams;
+  }) as ChildProcessWithoutNullStreams;
 }
 
 describe('normalizeCodexUsage', () => {

--- a/main/src/services/agents/agentIdentity.ts
+++ b/main/src/services/agents/agentIdentity.ts
@@ -6,7 +6,11 @@ export type CliAgentType = NonNullable<TerminalPanelState['agentType']>;
 
 export const CLI_AGENT_TYPES: readonly CliAgentType[] = ['claude', 'codex', 'cursor'];
 
-const AGENT_EXECUTABLES: Readonly<Record<string, CliAgentType>> = {
+interface AgentExecutableLookup {
+  readonly [executable: string]: CliAgentType;
+}
+
+const AGENT_EXECUTABLES: AgentExecutableLookup = {
   'cursor-agent': 'cursor',
   claude: 'claude',
   codex: 'codex',

--- a/main/src/services/cloudVmManager.test.ts
+++ b/main/src/services/cloudVmManager.test.ts
@@ -22,6 +22,11 @@ interface CloudVmManagerTestAccess {
   waitForStatus(config: CloudVmConfig, targetStatus: VmStatus, timeoutMs: number): Promise<CloudVmState>;
 }
 
+interface CloudConfigSnapshot {
+  cloud?: CloudVmConfig;
+  remoteDaemon?: RemoteDaemonConfig;
+}
+
 function createManager(configManager: ConfigManagerStub): CloudVmManager {
   // SAFETY: The stub implements the EventEmitter and configuration methods
   // CloudVmManager reaches in these isolated lifecycle tests.
@@ -42,13 +47,13 @@ class ConfigManagerStub extends EventEmitter {
     super();
   }
 
-  getConfig(): { cloud?: CloudVmConfig; remoteDaemon?: RemoteDaemonConfig } {
+  getConfig(): CloudConfigSnapshot {
     return { cloud: this.cloud, remoteDaemon: this.remoteDaemon };
   }
 
   async updateConfig(
     updates: { cloud?: CloudVmConfig; remoteDaemon?: RemoteDaemonConfig },
-  ): Promise<{ cloud?: CloudVmConfig; remoteDaemon?: RemoteDaemonConfig }> {
+  ): Promise<CloudConfigSnapshot> {
     if ('cloud' in updates) {
       this.cloud = updates.cloud;
     }

--- a/main/src/services/cloudVmManager.ts
+++ b/main/src/services/cloudVmManager.ts
@@ -7,7 +7,6 @@ import type { Logger } from '../utils/logger';
 import {
   type CloudRemoteConnectionStatus,
   createDefaultCloudVmState,
-  type CloudProvider,
   type CloudDaemonStatus,
   type CloudVmConfig,
   type CloudVmState,
@@ -22,7 +21,19 @@ import {
 } from '../../../shared/types/remoteDaemon';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 
-export type { CloudProvider, VmStatus, TunnelStatus, CloudVmConfig, CloudVmState };
+export type { VmStatus, TunnelStatus, CloudVmConfig, CloudVmState };
+
+interface HostedWorkspaceState {
+  provider: CloudVmState['provider'];
+  serverId: string | null;
+  daemonStatus: CloudDaemonStatus;
+  daemonBaseUrl: string | null;
+  linkedRemoteProfileId: string | null;
+  linkedRemoteProfileLabel: string | null;
+  remoteConnectionStatus: CloudRemoteConnectionStatus;
+  preferredAccess: CloudVmState['preferredAccess'];
+  allowNoVncFallback: boolean;
+}
 
 /**
  * Manages cloud VM lifecycle (start/stop/status) for Pane Cloud.
@@ -725,17 +736,7 @@ export class CloudVmManager extends EventEmitter {
     );
   }
 
-  private getHostedWorkspaceStateFromConfig(config: CloudVmConfig): {
-    provider: CloudProvider;
-    serverId: string | null;
-    daemonStatus: CloudDaemonStatus;
-    daemonBaseUrl: string | null;
-    linkedRemoteProfileId: string | null;
-    linkedRemoteProfileLabel: string | null;
-    remoteConnectionStatus: CloudRemoteConnectionStatus;
-    preferredAccess: CloudVmState['preferredAccess'];
-    allowNoVncFallback: boolean;
-  } {
+  private getHostedWorkspaceStateFromConfig(config: CloudVmConfig): HostedWorkspaceState {
     const remoteConfig = this.getRemoteDaemonConfig();
     const linkedProfile = this.getLinkedRemoteProfile(config, remoteConfig);
 

--- a/main/src/services/gitFileWatcher.ts
+++ b/main/src/services/gitFileWatcher.ts
@@ -64,6 +64,11 @@ interface WatchedSession {
   pendingRefresh: boolean;
 }
 
+interface GitFileWatcherStats {
+  totalWatched: number;
+  sessionsNeedingRefresh: number;
+}
+
 /**
  * Smart file watcher that detects when git status actually needs refreshing
  *
@@ -772,7 +777,7 @@ export class GitFileWatcher extends EventEmitter {
   /**
    * Get statistics about watched sessions
    */
-  getStats(): { totalWatched: number; sessionsNeedingRefresh: number } {
+  getStats(): GitFileWatcherStats {
     let sessionsNeedingRefresh = 0;
     for (const session of this.watchedSessions.values()) {
       if (session.pendingRefresh) {

--- a/main/src/services/gitPlumbingCommands.ts
+++ b/main/src/services/gitPlumbingCommands.ts
@@ -14,6 +14,17 @@ export interface GitIndexStatus {
   hasConflicts: boolean;
 }
 
+export interface GitAheadBehind {
+  ahead: number;
+  behind: number;
+}
+
+export interface GitDiffStats {
+  additions: number;
+  deletions: number;
+  filesChanged: number;
+}
+
 /**
  * Check the directory exists before attempting git operations.
  * This prevents ENOENT errors when worktrees have been deleted (e.g., /tmp cleanup).
@@ -108,7 +119,7 @@ export function fastCheckWorkingDirectory(cwd: string, wslContext?: WSLContext |
 /**
  * Get count of commits ahead/behind using rev-list (faster than rev-parse)
  */
-export function fastGetAheadBehind(cwd: string, baseBranch: string, wslContext?: WSLContext | null): { ahead: number; behind: number } {
+export function fastGetAheadBehind(cwd: string, baseBranch: string, wslContext?: WSLContext | null): GitAheadBehind {
   if (!directoryExists(cwd, wslContext)) {
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return { ahead: 0, behind: 0 };
@@ -131,7 +142,7 @@ export function fastGetAheadBehind(cwd: string, baseBranch: string, wslContext?:
 /**
  * Get statistics about changes (additions/deletions) efficiently
  */
-export function fastGetDiffStats(cwd: string, wslContext?: WSLContext | null): { additions: number; deletions: number; filesChanged: number } {
+export function fastGetDiffStats(cwd: string, wslContext?: WSLContext | null): GitDiffStats {
   if (!directoryExists(cwd, wslContext)) {
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return { additions: 0, deletions: 0, filesChanged: 0 };

--- a/main/src/services/paneChatManager.ts
+++ b/main/src/services/paneChatManager.ts
@@ -183,17 +183,18 @@ export class PaneChatManager {
   ): TerminalPanelState {
     const agentSessionId = this.resolveAgentSessionId(agent, previousState, forceNewAgentSession);
 
-    return {
+    const panelState: TerminalPanelState = {
       initialCommand: RUNPANE_CONTRACT.agentTemplates[agent].command,
       initialInput: this.buildInitialInput(agent, guidePath),
       initialInputMode: 'argument',
       initialInputSubmitStrategy: 'enter',
       initialInputDeliveryVersion: PANE_CHAT_BOOTSTRAP_VERSION,
       agentType: agent,
-      ...(agentSessionId ? { agentSessionId } : {}),
       isCliPanel: true,
       isCliReady: false,
     };
+    if (agentSessionId) panelState.agentSessionId = agentSessionId;
+    return panelState;
   }
 
   private buildInitialInput(agent: PaneChatAgent, guidePath: string): string {

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -11,7 +11,11 @@ import { testClaudeCodeAvailability, testClaudeCodeInDirectory } from '../../../
 import { findExecutableInPath } from '../../../utils/shellPath';
 import { PermissionManager } from '../../permissionManager';
 import { findNodeExecutable } from '../../../utils/nodeFinder';
-import { AbstractCliManager } from '../cli/AbstractCliManager';
+import {
+  AbstractCliManager,
+  type CliEnvironment,
+  type CliSpawnTuple,
+} from '../cli/AbstractCliManager';
 import { withLock } from '../../../utils/mutex';
 import { getAppDirectory } from '../../../utils/appDirectory';
 import { escapeForBash } from '../../../utils/wslUtils';
@@ -45,6 +49,11 @@ interface ClaudeCodeProcess {
   panelId: string;
   sessionId: string;
   worktreePath: string;
+}
+
+interface BaseProjectMcpServers {
+  mcpServers: JsonObject;
+  mcpJsonPath?: string;
 }
 
 /**
@@ -338,19 +347,20 @@ export class ClaudeCodeManager extends AbstractCliManager {
     return events;
   }
 
-  protected async initializeCliEnvironment(options: ClaudeSpawnOptions): Promise<{ [key: string]: string }> {
+  protected async initializeCliEnvironment(options: ClaudeSpawnOptions): Promise<CliEnvironment> {
     const { sessionId, permissionMode } = options;
     
     // Get basic system environment
     const systemEnv = await this.getSystemEnvironment();
     
     // Initialize environment with MCP-specific variables
-    const env: { [key: string]: string } = {
+    const env: CliEnvironment = {
       // Ensure MCP-related environment variables are preserved
       MCP_SOCKET_PATH: this.permissionIpcPath || '',
-      // Add debug mode for MCP if verbose logging is enabled
-      ...(this.configManager?.getConfig()?.verbose ? { MCP_DEBUG: '1' } : {})
     };
+    if (this.configManager?.getConfig()?.verbose) {
+      env.MCP_DEBUG = '1';
+    }
 
     // Set up MCP configuration if permission approval is requested
     const defaultMode = this.configManager?.getConfig()?.defaultPermissionMode || 'ignore';
@@ -551,8 +561,8 @@ export class ClaudeCodeManager extends AbstractCliManager {
   protected wrapSpawnArgs(
     cmd: string,
     args: string[],
-    env: { [key: string]: string }
-  ): { cmd: string; args: string[]; env: { [key: string]: string } } {
+    env: CliEnvironment
+  ): CliSpawnTuple {
     if (process.platform === 'win32') return { cmd, args, env };
     const line = [cmd, ...args].map(escapeForBash).join(' ');
     return { cmd: '/bin/sh', args: ['-c', `exec ${line}`], env };
@@ -806,8 +816,8 @@ export class ClaudeCodeManager extends AbstractCliManager {
    * When running in a worktree, Claude doesn't see MCP servers from the base project
    * because it uses the worktree path as the project key.
    */
-  private getBaseProjectMcpServers(sessionId: string): { mcpServers: JsonObject; mcpJsonPath?: string } {
-    const result: { mcpServers: JsonObject; mcpJsonPath?: string } = { mcpServers: {} };
+  private getBaseProjectMcpServers(sessionId: string): BaseProjectMcpServers {
+    const result: BaseProjectMcpServers = { mcpServers: {} };
 
     try {
       // Get the session to find the project
@@ -1044,7 +1054,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
 
     // Start with base project MCP servers
     const baseProjectMcp = this.getBaseProjectMcpServers(sessionId);
-    const mcpConfig: { mcpServers: JsonObject } = {
+    const mcpConfig = {
       "mcpServers": {
         // Include base project MCP servers first
         ...baseProjectMcp.mcpServers,
@@ -1054,7 +1064,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
           "args": mcpArgs
         }
       }
-    };
+    } satisfies { mcpServers: JsonObject };
 
     if (Object.keys(baseProjectMcp.mcpServers).length > 0) {
       this.logger?.info(`[MCP] Merged ${Object.keys(baseProjectMcp.mcpServers).length} base project MCP servers into config`);
@@ -1104,7 +1114,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
     return mcpConfigPath;
   }
 
-  private async setupMcpConfiguration(sessionId: string, env: { [key: string]: string }): Promise<void> {
+  private async setupMcpConfiguration(sessionId: string, env: CliEnvironment): Promise<void> {
     // This method is called from initializeCliEnvironment but for Claude we handle MCP in spawnCliProcess
     // Just set up the basic environment variables here
     return;

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -69,6 +69,16 @@ export interface CliSpawnOptions {
   [key: string]: JsonValue | undefined; // Allow CLI-specific serializable options
 }
 
+export interface CliEnvironment {
+  [key: string]: string;
+}
+
+export interface CliSpawnTuple {
+  cmd: string;
+  args: string[];
+  env: CliEnvironment;
+}
+
 const nodeFallbackTools = new Set<string>();
 
 class PtyHostUnavailableError extends Error {
@@ -147,8 +157,8 @@ export abstract class AbstractCliManager extends EventEmitter {
   protected wrapSpawnArgs(
     cmd: string,
     args: string[],
-    env: { [key: string]: string }
-  ): { cmd: string; args: string[]; env: { [key: string]: string } } {
+    env: CliEnvironment
+  ): CliSpawnTuple {
     return { cmd, args, env };
   }
 
@@ -169,7 +179,7 @@ export abstract class AbstractCliManager extends EventEmitter {
   /**
    * Handle CLI-specific initialization (e.g., setup config files, environment)
    */
-  protected abstract initializeCliEnvironment(options: CliSpawnOptions): Promise<{ [key: string]: string }>;
+  protected abstract initializeCliEnvironment(options: CliSpawnOptions): Promise<CliEnvironment>;
 
   /**
    * Clean up CLI-specific resources (e.g., config files, temporary files)
@@ -179,7 +189,7 @@ export abstract class AbstractCliManager extends EventEmitter {
   /**
    * Get CLI-specific environment variables
    */
-  protected abstract getCliEnvironment(options: CliSpawnOptions): Promise<{ [key: string]: string }>;
+  protected abstract getCliEnvironment(options: CliSpawnOptions): Promise<CliEnvironment>;
 
   /**
    * Hook called when a CLI process exits. Override in subclasses to clean up process-specific state.
@@ -1063,8 +1073,7 @@ export abstract class AbstractCliManager extends EventEmitter {
 
       // Detect crash signals (SIGSEGV=11, SIGABRT=6, SIGBUS=7)
       if (signal && [6, 7, 11].includes(signal)) {
-        const signalNames: Record<number, string> = { 6: 'SIGABRT', 7: 'SIGBUS', 11: 'SIGSEGV' };
-        const signalName = signalNames[signal] || `signal ${signal}`;
+        const signalName = signal === 6 ? 'SIGABRT' : signal === 7 ? 'SIGBUS' : 'SIGSEGV';
         this.logger?.error(`${this.getCliToolName()} process crashed with ${signalName} for session ${sessionId} (panel ${panelId})`);
 
         const crashMessage = `\n[Process Crash] ${this.getCliToolName()} was terminated by ${signalName}. Your system may be under memory pressure — check RAM usage.\n`;

--- a/main/src/services/remoteAnalytics.ts
+++ b/main/src/services/remoteAnalytics.ts
@@ -153,9 +153,13 @@ export function getConnectedClientCountBucket(count: number): RemotePaneAnalytic
   return '4+';
 }
 
+interface SanitizedRemotePaneProperties {
+  [key: string]: string | number | boolean | string[] | undefined;
+}
+
 function sanitizeRemotePaneProperties(
   properties: RemotePaneAnalyticsProperties,
-): Record<string, string | number | boolean | string[] | undefined> {
+): SanitizedRemotePaneProperties {
   return {
     surface: properties.surface,
     role: properties.role,

--- a/main/src/services/resourceMonitorService.test.ts
+++ b/main/src/services/resourceMonitorService.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { ResourceMonitorService, parseWslEnvironScan } from './resourceMonitorService';
 
+interface ResourceMonitorTestAccess {
+  getElectronMetrics(): unknown[];
+}
+
 describe('ResourceMonitorService', () => {
   it('returns no Electron metrics when initialized without an app', () => {
     const service = new ResourceMonitorService();
     service.initialize();
 
     // SAFETY: The assertion exposes one private pure query solely to verify the no-app initialization path.
-    expect((service as { getElectronMetrics(): unknown[] }).getElectronMetrics()).toEqual([]);
+    expect((service as ResourceMonitorTestAccess).getElectronMetrics()).toEqual([]);
   });
 });
 

--- a/main/src/services/runCommandManager.ts
+++ b/main/src/services/runCommandManager.ts
@@ -155,12 +155,12 @@ export class RunCommandManager extends EventEmitter {
             // For Linux, use current PATH to avoid slow shell detection
             const isLinux = process.platform === 'linux';
             const shellPath = isLinux ? (process.env.PATH || '') : getShellPath();
-            const env: Record<string, string> = {
+            const env = {
               ...Object.fromEntries(Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)),
               ...getGitAttributionEnv(getRuntimeConfigManager().getConfig()),
               WORKTREE_PATH: worktreePath,
               PATH: shellPath
-            };
+            } satisfies Record<string, string>;
             
             // Log environment details for debugging
             if (j === 0) {

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -26,6 +26,18 @@ interface CreateSessionOptions {
   hidden?: boolean;
 }
 
+interface ProjectContext {
+  project: Project;
+  pathResolver: PathResolver;
+  commandRunner: CommandRunner;
+}
+
+interface CommandExecutionError {
+  stderr?: string;
+  stdout?: string;
+  message?: string;
+}
+
 // Interface for generic JSON message data that can contain various properties
 interface MessageTextBlock { type: string; text?: string }
 interface GenericMessageData {
@@ -248,7 +260,7 @@ export class SessionManager extends EventEmitter {
     this.projectContextCache.delete(projectId);
   }
 
-  private getOrCreateContext(project: Project): { project: Project; pathResolver: PathResolver; commandRunner: CommandRunner } {
+  private getOrCreateContext(project: Project): ProjectContext {
     if (!this.projectContextCache.has(project.id)) {
       this.projectContextCache.set(project.id, {
         pathResolver: new PathResolver(project),
@@ -1355,7 +1367,7 @@ export class SessionManager extends EventEmitter {
           }
         } catch (cmdError) {
           console.error(`[SessionManager] Archive command failed: ${command}`, cmdError);
-          let error: { stderr?: string; stdout?: string; message?: string } = {};
+          let error: CommandExecutionError = {};
           try {
             error = decodeBoundary(cmdError, boundary.object({
               stderr: boundary.optional(boundary.string),
@@ -1437,7 +1449,7 @@ export class SessionManager extends EventEmitter {
           }
         } catch (cmdError) {
           console.error(`[SessionManager] Build command failed: ${command}`, cmdError);
-          let error: { stderr?: string; stdout?: string; message?: string } = {};
+          let error: CommandExecutionError = {};
           try {
             error = decodeBoundary(cmdError, boundary.object({
               stderr: boundary.optional(boundary.string),

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -974,7 +974,7 @@ export class TerminalPanelManager {
         baseEnv[key] = value;
       }
     }
-    const spawnEnv: Record<string, string> = {
+    const spawnEnv = {
       ...baseEnv,
       ...getGitAttributionEnv(getRuntimeConfigManager().getConfig()),
       PATH: enhancedPath,
@@ -987,7 +987,7 @@ export class TerminalPanelManager {
       PANE_PORT: String(panePort),
       PANE_WORKSPACE_PATH: cwd,
       ...wslEnvVars,
-    };
+    } satisfies Record<string, string>;
 
     // Read the setting once per spawn so we don't scatter config reads.
     // `getPtyHostRuntime()` returns null when the setting is off or when
@@ -1544,8 +1544,8 @@ export class TerminalPanelManager {
       !savedIsAlternateScreen && terminal.screenEmulator
         ? this.trimAnsiSafe(terminal.screenEmulator.serializeForRestore(true), MAX_RESTORE_PAYLOAD_SIZE)
         : terminal.scrollbackBuffer;
-    state.customState = {
-      ...state.customState,
+    const customState: TerminalPanelState = {
+      ...terminalCustomState(state),
       isInitialized: true,
       cwd: cwd,
       scrollbackBuffer: savedScrollback,
@@ -1557,10 +1557,12 @@ export class TerminalPanelManager {
       serializedBuffer: terminal.screenEmulator?.isAlternateScreen
         ? terminal.screenEmulator.serializeForRestore()
         : this.serializedBuffers.get(panelId),
-      ...(terminal.capturedAgentSessionId && terminal.agentType
-        ? { agentType: terminal.agentType, agentSessionId: terminal.capturedAgentSessionId }
-        : {})
     };
+    if (terminal.capturedAgentSessionId && terminal.agentType) {
+      customState.agentType = terminal.agentType;
+      customState.agentSessionId = terminal.capturedAgentSessionId;
+    }
+    state.customState = customState;
     
     await panelManager.updatePanel(panelId, { state });
     

--- a/main/src/services/terminalSessionManager.ts
+++ b/main/src/services/terminalSessionManager.ts
@@ -125,7 +125,7 @@ export class TerminalSessionManager extends EventEmitter {
     console.log(`Using shell: ${shellInfo.path} (${shellInfo.name})`);
     
     // Build spawn env once so both paths see identical values.
-    const rawEnv: Record<string, string | undefined> = {
+    const rawEnv = {
       ...process.env,
       ...getGitAttributionEnv(getRuntimeConfigManager().getConfig()),
       PATH: shellPath,
@@ -133,7 +133,7 @@ export class TerminalSessionManager extends EventEmitter {
       TERM: 'xterm-256color',      // Ensure TERM is set for color support
       COLORTERM: 'truecolor',      // Enable 24-bit color
       LANG: process.env.LANG || 'en_US.UTF-8',  // Set locale for proper character handling
-    };
+    } satisfies NodeJS.ProcessEnv;
 
     const spawnCols = 80;
     const spawnRows = 24;

--- a/main/src/services/uiStateManager.ts
+++ b/main/src/services/uiStateManager.ts
@@ -3,10 +3,18 @@ import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDec
 
 type SidebarSection = 'pinned' | 'repositories';
 
-const SIDEBAR_SECTION_KEYS: Record<SidebarSection, string> = {
+const SIDEBAR_SECTION_KEYS = {
   pinned: 'treeView.pinnedSectionExpanded',
   repositories: 'treeView.repositoriesSectionExpanded'
-};
+} satisfies Record<SidebarSection, string>;
+
+interface ExpandedUiState {
+  expandedProjects: number[];
+  expandedFolders: string[];
+  sessionSortAscending: boolean;
+  pinnedSectionExpanded: boolean;
+  repositoriesSectionExpanded: boolean;
+}
 
 class UIStateManager {
   private db: DatabaseService;
@@ -76,13 +84,7 @@ class UIStateManager {
     this.saveExpandedFolders(folderIds);
   }
 
-  getExpandedState(): {
-    expandedProjects: number[];
-    expandedFolders: string[];
-    sessionSortAscending: boolean;
-    pinnedSectionExpanded: boolean;
-    repositoriesSectionExpanded: boolean;
-  } {
+  getExpandedState(): ExpandedUiState {
     return {
       expandedProjects: this.getExpandedProjects(),
       expandedFolders: this.getExpandedFolders(),

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -11,6 +11,11 @@ import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDec
 
 type WorktreeAuditSource = 'session-delete' | 'project-delete' | 'create-cleanup';
 
+interface WorktreeEntry {
+  path: string;
+  branch: string;
+}
+
 export interface WorktreeAuditContext {
   source: WorktreeAuditSource;
   sessionId?: string;
@@ -466,14 +471,14 @@ export class WorktreeManager {
     });
   }
 
-  async listWorktrees(projectPath: string, commandRunner: CommandRunner): Promise<Array<{ path: string; branch: string }>> {
+  async listWorktrees(projectPath: string, commandRunner: CommandRunner): Promise<WorktreeEntry[]> {
     try {
       const { stdout } = await commandRunner.execAsync(`git worktree list --porcelain`, projectPath);
       
-      const worktrees: Array<{ path: string; branch: string }> = [];
+      const worktrees: WorktreeEntry[] = [];
       const lines = stdout.split('\n');
       
-      let currentWorktree: { path?: string; branch?: string } = {};
+      let currentWorktree: Partial<WorktreeEntry> = {};
       
       for (const line of lines) {
         if (line.startsWith('worktree ')) {

--- a/main/src/utils/nodeFinder.ts
+++ b/main/src/utils/nodeFinder.ts
@@ -234,7 +234,11 @@ export function findCliNodeScript(cliExecutablePath: string): string | null {
       console.log(`[NodeFinder] Detected pnpm structure, searching for ${commandName} in ${pnpmDir}`);
 
       // Define known package mappings (command name -> package patterns)
-      const packageMappings: Record<string, { patterns: string[]; entryFiles: string[] }> = {
+      interface PackageMappingLookup {
+        [command: string]: { patterns: string[]; entryFiles: string[] };
+      }
+
+      const packageMappings: PackageMappingLookup = {
         'claude': {
           patterns: ['@anthropic-ai+claude-code@'],
           entryFiles: ['cli.js', 'dist/index.js', 'index.js']

--- a/main/src/utils/sessionValidation.ts
+++ b/main/src/utils/sessionValidation.ts
@@ -221,7 +221,12 @@ export function logValidationFailure(context: string, validation: ValidationResu
 /**
  * Helper to create a standardized validation error response
  */
-export function createValidationError(validation: ValidationResult): { success: false; error: string } {
+interface ValidationErrorResponse {
+  success: false;
+  error: string;
+}
+
+export function createValidationError(validation: ValidationResult): ValidationErrorResponse {
   return {
     success: false,
     error: validation.error || 'Validation failed'

--- a/main/src/utils/shellDetector.ts
+++ b/main/src/utils/shellDetector.ts
@@ -9,6 +9,11 @@ interface ShellInfo {
   args?: string[];
 }
 
+interface ShellCommand {
+  shell: string;
+  args: string[];
+}
+
 /**
  * Detects the user's default shell in a robust, cross-platform way
  */
@@ -217,7 +222,7 @@ export class ShellDetector {
    * @param command The command to execute
    * @returns Array of arguments to pass to spawn/exec
    */
-  static getShellCommandArgs(command: string, preferredShell?: string): { shell: string; args: string[] } {
+  static getShellCommandArgs(command: string, preferredShell?: string): ShellCommand {
     const shellInfo = this.getDefaultShell(preferredShell);
 
     switch (shellInfo.name) {

--- a/main/src/utils/wslUtils.ts
+++ b/main/src/utils/wslUtils.ts
@@ -6,6 +6,17 @@ const execFileAsync = promisify(execFile);
 // Cache WSL user's $HOME per distro (one-time detection per distro).
 const wslHomeCache = new Map<string, string>();
 
+interface WSLCommand {
+  file: string;
+  args: string[];
+}
+
+interface WSLShellSpawn {
+  path: string;
+  name: string;
+  args: string[];
+}
+
 /**
  * Get the WSL user's $HOME directory for a given distro, cached after first call.
  * Used to save files to the WSL-native filesystem (e.g. pasted images) so that
@@ -115,7 +126,7 @@ export function escapeForBashDoubleQuote(str: string): string {
  * Bypasses cmd.exe entirely, avoiding all cmd.exe escaping issues (%, ^, &, etc.).
  * If cwd provided, cd to it first inside the bash -c command.
  */
-export function getWSLExecArgs(command: string, distro: string, cwd?: string, extraEnv?: Record<string, string>): { file: string; args: string[] } {
+export function getWSLExecArgs(command: string, distro: string, cwd?: string, extraEnv?: Record<string, string>): WSLCommand {
   let bashCommand = command;
   if (cwd) {
     bashCommand = `cd ${escapeForBash(cwd)} && ${command}`;
@@ -156,11 +167,7 @@ export function buildWSLENV(varNames: readonly string[]): string {
  * Get shell spawn info for opening an interactive WSL terminal.
  * Returns shape compatible with ShellDetector's ShellInfo.
  */
-export function getWSLShellSpawn(distro: string, cwd?: string): {
-  path: string;
-  name: string;
-  args: string[];
-} {
+export function getWSLShellSpawn(distro: string, cwd?: string): WSLShellSpawn {
   // Use bash -c "cd ... && exec bash" instead of --cd flag.
   // The --cd flag is broken on many WSL versions (e.g., 2.5.9.0) for Linux paths.
   const args = ['-d', distro, '--'];

--- a/packages/runpane/src/localControl.ts
+++ b/packages/runpane/src/localControl.ts
@@ -814,8 +814,8 @@ export async function runPanesPin(parsed: ParsedArgs, pinned: boolean): Promise<
   const request: PanePinRequest = {
     paneId: parsed.paneId,
     pinned,
-    ...(parsed.dryRun ? { dryRun: true } : {}),
   };
+  if (parsed.dryRun) request.dryRun = true;
   await confirmPanePin(parsed, request);
 
   const result = await invokeDaemon('runpane:panes:pin', [request], panePinResultSchema, {
@@ -843,8 +843,8 @@ export async function runPanesRename(parsed: ParsedArgs): Promise<number> {
   const request: PaneRenameRequest = {
     paneId: parsed.paneId,
     name,
-    ...(parsed.dryRun ? { dryRun: true } : {}),
   };
+  if (parsed.dryRun) request.dryRun = true;
   await confirmPaneRename(parsed, request);
 
   const result = await invokeDaemon('runpane:panes:rename', [request], paneRenameResultSchema, {

--- a/packages/runpane/src/telemetry.ts
+++ b/packages/runpane/src/telemetry.ts
@@ -69,7 +69,16 @@ export interface WrapperTelemetryContext {
   exitCode?: number;
 }
 
-type WrapperTelemetryProperties = Record<string, string | number | boolean>;
+interface WrapperTelemetryProperties {
+  [key: string]: string | number | boolean;
+}
+
+interface WrapperTelemetryInput {
+  installId: string;
+  wrapperVersion: string;
+  invocation: WrapperInvocation;
+  context: WrapperTelemetryContext;
+}
 
 export function createInitialTelemetryContext(argv: string[]): WrapperTelemetryContext {
   const first = argv[0];
@@ -210,12 +219,7 @@ function detectNpmInvocation(
   return 'unknown';
 }
 
-export function buildWrapperTelemetryProperties(input: {
-  installId: string;
-  wrapperVersion: string;
-  invocation: WrapperInvocation;
-  context: WrapperTelemetryContext;
-}): WrapperTelemetryProperties {
+export function buildWrapperTelemetryProperties(input: WrapperTelemetryInput): WrapperTelemetryProperties {
   const { context } = input;
   const properties: WrapperTelemetryProperties = {
     install_id: input.installId,

--- a/playwright.shared.ts
+++ b/playwright.shared.ts
@@ -1,5 +1,9 @@
 const DEFAULT_PLAYWRIGHT_PORT = 4521;
 
+interface PlaywrightServerEnvironment {
+  [name: string]: string;
+}
+
 export function getPlaywrightPort(): number {
   const rawPort = process.env.PLAYWRIGHT_PORT || process.env.VITE_PORT || process.env.PORT;
   if (!rawPort) {
@@ -20,8 +24,8 @@ export function getPlaywrightBaseURL(port = getPlaywrightPort()): string {
 
 export function getPlaywrightServerEnv(
   port = getPlaywrightPort(),
-  extraEnv: Record<string, string> = {},
-): Record<string, string> {
+  extraEnv: PlaywrightServerEnvironment = {},
+): PlaywrightServerEnvironment {
   return {
     ...extraEnv,
     PORT: String(port),

--- a/scripts/test-runpane-contract.js
+++ b/scripts/test-runpane-contract.js
@@ -1215,7 +1215,11 @@ async function checkPaneRenameParity() {
 
   daemonClient.invokeDaemon = async (channel, args) => {
     calls.push({ channel, request: args[0] });
-    return { ok: true, ...(args[0].dryRun ? { dryRun: true } : {}), pane: { paneId: args[0].paneId, name: args[0].name } };
+    return {
+      ok: true,
+      dryRun: args[0].dryRun ? true : undefined,
+      pane: { paneId: args[0].paneId, name: args[0].name },
+    };
   };
   console.log = (line) => stdout.push(String(line));
 

--- a/shared/types/models.ts
+++ b/shared/types/models.ts
@@ -14,7 +14,7 @@ export interface CodexModelConfig {
   description: string;
 }
 
-export const CODEX_MODELS: Record<OpenAICodexModel, CodexModelConfig> = {
+export const CODEX_MODELS = {
   'auto': {
     id: 'auto',
     label: 'Auto',
@@ -30,7 +30,7 @@ export const CODEX_MODELS: Record<OpenAICodexModel, CodexModelConfig> = {
     label: 'GPT-5 Codex',
     description: 'GPT-5 optimized for coding tasks'
   }
-};
+} satisfies Record<OpenAICodexModel, CodexModelConfig>;
 
 // Helper function to get model configuration
 export function getCodexModelConfig(model: string): CodexModelConfig | undefined {

--- a/shared/types/paneChat.ts
+++ b/shared/types/paneChat.ts
@@ -10,11 +10,11 @@ export const PANE_CHAT_PANEL_ID = '__pane_chat_terminal__';
 export const PANE_CHAT_CODEX_PANEL_ID = '__pane_chat_terminal_codex__';
 export const PANE_CHAT_CURSOR_PANEL_ID = '__pane_chat_terminal_cursor__';
 
-const PANE_CHAT_PANEL_IDS: Record<PaneChatAgent, string> = {
+const PANE_CHAT_PANEL_IDS = {
   claude: PANE_CHAT_PANEL_ID,
   codex: PANE_CHAT_CODEX_PANEL_ID,
   cursor: PANE_CHAT_CURSOR_PANEL_ID,
-};
+} satisfies Record<PaneChatAgent, string>;
 
 export interface PaneChatState<TSession = unknown> {
   session: TSession;

--- a/shared/types/panels.ts
+++ b/shared/types/panels.ts
@@ -258,8 +258,18 @@ export interface PanelCapabilities {
   canAppearInWorktrees?: boolean; // Whether panel can appear in worktree sessions
 }
 
+interface PanelCapabilityRegistry {
+  terminal: PanelCapabilities;
+  diff: PanelCapabilities;
+  explorer: PanelCapabilities;
+  logs: PanelCapabilities;
+  dashboard: PanelCapabilities;
+  'setup-tasks': PanelCapabilities;
+  browser: PanelCapabilities;
+}
+
 // Panel Registry - Currently only terminal is implemented
-export const PANEL_CAPABILITIES: Record<ToolPanelType, PanelCapabilities> = {
+export const PANEL_CAPABILITIES: PanelCapabilityRegistry = {
   terminal: {
     canEmit: ['terminal:command_executed', 'terminal:exit', 'files:changed'],
     canConsume: [], // Terminal doesn't consume events in Phase 1-2

--- a/shared/types/remoteDaemon.ts
+++ b/shared/types/remoteDaemon.ts
@@ -444,14 +444,17 @@ export function remoteImportPayloadToProfile(
   profileId = createRemoteProfileId(),
 ): RemotePaneConnectionProfile {
   const normalizedPayload = normalizePaneRemoteConnectionImportPayload(payload);
-  return {
+  const profile: RemotePaneConnectionProfile = {
     id: profileId,
     label: normalizedPayload.label,
     baseUrl: normalizedPayload.baseUrl,
     token: normalizedPayload.token,
     transport: normalizedPayload.transport,
-    ...(normalizedPayload.tunnel ? { tunnel: normalizedPayload.tunnel } : {}),
   };
+  if (normalizedPayload.tunnel) {
+    profile.tunnel = normalizedPayload.tunnel;
+  }
+  return profile;
 }
 
 export function normalizePaneRemoteConnectionImportPayload<Value>(
@@ -461,14 +464,17 @@ export function normalizePaneRemoteConnectionImportPayload<Value>(
   const baseUrl = normalizeRemoteImportBaseUrl(decoded.baseUrl.trim());
   const tunnel = decoded.tunnel === undefined ? undefined : normalizeRemoteImportTunnel(decoded.tunnel);
 
-  return {
+  const payload: PaneRemoteConnectionImportPayload = {
     v: 1,
     label: decoded.label.trim(),
     baseUrl,
     token: decoded.token.trim(),
     transport: decoded.transport,
-    ...(tunnel ? { tunnel } : {}),
   };
+  if (tunnel) {
+    payload.tunnel = tunnel;
+  }
+  return payload;
 }
 
 export function normalizeRemoteDaemonConfig<Value>(value: Value): RemoteDaemonConfig {
@@ -503,21 +509,25 @@ export function normalizeRemoteDaemonConfig<Value>(value: Value): RemoteDaemonCo
     activeProfileId = null;
   }
 
-  return {
-    host: {
-      config: {
-        enabled: readBoolean(hostConfig.enabled, defaults.host.config.enabled),
-        listenHost: readString(hostConfig.listenHost, defaults.host.config.listenHost),
-        listenPort: readPort(hostConfig.listenPort, defaults.host.config.listenPort),
-        pairingRequired: readBoolean(hostConfig.pairingRequired, defaults.host.config.pairingRequired),
-        allowInsecureHttpOnLoopback: readBoolean(
-          hostConfig.allowInsecureHttpOnLoopback,
-          defaults.host.config.allowInsecureHttpOnLoopback,
-        ),
-      },
-      clients: [...clients],
-      ...(access ? { access } : {}),
+  const hostSettings: RemoteDaemonHostSettings = {
+    config: {
+      enabled: readBoolean(hostConfig.enabled, defaults.host.config.enabled),
+      listenHost: readString(hostConfig.listenHost, defaults.host.config.listenHost),
+      listenPort: readPort(hostConfig.listenPort, defaults.host.config.listenPort),
+      pairingRequired: readBoolean(hostConfig.pairingRequired, defaults.host.config.pairingRequired),
+      allowInsecureHttpOnLoopback: readBoolean(
+        hostConfig.allowInsecureHttpOnLoopback,
+        defaults.host.config.allowInsecureHttpOnLoopback,
+      ),
     },
+    clients: [...clients],
+  };
+  if (access) {
+    hostSettings.access = access;
+  }
+
+  return {
+    host: hostSettings,
     client: {
       profiles: [...profiles],
       activeProfileId,
@@ -539,11 +549,14 @@ function normalizeRemoteDaemonHostAccess(value: JsonValue | undefined): RemoteDa
       : normalizeRemoteImportTunnel(access.tunnel);
     const updatedAt = readRequiredString(access.updatedAt, 'Remote host access timestamp');
 
-    return {
+    const normalizedAccess: RemoteDaemonHostAccess = {
       baseUrl,
-      ...(tunnel ? { tunnel } : {}),
       updatedAt,
     };
+    if (tunnel) {
+      normalizedAccess.tunnel = tunnel;
+    }
+    return normalizedAccess;
   } catch {
     return undefined;
   }
@@ -557,13 +570,14 @@ function normalizeRemoteImportTunnel(
     ? undefined
     : readRemoteTunnelIp(decoded.tailscaleIp);
 
-  return {
+  const tunnel: NonNullable<PaneRemoteConnectionImportPayload['tunnel']> = {
     kind: decoded.kind,
     selected: decoded.selected,
-    ...(decoded.command ? { command: decoded.command.trim() } : {}),
-    ...(decoded.note ? { note: decoded.note.trim() } : {}),
-    ...(tailscaleIp ? { tailscaleIp } : {}),
   };
+  if (decoded.command) tunnel.command = decoded.command.trim();
+  if (decoded.note) tunnel.note = decoded.note.trim();
+  if (tailscaleIp) tunnel.tailscaleIp = tailscaleIp;
+  return tunnel;
 }
 
 function readRemoteTunnelIp(value: JsonValue): string {


### PR DESCRIPTION
## Summary
- replace widened anonymous return and dictionary types with named owner contracts
- make optional property construction explicit instead of conditional empty spreads
- remove chained test assertions while preserving the modeled seams
- reduce the Phase 3a inventory from 119 targeted findings to zero

Closes #403 (partial)

## Validation
- `pnpm lint`
- `pnpm typecheck`
- Phase 3a advisory scan: 0 targeted findings
- frontend Vitest: 161/161
- main Vitest: 595/595
- RunPane CLI contract checks
- full signed universal macOS build (`pnpm build`)
- post-build Node 22 native ABI smoke: 4/4 database tests
