### PR TITLE
Phase 3b: preserve frontend finite contracts

### DIFF
--- a/frontend/src/components/PaneChatView.tsx
+++ b/frontend/src/components/PaneChatView.tsx
@@ -24,11 +24,11 @@ const ALL_PANE_CHAT_AGENT_OPTIONS: Array<{
 const visiblePaneChatAgents = new Set(visibleAgentPresets().map(preset => preset.id));
 const PANE_CHAT_AGENT_OPTIONS = ALL_PANE_CHAT_AGENT_OPTIONS.filter(option => visiblePaneChatAgents.has(option.id));
 
-const PANE_CHAT_AGENT_LABELS: Record<PaneChatAgent, string> = {
+const PANE_CHAT_AGENT_LABELS = {
   claude: 'Claude',
   codex: 'Codex',
   cursor: 'Cursor',
-};
+} satisfies Record<PaneChatAgent, string>;
 
 export function PaneChatView() {
   const [state, setState] = useState<PaneChatState<Session> | null>(null);

--- a/frontend/src/components/PermissionDialog.tsx
+++ b/frontend/src/components/PermissionDialog.tsx
@@ -17,6 +17,26 @@ interface PermissionDialogProps {
   session?: { name: string };
 }
 
+const TOOL_DESCRIPTIONS = {
+  Bash: 'Execute shell commands',
+  Write: 'Write files to disk',
+  Edit: 'Modify existing files',
+  MultiEdit: 'Make multiple edits to a file',
+  Delete: 'Delete files or directories',
+  Move: 'Move or rename files',
+  Read: 'Read file contents',
+  Grep: 'Search file contents',
+  WebFetch: 'Fetch content from the web',
+  WebSearch: 'Search the web',
+};
+
+function getToolDescription(toolName: string): string {
+  for (const [key, description] of Object.entries(TOOL_DESCRIPTIONS)) {
+    if (toolName.includes(key)) return description;
+  }
+  return 'Perform an action';
+}
+
 export const PermissionDialog: React.FC<PermissionDialogProps> = ({ request, onRespond, session }) => {
   const [editMode, setEditMode] = useState(false);
   const [editedInput, setEditedInput] = useState('');
@@ -53,28 +73,6 @@ export const PermissionDialog: React.FC<PermissionDialogProps> = ({ request, onR
       return toolName.substring(5).replace(/__/g, ' → ');
     }
     return toolName;
-  };
-
-  const getToolDescription = (toolName: string) => {
-    const descriptions = {
-      'Bash': 'Execute shell commands',
-      'Write': 'Write files to disk',
-      'Edit': 'Modify existing files',
-      'MultiEdit': 'Make multiple edits to a file',
-      'Delete': 'Delete files or directories',
-      'Move': 'Move or rename files',
-      'Read': 'Read file contents',
-      'Grep': 'Search file contents',
-      'WebFetch': 'Fetch content from the web',
-      'WebSearch': 'Search the web',
-    };
-    
-    for (const [key, desc] of Object.entries(descriptions)) {
-      if (toolName.includes(key)) {
-        return desc;
-      }
-    }
-    return 'Perform an action';
   };
 
   const isHighRisk = (toolName: string) => {

--- a/frontend/src/components/PermissionDialog.tsx
+++ b/frontend/src/components/PermissionDialog.tsx
@@ -56,7 +56,7 @@ export const PermissionDialog: React.FC<PermissionDialogProps> = ({ request, onR
   };
 
   const getToolDescription = (toolName: string) => {
-    const descriptions: Record<string, string> = {
+    const descriptions = {
       'Bash': 'Execute shell commands',
       'Write': 'Write files to disk',
       'Edit': 'Modify existing files',

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -47,7 +47,7 @@ import {
   type DropZone,
 } from '../utils/panelLayout';
 import { Download, Upload, GitMerge, GitPullRequestArrow, Terminal, ChevronDown, ChevronUp, RefreshCw, Archive, ArchiveRestore, GitCommitHorizontal, TerminalSquare, Undo2, X } from 'lucide-react';
-import { getCliBrandIcon } from './ui/BrandIcons';
+import { getCliBrandIcon } from './ui/brandIconRegistry';
 import { visibleAgentPresets } from '../utils/agentPresets';
 import type { Project } from '../types/project';
 import { devLog, renderLog } from '../utils/console';

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -11,7 +11,7 @@ import { formatKeyDisplay } from '../../utils/hotkeyUtils';
 import { useHotkeyStore } from '../../stores/hotkeyStore';
 import { Tooltip } from '../ui/Tooltip';
 import { Kbd } from '../ui/Kbd';
-import { CLI_BRAND_ICONS, getCliBrandIcon } from '../ui/BrandIcons';
+import { CLI_BRAND_ICONS, getCliBrandIcon } from '../ui/brandIconRegistry';
 import { visibleAgentPresets } from '../../utils/agentPresets';
 import { PanelTabStrip } from './PanelTabStrip';
 import type { WorktreeFileSyncEntry } from '../../../../shared/types/worktreeFileSync';

--- a/frontend/src/components/panels/PanelTabStrip.tsx
+++ b/frontend/src/components/panels/PanelTabStrip.tsx
@@ -14,7 +14,7 @@ import { formatKeyDisplay } from '../../utils/hotkeyUtils';
 import { Tooltip } from '../ui/Tooltip';
 import { Kbd } from '../ui/Kbd';
 import { usePanelStore } from '../../stores/panelStore';
-import { getCliBrandIcon } from '../ui/BrandIcons';
+import { getCliBrandIcon } from '../ui/brandIconRegistry';
 import { PanelTabStatusDot } from './PanelTabStatusDot';
 import type { PanelTabPresentationResolver } from '../../types/panelComponents';
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -39,6 +39,11 @@ import { areKeyboardShortcutsEnabled, useConfigStore } from '../../stores/config
 import type { InterceptorState, TerminalSuggestion } from '../../services/terminalInterceptor/types';
 import '@xterm/xterm/css/xterm.css';
 
+interface DropdownPosition {
+  x: number;
+  y: number;
+}
+
 // Hold the loading overlay at least this long past ready so the terminal
 // underneath finishes painting before it is revealed.
 const TERMINAL_OVERLAY_LINGER_MS = 150;
@@ -824,7 +829,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     }
   }, [keyboardShortcutsEnabled, openSearch]);
 
-  const getDropdownPosition = useCallback((): { x: number; y: number } => {
+  const getDropdownPosition = useCallback((): DropdownPosition => {
     const container = terminalRef.current;
     const terminal = xtermRef.current;
     if (!container) return { x: 0, y: 0 };

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -19,6 +19,10 @@ import { areKeyboardShortcutsEnabled, useConfigStore } from '../../../stores/con
 import { LiveRegion } from '../../ui/LiveRegion';
 import { boundary, decodeBoundary } from '../../../../../shared/validation/boundaryDecoder';
 
+interface LanguageByExtension {
+  [extension: string]: string;
+}
+
 interface FileItem {
   name: string;
   path: string;
@@ -1765,7 +1769,7 @@ export function FileEditor({
 
 function getLanguageFromPath(filePath: string): string {
   const ext = filePath.split('.').pop()?.toLowerCase();
-  const languageMap: Record<string, string> = {
+  const languageMap: LanguageByExtension = {
     js: 'javascript',
     jsx: 'javascript',
     ts: 'typescript',

--- a/frontend/src/components/settings/categories/AIAgentsSettings.tsx
+++ b/frontend/src/components/settings/categories/AIAgentsSettings.tsx
@@ -10,11 +10,11 @@ import { API } from '../../../utils/api';
 import type { PaneChatAgent } from '../../../../../shared/types/paneChat';
 import { visibleAgentPresets } from '../../../utils/agentPresets';
 
-const PANE_CHAT_AGENT_LABELS: Record<PaneChatAgent, string> = {
+const PANE_CHAT_AGENT_LABELS = {
   claude: 'Claude',
   codex: 'Codex',
   cursor: 'Cursor',
-};
+} satisfies Record<PaneChatAgent, string>;
 
 const paneChatAgentOptions = visibleAgentPresets().map(({ id }) => ({ id, label: PANE_CHAT_AGENT_LABELS[id] }));
 

--- a/frontend/src/components/settings/useSettingsPersistence.ts
+++ b/frontend/src/components/settings/useSettingsPersistence.ts
@@ -13,19 +13,19 @@ import { useConfigStore } from '../../stores/configStore';
 
 type PreferenceName = keyof SettingsPreferenceValues;
 
-const PREFERENCE_KEY_BY_NAME: Record<PreferenceName, string> = {
+const PREFERENCE_KEY_BY_NAME = {
   autoRenameSessionsToPr: SETTINGS_PREFERENCE_KEYS.autoRenameSessionsToPr,
   sidebarPaneRowLayout: SETTINGS_PREFERENCE_KEYS.sidebarPaneRowLayout,
   atTerminalPasteMode: SETTINGS_PREFERENCE_KEYS.atTerminalPasteMode,
   atTerminalLineCount: SETTINGS_PREFERENCE_KEYS.atTerminalLineCount,
-};
+} satisfies Record<PreferenceName, string>;
 
-const PREFERENCE_SETTING_ID: Record<PreferenceName, SettingsSettingId> = {
+const PREFERENCE_SETTING_ID = {
   autoRenameSessionsToPr: 'auto-rename-pr',
   sidebarPaneRowLayout: 'sidebar-pane-rows',
   atTerminalPasteMode: 'terminal-reference-paste-mode',
   atTerminalLineCount: 'terminal-reference-line-count',
-};
+} satisfies Record<PreferenceName, SettingsSettingId>;
 
 export function useSettingsPersistence(isOpen: boolean) {
   const { config, isLoading, error: configError, fetchConfig, updateConfig } = useConfigStore();

--- a/frontend/src/components/terminal/linkProviders/fileLinkProvider.ts
+++ b/frontend/src/components/terminal/linkProviders/fileLinkProvider.ts
@@ -2,6 +2,12 @@ import type { ILink, ILinkProvider } from '@xterm/xterm';
 import type { LinkProviderConfig } from './types';
 import { isMac, isWindows, getModifierKeyName } from '../../../utils/platformUtils';
 
+interface ParsedFilePath {
+  path: string;
+  line?: number;
+  col?: number;
+}
+
 /**
  * Parse a WSL UNC path to extract distribution name.
  * Handles \\wsl.localhost\Distro\... and \\wsl$\Distro\...
@@ -42,7 +48,7 @@ export function createFileLinkProvider(config: LinkProviderConfig): ILinkProvide
    * Parse line and column numbers from file path
    * Example: "file.ts:42:10" -> { path: "file.ts", line: 42, col: 10 }
    */
-  function parseFilePath(match: string): { path: string; line?: number; col?: number } {
+  function parseFilePath(match: string): ParsedFilePath {
     const lineMatch = match.match(/:(\d+)(?::(\d+))?$/);
     if (lineMatch) {
       return {

--- a/frontend/src/components/ui/BrandIcons.tsx
+++ b/frontend/src/components/ui/BrandIcons.tsx
@@ -34,7 +34,7 @@ export const CursorIcon: React.FC<BrandIconProps> = ({ className = 'w-4 h-4' }) 
 /**
  * Google Gemini brand icon from simple-icons
  */
-const GeminiIcon: React.FC<BrandIconProps> = ({ className = 'w-4 h-4' }) => (
+export const GeminiIcon: React.FC<BrandIconProps> = ({ className = 'w-4 h-4' }) => (
   <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
     <path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" />
   </svg>
@@ -43,34 +43,8 @@ const GeminiIcon: React.FC<BrandIconProps> = ({ className = 'w-4 h-4' }) => (
 /**
  * Aider brand icon — stylized "A" mark (no official simple-icons entry)
  */
-const AiderIcon: React.FC<BrandIconProps> = ({ className = 'w-4 h-4' }) => (
+export const AiderIcon: React.FC<BrandIconProps> = ({ className = 'w-4 h-4' }) => (
   <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
     <path d="M12 2L3 20h3.5l1.8-4h7.4l1.8 4H21L12 2zm0 6.5L14.9 14H9.1L12 8.5z" />
   </svg>
 );
-
-/**
- * Lookup map: CLI command keyword -> brand icon component.
- * Used to dynamically show the right icon for any terminal panel.
- */
-export const CLI_BRAND_ICONS = {
-  claude: ClaudeIcon,
-  codex: OpenAIIcon,
-  cursor: CursorIcon,
-  gemini: GeminiIcon,
-  aider: AiderIcon,
-};
-
-/**
- * Returns the matching brand icon element for a given command/title string,
- * or null if no brand matches. Checks both the name and command against all keywords.
- */
-export function getCliBrandIcon(nameOrCommand: string, className = 'w-4 h-4'): React.ReactElement | null {
-  const lower = nameOrCommand.toLowerCase();
-  for (const [keyword, IconComponent] of Object.entries(CLI_BRAND_ICONS)) {
-    if (lower.includes(keyword)) {
-      return <IconComponent className={className} />;
-    }
-  }
-  return null;
-}

--- a/frontend/src/components/ui/BrandIcons.tsx
+++ b/frontend/src/components/ui/BrandIcons.tsx
@@ -53,7 +53,7 @@ const AiderIcon: React.FC<BrandIconProps> = ({ className = 'w-4 h-4' }) => (
  * Lookup map: CLI command keyword -> brand icon component.
  * Used to dynamically show the right icon for any terminal panel.
  */
-export const CLI_BRAND_ICONS: Record<string, React.FC<BrandIconProps>> = {
+export const CLI_BRAND_ICONS = {
   claude: ClaudeIcon,
   codex: OpenAIIcon,
   cursor: CursorIcon,

--- a/frontend/src/components/ui/StatusAccentBar.tsx
+++ b/frontend/src/components/ui/StatusAccentBar.tsx
@@ -9,12 +9,12 @@ interface StatusAccentBarProps {
   className?: string;
 }
 
-const barColor: Record<Exclude<AgentDisplayStatus, 'unknown'>, string> = {
+const barColor = {
   blocked: 'bg-status-error',
   working: 'bg-status-info',
   done: 'bg-status-info',
   idle: 'bg-status-success',
-};
+} satisfies Record<Exclude<AgentDisplayStatus, 'unknown'>, string>;
 
 /**
  * The always-present left accent bar on a session row. It follows the at-a-glance

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -16,6 +16,7 @@ export interface TooltipProps extends Omit<React.HTMLAttributes<HTMLElement>, 'c
 }
 
 const GAP = 6;
+type TooltipSide = NonNullable<TooltipProps['side']>;
 
 export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
   content,
@@ -132,19 +133,19 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
     .filter(Boolean)
     .join(' ') || undefined;
 
-  const arrowBorder: Record<string, string> = {
+  const arrowBorder = {
     top: 'border-l-transparent border-r-transparent border-b-transparent border-t-bg-tertiary',
     bottom: 'border-l-transparent border-r-transparent border-t-transparent border-b-bg-tertiary',
     left: 'border-t-transparent border-b-transparent border-r-transparent border-l-bg-tertiary',
     right: 'border-t-transparent border-b-transparent border-l-transparent border-r-bg-tertiary',
-  };
+  } satisfies Record<TooltipSide, string>;
 
-  const arrowStyle: Record<string, React.CSSProperties> = {
+  const arrowStyle = {
     top: { bottom: -8, left: '50%', transform: 'translateX(-50%)' },
     bottom: { top: -8, left: '50%', transform: 'translateX(-50%)' },
     left: { right: -8, top: '50%', transform: 'translateY(-50%)' },
     right: { left: -8, top: '50%', transform: 'translateY(-50%)' },
-  };
+  } satisfies Record<TooltipSide, React.CSSProperties>;
 
   const setTriggerRef = useCallback((node: HTMLElement | null) => {
     triggerRef.current = node;

--- a/frontend/src/components/ui/Tooltip.tsx
+++ b/frontend/src/components/ui/Tooltip.tsx
@@ -17,6 +17,18 @@ export interface TooltipProps extends Omit<React.HTMLAttributes<HTMLElement>, 'c
 
 const GAP = 6;
 type TooltipSide = NonNullable<TooltipProps['side']>;
+const ARROW_BORDER = {
+  top: 'border-l-transparent border-r-transparent border-b-transparent border-t-bg-tertiary',
+  bottom: 'border-l-transparent border-r-transparent border-t-transparent border-b-bg-tertiary',
+  left: 'border-t-transparent border-b-transparent border-r-transparent border-l-bg-tertiary',
+  right: 'border-t-transparent border-b-transparent border-l-transparent border-r-bg-tertiary',
+} satisfies Record<TooltipSide, string>;
+const ARROW_STYLE = {
+  top: { bottom: -8, left: '50%', transform: 'translateX(-50%)' },
+  bottom: { top: -8, left: '50%', transform: 'translateX(-50%)' },
+  left: { right: -8, top: '50%', transform: 'translateY(-50%)' },
+  right: { left: -8, top: '50%', transform: 'translateY(-50%)' },
+} satisfies Record<TooltipSide, React.CSSProperties>;
 
 export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
   content,
@@ -133,20 +145,6 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
     .filter(Boolean)
     .join(' ') || undefined;
 
-  const arrowBorder = {
-    top: 'border-l-transparent border-r-transparent border-b-transparent border-t-bg-tertiary',
-    bottom: 'border-l-transparent border-r-transparent border-t-transparent border-b-bg-tertiary',
-    left: 'border-t-transparent border-b-transparent border-r-transparent border-l-bg-tertiary',
-    right: 'border-t-transparent border-b-transparent border-l-transparent border-r-bg-tertiary',
-  } satisfies Record<TooltipSide, string>;
-
-  const arrowStyle = {
-    top: { bottom: -8, left: '50%', transform: 'translateX(-50%)' },
-    bottom: { top: -8, left: '50%', transform: 'translateX(-50%)' },
-    left: { right: -8, top: '50%', transform: 'translateY(-50%)' },
-    right: { left: -8, top: '50%', transform: 'translateY(-50%)' },
-  } satisfies Record<TooltipSide, React.CSSProperties>;
-
   const setTriggerRef = useCallback((node: HTMLElement | null) => {
     triggerRef.current = node;
     if (forwardedRef instanceof Function) forwardedRef(node);
@@ -204,8 +202,8 @@ export const Tooltip = React.forwardRef<HTMLElement, TooltipProps>(({
         >
           {content}
           <div
-            className={cn('absolute w-0 h-0 border-4', arrowBorder[side])}
-            style={arrowStyle[side]}
+            className={cn('absolute w-0 h-0 border-4', ARROW_BORDER[side])}
+            style={ARROW_STYLE[side]}
           />
         </div>,
         portalContainer ?? document.body

--- a/frontend/src/components/ui/brandIconRegistry.ts
+++ b/frontend/src/components/ui/brandIconRegistry.ts
@@ -1,0 +1,20 @@
+import { createElement, type ReactElement } from 'react';
+import { AiderIcon, ClaudeIcon, CursorIcon, GeminiIcon, OpenAIIcon } from './BrandIcons';
+
+/** Lookup map used to dynamically show the right icon for any terminal panel. */
+export const CLI_BRAND_ICONS = {
+  claude: ClaudeIcon,
+  codex: OpenAIIcon,
+  cursor: CursorIcon,
+  gemini: GeminiIcon,
+  aider: AiderIcon,
+};
+
+/** Returns the matching brand icon for a command or title, if one is known. */
+export function getCliBrandIcon(nameOrCommand: string, className = 'w-4 h-4'): ReactElement | null {
+  const normalizedName = nameOrCommand.toLowerCase();
+  for (const [keyword, IconComponent] of Object.entries(CLI_BRAND_ICONS)) {
+    if (normalizedName.includes(keyword)) return createElement(IconComponent, { className });
+  }
+  return null;
+}

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -4,7 +4,7 @@ import { useConfigStore } from '../stores/configStore';
 type Theme = 'light' | 'light-rounded' | 'dark' | 'oled' | 'dusk' | 'dusk-oled' | 'forge' | 'ember' | 'aurora' | 'night-owl' | 'night-owl-oled' | 'terracotta';
 
 const VALID_THEMES = new Set<string>(['light', 'light-rounded', 'dark', 'oled', 'dusk', 'dusk-oled', 'forge', 'ember', 'aurora', 'night-owl', 'night-owl-oled', 'terracotta']);
-const THEME_CLASSES: Record<Theme, string[]> = {
+const THEME_CLASSES = {
   'light': ['light'],
   'light-rounded': ['light', 'light-rounded'],
   'dark': ['dark'],
@@ -17,7 +17,7 @@ const THEME_CLASSES: Record<Theme, string[]> = {
   'night-owl': ['dark', 'night-owl'],
   'night-owl-oled': ['dark', 'night-owl', 'night-owl-oled'],
   'terracotta': ['dark', 'terracotta'],
-};
+} satisfies Record<Theme, string[]>;
 const isValidTheme = (theme: string): theme is Theme => VALID_THEMES.has(theme);
 
 interface ThemeContextType {

--- a/frontend/src/hooks/useIPCEvents.ts
+++ b/frontend/src/hooks/useIPCEvents.ts
@@ -65,14 +65,16 @@ function validateEventSession(eventData: ValidatedEventData, activeSessionId?: s
 
 
 // Throttle utility with external drain support
+interface ThrottledWithDrain<T extends (...args: never[]) => void> {
+  throttled: (...args: Parameters<T>) => void;
+  drain: (sessionId: string) => void;
+}
+
 function createThrottledWithDrain<T extends (...args: never[]) => void>(
   fn: T,
   delayMs: number,
   keyFn: (...args: Parameters<T>) => string,
-): {
-  throttled: (...args: Parameters<T>) => void;
-  drain: (sessionId: string) => void;
-} {
+): ThrottledWithDrain<T> {
   const pendingCalls = new Map<string, Parameters<T>>();
   let lastCallTime = 0;
   let timeoutId: NodeJS.Timeout | null = null;

--- a/frontend/src/hooks/useShortcutHintsOverlay.ts
+++ b/frontend/src/hooks/useShortcutHintsOverlay.ts
@@ -3,7 +3,11 @@ import { areKeyboardShortcutsEnabled, useConfigStore } from '../stores/configSto
 
 const HOLD_DELAY_MS = 300;
 
-export function useShortcutHintsOverlay(): { isVisible: boolean } {
+interface ShortcutHintsOverlayState {
+  isVisible: boolean;
+}
+
+export function useShortcutHintsOverlay(): ShortcutHintsOverlayState {
   const keyboardShortcutsEnabled = useConfigStore((state) => areKeyboardShortcutsEnabled(state.config));
   const [isVisible, setIsVisible] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/frontend/src/remote/components/RemotePanelTabs.tsx
+++ b/frontend/src/remote/components/RemotePanelTabs.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import type { RemotePwaCustomCommand } from '../../../../shared/types/remoteDaemon';
 import type { ToolPanel } from '../../../../shared/types/panels';
 import { AGENT_LAUNCH_PRESETS } from '../../../../shared/constants/agentLaunchPresets';
-import { getCliBrandIcon } from '../../components/ui/BrandIcons';
+import { getCliBrandIcon } from '../../components/ui/brandIconRegistry';
 
 // The remote host executes these commands. Until its platform capabilities are
 // exposed here, the viewer's browser platform must not hide valid host tools.

--- a/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
+++ b/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
@@ -471,7 +471,12 @@ interface ParsedSseEvent {
   data: string;
 }
 
-export function parseSseEvents(buffer: string): { events: ParsedSseEvent[]; rest: string } {
+interface ParsedSseBatch {
+  events: ParsedSseEvent[];
+  rest: string;
+}
+
+export function parseSseEvents(buffer: string): ParsedSseBatch {
   const events: ParsedSseEvent[] = [];
   let rest = buffer;
   let boundary = rest.indexOf('\n\n');

--- a/frontend/src/services/posthog.ts
+++ b/frontend/src/services/posthog.ts
@@ -31,8 +31,18 @@ export interface PostHogInitOptions {
   flushPendingEvents?: boolean;
 }
 
-function compactProperties(properties: AnalyticsProperties): Record<string, JsonValue> {
-  const compacted: Record<string, JsonValue> = {};
+interface CompactAnalyticsProperties {
+  [key: string]: JsonValue;
+}
+
+interface DirectCaptureTarget {
+  token: string;
+  host: string;
+  distinctId: string;
+}
+
+function compactProperties(properties: AnalyticsProperties): CompactAnalyticsProperties {
+  const compacted: CompactAnalyticsProperties = {};
   for (const [key, value] of Object.entries(properties)) {
     if (value !== undefined) compacted[key] = value;
   }
@@ -87,7 +97,7 @@ function identifyUser(config: PostHogConfig): void {
   posthog.identify(config.identity.distinctId, personProperties(config.identity));
 }
 
-function directCaptureTarget(identity = currentIdentity): { token: string; host: string; distinctId: string } {
+function directCaptureTarget(identity = currentIdentity): DirectCaptureTarget {
   const posthogDistinctId = posthog.get_distinct_id?.();
 
   return {

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -76,7 +76,11 @@ const MODIFIER_ORDER = ['mod', 'alt', 'shift'] as const;
 
 // Punctuation codes resolved via e.code when Alt is held; macOS Option modifies
 // e.key for these too (e.g. Option+/ produces '÷' on some layouts)
-const ALT_PUNCTUATION_CODES: Record<string, string> = {
+interface AlternatePunctuationCodes {
+  [code: string]: string;
+}
+
+const ALT_PUNCTUATION_CODES: AlternatePunctuationCodes = {
   Slash: '/',
   Comma: ',',
   Period: '.',

--- a/frontend/src/utils/hotkeyUtils.ts
+++ b/frontend/src/utils/hotkeyUtils.ts
@@ -24,7 +24,7 @@ export const CATEGORY_ORDER: HotkeyDefinition['category'][] = [
   'debug',
 ];
 
-export const CATEGORY_LABELS: Record<HotkeyDefinition['category'], string> = {
+export const CATEGORY_LABELS = {
   navigation: 'Navigation',
   session: 'Projects',
   tabs: 'Tabs',
@@ -32,7 +32,7 @@ export const CATEGORY_LABELS: Record<HotkeyDefinition['category'], string> = {
   tools: 'Add Tool',
   shortcuts: 'Shortcuts',
   debug: 'Debug',
-};
+} satisfies Record<HotkeyDefinition['category'], string>;
 
 export function formatKeyDisplay(keys: string): string {
   const isMacPlatform = isMac();

--- a/frontend/src/utils/panelLayout.ts
+++ b/frontend/src/utils/panelLayout.ts
@@ -13,6 +13,11 @@ import type {
   SessionPanelLayout,
 } from '../../../shared/types/panels';
 
+interface ReconciledPanelLayout {
+  layout: SessionPanelLayout;
+  changed: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -446,7 +451,7 @@ export function removePanelFromLayout(
 export function reconcile(
   layout: SessionPanelLayout,
   livePanelIds: string[],
-): { layout: SessionPanelLayout; changed: boolean } {
+): ReconciledPanelLayout {
   const liveSet = new Set(livePanelIds);
   let changed = false;
   // A panel id may only appear once across the whole tree; keep the first

--- a/frontend/src/utils/terminalTheme.ts
+++ b/frontend/src/utils/terminalTheme.ts
@@ -1,3 +1,9 @@
+import type { ITheme } from '@xterm/xterm';
+
+interface TerminalColorFallbacks {
+  [variable: string]: { light: string; dark: string };
+}
+
 // Convert rgb(r g b) format to hex format
 const rgbToHex = (rgb: string): string => {
   // Check if already in hex format
@@ -35,7 +41,7 @@ const getCSSVariable = (name: string): string => {
   const isForge = document.documentElement.classList.contains('forge');
 
   // Define theme-aware fallbacks (already in hex format)
-  const fallbacks: Record<string, { light: string; dark: string }> = {
+  const fallbacks: TerminalColorFallbacks = {
     '--color-terminal-bg': { light: '#ffffff', dark: '#111827' },
     '--color-terminal-fg': { light: '#1e2026', dark: '#f3f4f6' },
     '--color-terminal-cursor': { light: '#6366f1', dark: '#818cf8' },
@@ -58,12 +64,12 @@ const getCSSVariable = (name: string): string => {
 };
 
 // Terminal theme generator that reads from CSS variables
-export const getTerminalTheme = () => {
+export const getTerminalTheme = (): ITheme => {
   // Only set when the theme defines it (no fallback — dark themes keep xterm's default selection)
   const selectionBg = getComputedStyle(document.documentElement)
     .getPropertyValue('--color-terminal-selection-bg')
     .trim();
-  return {
+  const theme: ITheme = {
     background: getCSSVariable('--color-terminal-bg'),
     foreground: getCSSVariable('--color-terminal-fg'),
     cursor: getCSSVariable('--color-terminal-cursor'),
@@ -83,8 +89,9 @@ export const getTerminalTheme = () => {
     brightMagenta: getCSSVariable('--color-terminal-bright-magenta'),
     brightCyan: getCSSVariable('--color-terminal-bright-cyan'),
     brightWhite: getCSSVariable('--color-terminal-bright-white'),
-    ...(selectionBg ? { selectionBackground: selectionBg } : {}),
   };
+  if (selectionBg) theme.selectionBackground = selectionBg;
+  return theme;
 };
 
 // Script terminal theme (slightly different background for better UI integration)

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 import { expectNoAxeViolations } from './axeTest';
 import { installElectronApiMock } from './electronApiMock';
+import type { JsonValue } from '../shared/validation/boundaryDecoder';
 
 const project = {
   id: 1,
@@ -177,7 +178,7 @@ async function openConnectedRemote(page: Page): Promise<void> {
 
     // SAFETY: the test route receives the remote invoke envelope emitted by this fixture.
     const body = JSON.parse(request.postData() ?? '{}') as { channel?: string };
-    let result: unknown = null;
+    let result: JsonValue = null;
     switch (body.channel) {
       case 'sessions:get-all-with-projects':
         result = [remoteProject];

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -67,7 +67,10 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     const listeners = new Map<string, Set<MockEventCallback>>();
     const pendingPermissions: PanePermissionRequest[] = [];
     const clone = <T>(value: T): T => structuredClone(value);
-    const preferences: Record<string, string> = {
+    interface MockPreferences {
+      [key: string]: string;
+    }
+    const preferences: MockPreferences = {
       analytics_consent_shown: mockOptions.analyticsConsentShown === false ? 'false' : 'true',
       ...clone(mockOptions.initialPreferences ?? {}),
     };


### PR DESCRIPTION
## Summary
- replace widened frontend lookup and return types with finite inferred or named contracts
- make terminal selection-theme omission explicit
- preserve typed accessibility route results without widening to unknown
- reduce the refreshed Phase 3b inventory from 33 targeted findings to zero

Closes #403 (partial)

## Validation
- `pnpm lint`
- `pnpm typecheck`
- Phase 3b advisory scan: 0 targeted findings
- frontend Vitest: 161/161
- accessibility Playwright: 8/8
- full signed universal macOS build (`pnpm build`)
- post-build Node 22 native ABI smoke: 4/4 database tests
