### PR TITLE
Remove deterministic ESLint warnings (phase 3a)

### DIFF
--- a/frontend/src/components/terminal/SelectionPopover.tsx
+++ b/frontend/src/components/terminal/SelectionPopover.tsx
@@ -23,7 +23,7 @@ const URL_PATTERN = /https?:\/\/[^\s<>"{}|\\^`[\]]+/;
 // File path patterns - detect Unix paths, Windows paths, and relative paths with extensions
 const FILE_PATH_PATTERNS = [
   /^[.~]?\/[\w\-./]+/, // Unix absolute or relative paths starting with / ./ ~/
-  /^[A-Za-z]:[\\\/][\w\-.\\/]+/, // Windows absolute paths C:\ or C:/
+  /^[A-Za-z]:[\\/][\w\-.\\/]+/, // Windows absolute paths C:\ or C:/
   /^[\w\-./\\]+\.[a-z]{1,10}(:\d+)?$/i, // Relative paths with extension like foo.ts, foo.ts:42, or dir\foo.ts
 ];
 

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -55,7 +55,7 @@ interface RawCommitData {
 
 function isValidGitUrl(url: string): boolean {
   // Accept https://, ssh://, and scp-style git@host:path formats
-  return /^(https?:\/\/[\w.\-\/:@]+|ssh:\/\/[\w.\-\/:@]+|git@[\w.\-]+:[\w.\-\/]+)(\.git)?$/.test(url);
+  return /^(https?:\/\/[\w./:@-]+|ssh:\/\/[\w./:@-]+|git@[\w.-]+:[\w./-]+)(\.git)?$/.test(url);
 }
 
 function extractRepoName(url: string): string {

--- a/main/src/ptyHost/ptyHostMain.ts
+++ b/main/src/ptyHost/ptyHostMain.ts
@@ -38,13 +38,11 @@ import { boundary, decodeBoundary, type JsonValue } from '../../../shared/valida
 // `terminalPanelManager.ts:1`. We use a typed `require` here because this
 // UtilityProcess entry is deliberately self-contained; importing via
 // `import * as pty` would couple to main's module graph.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 // SAFETY: This package's CommonJS entry exports the same typed node-pty API.
 const pty = require('@lydell/node-pty') as typeof import('@lydell/node-pty');
 
 // Electron exposes UtilityProcess parentPort on `process.parentPort` in this
 // runtime. Keep the module export as a compatibility fallback.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 // SAFETY: Electron's UtilityProcess runtime exposes the documented HostPort surface.
 const electron = require('electron') as { parentPort?: typeof process.parentPort };
 

--- a/main/src/services/mcpPermissionBridge.ts
+++ b/main/src/services/mcpPermissionBridge.ts
@@ -29,7 +29,7 @@ if (!sessionId || !ipcPath) {
 
 // Create IPC client to communicate with main process
 let ipcClient: net.Socket | null = null;
-let pendingRequests = new Map<string, (response: PermissionResponse) => void>();
+const pendingRequests = new Map<string, (response: PermissionResponse) => void>();
 
 function connectToMainProcess() {
   ipcClient = net.createConnection(ipcPath);

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -245,7 +245,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
 
   protected async getCliExecutablePath(): Promise<string> {
     // Use custom claude path if configured, otherwise find it in PATH
-    let claudeCommand = this.configManager?.getConfig()?.claudeExecutablePath;
+    const claudeCommand = this.configManager?.getConfig()?.claudeExecutablePath;
     if (claudeCommand) {
       this.logger?.info(`[ClaudeManager] Using custom Claude executable path: ${claudeCommand}`);
       return claudeCommand;
@@ -590,7 +590,6 @@ export class ClaudeCodeManager extends AbstractCliManager {
    */
   protected override isSpawnInProgress(panelId: string): boolean {
     // Use synchronous cache-hit path; panelManager.getPanel is sync.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { panelManager } = getPanelManagerModule();
     const panel = panelManager.getPanel(panelId);
     if (!panel) return false;

--- a/main/src/services/resourceMonitorService.ts
+++ b/main/src/services/resourceMonitorService.ts
@@ -365,10 +365,8 @@ export class ResourceMonitorService extends EventEmitter {
     const now = Date.now();
 
     // Lazy imports to avoid circular dependency at module load time
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     // SAFETY: This require targets the statically typed local module and selects its exported singleton.
     const { terminalPanelManager } = require('./terminalPanelManager') as { terminalPanelManager: { getSessionPids(): Map<string, number[]> } };
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     // SAFETY: This require targets the statically typed local module and selects its exported registry class.
     const { CliToolRegistry } = require('./cliToolRegistry') as { CliToolRegistry: { getInstance(): { getAllManagers(): { getSessionPids(): Map<string, number[]> }[] } } };
 

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -1820,7 +1820,7 @@ export class SessionManager extends EventEmitter {
   }
 
   async sendTerminalInput(sessionId: string, data: string): Promise<void> {
-    let session = this.activeSessions.get(sessionId);
+    const session = this.activeSessions.get(sessionId);
     let worktreePath: string;
     
     if (!session) {
@@ -1873,7 +1873,7 @@ export class SessionManager extends EventEmitter {
   }
 
   async preCreateTerminalSession(sessionId: string): Promise<void> {
-    let session = this.activeSessions.get(sessionId);
+    const session = this.activeSessions.get(sessionId);
     let worktreePath: string;
 
     if (!session) {

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -287,7 +287,6 @@ export class TaskQueue {
             data: initialPromptDisplay,
             timestamp: new Date()
           });
-        } else {
         }
         
         // Ensure default panels exist for this session (run in parallel)

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -539,7 +539,7 @@ export class WorktreeManager {
       for (const line of localLines) {
         const isCurrent = line.startsWith('*');
         // Remove leading *, +, and spaces. The + indicates uncommitted changes
-        const name = line.replace(/^[\*\+]?\s*[\+]?\s*/, '').trim();
+        const name = line.replace(/^[*+]?\s*[+]?\s*/, '').trim();
         if (name) {
           localBranches.push({
             name,

--- a/main/src/utils/nodeFinder.ts
+++ b/main/src/utils/nodeFinder.ts
@@ -135,7 +135,7 @@ function parseShellBinStub(content: string, binDir: string): string | null {
   // Match patterns that reference a .js file with $basedir
   const patterns = [
     // Pattern: "$basedir/path/to/script.js" or "$basedir/../path/to/script.js"
-    /\$basedir['"\/]*([^"'\s]+\.js)/g,
+    /\$basedir['"/]*([^"'\s]+\.js)/g,
     // Pattern: node "path/to/script.js" (relative path)
     /node\s+["']?([^"'\s]+\.js)/g,
   ];
@@ -146,7 +146,7 @@ function parseShellBinStub(content: string, binDir: string): string | null {
       let jsPath = match[1];
 
       // Remove leading quotes or slashes
-      jsPath = jsPath.replace(/^["'\/]+/, '');
+      jsPath = jsPath.replace(/^["'/]+/, '');
 
       // Resolve the path relative to binDir
       // $basedir refers to the directory containing the bin stub

--- a/main/src/utils/shellPath.ts
+++ b/main/src/utils/shellPath.ts
@@ -366,7 +366,7 @@ export function getShellPath(): string {
         ];
         
         console.log(`[ShellPath] Checking shell config files: ${shellConfigPaths.join(', ')}`);
-        let extractedPaths: string[] = [];
+        const extractedPaths: string[] = [];
         
         for (const configPath of shellConfigPaths) {
           if (fs.existsSync(configPath)) {

--- a/main/src/utils/worktreeUtils.ts
+++ b/main/src/utils/worktreeUtils.ts
@@ -11,7 +11,7 @@ export function getCurrentWorktreeName(cwd: string): string | undefined {
     // Match worktrees directory followed by worktree name
     // Handles both Unix (/) and Windows (\) path separators
     // For paths like "worktrees/feature/dev-mode-worktree-label", captures "feature/dev-mode-worktree-label"
-    const worktreeMatch = cwd.match(/worktrees[\/\\](.+)/);
+    const worktreeMatch = cwd.match(/worktrees[/\\](.+)/);
     return worktreeMatch ? worktreeMatch[1] : undefined;
   } catch (error) {
     console.log('Could not extract worktree name:', error);


### PR DESCRIPTION
## Summary
- remove all 11 unnecessary regex escapes without changing accepted character sets
- apply all 5 safe `prefer-const` fixes and remove the lone empty block
- delete 5 stale ESLint disable comments that did not suppress their intended imports
- reduce residual ESLint warnings from 335 to 313 with no increase in another lane

Continues #403.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `CI=1 pnpm --filter main exec vitest run` (596 tests)
- `CI=1 pnpm --filter frontend exec vitest run` (161 tests)
- `pnpm build:frontend`
- `pnpm build:main`