### PR TITLE
Remove unused main process declarations

### DIFF
--- a/main/src/daemon/remoteTransportController.test.ts
+++ b/main/src/daemon/remoteTransportController.test.ts
@@ -1,6 +1,6 @@
 import http from 'http';
 import { EventEmitter } from 'events';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createDefaultRemoteDaemonConfig, type RemoteDaemonConfig } from '../../../shared/types/remoteDaemon';
 import { hashRemoteDaemonToken } from './auth';
 import { PaneCommandRegistry } from './commandRegistry';

--- a/main/src/events.ts
+++ b/main/src/events.ts
@@ -1,4 +1,3 @@
-import { execSync } from './utils/commandExecutor';
 import { getPaneEventSink } from './core/runtime';
 import type { AppServices } from './ipc/types';
 import type { VersionInfo } from './services/versionChecker';

--- a/main/src/ipc/dashboard.ts
+++ b/main/src/ipc/dashboard.ts
@@ -1,7 +1,6 @@
 import { IpcMain } from 'electron';
 import { formatForDatabase } from '../utils/timestampUtils';
 import type { AppServices } from './types';
-import path from 'path';
 import fs from 'fs';
 import type { CommandRunner } from '../utils/commandRunner';
 import type { PathResolver } from '../utils/pathResolver';

--- a/main/src/ipc/nimbalyst.ts
+++ b/main/src/ipc/nimbalyst.ts
@@ -5,7 +5,7 @@ import type { AppServices } from './types';
 
 const NIMBALYST_PATH = '/Applications/Nimbalyst.app/Contents/MacOS/Nimbalyst';
 
-export function registerNimbalystHandlers(ipcMain: IpcMain, services: AppServices): void {
+export function registerNimbalystHandlers(ipcMain: IpcMain, _services: AppServices): void {
   // Check if Nimbalyst is installed
   ipcMain.handle('nimbalyst:check-installed', () => {
     try {

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -19,7 +19,6 @@ import { terminalPanelManager } from '../services/terminalPanelManager';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import {
   validateSessionExists,
-  validatePanelSessionOwnership,
   validatePanelExists,
   validateSessionIsActive,
   logValidationFailure,

--- a/main/src/polyfills/readablestream.ts
+++ b/main/src/polyfills/readablestream.ts
@@ -15,7 +15,7 @@ if (!globalThis.ReadableStream) {
     globalThis.TransformStream = TransformStream;
     
     console.log('[Polyfill] Using Node.js built-in ReadableStream from stream/web');
-  } catch (error) {
+  } catch {
     // If stream/web is not available, use the web-streams-polyfill package
     try {
       const streams = require('web-streams-polyfill/ponyfill');

--- a/main/src/services/analyticsManager.ts
+++ b/main/src/services/analyticsManager.ts
@@ -4,11 +4,6 @@ import { app, BrowserWindow } from 'electron';
 import * as crypto from 'crypto';
 import * as os from 'os';
 
-interface AnalyticsEvent {
-  eventName: string;
-  properties?: Record<string, string | number | boolean | string[] | undefined>;
-}
-
 export class AnalyticsManager extends EventEmitter {
   private configManager: ConfigManager;
   private mainWindow: BrowserWindow | null = null;

--- a/main/src/services/executionTracker.ts
+++ b/main/src/services/executionTracker.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events';
 import type { Logger } from '../utils/logger';
-import type { SessionManager } from './sessionManager';
 import { GitDiffManager, type GitDiffResult } from './gitDiffManager';
 import type { CreateExecutionDiffData, ExecutionDiff } from '../database/models';
 

--- a/main/src/services/mcpPermissionBridge.ts
+++ b/main/src/services/mcpPermissionBridge.ts
@@ -10,9 +10,6 @@ import {
   ListToolsRequestSchema 
 } from '@modelcontextprotocol/sdk/types.js';
 import net from 'net';
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
 import type { PermissionResponse } from './permissionManager';
 import type { PanePermissionInput } from '../../../shared/types/daemon';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';

--- a/main/src/services/panelEventBus.ts
+++ b/main/src/services/panelEventBus.ts
@@ -1,4 +1,4 @@
-import { PanelEvent, PanelEventType, PanelEventSubscription } from '../../../shared/types/panels';
+import { PanelEvent } from '../../../shared/types/panels';
 import { EventEmitter } from 'events';
 
 class PanelEventBus extends EventEmitter {

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -10,7 +10,6 @@ import type { ConversationMessage } from '../../../database/models';
 import { testClaudeCodeAvailability, testClaudeCodeInDirectory } from '../../../utils/claudeCodeTest';
 import { findExecutableInPath } from '../../../utils/shellPath';
 import { PermissionManager } from '../../permissionManager';
-import { findNodeExecutable } from '../../../utils/nodeFinder';
 import {
   AbstractCliManager,
   type CliEnvironment,

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -9,7 +9,7 @@ import type { Logger } from '../../../utils/logger';
 import { getPtyHostRuntime, type PtyHandleLike } from '../../../core/runtime';
 import type { ConfigManager } from '../../configManager';
 import type { ConversationMessage } from '../../../database/models';
-import { getShellPath, findExecutableInPath } from '../../../utils/shellPath';
+import { getShellPath } from '../../../utils/shellPath';
 import { findNodeExecutable } from '../../../utils/nodeFinder';
 import { getGitAttributionEnv } from '../../../utils/attribution';
 

--- a/main/src/services/permissionIpcServer.ts
+++ b/main/src/services/permissionIpcServer.ts
@@ -2,7 +2,6 @@ import net from 'net';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { app } from 'electron';
 import { PermissionManager } from './permissionManager';
 import { getAppSubdirectory } from '../utils/appDirectory';
 

--- a/main/src/services/permissionManager.ts
+++ b/main/src/services/permissionManager.ts
@@ -1,7 +1,5 @@
 import { PanePermissionBroker } from '../daemon/permissionBroker';
 import type {
-  PanePermissionInput as PermissionInput,
-  PanePermissionRequest as PermissionRequest,
   PanePermissionResponse as PermissionResponse,
 } from '../../../shared/types/daemon';
 

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -14,7 +14,7 @@ import type { DatabaseService } from '../database/database';
 import type { Session as DbSession, CreateSessionData, UpdateSessionData, ConversationMessage, PromptMarker, ExecutionDiff, CreateExecutionDiffData, Project } from '../database/models';
 import { getShellPath } from '../utils/shellPath';
 import { TerminalSessionManager } from './terminalSessionManager';
-import type { BaseAIPanelState, ToolPanelState, ToolPanel, ResumableSession, TerminalPanelState } from '../../../shared/types/panels';
+import type { ToolPanelState, ResumableSession } from '../../../shared/types/panels';
 import { formatForDisplay } from '../utils/timestampUtils';
 import { isCliAgentType, resolveAgentTypeFromCommand } from './agents/agentIdentity';
 import { resolveResumeId } from './agents/agentResume';

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -12,7 +12,6 @@ import * as os from 'os';
 import * as fs from 'fs';
 import { panelManager } from './panelManager';
 import { PathResolver } from '../utils/pathResolver';
-import type { DatabaseService } from '../database/database';
 import type { Project } from '../database/models';
 import { worktreeFileSyncService, type WorktreeFileSyncFailure } from './worktreeFileSyncService';
 import { terminalPanelManager } from './terminalPanelManager';

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -1,8 +1,7 @@
 import * as pty from '@lydell/node-pty';
-import { ToolPanel, TerminalPanelState, PanelEventType } from '../../../shared/types/panels';
+import { ToolPanel, TerminalPanelState } from '../../../shared/types/panels';
 import { getPaneDaemonEventSink, getPaneEventSink, getPtyHostRuntime, getRuntimeConfigManager, type PtyHandleLike, type PtyHostRuntime } from '../core/runtime';
 import { panelManager } from './panelManager';
-import * as os from 'os';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { getShellPath } from '../utils/shellPath';

--- a/main/src/utils/contextCompactor.ts
+++ b/main/src/utils/contextCompactor.ts
@@ -1,7 +1,7 @@
 import type { DatabaseService } from '../database/database';
 import type { Session, ConversationMessage, PromptMarker, ExecutionDiff } from '../database/models';
 import type { SessionOutput } from '../types/session';
-import { formatDuration, getTimeDifference, parseTimestamp } from './timestampUtils';
+import { formatDuration, getTimeDifference } from './timestampUtils';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
 interface CompactionData {
@@ -16,12 +16,6 @@ interface FileModification {
   path: string;
   operations: Array<'create' | 'edit'>;
   changeCount: number;
-}
-
-interface ToolCall {
-  name: string;
-  input: unknown;
-  id: string;
 }
 
 interface PromptAnalysis {

--- a/main/src/utils/mutex.ts
+++ b/main/src/utils/mutex.ts
@@ -1,5 +1,3 @@
-import { Logger } from './logger';
-
 // Use console logging for mutex operations since logger might not be available
 const logger = {
   debug: (msg: string) => console.log(`[Mutex] ${msg}`),

--- a/main/src/utils/timestampUtils.ts
+++ b/main/src/utils/timestampUtils.ts
@@ -36,15 +36,6 @@ function formatFullDateTime(timestamp: string | Date): string {
 }
 
 /**
- * Parses a database timestamp string to a Date object
- * @param timestamp - The timestamp string from database
- * @returns Date object
- */
-export function parseTimestamp(timestamp: string): Date {
-  return new Date(timestamp);
-}
-
-/**
  * Gets the current timestamp in ISO format for database storage
  * @returns ISO 8601 formatted string
  */

--- a/main/src/utils/toolFormatter.ts
+++ b/main/src/utils/toolFormatter.ts
@@ -21,11 +21,6 @@ interface PendingToolCall {
   timestamp: string;
 }
 
-interface TodoItem {
-  status: string;
-  content: string;
-}
-
 interface ThinkingItem {
   type: 'thinking';
   thinking?: string;


### PR DESCRIPTION
## Summary

- remove 28 unused imports, types, declarations, and bindings from main-process code without suppressions
- delete the now-unreferenced `parseTimestamp` utility so Knip remains at zero
- reduce the repository ESLint baseline from 304 warnings to 276 with no runtime behavior changes

Part of #403.

## Validation

- `pnpm lint` — blocking lint and Knip pass; anti-slop remains at zero
- `pnpm typecheck`
- `pnpm --filter main exec vitest run` — 596 passed
- `pnpm build:main`
- ESLint JSON audit — 276 warnings, 0 errors

Delivery lane: medium, using the approved zero-findings campaign plan with current-head implementation review and required PR CI/review gates before merge.
