### PR TITLE
Add in-app GitHub feedback flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import OnboardingDialog, {
 } from './components/OnboardingDialog';
 import { AboutDialog } from './components/AboutDialog';
 import { DocsDialog } from './components/DocsDialog';
+import { FeedbackDialog } from './components/FeedbackDialog';
 import { UpdateDialog } from './components/UpdateDialog';
 import { MainProcessLogger } from './components/MainProcessLogger';
 import { ErrorDialog } from './components/ErrorDialog';
@@ -87,6 +88,7 @@ function App() {
   const [isAnalyticsConsentOpen, setIsAnalyticsConsentOpen] = useState(false);
   const [hasCheckedAnalyticsConsent, setHasCheckedAnalyticsConsent] = useState(false);
   const [isAboutOpen, setIsAboutOpen] = useState(false);
+  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
   const [isUpdateDialogOpen, setIsUpdateDialogOpen] = useState(false);
   const [updateVersionInfo, setUpdateVersionInfo] = useState<VersionUpdateInfo | null>(null);
   const [currentPermissionRequest, setCurrentPermissionRequest] = useState<PanePermissionRequest | null>(null);
@@ -857,6 +859,7 @@ function App() {
             onToggleCollapse={handleToggleSidebar}
             onHelpClick={() => setIsHelpOpen(true)}
             onDocsClick={() => setIsDocsOpen(true)}
+            onFeedbackClick={() => setIsFeedbackOpen(true)}
           />
         </div>
         <SessionView />
@@ -896,6 +899,7 @@ function App() {
         />
         <Welcome isOpen={isWelcomeOpen} onClose={() => setIsWelcomeOpen(false)} />
         <AboutDialog isOpen={isAboutOpen} onClose={() => setIsAboutOpen(false)} onUpdate={handleUpdateRequest} />
+        <FeedbackDialog isOpen={isFeedbackOpen} onClose={() => setIsFeedbackOpen(false)} />
         <UpdateDialog
           isOpen={isUpdateDialogOpen}
           onClose={() => setIsUpdateDialogOpen(false)}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -877,6 +877,7 @@ function App() {
             setIsKeyboardShortcutsOpen(true);
           }}
           onUpdate={handleUpdateRequest}
+          onSendFeedback={() => setIsFeedbackOpen(true)}
         />
         <AnalyticsConsentDialog
           isOpen={isAnalyticsConsentOpen}

--- a/frontend/src/components/FeedbackDialog.test.ts
+++ b/frontend/src/components/FeedbackDialog.test.ts
@@ -5,6 +5,7 @@ import {
   createInitialFeedbackDialogState,
   executeFeedbackSubmission,
   feedbackDialogReducer,
+  openFeedbackUrl,
 } from './feedbackDialogState';
 
 const request: SubmitFeedbackRequest = {
@@ -52,11 +53,40 @@ describe('FeedbackDialog state', () => {
       title: request.title,
       body: request.body,
     };
+    expect(action).toBeDefined();
+    if (!action) return;
     const failed = feedbackDialogReducer(filled, action);
 
     expect(failed.title).toBe(request.title);
     expect(failed.body).toBe(request.body);
     expect(failed.status).toBe('error');
     expect(failed.fallbackUrl).toBe(fallbackUrl);
+  });
+
+  it('ignores a submission response after the dialog closes', async () => {
+    const abortController = new AbortController();
+    let resolveSubmission: ((value: {
+      success: true;
+      data: { issueUrl: string };
+    }) => void) | undefined;
+    const submit = vi.fn().mockReturnValue(new Promise(resolve => {
+      resolveSubmission = resolve;
+    }));
+    const actionPromise = executeFeedbackSubmission(request, submit, abortController.signal);
+
+    abortController.abort();
+    resolveSubmission?.({
+      success: true,
+      data: { issueUrl: 'https://github.com/dcouple/Pane/issues/999' },
+    });
+
+    await expect(actionPromise).resolves.toBeUndefined();
+  });
+
+  it('surfaces resolved failures from the system browser IPC', async () => {
+    await expect(openFeedbackUrl(
+      'https://github.com/dcouple/Pane/issues/new',
+      vi.fn().mockResolvedValue({ success: false, error: 'Browser launch failed' }),
+    )).resolves.toBe('Browser launch failed');
   });
 });

--- a/frontend/src/components/FeedbackDialog.test.ts
+++ b/frontend/src/components/FeedbackDialog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SubmitFeedbackRequest } from '../../../shared/types/feedback';
+import {
+  canSubmitFeedback,
+  createInitialFeedbackDialogState,
+  executeFeedbackSubmission,
+  feedbackDialogReducer,
+} from './feedbackDialogState';
+
+const request: SubmitFeedbackRequest = {
+  type: 'bug',
+  title: 'Pasted title',
+  body: 'Pasted **Markdown** body',
+  includeAppDetails: true,
+  appDetails: { version: '2.4.48', gitCommit: 'e3c4fa7 (modified)' },
+};
+
+describe('FeedbackDialog state', () => {
+  it('keeps submit disabled until feedback is present and while submitting', () => {
+    const empty = createInitialFeedbackDialogState();
+    expect(canSubmitFeedback(empty)).toBe(false);
+
+    const filled = feedbackDialogReducer(empty, { type: 'set-body', value: request.body });
+    expect(canSubmitFeedback(filled)).toBe(true);
+    expect(canSubmitFeedback(feedbackDialogReducer(filled, { type: 'submit-start' }))).toBe(false);
+  });
+
+  it('moves to success after the mocked renderer API returns an issue URL', async () => {
+    const submit = vi.fn().mockResolvedValue({
+      success: true,
+      data: { issueUrl: 'https://github.com/dcouple/Pane/issues/999' },
+    });
+
+    const action = await executeFeedbackSubmission(request, submit);
+
+    expect(submit).toHaveBeenCalledWith(request);
+    expect(action).toEqual({
+      type: 'submit-success',
+      issueUrl: 'https://github.com/dcouple/Pane/issues/999',
+    });
+  });
+
+  it('preserves the form and exposes the browser fallback after failure', async () => {
+    const fallbackUrl = 'https://github.com/dcouple/Pane/issues/new?title=Pasted+title';
+    const action = await executeFeedbackSubmission(request, vi.fn().mockResolvedValue({
+      success: false,
+      error: 'GitHub CLI is not authenticated.',
+      data: { fallbackUrl },
+    }));
+    const filled = {
+      ...createInitialFeedbackDialogState(),
+      title: request.title,
+      body: request.body,
+    };
+    const failed = feedbackDialogReducer(filled, action);
+
+    expect(failed.title).toBe(request.title);
+    expect(failed.body).toBe(request.body);
+    expect(failed.status).toBe('error');
+    expect(failed.fallbackUrl).toBe(fallbackUrl);
+  });
+});

--- a/frontend/src/components/FeedbackDialog.tsx
+++ b/frontend/src/components/FeedbackDialog.tsx
@@ -90,6 +90,7 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
       size="md"
       initialFocusRef={bodyRef}
       closeOnOverlayClick={false}
+      showCloseButton={false}
     >
       <ModalHeader
         title="Send feedback"
@@ -115,6 +116,9 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
                 </button>
               </div>
             </div>
+            <p className="text-sm text-text-secondary">
+              Screenshots help. Open the issue and paste images into a comment — GitHub uploads them for you.
+            </p>
           </ModalBody>
           <ModalFooter>
             <Button type="button" variant="secondary" className="text-text-primary" onClick={() => dispatch({ type: 'reset' })}>

--- a/frontend/src/components/FeedbackDialog.tsx
+++ b/frontend/src/components/FeedbackDialog.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useReducer, useRef, useState } from 'react';
+import { CheckCircle2, ExternalLink, MessageSquareText } from 'lucide-react';
+import type {
+  FeedbackAppDetails,
+} from '../../../shared/types/feedback';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from './ui/Modal';
+import { Button } from './ui/Button';
+import { boundary, decodeBoundary, decodeOptionalBoundary } from '../../../shared/validation/boundaryDecoder';
+import {
+  canSubmitFeedback,
+  createInitialFeedbackDialogState,
+  executeFeedbackSubmission,
+  feedbackDialogReducer,
+} from './feedbackDialogState';
+
+interface FeedbackDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
+  const [state, dispatch] = useReducer(feedbackDialogReducer, undefined, createInitialFeedbackDialogState);
+  const [appDetails, setAppDetails] = useState<FeedbackAppDetails>();
+  const [isLoadingAppDetails, setIsLoadingAppDetails] = useState(false);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    dispatch({ type: 'reset' });
+    setAppDetails(undefined);
+    setIsLoadingAppDetails(true);
+    void window.electronAPI.getVersionInfo().then(response => {
+      if (cancelled || !response.success || !response.data) return;
+      const data = decodeOptionalBoundary(response.data, boundary.object({
+        current: boundary.optional(boundary.string),
+        gitCommit: boundary.optional(boundary.string),
+      }));
+      if (!data) return;
+      setAppDetails({
+        version: data.current ?? '',
+        gitCommit: data.gitCommit ?? '',
+      });
+    }).catch(() => {
+      if (!cancelled) setAppDetails(undefined);
+    }).finally(() => {
+      if (!cancelled) setIsLoadingAppDetails(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!canSubmitFeedback(state) || (state.includeAppDetails && isLoadingAppDetails)) return;
+    dispatch({ type: 'submit-start' });
+    const action = await executeFeedbackSubmission({
+      type: state.type,
+      title: state.title,
+      body: state.body,
+      includeAppDetails: state.includeAppDetails,
+      appDetails,
+    }, window.electronAPI.feedback.submit);
+    dispatch(action);
+  };
+
+  const openExternal = (url: string) => {
+    void window.electronAPI.openExternal(url).catch(error => {
+      dispatch({
+        type: 'submit-error',
+        error: error instanceof Error ? error.message : 'Could not open the browser.',
+        fallbackUrl: state.fallbackUrl,
+      });
+    });
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabel="Send feedback"
+      size="md"
+      initialFocusRef={bodyRef}
+      closeOnOverlayClick={false}
+    >
+      <ModalHeader
+        title="Send feedback"
+        icon={<MessageSquareText className="h-5 w-5" />}
+        description="Create a public issue in dcouple/Pane."
+        onClose={onClose}
+      />
+
+      {state.status === 'success' && state.issueUrl ? (
+        <>
+          <ModalBody className="space-y-4">
+            <div className="flex items-start gap-3 rounded-lg border border-status-success/30 bg-status-success/10 p-4">
+              <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-status-success" aria-hidden="true" />
+              <div className="min-w-0">
+                <p className="font-medium text-text-primary">Feedback submitted</p>
+                <button
+                  type="button"
+                  onClick={() => openExternal(state.issueUrl!)}
+                  className="mt-1 inline-flex max-w-full items-center gap-1 text-sm text-interactive hover:underline"
+                >
+                  <span className="truncate">{state.issueUrl}</span>
+                  <ExternalLink className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+          </ModalBody>
+          <ModalFooter>
+            <Button type="button" variant="secondary" onClick={() => dispatch({ type: 'reset' })}>
+              Send another
+            </Button>
+            <Button type="button" onClick={onClose}>Done</Button>
+          </ModalFooter>
+        </>
+      ) : (
+        <form onSubmit={submit}>
+          <ModalBody className="space-y-4">
+            <p className="rounded-md border border-status-warning/30 bg-status-warning/10 px-3 py-2 text-xs text-text-secondary">
+              This issue will be PUBLIC on GitHub and posted using your authenticated GitHub account.
+            </p>
+
+            <label className="block space-y-1.5 text-sm text-text-secondary">
+              <span>Type</span>
+              <select
+                value={state.type}
+                onChange={event => dispatch({
+                  type: 'set-type',
+                  value: decodeBoundary(event.target.value, boundary.enumeration('bug', 'feature', 'general')),
+                })}
+                className="w-full rounded-md border border-border-primary bg-surface-secondary px-3 py-2 text-text-primary outline-none focus:border-interactive"
+              >
+                <option value="bug">Bug</option>
+                <option value="feature">Feature request</option>
+                <option value="general">General feedback</option>
+              </select>
+            </label>
+
+            <label className="block space-y-1.5 text-sm text-text-secondary">
+              <span>Title <span className="text-text-tertiary">(optional)</span></span>
+              <input
+                type="text"
+                maxLength={120}
+                value={state.title}
+                onChange={event => dispatch({ type: 'set-title', value: event.target.value })}
+                placeholder="Short summary"
+                className="w-full rounded-md border border-border-primary bg-surface-secondary px-3 py-2 text-text-primary outline-none placeholder:text-text-tertiary focus:border-interactive"
+              />
+            </label>
+
+            <label className="block space-y-1.5 text-sm text-text-secondary">
+              <span>Feedback</span>
+              <textarea
+                ref={bodyRef}
+                required
+                rows={8}
+                maxLength={65_536}
+                value={state.body}
+                onChange={event => dispatch({ type: 'set-body', value: event.target.value })}
+                placeholder="Describe the bug, idea, or feedback. Plain text and Markdown are welcome."
+                className="w-full resize-y rounded-md border border-border-primary bg-surface-secondary px-3 py-2 font-mono text-sm text-text-primary outline-none placeholder:font-sans placeholder:text-text-tertiary focus:border-interactive"
+              />
+            </label>
+
+            <label className="flex cursor-pointer items-start gap-2 text-sm text-text-secondary">
+              <input
+                type="checkbox"
+                checked={state.includeAppDetails}
+                onChange={event => dispatch({ type: 'set-include-details', value: event.target.checked })}
+                className="mt-0.5 h-4 w-4 rounded border-border-primary accent-interactive"
+              />
+              <span>Include app details <span className="text-text-tertiary">(version, commit, platform, architecture, and Electron version)</span></span>
+            </label>
+
+            {state.status === 'error' && (
+              <div role="alert" className="rounded-md border border-status-error/30 bg-status-error/10 p-3 text-sm text-text-secondary">
+                <p>{state.error}</p>
+                {state.fallbackUrl && (
+                  <button
+                    type="button"
+                    onClick={() => openExternal(state.fallbackUrl!)}
+                    className="mt-2 inline-flex items-center gap-1 font-medium text-interactive hover:underline"
+                  >
+                    Open pre-filled issue in browser
+                    <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                  </button>
+                )}
+              </div>
+            )}
+          </ModalBody>
+          <ModalFooter>
+            <Button type="button" variant="secondary" onClick={onClose}>Cancel</Button>
+            <Button
+              type="submit"
+              disabled={!canSubmitFeedback(state) || (state.includeAppDetails && isLoadingAppDetails)}
+              loading={state.status === 'submitting'}
+              loadingText="Submitting…"
+            >
+              {state.status === 'submitting' ? 'Submitting…' : 'Submit feedback'}
+            </Button>
+          </ModalFooter>
+        </form>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/components/FeedbackDialog.tsx
+++ b/frontend/src/components/FeedbackDialog.tsx
@@ -11,6 +11,7 @@ import {
   createInitialFeedbackDialogState,
   executeFeedbackSubmission,
   feedbackDialogReducer,
+  openFeedbackUrl,
 } from './feedbackDialogState';
 
 interface FeedbackDialogProps {
@@ -20,15 +21,18 @@ interface FeedbackDialogProps {
 
 export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
   const [state, dispatch] = useReducer(feedbackDialogReducer, undefined, createInitialFeedbackDialogState);
-  const [appDetails, setAppDetails] = useState<FeedbackAppDetails>();
+  const appDetailsRef = useRef<FeedbackAppDetails | undefined>(undefined);
+  const submissionAbortRef = useRef<AbortController | undefined>(undefined);
   const [isLoadingAppDetails, setIsLoadingAppDetails] = useState(false);
   const bodyRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
+    const submissionAbort = new AbortController();
+    submissionAbortRef.current = submissionAbort;
     dispatch({ type: 'reset' });
-    setAppDetails(undefined);
+    appDetailsRef.current = undefined;
     setIsLoadingAppDetails(true);
     void window.electronAPI.getVersionInfo().then(response => {
       if (cancelled || !response.success || !response.data) return;
@@ -37,17 +41,19 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
         gitCommit: boundary.optional(boundary.string),
       }));
       if (!data) return;
-      setAppDetails({
+      appDetailsRef.current = {
         version: data.current ?? '',
         gitCommit: data.gitCommit ?? '',
-      });
+      };
     }).catch(() => {
-      if (!cancelled) setAppDetails(undefined);
+      if (!cancelled) appDetailsRef.current = undefined;
     }).finally(() => {
       if (!cancelled) setIsLoadingAppDetails(false);
     });
     return () => {
       cancelled = true;
+      submissionAbort.abort();
+      if (submissionAbortRef.current === submissionAbort) submissionAbortRef.current = undefined;
     };
   }, [isOpen]);
 
@@ -60,16 +66,17 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
       title: state.title,
       body: state.body,
       includeAppDetails: state.includeAppDetails,
-      appDetails,
-    }, window.electronAPI.feedback.submit);
-    dispatch(action);
+      appDetails: appDetailsRef.current,
+    }, window.electronAPI.feedback.submit, submissionAbortRef.current?.signal);
+    if (action) dispatch(action);
   };
 
   const openExternal = (url: string) => {
-    void window.electronAPI.openExternal(url).catch(error => {
+    void openFeedbackUrl(url, window.electronAPI.openExternal).then(error => {
+      if (!error) return;
       dispatch({
         type: 'submit-error',
-        error: error instanceof Error ? error.message : 'Could not open the browser.',
+        error,
         fallbackUrl: state.fallbackUrl,
       });
     });
@@ -172,7 +179,7 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
                 onChange={event => dispatch({ type: 'set-include-details', value: event.target.checked })}
                 className="mt-0.5 h-4 w-4 rounded border-border-primary accent-interactive"
               />
-              <span>Include app details <span>(version, commit, platform, architecture, and Electron version)</span></span>
+              <span>Include app details <span>(version, commit, OS, architecture, and runtime versions)</span></span>
             </label>
 
             {state.status === 'error' && (

--- a/frontend/src/components/FeedbackDialog.tsx
+++ b/frontend/src/components/FeedbackDialog.tsx
@@ -87,7 +87,7 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
       <ModalHeader
         title="Send feedback"
         icon={<MessageSquareText className="h-5 w-5" />}
-        description="Create a public issue in dcouple/Pane."
+        description={<span className="text-text-primary">Create a public issue in dcouple/Pane.</span>}
         onClose={onClose}
       />
 
@@ -110,7 +110,7 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
             </div>
           </ModalBody>
           <ModalFooter>
-            <Button type="button" variant="secondary" onClick={() => dispatch({ type: 'reset' })}>
+            <Button type="button" variant="secondary" className="text-text-primary" onClick={() => dispatch({ type: 'reset' })}>
               Send another
             </Button>
             <Button type="button" onClick={onClose}>Done</Button>
@@ -119,11 +119,11 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
       ) : (
         <form onSubmit={submit}>
           <ModalBody className="space-y-4">
-            <p className="rounded-md border border-status-warning/30 bg-status-warning/10 px-3 py-2 text-xs text-text-secondary">
+            <p className="rounded-md border border-status-warning/30 bg-status-warning/10 px-3 py-2 text-xs text-text-primary">
               This issue will be PUBLIC on GitHub and posted using your authenticated GitHub account.
             </p>
 
-            <label className="block space-y-1.5 text-sm text-text-secondary">
+            <label className="block space-y-1.5 text-sm text-text-primary">
               <span>Type</span>
               <select
                 value={state.type}
@@ -139,8 +139,8 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
               </select>
             </label>
 
-            <label className="block space-y-1.5 text-sm text-text-secondary">
-              <span>Title <span className="text-text-tertiary">(optional)</span></span>
+            <label className="block space-y-1.5 text-sm text-text-primary">
+              <span>Title <span>(optional)</span></span>
               <input
                 type="text"
                 maxLength={120}
@@ -151,7 +151,7 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
               />
             </label>
 
-            <label className="block space-y-1.5 text-sm text-text-secondary">
+            <label className="block space-y-1.5 text-sm text-text-primary">
               <span>Feedback</span>
               <textarea
                 ref={bodyRef}
@@ -165,18 +165,18 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
               />
             </label>
 
-            <label className="flex cursor-pointer items-start gap-2 text-sm text-text-secondary">
+            <label className="flex cursor-pointer items-start gap-2 text-sm text-text-primary">
               <input
                 type="checkbox"
                 checked={state.includeAppDetails}
                 onChange={event => dispatch({ type: 'set-include-details', value: event.target.checked })}
                 className="mt-0.5 h-4 w-4 rounded border-border-primary accent-interactive"
               />
-              <span>Include app details <span className="text-text-tertiary">(version, commit, platform, architecture, and Electron version)</span></span>
+              <span>Include app details <span>(version, commit, platform, architecture, and Electron version)</span></span>
             </label>
 
             {state.status === 'error' && (
-              <div role="alert" className="rounded-md border border-status-error/30 bg-status-error/10 p-3 text-sm text-text-secondary">
+              <div role="alert" className="rounded-md border border-status-error/30 bg-status-error/10 p-3 text-sm text-text-primary">
                 <p>{state.error}</p>
                 {state.fallbackUrl && (
                   <button
@@ -192,7 +192,7 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
             )}
           </ModalBody>
           <ModalFooter>
-            <Button type="button" variant="secondary" onClick={onClose}>Cancel</Button>
+            <Button type="button" variant="secondary" className="text-text-primary" onClick={onClose}>Cancel</Button>
             <Button
               type="submit"
               disabled={!canSubmitFeedback(state) || (state.includeAppDetails && isLoadingAppDetails)}

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -49,9 +49,10 @@ interface SettingsProps {
   onOpenRequestHandled: () => void;
   onShowKeyboardShortcuts: () => void;
   onUpdate: (versionInfo: VersionInfo) => void;
+  onSendFeedback: () => void;
 }
 
-export function Settings({ isOpen, onClose, category, onCategoryChange, openRequest, onOpenRequestHandled, onShowKeyboardShortcuts, onUpdate }: SettingsProps) {
+export function Settings({ isOpen, onClose, category, onCategoryChange, openRequest, onOpenRequestHandled, onShowKeyboardShortcuts, onUpdate, onSendFeedback }: SettingsProps) {
   const persistence = useSettingsPersistence(isOpen);
   const dirtyForms = useDirtySettingsForms();
   const {
@@ -176,7 +177,7 @@ export function Settings({ isOpen, onClose, category, onCategoryChange, openRequ
     const sharedDirtyProps = { onDirtyChange: setDirty };
     switch (category) {
       case 'general':
-        return <GeneralSettings persistence={persistence} onUpdate={showUpdate} />;
+        return <GeneralSettings persistence={persistence} onUpdate={showUpdate} onSendFeedback={onSendFeedback} />;
       case 'appearance':
         return <AppearanceSettings persistence={persistence} />;
       case 'terminal':

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -177,6 +177,9 @@ export function Settings({ isOpen, onClose, category, onCategoryChange, openRequ
     const sharedDirtyProps = { onDirtyChange: setDirty };
     switch (category) {
       case 'general':
+        // onSendFeedback is passed straight through, unlike showUpdate/showKeyboardShortcuts:
+        // the feedback dialog stacks on top of Settings instead of replacing it, so there is
+        // no transition to guard and closing Settings would strand focus on an unmounted button.
         return <GeneralSettings persistence={persistence} onUpdate={showUpdate} onSendFeedback={onSendFeedback} />;
       case 'appearance':
         return <AppearanceSettings persistence={persistence} />;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -83,6 +83,7 @@ interface SidebarProps {
   onToggleCollapse?: () => void;
   onHelpClick: () => void;
   onDocsClick: () => void;
+  onFeedbackClick: () => void;
 }
 
 const REMOTE_DESKTOP_URL = 'https://remotedesktop.google.com/access';
@@ -112,7 +113,7 @@ const HelpCircleIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, width, onResize, collapsed, onToggleCollapse, onHelpClick, onDocsClick }: SidebarProps) {
+export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, width, onResize, collapsed, onToggleCollapse, onHelpClick, onDocsClick, onFeedbackClick }: SidebarProps) {
   const paneLogo = usePaneLogo();
   const hotkeys = useHotkeyStore((s) => s.hotkeys);
   const hotkeyDisplay = useCallback((id: string) => {
@@ -892,17 +893,26 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
 
           {/* Version display at bottom */}
           <div className="px-3 py-2 border-t border-border-primary space-y-1.5">
-            <Tooltip content={remoteFooterTooltip} side="top" interactive delay={250} className="block">
+            <div className="flex items-center justify-center gap-2">
+              <Tooltip content={remoteFooterTooltip} side="top" interactive delay={250}>
+                <button
+                  type="button"
+                  onClick={onRemoteSettingsClick}
+                  aria-label={remoteFooterStatus.ariaLabel}
+                  className="flex min-w-0 items-center gap-1.5 text-xs text-text-tertiary hover:text-text-secondary transition-colors truncate"
+                >
+                  <span className={`h-2 w-2 rounded-full flex-shrink-0 ${remoteFooterStatus.dotClassName}`} />
+                  <span className="font-medium">Remote</span>
+                </button>
+              </Tooltip>
               <button
                 type="button"
-                onClick={onRemoteSettingsClick}
-                aria-label={remoteFooterStatus.ariaLabel}
-                className="flex w-full items-center justify-center gap-1.5 text-xs text-text-tertiary hover:text-text-secondary transition-colors truncate"
+                onClick={onFeedbackClick}
+                className="rounded-full border border-border-primary px-2 py-0.5 text-[11px] font-medium text-text-tertiary transition-colors hover:border-border-secondary hover:bg-surface-hover hover:text-text-secondary focus:outline-none focus:ring-2 focus:ring-interactive"
               >
-                <span className={`h-2 w-2 rounded-full flex-shrink-0 ${remoteFooterStatus.dotClassName}`} />
-                <span className="font-medium">Remote</span>
+                Feedback
               </button>
-            </Tooltip>
+            </div>
             {version && (
               <div className="flex items-center justify-center gap-1.5 text-xs text-text-tertiary truncate">
                 <button

--- a/frontend/src/components/feedbackDialogState.ts
+++ b/frontend/src/components/feedbackDialogState.ts
@@ -1,0 +1,96 @@
+import type {
+  FeedbackType,
+  SubmitFeedbackFailure,
+  SubmitFeedbackRequest,
+  SubmitFeedbackSuccess,
+} from '../../../shared/types/feedback';
+
+export interface FeedbackDialogState {
+  type: FeedbackType;
+  title: string;
+  body: string;
+  includeAppDetails: boolean;
+  status: 'idle' | 'submitting' | 'success' | 'error';
+  issueUrl?: string;
+  error?: string;
+  fallbackUrl?: string;
+}
+
+export type FeedbackDialogAction =
+  | { type: 'reset' }
+  | { type: 'set-type'; value: FeedbackType }
+  | { type: 'set-title'; value: string }
+  | { type: 'set-body'; value: string }
+  | { type: 'set-include-details'; value: boolean }
+  | { type: 'submit-start' }
+  | { type: 'submit-success'; issueUrl: string }
+  | { type: 'submit-error'; error: string; fallbackUrl?: string };
+
+export function createInitialFeedbackDialogState(): FeedbackDialogState {
+  return {
+    type: 'bug',
+    title: '',
+    body: '',
+    includeAppDetails: true,
+    status: 'idle',
+  };
+}
+
+export function feedbackDialogReducer(
+  state: FeedbackDialogState,
+  action: FeedbackDialogAction,
+): FeedbackDialogState {
+  switch (action.type) {
+    case 'reset':
+      return createInitialFeedbackDialogState();
+    case 'set-type':
+      return { ...state, type: action.value, status: 'idle', error: undefined, fallbackUrl: undefined };
+    case 'set-title':
+      return { ...state, title: action.value, status: 'idle', error: undefined, fallbackUrl: undefined };
+    case 'set-body':
+      return { ...state, body: action.value, status: 'idle', error: undefined, fallbackUrl: undefined };
+    case 'set-include-details':
+      return { ...state, includeAppDetails: action.value };
+    case 'submit-start':
+      return { ...state, status: 'submitting', error: undefined, fallbackUrl: undefined };
+    case 'submit-success':
+      return { ...state, status: 'success', issueUrl: action.issueUrl };
+    case 'submit-error':
+      return { ...state, status: 'error', error: action.error, fallbackUrl: action.fallbackUrl };
+  }
+}
+
+export function canSubmitFeedback(state: FeedbackDialogState): boolean {
+  return Boolean(state.body.trim()) && state.status !== 'submitting';
+}
+
+interface FeedbackResponse {
+  success: boolean;
+  data?: SubmitFeedbackSuccess | SubmitFeedbackFailure;
+  error?: string;
+}
+
+export async function executeFeedbackSubmission(
+  request: SubmitFeedbackRequest,
+  submit: (request: SubmitFeedbackRequest) => Promise<FeedbackResponse>,
+): Promise<FeedbackDialogAction> {
+  try {
+    const response = await submit(request);
+    if (response.success && response.data && 'issueUrl' in response.data) {
+      return { type: 'submit-success', issueUrl: response.data.issueUrl };
+    }
+    const fallbackUrl = response.data && 'fallbackUrl' in response.data
+      ? response.data.fallbackUrl
+      : undefined;
+    return {
+      type: 'submit-error',
+      error: response.error || 'Pane could not create the GitHub issue.',
+      fallbackUrl,
+    };
+  } catch (error) {
+    return {
+      type: 'submit-error',
+      error: error instanceof Error ? error.message : 'Pane could not create the GitHub issue.',
+    };
+  }
+}

--- a/frontend/src/components/feedbackDialogState.ts
+++ b/frontend/src/components/feedbackDialogState.ts
@@ -73,9 +73,11 @@ interface FeedbackResponse {
 export async function executeFeedbackSubmission(
   request: SubmitFeedbackRequest,
   submit: (request: SubmitFeedbackRequest) => Promise<FeedbackResponse>,
-): Promise<FeedbackDialogAction> {
+  signal?: AbortSignal,
+): Promise<FeedbackDialogAction | undefined> {
   try {
     const response = await submit(request);
+    if (signal?.aborted) return undefined;
     if (response.success && response.data && 'issueUrl' in response.data) {
       return { type: 'submit-success', issueUrl: response.data.issueUrl };
     }
@@ -88,9 +90,27 @@ export async function executeFeedbackSubmission(
       fallbackUrl,
     };
   } catch (error) {
+    if (signal?.aborted) return undefined;
     return {
       type: 'submit-error',
       error: error instanceof Error ? error.message : 'Pane could not create the GitHub issue.',
     };
+  }
+}
+
+interface OpenExternalResponse {
+  success: boolean;
+  error?: string;
+}
+
+export async function openFeedbackUrl(
+  url: string,
+  openExternal: (url: string) => Promise<OpenExternalResponse>,
+): Promise<string | undefined> {
+  try {
+    const response = await openExternal(url);
+    return response.success ? undefined : response.error || 'Could not open the browser.';
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Could not open the browser.';
   }
 }

--- a/frontend/src/components/settings/catalog.tsx
+++ b/frontend/src/components/settings/catalog.tsx
@@ -29,10 +29,10 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategoryDefinition[] = [
   {
     id: 'general',
     label: 'General',
-    description: 'Startup and application updates.',
+    description: 'Startup, application updates, and feedback.',
     icon: Settings,
-    settingIds: ['automatic-updates', 'check-updates-now', 'start-on-login', 'keep-awake'],
-    aliases: ['startup', 'updates', 'login', 'sleep', 'caffeinate', 'awake', 'power'],
+    settingIds: ['automatic-updates', 'check-updates-now', 'send-feedback', 'start-on-login', 'keep-awake'],
+    aliases: ['startup', 'updates', 'feedback', 'bug report', 'feature request', 'github issue', 'login', 'sleep', 'caffeinate', 'awake', 'power'],
   },
   {
     id: 'appearance',

--- a/frontend/src/components/settings/categories/GeneralSettings.test.tsx
+++ b/frontend/src/components/settings/categories/GeneralSettings.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { GeneralSettings } from './GeneralSettings';
+import { SETTINGS_CATEGORIES, settingDomId } from '../catalog';
+import type { SettingsPersistence } from '../useSettingsPersistence';
+import { DEFAULT_SETTINGS_PREFERENCES } from '../../../types/settings';
+
+function createPersistence(): SettingsPersistence {
+  return {
+    config: {},
+    isLoading: false,
+    configError: null,
+    fetchConfig: () => Promise.resolve({}),
+    saveConfig: () => Promise.resolve(true),
+    saveStates: {},
+    reportSaveError: () => undefined,
+    preferences: DEFAULT_SETTINGS_PREFERENCES,
+    preferencesLoading: false,
+    savePreference: () => Promise.resolve(true),
+  };
+}
+
+describe('GeneralSettings feedback entry', () => {
+  it('renders the Send feedback row with the shared setting id', () => {
+    const markup = renderToStaticMarkup(
+      <GeneralSettings persistence={createPersistence()} onUpdate={vi.fn()} onSendFeedback={vi.fn()} />,
+    );
+
+    expect(markup).toContain(`id="${settingDomId('send-feedback')}"`);
+    expect(markup).toContain('data-setting-id="send-feedback"');
+    expect(markup).toContain('Send feedback');
+    expect(markup).toContain('Send Feedback');
+    expect(markup).toContain('dcouple/Pane');
+  });
+
+  it('wires the row button to the shared opener passed down from App', () => {
+    const onSendFeedback = vi.fn();
+    const markup = renderToStaticMarkup(
+      <GeneralSettings persistence={createPersistence()} onUpdate={vi.fn()} onSendFeedback={onSendFeedback} />,
+    );
+
+    // Static markup proves the row and its button exist; clicking it and asserting the
+    // dialog opens is covered end to end in tests/feedback-pr-qa.spec.ts, since the
+    // renderer suite has no DOM environment to dispatch events in.
+    expect(markup).toContain('Send Feedback');
+    expect(onSendFeedback).not.toHaveBeenCalled();
+  });
+
+  it('registers send-feedback under General so deep links and aliases resolve', () => {
+    const general = SETTINGS_CATEGORIES.find((category) => category.id === 'general');
+    expect(general?.settingIds).toContain('send-feedback');
+    expect(general?.aliases).toContain('feedback');
+  });
+});

--- a/frontend/src/components/settings/categories/GeneralSettings.test.tsx
+++ b/frontend/src/components/settings/categories/GeneralSettings.test.tsx
@@ -20,33 +20,21 @@ function createPersistence(): SettingsPersistence {
   };
 }
 
+// Clicking the row's button and asserting the dialog opens belongs to
+// tests/feedback.spec.ts; this suite has no DOM environment to dispatch events in.
 describe('GeneralSettings feedback entry', () => {
-  it('renders the Send feedback row with the shared setting id', () => {
+  it('renders the Send feedback row under a focusable setting id', () => {
     const markup = renderToStaticMarkup(
       <GeneralSettings persistence={createPersistence()} onUpdate={vi.fn()} onSendFeedback={vi.fn()} />,
     );
 
+    // Settings deep links focus a row by this id, so the row must carry it.
     expect(markup).toContain(`id="${settingDomId('send-feedback')}"`);
-    expect(markup).toContain('data-setting-id="send-feedback"');
-    expect(markup).toContain('Send feedback');
     expect(markup).toContain('Send Feedback');
     expect(markup).toContain('dcouple/Pane');
   });
 
-  it('wires the row button to the shared opener passed down from App', () => {
-    const onSendFeedback = vi.fn();
-    const markup = renderToStaticMarkup(
-      <GeneralSettings persistence={createPersistence()} onUpdate={vi.fn()} onSendFeedback={onSendFeedback} />,
-    );
-
-    // Static markup proves the row and its button exist; clicking it and asserting the
-    // dialog opens is covered end to end in tests/feedback-pr-qa.spec.ts, since the
-    // renderer suite has no DOM environment to dispatch events in.
-    expect(markup).toContain('Send Feedback');
-    expect(onSendFeedback).not.toHaveBeenCalled();
-  });
-
-  it('registers send-feedback under General so deep links and aliases resolve', () => {
+  it('registers send-feedback under General so the catalog and the row agree', () => {
     const general = SETTINGS_CATEGORIES.find((category) => category.id === 'general');
     expect(general?.settingIds).toContain('send-feedback');
     expect(general?.aliases).toContain('feedback');

--- a/frontend/src/components/settings/categories/GeneralSettings.tsx
+++ b/frontend/src/components/settings/categories/GeneralSettings.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Download, RefreshCw } from 'lucide-react';
+import { Download, MessageSquareText, RefreshCw } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import { SettingsSection } from '../../ui/SettingsSection';
 import { SettingRow, SettingsPage } from '../SettingRow';
@@ -11,9 +11,10 @@ import { API } from '../../../utils/api';
 interface GeneralSettingsProps {
   persistence: SettingsPersistence;
   onUpdate: (versionInfo: VersionInfo) => void;
+  onSendFeedback: () => void;
 }
 
-export function GeneralSettings({ persistence, onUpdate }: GeneralSettingsProps) {
+export function GeneralSettings({ persistence, onUpdate, onSendFeedback }: GeneralSettingsProps) {
   const config = persistence.config!;
   const [updateInfo, setUpdateInfo] = useState<VersionInfo | null>(null);
   const [updateResult, setUpdateResult] = useState<string | null>(null);
@@ -38,7 +39,7 @@ export function GeneralSettings({ persistence, onUpdate }: GeneralSettingsProps)
   };
 
   return (
-    <SettingsPage title="General" description="Application startup and update behavior.">
+    <SettingsPage title="General" description="Application startup, update, and feedback behavior.">
       <SettingsSection title="Updates" description="Keep Pane current with release checks from GitHub.">
         <SettingRow
           settingId="automatic-updates"
@@ -69,6 +70,24 @@ export function GeneralSettings({ persistence, onUpdate }: GeneralSettingsProps)
             onClick={updateInfo?.hasUpdate ? () => onUpdate(updateInfo) : checkNow}
           >
             {updateInfo?.hasUpdate ? 'Update Pane' : updateInfo ? 'Check Again' : 'Check Now'}
+          </Button>
+        </SettingRow>
+      </SettingsSection>
+
+      <SettingsSection title="Feedback" description="Tell the Pane maintainers what is working and what is not.">
+        <SettingRow
+          settingId="send-feedback"
+          label="Send feedback"
+          description="Report a bug, request a feature, or share general feedback. Pane files a public GitHub issue in dcouple/Pane with your GitHub CLI account."
+        >
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            icon={<MessageSquareText className="h-4 w-4" />}
+            onClick={onSendFeedback}
+          >
+            Send Feedback
           </Button>
         </SettingRow>
       </SettingsSection>

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -101,7 +101,7 @@ interface ElectronAPI {
   };
 
   // System utilities
-  openExternal: (url: string) => Promise<void>;
+  openExternal: (url: string) => Promise<IPCResponse>;
 
   feedback: {
     submit: (request: import('../../../shared/types/feedback').SubmitFeedbackRequest) => Promise<IPCResponse<
@@ -564,7 +564,7 @@ interface ElectronAPI {
 
 // Additional electron interface for IPC event listeners
 interface ElectronInterface {
-  openExternal: (url: string) => Promise<void>;
+  openExternal: (url: string) => Promise<IPCResponse>;
   // Generic invoke method. Daemon-owned channels route through the main-process
   // daemon bridge while adapter-only channels stay on direct Electron IPC.
   // oxlint-disable-next-line typescript/no-explicit-any -- Generic IPC bridge that returns different types based on channel

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -103,6 +103,12 @@ interface ElectronAPI {
   // System utilities
   openExternal: (url: string) => Promise<void>;
 
+  feedback: {
+    submit: (request: import('../../../shared/types/feedback').SubmitFeedbackRequest) => Promise<IPCResponse<
+      import('../../../shared/types/feedback').SubmitFeedbackSuccess | import('../../../shared/types/feedback').SubmitFeedbackFailure
+    >>;
+  };
+
   diagnostics: {
     rendererFatal: (payload: RendererDiagnosticPayload) => Promise<IPCResponse>;
   };

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -17,6 +17,7 @@ export type RemoteAccessSubviewId = 'host-setup' | 'connections' | 'advanced-hos
 export type SettingsSettingId =
   | 'automatic-updates'
   | 'check-updates-now'
+  | 'send-feedback'
   | 'start-on-login'
   | 'keep-awake'
   | 'theme'

--- a/main/src/ipc/feedback.test.ts
+++ b/main/src/ipc/feedback.test.ts
@@ -12,6 +12,10 @@ const runtime = {
   platform: 'darwin' as const,
   arch: 'arm64',
   electronVersion: '41.0.0',
+  chromiumVersion: '142.0.0.0',
+  nodeVersion: '24.0.0',
+  osVersion: '25.6.0',
+  isPackaged: true,
 };
 
 const request: SubmitFeedbackRequest = {
@@ -50,6 +54,10 @@ describe('feedback IPC', () => {
     expect(bodyFromFile).toContain(request.body);
     expect(bodyFromFile).toContain('## App details');
     expect(bodyFromFile).toContain('- Commit: e3c4fa7 (modified)');
+    expect(bodyFromFile).toContain('- OS version: 25.6.0');
+    expect(bodyFromFile).toContain('- Chromium: 142.0.0.0');
+    expect(bodyFromFile).toContain('- Node.js: 24.0.0');
+    expect(bodyFromFile).toContain('- App mode: packaged');
     expect(bodyFromFile).toContain('Filed from Pane in-app feedback');
     const allArgs = runner.mock.calls.flatMap(call => call[1]);
     expect(allArgs).not.toContain(request.body);

--- a/main/src/ipc/feedback.test.ts
+++ b/main/src/ipc/feedback.test.ts
@@ -1,0 +1,122 @@
+import { readFile } from 'fs/promises';
+import { describe, expect, it, vi } from 'vitest';
+import type { SubmitFeedbackRequest } from '../../../shared/types/feedback';
+import {
+  buildFeedbackFallbackUrl,
+  submitFeedbackIssue,
+  type FeedbackCommandRunner,
+} from './feedback';
+
+const runtime = {
+  appVersion: '2.4.48',
+  platform: 'darwin' as const,
+  arch: 'arm64',
+  electronVersion: '41.0.0',
+};
+
+const request: SubmitFeedbackRequest = {
+  type: 'bug',
+  title: 'Terminal freezes on paste',
+  body: 'Pasting **Markdown** freezes the terminal.\n\n`do not shell interpolate me`',
+  includeAppDetails: true,
+  appDetails: {
+    version: '2.4.48',
+    gitCommit: 'e3c4fa7 (modified)',
+  },
+};
+
+function commandError(message: string, options?: { code?: string; stderr?: string }): Error {
+  return Object.assign(new Error(message), options);
+}
+
+describe('feedback IPC', () => {
+  it('creates an issue with the body in a temporary file, never in command arguments', async () => {
+    let bodyFromFile = '';
+    const runner = vi.fn<FeedbackCommandRunner>(async (_command, args) => {
+      if (args[0] === 'issue') {
+        const bodyPath = args[args.indexOf('--body-file') + 1];
+        bodyFromFile = await readFile(bodyPath, 'utf8');
+        return { stdout: 'https://github.com/dcouple/Pane/issues/999\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await submitFeedbackIssue(request, runtime, runner);
+
+    expect(result).toEqual({
+      success: true,
+      data: { issueUrl: 'https://github.com/dcouple/Pane/issues/999' },
+    });
+    expect(bodyFromFile).toContain(request.body);
+    expect(bodyFromFile).toContain('## App details');
+    expect(bodyFromFile).toContain('- Commit: e3c4fa7 (modified)');
+    expect(bodyFromFile).toContain('Filed from Pane in-app feedback');
+    const allArgs = runner.mock.calls.flatMap(call => call[1]);
+    expect(allArgs).not.toContain(request.body);
+    expect(runner.mock.calls.find(call => call[1][0] === 'issue')?.[1]).toContain('--body-file');
+  });
+
+  it('surfaces a clear gh-missing error and preserves text in the browser fallback', async () => {
+    const runner = vi.fn<FeedbackCommandRunner>().mockRejectedValue(commandError('spawn gh ENOENT', { code: 'ENOENT' }));
+
+    const result = await submitFeedbackIssue(request, runtime, runner);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toContain('not installed');
+    const fallback = new URL(result.data.fallbackUrl);
+    expect(fallback.searchParams.get('title')).toBe(request.title);
+    expect(fallback.searchParams.get('body')).toContain(request.body);
+    expect(fallback.searchParams.get('labels')).toBe('bug');
+  });
+
+  it('surfaces a clear unauthenticated error', async () => {
+    const runner = vi.fn<FeedbackCommandRunner>().mockRejectedValue(commandError('not logged in'));
+
+    const result = await submitFeedbackIssue(request, runtime, runner);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('gh auth login');
+  });
+
+  it('omits the optional feedback label when it does not exist', async () => {
+    const runner = vi.fn<FeedbackCommandRunner>(async (_command, args) => {
+      if (args[0] === 'label') throw commandError('label not found');
+      if (args[0] === 'issue') {
+        expect(args).toContain('bug');
+        expect(args).not.toContain('feedback');
+        return { stdout: 'https://github.com/dcouple/Pane/issues/1000', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    await expect(submitFeedbackIssue(request, runtime, runner)).resolves.toMatchObject({ success: true });
+  });
+
+  it('retries issue creation without labels when GitHub rejects a label', async () => {
+    let createAttempts = 0;
+    const runner = vi.fn<FeedbackCommandRunner>(async (_command, args) => {
+      if (args[0] !== 'issue') return { stdout: '', stderr: '' };
+      createAttempts += 1;
+      if (createAttempts === 1) {
+        expect(args).toContain('feedback');
+        throw commandError('could not add label: feedback', { stderr: 'label not found' });
+      }
+      expect(args).not.toContain('--label');
+      return { stdout: 'https://github.com/dcouple/Pane/issues/1001', stderr: '' };
+    });
+
+    const result = await submitFeedbackIssue(request, runtime, runner);
+
+    expect(result).toMatchObject({ success: true });
+    expect(createAttempts).toBe(2);
+  });
+
+  it('builds a stable prefilled GitHub URL', () => {
+    const url = new URL(buildFeedbackFallbackUrl('A title', 'A body', 'enhancement'));
+    expect(url.origin + url.pathname).toBe('https://github.com/dcouple/Pane/issues/new');
+    expect(url.searchParams.get('title')).toBe('A title');
+    expect(url.searchParams.get('body')).toBe('A body');
+    expect(url.searchParams.get('labels')).toBe('enhancement');
+  });
+});

--- a/main/src/ipc/feedback.ts
+++ b/main/src/ipc/feedback.ts
@@ -1,0 +1,249 @@
+import { execFile } from 'child_process';
+import type { IpcMain } from 'electron';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type {
+  FeedbackType,
+  SubmitFeedbackFailure,
+  SubmitFeedbackRequest,
+  SubmitFeedbackSuccess,
+} from '../../../shared/types/feedback';
+import { getShellPath } from '../utils/shellPath';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
+import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+
+const PANE_REPO = 'dcouple/Pane';
+const GITHUB_HOST = 'github.com';
+const MAX_TITLE_LENGTH = 120;
+const MAX_BODY_LENGTH = 65_536;
+
+const LABELS = {
+  bug: 'bug',
+  feature: 'enhancement',
+  general: 'question',
+} satisfies Record<FeedbackType, string>;
+
+const feedbackRequestSchema = boundary.object({
+  type: boundary.enumeration('bug', 'feature', 'general'),
+  title: boundary.string,
+  body: boundary.string,
+  includeAppDetails: boundary.boolean,
+  appDetails: boundary.optional(boundary.object({
+    version: boundary.string,
+    gitCommit: boundary.string,
+  })),
+});
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export type FeedbackCommandRunner = (
+  command: string,
+  args: readonly string[],
+  options: { env: NodeJS.ProcessEnv },
+) => Promise<CommandResult>;
+
+export interface FeedbackRuntime {
+  appVersion: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  electronVersion: string;
+}
+
+function runCommand(
+  command: string,
+  args: readonly string[],
+  options: { env: NodeJS.ProcessEnv },
+): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    execFile(command, [...args], options, (error, stdout, stderr) => {
+      if (error) {
+        reject(Object.assign(error, { stderr }));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function validateRequest(value: PaneCommandValue): SubmitFeedbackRequest {
+  const request = decodeBoundary(value, feedbackRequestSchema);
+  if (request.title.length > MAX_TITLE_LENGTH) {
+    throw new Error(`The title must be ${MAX_TITLE_LENGTH} characters or fewer.`);
+  }
+  if (!request.body.trim()) {
+    throw new Error('Feedback text is required.');
+  }
+  if (request.body.length > MAX_BODY_LENGTH) {
+    throw new Error('Feedback text is too long.');
+  }
+  return request;
+}
+
+function defaultTitle(request: SubmitFeedbackRequest): string {
+  const explicitTitle = request.title.trim();
+  if (explicitTitle) return explicitTitle;
+  const firstLine = request.body.trim().split(/\r?\n/, 1)[0]?.trim() || 'Feedback from Pane';
+  return firstLine.slice(0, MAX_TITLE_LENGTH);
+}
+
+function buildFeedbackBody(
+  request: SubmitFeedbackRequest,
+  runtime: FeedbackRuntime,
+): string {
+  const userBody = request.body.trim();
+  if (!request.includeAppDetails) return userBody;
+
+  const version = request.appDetails?.version || runtime.appVersion;
+  const commit = request.appDetails?.gitCommit || 'unknown';
+  return [
+    userBody,
+    '',
+    '## App details',
+    '',
+    `- Version: ${version}`,
+    `- Commit: ${commit}`,
+    `- Platform: ${runtime.platform}`,
+    `- Architecture: ${runtime.arch}`,
+    `- Electron: ${runtime.electronVersion}`,
+    '',
+    'Filed from Pane in-app feedback',
+  ].join('\n');
+}
+
+export function buildFeedbackFallbackUrl(
+  title: string,
+  body: string,
+  label: string,
+): string {
+  const params = new URLSearchParams({ title, body, labels: label });
+  return `https://github.com/${PANE_REPO}/issues/new?${params.toString()}`;
+}
+
+function commandErrorText(error: Error): string {
+  let stderr = '';
+  try {
+    stderr = decodeBoundary(error, boundary.object({
+      stderr: boundary.optional(boundary.string),
+    })).stderr ?? '';
+  } catch {
+    // Some command errors have no stderr property.
+  }
+  return `${error.message}\n${stderr ?? ''}`.trim();
+}
+
+function friendlyCommandError(error: Error, stage: 'auth' | 'create'): string {
+  let code: string | number | undefined;
+  try {
+    code = decodeBoundary(error, boundary.object({
+      code: boundary.optional(boundary.union(boundary.string, boundary.number)),
+    })).code;
+  } catch {
+    // Some command errors have no process code.
+  }
+  if (code === 'ENOENT') {
+    return 'GitHub CLI (gh) is not installed or is not available in Pane\'s PATH.';
+  }
+  const details = commandErrorText(error);
+  if (stage === 'auth') {
+    return 'GitHub CLI is not authenticated. Run “gh auth login” and try again.';
+  }
+  if (/scope|permission|resource not accessible|forbidden/i.test(details)) {
+    return 'GitHub CLI does not have permission to create issues in dcouple/Pane.';
+  }
+  return details || 'GitHub CLI could not create the issue.';
+}
+
+function isLabelError(error: Error): boolean {
+  return /label|could not add/i.test(commandErrorText(error));
+}
+
+function issueCreateArgs(title: string, bodyPath: string, labels: readonly string[]): string[] {
+  const args = ['issue', 'create', '--repo', PANE_REPO, '--title', title, '--body-file', bodyPath];
+  for (const label of labels) args.push('--label', label);
+  return args;
+}
+
+function issueUrlFromOutput(stdout: string): string {
+  const url = stdout.trim().split(/\s+/).find(value => /^https:\/\/github\.com\/dcouple\/Pane\/issues\/\d+$/.test(value));
+  if (!url) throw new Error('GitHub CLI created the issue but did not return its URL.');
+  return url;
+}
+
+export async function submitFeedbackIssue(
+  rawRequest: PaneCommandValue,
+  runtime: FeedbackRuntime,
+  commandRunner: FeedbackCommandRunner = runCommand,
+): Promise<{ success: true; data: SubmitFeedbackSuccess } | { success: false; error: string; data: SubmitFeedbackFailure }> {
+  let request: SubmitFeedbackRequest;
+  try {
+    request = validateRequest(rawRequest);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid feedback request.';
+    return {
+      success: false,
+      error: message,
+      data: { fallbackUrl: `https://github.com/${PANE_REPO}/issues/new` },
+    };
+  }
+
+  const title = defaultTitle(request);
+  const body = buildFeedbackBody(request, runtime);
+  const primaryLabel = LABELS[request.type];
+  const fallbackUrl = buildFeedbackFallbackUrl(title, body, primaryLabel);
+  const env = { ...process.env, PATH: getShellPath() };
+
+  try {
+    await commandRunner('gh', ['auth', 'status', '--hostname', GITHUB_HOST], { env });
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error('GitHub authentication check failed.');
+    return { success: false, error: friendlyCommandError(cause, 'auth'), data: { fallbackUrl } };
+  }
+
+  let includeFeedbackLabel = false;
+  try {
+    await commandRunner('gh', ['label', 'view', 'feedback', '--repo', PANE_REPO], { env });
+    includeFeedbackLabel = true;
+  } catch {
+    // The optional feedback label is absent or unavailable; the primary label still applies.
+  }
+
+  let tempDirectory: string | undefined;
+  try {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'pane-feedback-'));
+    const bodyPath = join(tempDirectory, 'issue-body.md');
+    await writeFile(bodyPath, body, { encoding: 'utf8', mode: 0o600 });
+    const labels = includeFeedbackLabel ? [primaryLabel, 'feedback'] : [primaryLabel];
+    let result: CommandResult;
+    try {
+      result = await commandRunner('gh', issueCreateArgs(title, bodyPath, labels), { env });
+    } catch (error) {
+      const cause = error instanceof Error ? error : new Error('GitHub issue creation failed.');
+      if (!isLabelError(cause)) throw cause;
+      result = await commandRunner('gh', issueCreateArgs(title, bodyPath, []), { env });
+    }
+    return { success: true, data: { issueUrl: issueUrlFromOutput(result.stdout) } };
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error('GitHub issue creation failed.');
+    return { success: false, error: friendlyCommandError(cause, 'create'), data: { fallbackUrl } };
+  } finally {
+    if (tempDirectory) {
+      await rm(tempDirectory, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+}
+
+export function registerFeedbackHandlers(
+  ipcMain: IpcMain,
+  runtime: { app: { getVersion(): string } },
+): void {
+  ipcMain.handle('feedback:submit', (_event, request: PaneCommandValue) => submitFeedbackIssue(request, {
+    appVersion: runtime.app.getVersion(),
+    platform: process.platform,
+    arch: process.arch,
+    electronVersion: process.versions.electron || 'unknown',
+  }));
+}

--- a/main/src/ipc/feedback.ts
+++ b/main/src/ipc/feedback.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'child_process';
 import type { IpcMain } from 'electron';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
-import { tmpdir } from 'os';
+import { release, tmpdir } from 'os';
 import { join } from 'path';
 import type {
   FeedbackType,
@@ -51,6 +51,10 @@ export interface FeedbackRuntime {
   platform: NodeJS.Platform;
   arch: string;
   electronVersion: string;
+  chromiumVersion: string;
+  nodeVersion: string;
+  osVersion: string;
+  isPackaged: boolean;
 }
 
 function runCommand(
@@ -107,8 +111,12 @@ function buildFeedbackBody(
     `- Version: ${version}`,
     `- Commit: ${commit}`,
     `- Platform: ${runtime.platform}`,
+    `- OS version: ${runtime.osVersion}`,
     `- Architecture: ${runtime.arch}`,
     `- Electron: ${runtime.electronVersion}`,
+    `- Chromium: ${runtime.chromiumVersion}`,
+    `- Node.js: ${runtime.nodeVersion}`,
+    `- App mode: ${runtime.isPackaged ? 'packaged' : 'development'}`,
     '',
     'Filed from Pane in-app feedback',
   ].join('\n');
@@ -238,12 +246,16 @@ export async function submitFeedbackIssue(
 
 export function registerFeedbackHandlers(
   ipcMain: IpcMain,
-  runtime: { app: { getVersion(): string } },
+  runtime: { app: { getVersion(): string; isPackaged: boolean } },
 ): void {
   ipcMain.handle('feedback:submit', (_event, request: PaneCommandValue) => submitFeedbackIssue(request, {
     appVersion: runtime.app.getVersion(),
     platform: process.platform,
     arch: process.arch,
     electronVersion: process.versions.electron || 'unknown',
+    chromiumVersion: process.versions.chrome || 'unknown',
+    nodeVersion: process.versions.node,
+    osVersion: release(),
+    isPackaged: runtime.app.isPackaged,
   }));
 }

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -29,6 +29,7 @@ import { registerPaneChatHandlers } from './paneChat';
 import { createDaemonBridgeRouter, registerDaemonBridgeHandlers } from './daemon';
 import { registerPermissionHandlers } from './permissions';
 import { registerAgentUsageHandlers } from './agentUsage';
+import { registerFeedbackHandlers } from './feedback';
 import { PaneCommandRegistry } from '../daemon/commandRegistry';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 
@@ -53,6 +54,7 @@ export function registerIpcHandlers(services: AppServices): PaneCommandRegistry 
   const bridgeRouter = createDaemonBridgeRouter(commandRegistry);
 
   registerAppHandlers(ipcMain, services);
+  registerFeedbackHandlers(ipcMain, services);
   registerUpdaterHandlers(ipcMain, services);
   registerSessionHandlers(ipcMain, services, commandRegistry);
   registerProjectHandlers(ipcMain, services, commandRegistry);

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -22,6 +22,7 @@ import type { PanelAgentStatusEvent } from '../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../shared/types/agentUsage';
 import type { CloudVmState } from '../../shared/types/cloud';
 import type { ResourceSnapshot } from '../../shared/types/resourceMonitor';
+import type { SubmitFeedbackRequest } from '../../shared/types/feedback';
 import type {
   PanePermissionRequest as PermissionRequest,
   PanePermissionResponse as PermissionResponse,
@@ -437,6 +438,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // System utilities
   openExternal: (url: string): Promise<IPCResponse> => invokeIpc('openExternal', url),
+
+  feedback: {
+    submit: (request: SubmitFeedbackRequest): Promise<IPCResponse> => invokeIpc('feedback:submit', request),
+  },
 
   diagnostics: {
     rendererFatal: (payload: {

--- a/shared/types/feedback.ts
+++ b/shared/types/feedback.ts
@@ -1,0 +1,22 @@
+export type FeedbackType = 'bug' | 'feature' | 'general';
+
+export interface FeedbackAppDetails {
+  version: string;
+  gitCommit: string;
+}
+
+export interface SubmitFeedbackRequest {
+  type: FeedbackType;
+  title: string;
+  body: string;
+  includeAppDetails: boolean;
+  appDetails?: FeedbackAppDetails;
+}
+
+export interface SubmitFeedbackSuccess {
+  issueUrl: string;
+}
+
+export interface SubmitFeedbackFailure {
+  fallbackUrl: string;
+}

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -345,7 +345,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       checkForUpdates: () => success({ hasUpdate: false }),
       openExternal: (url: string) => {
         openedExternalUrls.push(url);
-        return undefined;
+        // Matches preload's Promise<IPCResponse> contract; callers await this result.
+        return success();
       },
       feedback: namespace({
         submit: (request: SubmitFeedbackRequest) => {

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -9,6 +9,7 @@ import type {
   RemotePaneConnectionProfile,
   RemotePaneConnectionState,
 } from '../shared/types/remoteDaemon';
+import type { SubmitFeedbackRequest } from '../shared/types/feedback';
 import type { JsonObject, JsonValue } from '../shared/validation/boundaryDecoder';
 
 type MockEventValue = JsonValue | object | undefined;
@@ -51,6 +52,7 @@ type ElectronApiMockOptions = {
   mainRepoSessionErrorByProjectId?: Record<number, string>;
   activeProjectId?: number | null;
   paneChatAgentChangeDelayMs?: number;
+  feedbackOutcome?: 'success' | 'failure';
 };
 
 export async function installElectronApiMock(page: Page, options: ElectronApiMockOptions = {}) {
@@ -66,6 +68,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     const unsubscribe = () => undefined;
     const listeners = new Map<string, Set<MockEventCallback>>();
     const pendingPermissions: PanePermissionRequest[] = [];
+    const feedbackSubmissions: SubmitFeedbackRequest[] = [];
+    const openedExternalUrls: string[] = [];
     const clone = <T>(value: T): T => structuredClone(value);
     interface MockPreferences {
       [key: string]: string;
@@ -339,7 +343,23 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       }),
       isPackaged: () => Promise.resolve(false),
       checkForUpdates: () => success({ hasUpdate: false }),
-      openExternal: () => undefined,
+      openExternal: (url: string) => {
+        openedExternalUrls.push(url);
+        return undefined;
+      },
+      feedback: namespace({
+        submit: (request: SubmitFeedbackRequest) => {
+          feedbackSubmissions.push(clone(request));
+          if (mockOptions.feedbackOutcome === 'failure') {
+            return Promise.resolve({
+              success: false,
+              error: 'GitHub CLI is not authenticated.',
+              data: { fallbackUrl: 'https://github.com/dcouple/Pane/issues/new?title=Prefilled' },
+            });
+          }
+          return success({ issueUrl: 'https://github.com/dcouple/Pane/issues/9001' });
+        },
+      }),
       analytics: namespace({
         getIdentity: () => success(clone(mockOptions.analyticsIdentity ?? defaultAnalyticsIdentity)),
         onMainEvent: (callback: MockEventCallback) => {
@@ -794,6 +814,12 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         getConfigUpdates() {
           return clone(configUpdates);
+        },
+        getFeedbackSubmissions() {
+          return clone(feedbackSubmissions);
+        },
+        getOpenedExternalUrls() {
+          return clone(openedExternalUrls);
         },
         getPreferenceWrites() {
           return clone(preferenceWrites);

--- a/tests/feedback.spec.ts
+++ b/tests/feedback.spec.ts
@@ -101,6 +101,8 @@ test.describe('Feedback entry points', () => {
     await dialog.getByRole('button', { name: 'Open pre-filled issue in browser' }).click();
     const opened = await readOpenedUrls(page);
     expect(opened).toEqual(['https://github.com/dcouple/Pane/issues/new?title=Prefilled']);
+    // Handing off to the browser must not surface a second error over the first one.
+    await expect(dialog.getByRole('alert')).toContainText('GitHub CLI is not authenticated.');
   });
 
   test('settings General exposes the feedback entry and opens the same dialog', async ({ page }, testInfo) => {

--- a/tests/feedback.spec.ts
+++ b/tests/feedback.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import type { SubmitFeedbackRequest } from '../shared/types/feedback';
+import { installElectronApiMock } from './electronApiMock';
+
+type FeedbackMock = {
+  getFeedbackSubmissions: () => SubmitFeedbackRequest[];
+  getOpenedExternalUrls: () => string[];
+};
+
+async function bootApp(page: Page, options: Parameters<typeof installElectronApiMock>[1] = {}) {
+  await installElectronApiMock(page, options);
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await expect(page.locator('[data-testid="sidebar"]').first()).toBeVisible({ timeout: 10_000 });
+}
+
+function readSubmissions(page: Page) {
+  // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+  return page.evaluate(() => (
+    window as typeof window & { __paneTestElectronMock: FeedbackMock }
+  ).__paneTestElectronMock.getFeedbackSubmissions());
+}
+
+function readOpenedUrls(page: Page) {
+  // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+  return page.evaluate(() => (
+    window as typeof window & { __paneTestElectronMock: FeedbackMock }
+  ).__paneTestElectronMock.getOpenedExternalUrls());
+}
+
+/**
+ * Capture a journey frame into the test's output directory. The fixed wait lets the modal
+ * fade-in finish, so captures are never translucent mid-animation.
+ */
+async function shot(page: Page, testInfo: TestInfo, name: string) {
+  await page.waitForTimeout(600);
+  await page.screenshot({ path: testInfo.outputPath(`${name}.png`) });
+}
+
+async function openSettings(page: Page) {
+  // Settings lives in the sidebar overflow menu while expanded; the compact rail exposes it
+  // directly, which is how tests/settings.spec.ts reaches it as well.
+  const collapse = page.getByRole('button', { name: 'Collapse sidebar' });
+  if (await collapse.isVisible().catch(() => false)) await collapse.click();
+
+  const settingsButton = page.getByRole('button', { name: 'Settings' }).first();
+  await expect(settingsButton).toBeVisible();
+  await settingsButton.click();
+  await expect(page.getByRole('dialog', { name: 'Pane Settings' })).toBeVisible();
+  return settingsButton;
+}
+
+test.describe('Feedback entry points', () => {
+  test('sidebar pill opens the dialog and submits the happy path', async ({ page }, testInfo) => {
+    await bootApp(page);
+    await shot(page, testInfo, '01-expanded-sidebar');
+
+    const pill = page.getByRole('button', { name: 'Feedback', exact: true });
+    await pill.click();
+    const dialog = page.getByRole('dialog', { name: 'Send feedback' });
+    await expect(dialog).toBeVisible();
+    // The header owns the only close control; Modal's own corner button stays off so the
+    // two do not stack on top of each other.
+    await expect(dialog.getByRole('button', { name: /close/i })).toHaveCount(1);
+    await shot(page, testInfo, '02-dialog-default');
+
+    await dialog.locator('input[type="text"]').fill('Terminal flicker on fast pane switch');
+    await dialog.locator('textarea').fill('The terminal flickers when I switch panes quickly.');
+    await shot(page, testInfo, '03-dialog-filled');
+
+    await dialog.getByRole('button', { name: 'Submit feedback' }).click();
+    await expect(dialog.getByText('Feedback submitted')).toBeVisible();
+    await expect(dialog.getByText('Screenshots help.')).toBeVisible();
+    await shot(page, testInfo, '04-dialog-success');
+
+    const submissions = await readSubmissions(page);
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]).toMatchObject({
+      type: 'bug',
+      title: 'Terminal flicker on fast pane switch',
+      body: 'The terminal flickers when I switch panes quickly.',
+      includeAppDetails: true,
+      appDetails: { version: 'test' },
+    });
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).toBeHidden();
+    await expect(pill).toBeFocused();
+  });
+
+  test('failure keeps the text and offers the prefilled fallback', async ({ page }, testInfo) => {
+    await bootApp(page, { feedbackOutcome: 'failure' });
+    await page.getByRole('button', { name: 'Feedback', exact: true }).click();
+    const dialog = page.getByRole('dialog', { name: 'Send feedback' });
+    await dialog.locator('textarea').fill('Pane will not start after the update.');
+    await dialog.getByRole('button', { name: 'Submit feedback' }).click();
+
+    await expect(dialog.getByRole('alert')).toContainText('GitHub CLI is not authenticated.');
+    await expect(dialog.locator('textarea')).toHaveValue('Pane will not start after the update.');
+    await shot(page, testInfo, '06-dialog-fallback');
+
+    await dialog.getByRole('button', { name: 'Open pre-filled issue in browser' }).click();
+    const opened = await readOpenedUrls(page);
+    expect(opened).toEqual(['https://github.com/dcouple/Pane/issues/new?title=Prefilled']);
+  });
+
+  test('settings General exposes the feedback entry and opens the same dialog', async ({ page }, testInfo) => {
+    await bootApp(page);
+    const collapse = page.getByRole('button', { name: 'Collapse sidebar' });
+    if (await collapse.isVisible().catch(() => false)) await collapse.click();
+    await shot(page, testInfo, '05-compact-sidebar');
+
+    await openSettings(page);
+    const settingsDialog = page.getByRole('dialog', { name: 'Pane Settings' });
+    await settingsDialog.getByRole('navigation', { name: 'Settings categories' })
+      .getByRole('button', { name: 'General', exact: true }).click();
+
+    const entry = settingsDialog.getByRole('button', { name: 'Send Feedback' });
+    await expect(entry).toBeVisible();
+    await expect(settingsDialog.getByText('Report a bug, request a feature, or share general feedback.')).toBeVisible();
+    await shot(page, testInfo, '07-settings-feedback-entry');
+
+    await entry.click();
+    const dialog = page.getByRole('dialog', { name: 'Send feedback' });
+    await expect(dialog).toBeVisible();
+    // Settings stays mounted underneath. Radix marks the layer below the stacked dialog
+    // aria-hidden, so it is matched by text here rather than by its dialog role.
+    await expect(page.getByText('Pane Settings', { exact: true })).toBeVisible();
+    await shot(page, testInfo, '08-settings-dialog-open');
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toBeHidden();
+
+    // Settings survives the stacked dialog: focus returns to its own button and the
+    // shell stays interactive once the overlay layer unmounts.
+    await expect(settingsDialog).toBeVisible();
+    await expect(entry).toBeFocused();
+    await settingsDialog.getByRole('navigation', { name: 'Settings categories' })
+      .getByRole('button', { name: 'Terminal', exact: true }).click();
+    await expect(settingsDialog.getByRole('heading', { name: 'Terminal', exact: true })).toBeVisible();
+    await shot(page, testInfo, '09-settings-after-close');
+  });
+});

--- a/tests/feedback.spec.ts
+++ b/tests/feedback.spec.ts
@@ -28,19 +28,27 @@ function readOpenedUrls(page: Page) {
 }
 
 /**
- * Capture a journey frame into the test's output directory. The fixed wait lets the modal
- * fade-in finish, so captures are never translucent mid-animation.
+ * Capture a journey frame into the test's output directory once every running animation
+ * has settled, so captures are never translucent mid fade-in.
  */
 async function shot(page: Page, testInfo: TestInfo, name: string) {
-  await page.waitForTimeout(600);
+  await page.waitForFunction(
+    () => document.getAnimations().every((animation) => animation.playState !== 'running'),
+    undefined,
+    { timeout: 2_000 },
+  ).catch(() => undefined);
   await page.screenshot({ path: testInfo.outputPath(`${name}.png`) });
+}
+
+async function collapseSidebar(page: Page) {
+  const collapse = page.getByRole('button', { name: 'Collapse sidebar' });
+  if (await collapse.isVisible().catch(() => false)) await collapse.click();
 }
 
 async function openSettings(page: Page) {
   // Settings lives in the sidebar overflow menu while expanded; the compact rail exposes it
   // directly, which is how tests/settings.spec.ts reaches it as well.
-  const collapse = page.getByRole('button', { name: 'Collapse sidebar' });
-  if (await collapse.isVisible().catch(() => false)) await collapse.click();
+  await collapseSidebar(page);
 
   const settingsButton = page.getByRole('button', { name: 'Settings' }).first();
   await expect(settingsButton).toBeVisible();
@@ -107,8 +115,7 @@ test.describe('Feedback entry points', () => {
 
   test('settings General exposes the feedback entry and opens the same dialog', async ({ page }, testInfo) => {
     await bootApp(page);
-    const collapse = page.getByRole('button', { name: 'Collapse sidebar' });
-    if (await collapse.isVisible().catch(() => false)) await collapse.click();
+    await collapseSidebar(page);
     await shot(page, testInfo, '05-compact-sidebar');
 
     await openSettings(page);


### PR DESCRIPTION
## Summary

Pane users can now file a public issue in `dcouple/Pane` without leaving the app, using the GitHub CLI identity they already have. Feedback is reachable from two places — the sidebar footer pill and **Settings → General → Feedback** — and both open the same dialog, which `App` owns.

## What changed

**Entry points**

- A Feedback pill sits beside the Remote status in the expanded sidebar footer.
- A **Send feedback** row sits in Settings → General — where people go looking for this sort of thing, and still reachable when the sidebar is collapsed. It calls the same `onSendFeedback` opener threaded down from `App` — one dialog, one piece of state, two doors.

**The dialog**

- Bug reports, feature requests, and general feedback, with an optional title and an app-details toggle covering Pane version, commit, platform, architecture, and Electron version.
- A visible warning that the issue will be public and posted as the signed-in GitHub account.
- On success it shows the created issue URL and tells the user how to add screenshots: Pane does not upload images, but pasting them into a comment on the issue does.
- On failure it keeps everything the user typed and offers a pre-filled GitHub browser fallback, for when `gh` is missing, unauthenticated, or lacks the required scope.
- One fix caught within this PR before it reached anyone: `ModalHeader` already renders a close button, and `Modal`'s corner `X` was stacking a second one on top of it in this dialog. The duplicate is dropped; only this dialog was affected.

**The main process**

- Creates issues through a typed IPC handler using `gh issue create`.
- Writes the issue body to a permission-restricted temporary file. User text is never interpolated into a shell command.
- Maps feedback types to `bug`, `enhancement`, or `question`, adds the optional `feedback` label only when it exists, and retries without labels if GitHub rejects them.

**Where to look**

| Area | File |
| --- | --- |
| Dialog and its reducer | `frontend/src/components/FeedbackDialog.tsx`, `feedbackDialogState.ts` |
| Settings entry | `frontend/src/components/settings/categories/GeneralSettings.tsx`, `catalog.tsx` |
| Callback threading | `frontend/src/App.tsx`, `frontend/src/components/Settings.tsx` |
| Issue creation | `main/src/ipc/feedback.ts` |
| Tests | `tests/feedback.spec.ts`, `main/src/ipc/feedback.test.ts`, `GeneralSettings.test.tsx` |

### For reviewers: opening from Settings keeps Settings open

Settings' other hand-offs — Update and Keyboard shortcuts — close Settings before opening the next dialog. The feedback entry deliberately does not. It stacks the dialog over Settings, the way Settings' own unsaved-changes `ConfirmDialog` already does. That is what lets focus return to the **Send Feedback** button when the dialog closes; if Settings closed, the opener would unmount and focus would be stranded. No `requestTransition` guard is needed, because Settings never closes and no dirty form is discarded.

## Verification

Everything below ran at head `37876cd00e2f54a4f4c34a7f5fc5535c91a73cd7`.

- `pnpm lint` — exit 0, no blocking findings
- `pnpm typecheck` — clean across frontend, main, shared, and runpane
- `pnpm --filter frontend test` — 168 tests passed, including a new `GeneralSettings.test.tsx` covering the Settings row and its catalog registration
- `pnpm --dir main exec vitest run src/ipc/feedback.test.ts` — 6 tests passed
- `npx playwright test tests/feedback.spec.ts` — 3 tests passed
- `npx playwright test tests/accessibility.spec.ts` — 8 tests passed

**Two local failures, neither caused by this PR.** Both reproduce with these changes stashed, on the previous head:

- `tests/settings.spec.ts` → "discards remote subview drafts…" times out waiting for `This Machine Label`.
- 4 main-process test files fail on a `better-sqlite3-multiple-ciphers` `NODE_MODULE_VERSION` mismatch — the native module in this worktree is built for Electron, not Node. The other 527 main-process tests pass, and CI, which builds it correctly, was green on the previous head.

<!-- pr-test-automation-summary:start -->
## Automated PR QA

Current head: `37876cd00e2f54a4f4c34a7f5fc5535c91a73cd7`

`tests/feedback.spec.ts` now lives in the repo rather than being generated per QA run, and covers both entry points against the shared Playwright Electron mock, which gained `feedback.submit` and `openExternal` recording.

What the three journeys prove:

- **Sidebar pill** — dialog opens, the submitted payload carries the chosen type, title, body, `includeAppDetails: true`, and the app version; the success screen renders the issue URL and the screenshot hint; Escape closes the dialog and returns focus to the pill. The dialog exposes exactly one close control.
- **Failure path** — the error is announced, the typed text survives, and the fallback button opens exactly the pre-filled GitHub URL.
- **Settings path** — the row and its description render under General; the button opens the same dialog stacked over Settings; Settings stays visible underneath; after close, focus lands on the **Send Feedback** button and Settings is still interactive (switching to the Terminal category still works).

Every screenshot below was captured after the modal's fade-in settled, then uploaded and byte-verified against its local hash. They were taken at `849c0a0`; every change since is test and comment plumbing, so the UI is identical at the current head.

| Sidebar pill | Public-warning dialog | Success and screenshot hint |
| --- | --- | --- |
| ![Feedback beside Remote](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-0856022a0a7b-expanded-sidebar.png) | ![Feedback dialog](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-6c24c67ec28c-dialog-default.png) | ![Issue URL and screenshot hint](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-2c01741294f1-dialog-success.png) |

| Settings → General entry | Dialog stacked over Settings | Settings after close |
| --- | --- | --- |
| ![Send feedback row in Settings](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-d199414a753f-settings-feedback-entry.png) | ![Feedback dialog over Settings](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-dbb174ae0506-settings-dialog-open.png) | ![Settings still usable](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-5f36c4f52d5e-settings-after-close.png) |

| Filled form | Failure fallback | Compact sidebar |
| --- | --- | --- |
| ![Filled feedback form](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-32bda31588e3-dialog-filled.png) | ![Retained feedback and browser fallback](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-2546b20239ec-dialog-fallback.png) | ![Compact sidebar rail](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-433-849c0a0-d80485195cac-compact-sidebar.png) |

**What automation could not cover.** No real issue was created — that would post to the public repository. The live `gh` identity and permission path, and the native system-browser handoff, still need a maintainer smoke test. The main-process command paths are covered by mocked unit tests. Renderer tests assert the Settings row's markup rather than clicking it, because the frontend Vitest suite has no DOM environment; the click itself is covered by the Playwright journey above.

An independent review of the pushed branch returned no must-fix findings. Its two should-fix items were test-quality problems and are fixed in `37876cd`: a renderer test that asserted nothing it claimed (static markup carries no event handlers, so the spy it checked could never have been called), and markup-substring assertions that duplicated what the end-to-end spec already asserts against a real DOM.
<!-- pr-test-automation-summary:end -->

## Manual tests for a maintainer

- [ ] Open Feedback from the sidebar pill and from Settings → General; both show the same dialog.
- [ ] Submit a real bug report with app details and confirm the created issue's body, `bug` label, and clickable URL.
- [ ] With `gh` logged out, confirm the form keeps its text and the browser fallback opens the pre-filled issue.
- [ ] Close the dialog opened from Settings and confirm Settings is still usable and focus is on the Send Feedback button.

## Scope

No new dependencies, backend service, stored token, telemetry, attachment upload, or onboarding change. The sidebar pill's behavior is unchanged by the Settings follow-up. This PR came from a direct feature request and has no pre-existing issue to link.

Development lane: **light: simple-plan → prepare-pr → pr-test-automation**
