### PR TITLE
Remove unused catch bindings

### DIFF
--- a/frontend/src/components/MermaidRenderer.tsx
+++ b/frontend/src/components/MermaidRenderer.tsx
@@ -70,7 +70,7 @@ export const MermaidRenderer: React.FC<MermaidRendererProps> = ({ chart, id }) =
             // @ts-expect-error - Mermaid API types don't include reset method
             window.mermaid.mermaidAPI.reset();
           }
-        } catch (e) {
+        } catch {
           // Ignore reset errors
         }
       }

--- a/frontend/src/components/panels/SetupTasksPanel.tsx
+++ b/frontend/src/components/panels/SetupTasksPanel.tsx
@@ -49,7 +49,7 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
              content.includes('/worktree-*/') ||
              content.includes('worktrees/') ||
              content.includes('worktree-*/');
-    } catch (error) {
+    } catch {
       // If .gitignore doesn't exist, that's ok - it's not found
       return false;
     }

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -1425,7 +1425,7 @@ export const useSessionView = (
     try {
       await API.sessions.rename(activeSession.id, editName.trim());
       setIsEditingName(false);
-    } catch (error) {
+    } catch {
       alert('Failed to rename pane');
       setEditName(activeSession.name);
       setIsEditingName(false);

--- a/frontend/src/stores/sessionPreferencesStore.ts
+++ b/frontend/src/stores/sessionPreferencesStore.ts
@@ -71,7 +71,7 @@ export const useSessionPreferencesStore = create<SessionPreferencesStore>((set, 
       } else {
         set({ error: response.error || 'Failed to load session preferences', isLoading: false });
       }
-    } catch (error) {
+    } catch {
       set({ error: 'Failed to load session preferences', isLoading: false });
     }
   },
@@ -105,7 +105,7 @@ export const useSessionPreferencesStore = create<SessionPreferencesStore>((set, 
         // Revert on failure
         set({ preferences: currentPreferences, error: response.error || 'Failed to save preferences' });
       }
-    } catch (error) {
+    } catch {
       // Revert on failure
       set({ preferences: currentPreferences, error: 'Failed to save preferences' });
     }

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -1458,12 +1458,6 @@ export class DatabaseService {
         .run();
       console.log("[Database] Added tool_type column to sessions table");
 
-      // Best effort: mark known Codex sessions (removed model-based detection)
-      try {
-        // No longer detecting based on model since it's panel-level now
-      } catch (error) {
-        // Migration error handling removed - empty try/catch serves no purpose
-      }
     }
 
     // Add user_preferences table to store all user preferences
@@ -4933,7 +4927,7 @@ export class DatabaseService {
         if (data.cache_creation_input_tokens) {
           totalCacheCreationTokens += data.cache_creation_input_tokens;
         }
-      } catch (e) {
+      } catch {
         // Ignore parse errors
       }
     });
@@ -5108,7 +5102,7 @@ export class DatabaseService {
               }
             });
           }
-        } catch (e) {
+        } catch {
           // Ignore parse errors
         }
       },

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -732,7 +732,7 @@ async function createWindow() {
           originalError('[Main] Failed to send error to renderer:', e);
         }
       }
-    } catch (e) {
+    } catch {
       // If anything fails in the error handler, fall back to original
       originalError.apply(console, args);
     } finally {

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -1702,7 +1702,7 @@ export function registerSessionHandlers(
               ? diff.files_changed 
               : JSON.parse(diff.files_changed);
             files.forEach((file: string) => filesModified.add(file));
-          } catch (e) {
+          } catch {
             // Ignore parse errors
           }
         }

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -350,7 +350,7 @@ try {
       console.error('Failed to dispatch browser-panel:popup-requested to window:', e);
     }
   });
-} catch (e) {
+} catch {
   // Ignore if IPC is not available for some reason
 }
 

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -379,7 +379,7 @@ export class GitDiffManager {
   getCurrentCommitHash(worktreePath: string, commandRunner: CommandRunner): string {
     try {
       return commandRunner.exec('git rev-parse HEAD', worktreePath).trim();
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not get current commit hash in ${worktreePath}`);
       return '';
     }
@@ -442,7 +442,7 @@ export class GitDiffManager {
   private getGitCommitDiff(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): string {
     try {
       return commandRunner.exec(`git diff ${fromCommit}..${toCommit}`, worktreePath);
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not get git commit diff in ${worktreePath}`);
       return '';
     }
@@ -459,7 +459,7 @@ export class GitDiffManager {
       
       // Combine both lists
       return [...trackedFiles, ...untrackedFiles];
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not get changed files in ${worktreePath}`);
       return [];
     }
@@ -469,7 +469,7 @@ export class GitDiffManager {
     try {
       const output = commandRunner.exec(`git diff --name-only ${fromCommit}..${toCommit}`, worktreePath);
       return output.trim().split('\n').filter((f: string) => f.length > 0);
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not get changed files between commits in ${worktreePath}`);
       return [];
     }
@@ -509,7 +509,7 @@ export class GitDiffManager {
       }
       
       return trackedStats;
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not get diff stats in ${worktreePath}`);
       return { additions: 0, deletions: 0, filesChanged: 0 };
     }
@@ -520,7 +520,7 @@ export class GitDiffManager {
       const output = commandRunner.exec(`git diff --stat ${fromCommit}..${toCommit}`, worktreePath);
       
       return this.parseDiffStats(output);
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not get commit diff stats in ${worktreePath}`);
       return { additions: 0, deletions: 0, filesChanged: 0 };
     }
@@ -549,7 +549,7 @@ export class GitDiffManager {
     try {
       const output = commandRunner.exec('git status --porcelain', worktreePath);
       return output.trim().length > 0;
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not check git status in ${worktreePath}`);
       return false;
     }
@@ -568,7 +568,7 @@ export class GitDiffManager {
       }
       
       return output.trim().split('\n').filter((f: string) => f && f.trim().length > 0);
-    } catch (error) {
+    } catch {
       this.logger?.warn(`Could not get untracked files in ${worktreePath}`);
       return [];
     }

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -322,7 +322,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
         data: jsonMessage,
         timestamp: new Date()
       });
-    } catch (error) {
+    } catch {
       // If not valid JSON, treat as regular output
       this.logger?.verbose(`Raw output from panel ${panelId} (session ${sessionId}): ${data.substring(0, 200)}`);
 

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -755,7 +755,7 @@ export abstract class AbstractCliManager extends EventEmitter {
               scriptPath = foundScript;
               this.logger?.verbose(`[${this.getCliToolName()}] Found script at: ${scriptPath}`);
             }
-          } catch (e) {
+          } catch {
             // If we can't find the script helper, just use the command as-is
             this.logger?.verbose(`[${this.getCliToolName()}] Using command directly for Node.js invocation`);
           }
@@ -1248,7 +1248,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         }
 
         processInfo.push({ pid, name: name || 'unknown' });
-      } catch (error) {
+      } catch {
         processInfo.push({ pid, name: 'unknown' });
       }
     }
@@ -1277,7 +1277,7 @@ export abstract class AbstractCliManager extends EventEmitter {
           for (const childPid of descendantPids) {
             try {
               await this.execAsync(`taskkill /F /PID ${childPid}`);
-            } catch (e) {
+            } catch {
               // Process might already be dead
             }
           }
@@ -1303,7 +1303,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         // Force kill
         try {
           process.kill(pid, 'SIGKILL');
-        } catch (error) {
+        } catch {
           // Process might already be dead
         }
 
@@ -1318,7 +1318,7 @@ export abstract class AbstractCliManager extends EventEmitter {
           try {
             await this.execAsync(`kill -9 ${childPid}`);
             this.logger?.verbose(`[${this.getCliToolName()}] Killed descendant process ${childPid}`);
-          } catch (error) {
+          } catch {
             this.logger?.verbose(`[${this.getCliToolName()}] Process ${childPid} already terminated`);
           }
         }
@@ -1326,7 +1326,7 @@ export abstract class AbstractCliManager extends EventEmitter {
         // Final cleanup attempt
         try {
           await this.execAsync(`pkill -9 -P ${pid}`);
-        } catch (error) {
+        } catch {
           // Ignore errors - processes might already be dead
         }
       }
@@ -1361,7 +1361,7 @@ export abstract class AbstractCliManager extends EventEmitter {
       if (cliProcess) {
         cliProcess.process.kill();
       }
-    } catch (error) {
+    } catch {
       // Process might already be dead
     }
 

--- a/main/src/services/panels/logPanel/logsManager.ts
+++ b/main/src/services/panels/logPanel/logsManager.ts
@@ -265,7 +265,7 @@ class LogsManager {
             // Recursively get children of this process
             descendants.push(...this.getAllDescendantPids(pid));
           }
-        } catch (e) {
+        } catch {
           // If that fails, try macOS/BSD style
           try {
             // Get all processes with their parent PIDs, then filter
@@ -279,12 +279,12 @@ class LogsManager {
               // Recursively get children of this process
               descendants.push(...this.getAllDescendantPids(pid));
             }
-          } catch (e2) {
+          } catch {
             // Could not find children
           }
         }
       }
-    } catch (error) {
+    } catch {
       // Command might fail if no children exist, which is fine
     }
     
@@ -366,7 +366,7 @@ class LogsManager {
         for (const targetPid of allPids) {
           try {
             process.kill(targetPid, 'SIGKILL');
-          } catch (error: unknown) {
+          } catch {
             // Process might already be dead or inaccessible
           }
         }

--- a/main/src/services/runCommandManager.ts
+++ b/main/src/services/runCommandManager.ts
@@ -369,7 +369,7 @@ export class RunCommandManager extends EventEmitter {
         // Also try to kill via pty interface as fallback
         try {
           runProcess.process.kill();
-        } catch (error) {
+        } catch {
           // Process might already be dead
         }
       } catch (error) {
@@ -493,7 +493,7 @@ export class RunCommandManager extends EventEmitter {
           for (const childPid of descendantPids) {
             try {
               await execAsync(`taskkill /F /PID ${childPid}`);
-            } catch (e) {
+            } catch {
               // Process might already be dead
             }
           }
@@ -524,7 +524,7 @@ export class RunCommandManager extends EventEmitter {
         // Now forcefully kill the main process
         try {
           process.kill(pid, 'SIGKILL');
-        } catch (error) {
+        } catch {
           // Process might already be dead
         }
         
@@ -541,7 +541,7 @@ export class RunCommandManager extends EventEmitter {
           try {
             await execAsync(`kill -9 ${childPid}`);
             this.logger?.verbose(`Killed descendant process ${childPid}`);
-          } catch (error) {
+          } catch {
             this.logger?.verbose(`Process ${childPid} already terminated`);
           }
         }
@@ -549,7 +549,7 @@ export class RunCommandManager extends EventEmitter {
         // Final cleanup attempt using pkill
         try {
           await execAsync(`pkill -9 -P ${pid}`);
-        } catch (error) {
+        } catch {
           // Ignore errors - processes might already be dead
         }
       }
@@ -612,7 +612,7 @@ export class RunCommandManager extends EventEmitter {
               allDescendants.push(...pgPids);
             }
           }
-        } catch (error) {
+        } catch {
           // Process might be gone already
         }
       }
@@ -626,7 +626,7 @@ export class RunCommandManager extends EventEmitter {
           try {
             await execAsync(`kill -9 ${pid}`);
             this.logger?.info(`Killed escaped process ${pid}`);
-          } catch (error) {
+          } catch {
             // Process might already be dead
           }
         }

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -227,7 +227,7 @@ export class SessionManager extends EventEmitter {
       const panel = this.db.getPanel(panelId);
       const customState = parseTerminalResumeState(panel?.state?.customState);
       return customState?.agentSessionId;
-    } catch (e) {
+    } catch {
       return undefined;
     }
   }
@@ -1542,7 +1542,7 @@ export class SessionManager extends EventEmitter {
           descendants.push(...this.getAllDescendantPids(pid));
         }
       }
-    } catch (error) {
+    } catch {
       // Command might fail if no children exist, which is fine
     }
     
@@ -1662,7 +1662,7 @@ export class SessionManager extends EventEmitter {
               try {
                 process.kill('SIGKILL');
                 addSessionLog(sessionId, 'info', `[Sent SIGKILL to process ${process.pid}]`, 'System');
-              } catch (error) {
+              } catch {
                 // Process might already be dead
                 addSessionLog(sessionId, 'info', `[Process ${process.pid} already terminated]`, 'System');
               }

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -751,7 +751,7 @@ export class TaskQueue {
           const worktreePath = resolver.join(project.path, worktreeFolder, uniqueWorktreeName);
           worktreePathExists = fs.existsSync(resolver.toFileSystem(worktreePath));
         }
-      } catch (e) {
+      } catch {
         // Ignore filesystem check errors
       }
       

--- a/main/src/services/terminalSessionManager.ts
+++ b/main/src/services/terminalSessionManager.ts
@@ -264,7 +264,7 @@ export class TerminalSessionManager extends EventEmitter {
         // Also try to kill via pty interface as fallback
         try {
           session.pty.kill();
-        } catch (error) {
+        } catch {
           // PTY might already be dead
         }
       } catch (error) {
@@ -361,7 +361,7 @@ export class TerminalSessionManager extends EventEmitter {
           for (const childPid of descendantPids) {
             try {
               await execAsync(`taskkill /F /PID ${childPid}`);
-            } catch (e) {
+            } catch {
               // Process might already be dead
             }
           }
@@ -384,7 +384,7 @@ export class TerminalSessionManager extends EventEmitter {
           if (!isNaN(foundPgid)) {
             pgid = foundPgid;
           }
-        } catch (error) {
+        } catch {
           // Use original PID as fallback
         }
         
@@ -400,7 +400,7 @@ export class TerminalSessionManager extends EventEmitter {
         // Now forcefully kill the main process
         try {
           process.kill(pid, 'SIGKILL');
-        } catch (error) {
+        } catch {
           // Process might already be dead
         }
         
@@ -415,7 +415,7 @@ export class TerminalSessionManager extends EventEmitter {
         for (const childPid of descendantPids) {
           try {
             await execAsync(`kill -9 ${childPid}`);
-          } catch (error) {
+          } catch {
             // Process already terminated
           }
         }
@@ -423,7 +423,7 @@ export class TerminalSessionManager extends EventEmitter {
         // Final cleanup attempt using pkill
         try {
           await execAsync(`pkill -9 -P ${pid}`);
-        } catch (error) {
+        } catch {
           // Ignore errors - processes might already be dead
         }
       }

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -237,7 +237,7 @@ export class WorktreeManager {
       try {
         await commandRunner.execAsync(`git rev-parse --is-inside-work-tree`, projectPath);
         isGitRepo = true;
-      } catch (error) {
+      } catch {
         // Initialize git repository
         await commandRunner.execAsync(`git init`, projectPath);
       }
@@ -285,7 +285,7 @@ export class WorktreeManager {
       try {
         await commandRunner.execAsync(`git rev-parse HEAD`, projectPath);
         hasCommits = true;
-      } catch (error) {
+      } catch {
         // Repository has no commits yet, create initial commit
         // Use cross-platform approach without shell operators
         try {

--- a/main/src/utils/claudeCodeTest.ts
+++ b/main/src/utils/claudeCodeTest.ts
@@ -72,7 +72,7 @@ function getAugmentedPath(): string {
               paths.push(fullPath);
             }
           }
-        } catch (e) {
+        } catch {
           // Ignore errors reading directories
         }
       }
@@ -124,7 +124,7 @@ export async function testClaudeCodeAvailability(customClaudePath?: string): Pro
       try {
         await fs.promises.access(customClaudePath, fs.constants.X_OK);
         claudePath = customClaudePath;
-      } catch (error) {
+      } catch {
         console.error(`[ClaudeTest] Custom Claude path is not accessible or not executable: ${customClaudePath}`);
         return { 
           available: false, 

--- a/main/src/utils/contextCompactor.ts
+++ b/main/src/utils/contextCompactor.ts
@@ -168,7 +168,7 @@ export class ProgrammaticCompactor {
               }
             });
           }
-        } catch (e) {
+        } catch {
           // Skip invalid JSON
         }
       }
@@ -194,7 +194,7 @@ export class ProgrammaticCompactor {
               }
             });
           }
-        } catch (e) {
+        } catch {
           // Skip invalid JSON
         }
       }
@@ -220,7 +220,7 @@ export class ProgrammaticCompactor {
               }
             });
           }
-        } catch (e) {
+        } catch {
           // Skip invalid JSON
         }
       }
@@ -274,7 +274,7 @@ export class ProgrammaticCompactor {
               }
             }
           }
-        } catch (e) {
+        } catch {
           // Skip invalid JSON
         }
       }

--- a/main/src/utils/nodeFinder.ts
+++ b/main/src/utils/nodeFinder.ts
@@ -81,7 +81,7 @@ export async function findNodeExecutable(): Promise<string> {
               return fullPath;
             }
           }
-        } catch (e) {
+        } catch {
           // Ignore errors reading directories
         }
       }

--- a/main/src/utils/shellDetector.ts
+++ b/main/src/utils/shellDetector.ts
@@ -134,7 +134,7 @@ export class ShellDetector {
             return { path: shellPath, name, args: this.getShellArgs(name) };
           }
         }
-      } catch (error) {
+      } catch {
         // Ignore errors and continue with fallback detection
       }
     }
@@ -152,7 +152,7 @@ export class ShellDetector {
           return { path: shellPath, name, args: this.getShellArgs(name) };
         }
       }
-    } catch (error) {
+    } catch {
       // Ignore errors and continue with fallback detection
     }
 


### PR DESCRIPTION
## Summary

- omit 59 unused catch bindings while preserving every fallback and error-handling branch
- remove one already-empty migration `try/catch` whose body and handler were both inert
- reduce the repository ESLint baseline from 276 warnings to 217 without suppressions

Part of #403.

## Validation

- `pnpm lint` — blocking lint and Knip pass; anti-slop remains at zero
- `pnpm typecheck`
- `pnpm --filter main exec vitest run` — 596 passed
- `pnpm --filter frontend exec vitest run` — 163 passed
- `pnpm build:main`
- `pnpm --filter frontend build`
- ESLint JSON audit — 217 warnings, 0 errors

Delivery lane: medium, using the approved zero-findings campaign plan with current-head implementation review and required PR CI/review gates before merge.
