### PR TITLE
Mark intentionally unused parameters

### DIFF
--- a/frontend/src/components/MarkdownPreview.tsx
+++ b/frontend/src/components/MarkdownPreview.tsx
@@ -28,7 +28,7 @@ export const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, class
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          code({ node, className, children, ...props }: CodeComponentProps) {
+          code({ node: _node, className, children, ...props }: CodeComponentProps) {
             const match = /language-(\w+)/.exec(className || '');
             const language = match ? match[1] : '';
             const codeString = String(children).replace(/\n$/, '');

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -5031,7 +5031,7 @@ export class DatabaseService {
 
     // Process each message
     toolUseRows.forEach(
-      (row: { data: string; timestamp: string }, index: number) => {
+      (row: { data: string; timestamp: string }, _index: number) => {
         try {
           const data = decodeBoundary(JSON.parse(row.data), toolAnalyticsMessageSchema);
           const message = data.message;

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -1161,7 +1161,7 @@ export function registerSessionHandlers(
   });
 
   // Generic panel input handlers that route to specific panel type handlers
-  commandRegistry.register('panels:send-input', async (panelId: string, input: string) => {
+  commandRegistry.register('panels:send-input', async (panelId: string, _input: string) => {
     try {
       console.log(`[IPC] panels:send-input called for panel: ${panelId}`);
 
@@ -1201,7 +1201,7 @@ export function registerSessionHandlers(
     }
   });
 
-  commandRegistry.register('panels:continue', async (panelId: string, input: string, model?: string) => {
+  commandRegistry.register('panels:continue', async (panelId: string, _input: string, _model?: string) => {
     try {
       console.log(`[IPC] panels:continue called for panel: ${panelId}`);
 

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -425,7 +425,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
     }
   }
 
-  protected async getCliEnvironment(options: ClaudeSpawnOptions): Promise<{ [key: string]: string }> {
+  protected async getCliEnvironment(_options: ClaudeSpawnOptions): Promise<{ [key: string]: string }> {
     // This is handled in initializeCliEnvironment for Claude
     return {};
   }
@@ -1112,7 +1112,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
     return mcpConfigPath;
   }
 
-  private async setupMcpConfiguration(sessionId: string, env: CliEnvironment): Promise<void> {
+  private async setupMcpConfiguration(_sessionId: string, _env: CliEnvironment): Promise<void> {
     // This method is called from initializeCliEnvironment but for Claude we handle MCP in spawnCliProcess
     // Just set up the basic environment variables here
     return;

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -1117,7 +1117,7 @@ export abstract class AbstractCliManager extends EventEmitter {
   /**
    * Handle process startup failure
    */
-  protected async handleProcessStartupFailure(exitCode: number | null, signal: number | undefined, panelId: string, sessionId: string, lastOutput: string): Promise<void> {
+  protected async handleProcessStartupFailure(exitCode: number | null, signal: number | undefined, panelId: string, sessionId: string, _lastOutput: string): Promise<void> {
     this.logger?.error(`No output received from ${this.getCliToolName()}. This might indicate a startup failure.`);
 
     const errorMessage = {

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -1061,7 +1061,7 @@ export class SessionManager extends EventEmitter {
     return this.db.getPanelPromptMarkers(panelId);
   }
 
-  addPanelInitialPromptMarker(panelId: string, prompt: string): void {
+  addPanelInitialPromptMarker(_panelId: string, _prompt: string): void {
     // Prompt markers are no longer needed for panels - using conversation_messages instead
     // The prompt is already being added to conversation_messages in addPanelConversationMessage
   }

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -150,11 +150,11 @@ export class TaskQueue {
     }
     
     // Add event handlers for debugging
-    this.sessionQueue.on('active', (job: { id: string | number }) => {
+    this.sessionQueue.on('active', (_job: { id: string | number }) => {
       // Job active tracking removed - verbose debug logging
     });
     
-    this.sessionQueue.on('completed', (job: SessionCreationJob, result: CreateSessionQueueResult) => {
+    this.sessionQueue.on('completed', (_job: SessionCreationJob, _result: CreateSessionQueueResult) => {
       // Job completion tracking removed - verbose debug logging
     });
     

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -214,7 +214,7 @@ export class WorktreeManager {
     return this.projectsCache.get(cacheKey)!;
   }
 
-  async initializeProject(projectPath: string, worktreeFolder: string | undefined, pathResolver: PathResolver, commandRunner: CommandRunner): Promise<void> {
+  async initializeProject(projectPath: string, worktreeFolder: string | undefined, pathResolver: PathResolver, _commandRunner: CommandRunner): Promise<void> {
     const { baseDir } = this.getProjectPaths(projectPath, worktreeFolder, pathResolver);
     try {
       await mkdir(pathResolver.toFileSystem(baseDir), { recursive: true });

--- a/main/src/utils/contextCompactor.ts
+++ b/main/src/utils/contextCompactor.ts
@@ -245,7 +245,7 @@ export class ProgrammaticCompactor {
     };
   }
 
-  private detectInterruption(session: Session, prompts: PromptMarker[], outputs: SessionOutput[]): boolean {
+  private detectInterruption(session: Session, prompts: PromptMarker[], _outputs: SessionOutput[]): boolean {
     // Check if session ended without completing the last prompt
     if (prompts.length === 0) return false;
     


### PR DESCRIPTION
## Summary

- explicitly mark 16 required callback and interface parameters as intentionally unused
- preserve every public signature and runtime code path while eliminating false-positive parameter findings
- reduce the repository ESLint baseline from 217 warnings to 201 without suppressions

Part of #403.

## Validation

- `pnpm lint` — blocking lint and Knip pass; anti-slop remains at zero
- `pnpm typecheck`
- `pnpm --filter main exec vitest run` — 596 passed
- `pnpm --filter frontend exec vitest run` — 163 passed
- `pnpm build:main`
- `pnpm --filter frontend build`
- ESLint JSON audit — 201 warnings, 0 errors

Delivery lane: small, using the approved zero-findings campaign plan with current-head implementation review and required PR CI/review gates before merge.
