### PR TITLE
Remove dead declarations and assignments

### DIFF
--- a/frontend/src/stores/sessionPreferencesStore.ts
+++ b/frontend/src/stores/sessionPreferencesStore.ts
@@ -77,7 +77,8 @@ export const useSessionPreferencesStore = create<SessionPreferencesStore>((set, 
   },
 
   updatePreferences: async (updates: Partial<SessionCreationPreferences>) => {
-    const { sessionCount: _ignoredSessionCount, ...allowedUpdates } = updates;
+    const allowedUpdates = { ...updates };
+    delete allowedUpdates.sessionCount;
     const currentPreferences = get().preferences;
     
     // Deep merge the updates while keeping session count at its default

--- a/main/src/daemon/tailscaleSetup.ts
+++ b/main/src/daemon/tailscaleSetup.ts
@@ -72,10 +72,6 @@ export function resolveTailscaleCommand(
   return null;
 }
 
-function ensureTailscaleInstalled(dependencies: TailscaleSetupDependencies): ResolvedCommand {
-  return resolveTailscaleCommand(dependencies) ?? installTailscaleCommandOrThrow(dependencies);
-}
-
 export function ensureTailscaleInstalledInteractive(
   dependencies: TailscaleSetupDependencies = defaultTailscaleSetupDependencies,
 ): ResolvedCommand {

--- a/main/src/events.ts
+++ b/main/src/events.ts
@@ -235,7 +235,6 @@ export function setupEventListeners(services: AppServices): void {
     // Refresh git status after Claude exits, as it may have made commits
     // Also invalidate PR cache since Claude may have pushed/created PRs
     try {
-      const session = sessionManager.getSession(sessionId);
       const project = sessionManager.getProjectForSession(sessionId);
       if (project?.path) {
         gitStatusManager.invalidatePrCache(project.path);

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -60,7 +60,7 @@ if (process.platform === 'win32') {
 }
 
 // Now import the rest of electron
-import { BrowserWindow, Menu, ipcMain, shell, dialog, IpcMainInvokeEvent, session, WebContents, webContents, WebContentsView, type BrowserWindowConstructorOptions } from 'electron';
+import { BrowserWindow, Menu, ipcMain, shell, dialog, session, WebContents, webContents, WebContentsView, type BrowserWindowConstructorOptions } from 'electron';
 import * as path from 'path';
 import * as os from 'os';
 import type { SessionManager } from './services/sessionManager';
@@ -86,7 +86,6 @@ import { setupConsoleWrapper } from './utils/consoleWrapper';
 import * as fs from 'fs';
 import { terminalPanelManager } from './services/terminalPanelManager';
 import { panelManager } from './services/panelManager';
-import { TerminalPanelState } from '../../shared/types/panels';
 import { worktreePoolManager } from './services/worktreePoolManager';
 import { PtyHostSupervisor } from './ptyHost/ptyHostSupervisor';
 import { syncAutoStartOnBoot } from './utils/autoStart';

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -111,7 +111,7 @@ export function registerGitHandlers(
   services: AppServices,
   commandRegistry: PaneCommandRegistry,
 ): void {
-  const { sessionManager, gitDiffManager, worktreeManager, claudeCodeManager, gitStatusManager, databaseService } = services;
+  const { sessionManager, gitDiffManager, worktreeManager, claudeCodeManager, gitStatusManager } = services;
 
   // Helper function to emit git operation events to all sessions in a project
   const emitGitOperationToProject = (sessionId: string, eventType: PanelEventType, message: string, details?: JsonObject) => {

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -93,7 +93,6 @@ export function registerSessionHandlers(
     databaseService,
     taskQueue,
     worktreeManager,
-    cliManagerFactory,
     claudeCodeManager, // For backward compatibility
     worktreeNameGenerator,
     gitStatusManager,
@@ -101,23 +100,6 @@ export function registerSessionHandlers(
     spotlightManager,
     runCommandManager
   } = services;
-
-  // Helper function to get CLI manager for a specific tool
-  // TODO: This will be used in the future to support multiple CLI tools
-  const getCliManager = async (toolId: string = 'claude') => {
-    try {
-      return await cliManagerFactory.createManager(toolId, {
-        sessionManager,
-        additionalOptions: {}
-      });
-    } catch (error) {
-      console.warn(`Failed to get CLI manager for ${toolId}, falling back to default:`, error);
-      return claudeCodeManager; // Fallback to default for backward compatibility
-    }
-  };
-
-  // NOTE: Current IPC handlers use claudeCodeManager directly for backward compatibility
-  // Future versions will use getCliManager() to support multiple CLI tools dynamically
 
   const attachCachedGitStatus = (session: Session): Session => {
     const cached = gitStatusManager.getCachedStatus(session.id)?.status;
@@ -1685,13 +1667,11 @@ export function registerSessionHandlers(
       const executionDiffs = databaseService.getExecutionDiffs(sessionId);
       
       // Calculate file statistics
-      let totalFilesChanged = 0;
       let totalLinesAdded = 0;
       let totalLinesDeleted = 0;
       const filesModified = new Set<string>();
       
       executionDiffs.forEach(diff => {
-        totalFilesChanged += diff.stats_files_changed || 0;
         totalLinesAdded += diff.stats_additions || 0;
         totalLinesDeleted += diff.stats_deletions || 0;
         

--- a/main/src/ptyHost/ptyHostMain.ts
+++ b/main/src/ptyHost/ptyHostMain.ts
@@ -69,16 +69,6 @@ interface HostPty {
   resume(): void;
 }
 
-/** Port handoff message shape; the supervisor posts exactly this on init. */
-interface InitMessage {
-  type: 'init';
-}
-
-/** Raw heartbeat frame; NOT an RPC request (no `id`, no `method`). */
-interface HeartbeatPing {
-  type: 'heartbeat-ping';
-}
-
 interface SpawnFailure {
   message: string;
   code?: string;

--- a/main/src/ptyHost/ptyHostSupervisor.ts
+++ b/main/src/ptyHost/ptyHostSupervisor.ts
@@ -216,21 +216,6 @@ interface WindowPortPair {
   rendererPort: MessagePortMain;
 }
 
-/**
- * Supervisor events. Consumed by Chunk E (`respawnAll`) and future telemetry.
- *
- * - `restart`: emitted when the UtilityProcess exits and a restart is scheduled.
- * - `ready`: emitted on every successful `start()` (initial AND restart).
- * - `ready-after-restart`: emitted ONLY after a restart completes; callers use
- *   this to drive per-manager `respawnAll()` without firing on the initial boot.
- */
-interface PtyHostSupervisorEvents {
-  restart: () => void;
-  ready: () => void;
-  'ready-after-restart': () => void;
-  'renderer-ack': (ptyId: string, bytes: number) => void;
-}
-
 export class PtyHostSupervisor extends EventEmitter {
   private proc: UtilityProcess | null = null;
   /** Main-side end of the RPC channel to `ptyHostMain.ts`. Field, not local. */

--- a/main/src/services/cliManagerFactory.ts
+++ b/main/src/services/cliManagerFactory.ts
@@ -285,9 +285,3 @@ export class CliManagerFactory {
     // Additional validation can be added here
   }
 }
-
-/**
- * Convenience function to get the factory instance
- */
-const getCliManagerFactory = (logger?: Logger, configManager?: ConfigManager) =>
-  CliManagerFactory.getInstance(logger, configManager);

--- a/main/src/services/cliToolRegistry.ts
+++ b/main/src/services/cliToolRegistry.ts
@@ -519,6 +519,3 @@ export const CLI_OUTPUT_FORMATS = {
   MARKDOWN: { id: 'markdown', name: 'Markdown', isStructured: false, mimeType: 'text/markdown' },
   YAML: { id: 'yaml', name: 'YAML', isStructured: true, mimeType: 'application/x-yaml' }
 } as const;
-
-// Export default instance getter for convenience
-const getCliToolRegistry = () => CliToolRegistry.getInstance();

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -43,13 +43,6 @@ interface ClaudeSpawnOptions {
   isInteractive?: boolean;  // Interactive mode: don't add -p flag, send prompt via stdin
 }
 
-interface ClaudeCodeProcess {
-  process: import('@lydell/node-pty').IPty;
-  panelId: string;
-  sessionId: string;
-  worktreePath: string;
-}
-
 interface BaseProjectMcpServers {
   mcpServers: JsonObject;
   mcpJsonPath?: string;
@@ -348,9 +341,6 @@ export class ClaudeCodeManager extends AbstractCliManager {
 
   protected async initializeCliEnvironment(options: ClaudeSpawnOptions): Promise<CliEnvironment> {
     const { sessionId, permissionMode } = options;
-    
-    // Get basic system environment
-    const systemEnv = await this.getSystemEnvironment();
     
     // Initialize environment with MCP-specific variables
     const env: CliEnvironment = {
@@ -967,7 +957,7 @@ export class ClaudeCodeManager extends AbstractCliManager {
         fs.writeFileSync(tempScriptPath, scriptContent);
         fs.chmodSync(tempScriptPath, 0o755);
 
-        const stats = fs.statSync(tempScriptPath);
+        fs.statSync(tempScriptPath);
         this.logger?.verbose(`[MCP] Script extracted to: ${tempScriptPath}`);
 
         mcpBridgePath = tempScriptPath;

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -93,24 +93,6 @@ interface CliOutputEvent {
   timestamp: Date;
 }
 
-interface CliExitEvent {
-  panelId: string;
-  sessionId: string;
-  exitCode: number | null;
-  signal: number | null;
-}
-
-interface CliErrorEvent {
-  panelId: string;
-  sessionId: string;
-  error: string;
-}
-
-interface CliSpawnedEvent {
-  panelId: string;
-  sessionId: string;
-}
-
 /**
  * Abstract base class for managing CLI tool processes in Pane
  * Provides common functionality for spawning, managing, and communicating with CLI tools
@@ -513,8 +495,6 @@ export abstract class AbstractCliManager extends EventEmitter {
   ): Promise<void> {
     try {
       const fs = await import('fs').then(m => m.promises);
-      const path = await import('path');
-      
       // Check if session directory exists
       try {
         await fs.access(sessionIdPath);

--- a/main/src/services/panels/logPanel/logsManager.ts
+++ b/main/src/services/panels/logPanel/logsManager.ts
@@ -545,7 +545,7 @@ class LogsManager {
    */
   async cleanup(): Promise<void> {
     // Stop all running processes
-    for (const [panelId, process] of this.activeProcesses) {
+    for (const panelId of this.activeProcesses.keys()) {
       await this.stopScript(panelId);
     }
     this.activeProcesses.clear();

--- a/main/src/services/runCommandManager.ts
+++ b/main/src/services/runCommandManager.ts
@@ -133,8 +133,6 @@ export class RunCommandManager extends EventEmitter {
 
       this.logger?.info(`Starting ${runCommands.length} RUN commands sequentially for session ${sessionId}`);
       
-      const processes: RunProcess[] = [];
-
       // Execute commands sequentially
       for (let i = 0; i < runCommands.length; i++) {
         const command = runCommands[i];
@@ -269,8 +267,6 @@ export class RunCommandManager extends EventEmitter {
 
             // Wait for this command line to complete before starting the next one
             await new Promise<void>((resolve, reject) => {
-              let hasExited = false;
-
               // Handle output from the run command
               ptyProcess.onData((data: string) => {
                 this.emit('output', {
@@ -284,7 +280,6 @@ export class RunCommandManager extends EventEmitter {
               });
 
               ptyProcess.onExit(({ exitCode, signal }) => {
-                hasExited = true;
                 this.logger?.info(`Command line exited: ${commandLine}, exitCode: ${exitCode}, signal: ${signal}`);
                 
                 // Only emit exit event for the last line of a command
@@ -388,7 +383,7 @@ export class RunCommandManager extends EventEmitter {
 
   async stopAllRunCommands(): Promise<void> {
     const stopPromises = [];
-    for (const [sessionId, processes] of this.processes) {
+    for (const sessionId of this.processes.keys()) {
       stopPromises.push(this.stopRunCommands(sessionId));
     }
     await Promise.all(stopPromises);

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -676,10 +676,6 @@ export class SessionManager extends EventEmitter {
   addSessionOutput(id: string, output: Omit<SessionOutput, 'sessionId'>): void {
     const message = parseGenericMessage(output);
     const messageContent = getMessageContent(message?.message);
-    // Check if this is the first output for this session
-    const existingOutputs = this.db.getSessionOutputs(id, 1);
-    const isFirstOutput = existingOutputs.length === 0;
-    
     // Store in database (stringify JSON objects and error objects)
     const dataToStore = (output.type === 'json' || output.type === 'error') ? JSON.stringify(output.data) : String(output.data);
     this.db.addSessionOutput(id, output.type, dataToStore);
@@ -897,11 +893,6 @@ export class SessionManager extends EventEmitter {
       return;
     }
 
-    // Check for JSON message type and store appropriately
-    const existingOutputs = this.db.getPanelOutputs(panelId, 1);
-    const isContinuing = existingOutputs.length > 0 && 
-                        existingOutputs[existingOutputs.length - 1]?.type === 'json';
-    
     const dataToStore = (output.type === 'json' || output.type === 'error') 
       ? JSON.stringify(output.data) 
       : String(output.data);
@@ -983,8 +974,6 @@ export class SessionManager extends EventEmitter {
       }
       
       if (promptText) {
-        // Get current output count to use as index for prompt markers
-        const outputs = this.db.getPanelOutputs(panelId);
         // Note: Panel-based prompt markers would need addPanelPromptMarker method
         // For now, we rely on the explicit addPanelConversationMessage calls in IPC handlers
         // this.db.addPanelPromptMarker(panelId, promptText, outputs.length - 1);

--- a/main/src/services/spotlightManager.ts
+++ b/main/src/services/spotlightManager.ts
@@ -349,7 +349,7 @@ export class SpotlightManager extends EventEmitter {
 
   handleSessionDeleted(sessionId: string): void {
     // Check if this session is spotlighted
-    for (const [_projectId, state] of this.activeSpotlights.entries()) {
+    for (const state of this.activeSpotlights.values()) {
       if (state.sessionId === sessionId) {
         this.logger?.info(`[SpotlightManager] Session ${sessionId} deleted, disabling spotlight`);
         this.disable(sessionId);

--- a/main/src/services/taskQueue.ts
+++ b/main/src/services/taskQueue.ts
@@ -717,7 +717,7 @@ export class TaskQueue {
   }
 
   private async ensureUniqueNames(baseSessionName: string, baseWorktreeName: string, project: Project, index?: number): Promise<{ sessionName: string; worktreeName: string }> {
-    const { sessionManager, worktreeManager } = this.options;
+    const { sessionManager } = this.options;
     const db = sessionManager.db;
     
     let candidateSessionName = baseSessionName;

--- a/main/src/services/worktreeFileSyncService.ts
+++ b/main/src/services/worktreeFileSyncService.ts
@@ -557,42 +557,6 @@ async function detectInstallCommand(
   return null;
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-/**
- * Lightweight lock file detection that works from any context.
- * Uses fs.existsSync for local paths. For WSL paths (which start with /
- * on a Windows host), falls back to checking common path patterns.
- *
- * This is used by terminalPanelManager to auto-detect the install command
- * when a terminal panel initializes — no CommandRunner needed.
- */
-function detectInstallCommandSync(cwd: string): string | null {
-  const lockFiles: Array<{ file: string; command: string }> = [
-    { file: 'pnpm-lock.yaml', command: 'pnpm install' },
-    { file: 'package-lock.json', command: 'npm install' },
-    { file: 'yarn.lock', command: 'yarn install' },
-    { file: 'bun.lockb', command: 'bun install' },
-  ];
-
-  for (const { file, command } of lockFiles) {
-    try {
-      // path.join works for local paths; for WSL Linux paths on Windows host,
-      // fs.existsSync will fail gracefully (returns false)
-      const lockPath = path.join(cwd, file);
-      if (fs.existsSync(lockPath)) {
-        return command;
-      }
-    } catch {
-      // Skip on any error
-    }
-  }
-
-  return null;
-}
-
 /**
  * Heavyweight entries (node_modules) can take tens of seconds to copy, so
  * they must never delay small/critical entries like .env files.

--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -233,10 +233,8 @@ export class WorktreeManager {
 
     try {
       // First check if this is a git repository
-      let isGitRepo = false;
       try {
         await commandRunner.execAsync(`git rev-parse --is-inside-work-tree`, projectPath);
-        isGitRepo = true;
       } catch {
         // Initialize git repository
         await commandRunner.execAsync(`git init`, projectPath);
@@ -281,10 +279,8 @@ export class WorktreeManager {
       }
 
       // Check if the repository has any commits
-      let hasCommits = false;
       try {
         await commandRunner.execAsync(`git rev-parse HEAD`, projectPath);
-        hasCommits = true;
       } catch {
         // Repository has no commits yet, create initial commit
         // Use cross-platform approach without shell operators
@@ -294,7 +290,6 @@ export class WorktreeManager {
           // Ignore add errors (no files to add)
         }
         await commandRunner.execAsync('git commit -m "Initial commit" --allow-empty', projectPath, { env: getGitAttributionEnv(this.configManager?.getConfig()) });
-        hasCommits = true;
       }
 
       // Check if branch already exists
@@ -840,8 +835,7 @@ export class WorktreeManager {
 
         return { hasConflicts: false, canAutoMerge: true };
 
-      } catch (error: unknown) {
-        const err = decodeBoundary(error, commandErrorSchema);
+      } catch {
         // If merge-tree is not available (older git), fall back to checking modified files
         console.log(`[WorktreeManager] merge-tree not available, using fallback conflict detection`);
 
@@ -961,11 +955,11 @@ export class WorktreeManager {
     try {
       // Check if we're in the middle of a rebase
       const statusCommand = `git status --porcelain=v1`;
-      const { stdout: statusOut } = await commandRunner.execAsync(statusCommand, worktreePath);
+      await commandRunner.execAsync(statusCommand, worktreePath);
 
       // Abort the rebase
       const command = `git rebase --abort`;
-      const { stdout, stderr } = await commandRunner.execAsync(command, worktreePath);
+      const { stderr } = await commandRunner.execAsync(command, worktreePath);
 
       if (stderr && !stderr.includes('No rebase in progress')) {
         throw new Error(`Failed to abort rebase: ${stderr}`);

--- a/main/src/utils/commandExecutor.ts
+++ b/main/src/utils/commandExecutor.ts
@@ -233,6 +233,3 @@ export const commandExecutor = new CommandExecutor();
 
 // Export the execSync function as a drop-in replacement
 export const execSync = commandExecutor.execSync.bind(commandExecutor);
-
-// Export the execAsync function
-const execAsync = commandExecutor.execAsync.bind(commandExecutor);

--- a/main/src/utils/contextCompactor.ts
+++ b/main/src/utils/contextCompactor.ts
@@ -291,7 +291,7 @@ export class ProgrammaticCompactor {
     wasInterrupted: boolean;
     conversationMessages: ConversationMessage[];
   }): string {
-    const { session, promptAnalysis, fileModifications, todos, gitStatus, wasInterrupted } = data;
+    const { promptAnalysis, fileModifications, todos, gitStatus, wasInterrupted } = data;
     
     let summary = `<session_context>\n`;
     

--- a/main/src/utils/mutex.ts
+++ b/main/src/utils/mutex.ts
@@ -10,7 +10,6 @@ const logger = {
  */
 class Mutex {
   private locks = new Map<string, Promise<void>>();
-  private lockCounts = new Map<string, number>();
   private defaultTimeout = 30000; // 30 seconds
 
   /**
@@ -39,10 +38,6 @@ class Mutex {
 
     // Store the lock
     this.locks.set(resourceName, lockPromise);
-    this.lockCounts.set(resourceName, (this.lockCounts.get(resourceName) || 0) + 1);
-    
-    const lockId = this.lockCounts.get(resourceName);
-
     // Return the release function
     return () => {
       if (this.locks.get(resourceName) === lockPromise) {
@@ -107,7 +102,6 @@ class Mutex {
   releaseAll(): void {
     logger.warn(`[Mutex] Force releasing all locks (${this.locks.size} active locks)`);
     this.locks.clear();
-    this.lockCounts.clear();
   }
 }
 
@@ -127,23 +121,4 @@ export async function withLock<T>(
   timeout?: number
 ): Promise<T> {
   return mutex.withLock(resourceName, fn, timeout);
-}
-
-/**
- * Convenience function to acquire a named lock
- * @param resourceName - Unique name for the resource to lock
- * @param timeout - Optional timeout in milliseconds
- * @returns Promise<() => void> - Release function to unlock the resource
- */
-async function acquireLock(resourceName: string, timeout?: number): Promise<() => void> {
-  return mutex.acquire(resourceName, timeout);
-}
-
-/**
- * Check if a resource is currently locked
- * @param resourceName - Name of the resource to check
- * @returns boolean - True if the resource is locked
- */
-function isLocked(resourceName: string): boolean {
-  return mutex.isLocked(resourceName);
 }

--- a/main/src/utils/nodeFinder.ts
+++ b/main/src/utils/nodeFinder.ts
@@ -72,7 +72,6 @@ export async function findNodeExecutable(): Promise<string> {
       const baseDir = path.dirname(nodePath.split('*')[0]);
       if (fs.existsSync(baseDir)) {
         try {
-          const pattern = path.basename(nodePath);
           const entries = fs.readdirSync(baseDir);
           for (const entry of entries) {
             const fullPath = path.join(baseDir, entry, 'bin', 'node');
@@ -367,9 +366,3 @@ export function findCliNodeScript(cliExecutablePath: string): string | null {
 
   return null;
 }
-
-/**
- * @deprecated Use findCliNodeScript instead
- * Kept for backward compatibility
- */
-const findClaudeCodeScript = findCliNodeScript;

--- a/main/src/utils/shellEscape.ts
+++ b/main/src/utils/shellEscape.ts
@@ -52,23 +52,3 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : message;
   const escapedMessage = escapeShellArg(fullMessage);
   return `git commit -m ${escapedMessage}`;
 }
-
-/**
- * Escape an array of shell arguments
- * @param args The arguments to escape
- * @returns The escaped arguments joined with spaces
- */
-function escapeShellArgs(args: string[]): string {
-  return args.map(escapeShellArg).join(' ');
-}
-
-/**
- * Build a safe shell command with escaped arguments
- * @param command The base command
- * @param args The arguments to escape and append
- * @returns The safe command string
- */
-function buildSafeCommand(command: string, ...args: string[]): string {
-  if (args.length === 0) return command;
-  return `${command} ${escapeShellArgs(args)}`;
-}

--- a/main/src/utils/timestampUtils.ts
+++ b/main/src/utils/timestampUtils.ts
@@ -26,24 +26,6 @@ export function formatForDisplay(timestamp: string | Date): string {
 }
 
 /**
- * Formats a timestamp with full date and time for display
- * @param timestamp - The timestamp string from database or Date object
- * @returns Localized date and time string
- */
-function formatFullDateTime(timestamp: string | Date): string {
-  const date = toDate(timestamp);
-  return date.toLocaleString();
-}
-
-/**
- * Gets the current timestamp in ISO format for database storage
- * @returns ISO 8601 formatted string
- */
-function getCurrentTimestamp(): string {
-  return new Date().toISOString();
-}
-
-/**
  * Checks if a timestamp is valid
  * @param timestamp - The timestamp to validate
  * @returns boolean indicating if the timestamp is valid
@@ -52,16 +34,6 @@ export function isValidTimestamp(timestamp: string | Date | null | undefined): b
   if (!timestamp) return false;
   const date = toDate(timestamp);
   return !isNaN(date.getTime());
-}
-
-/**
- * Converts a timestamp to UTC
- * @param timestamp - The timestamp to convert
- * @returns UTC ISO string
- */
-function toUTC(timestamp: string | Date): string {
-  const date = toDate(timestamp);
-  return date.toISOString();
 }
 
 /**

--- a/main/src/utils/toolFormatter.ts
+++ b/main/src/utils/toolFormatter.ts
@@ -502,7 +502,6 @@ export function formatJsonForOutputEnhanced(jsonMessage: JsonObject, gitRepoPath
 
     if (itemType === 'command_execution') {
       const command = readString(item, 'command') || '';
-      const status = readString(item, 'status') || '';
       const exitCode = readNumber(item, 'exit_code');
       const aggregatedOutput = readString(item, 'aggregated_output') || '';
 


### PR DESCRIPTION
## Summary

- remove the remaining 47 unused imports, types, helpers, bindings, and assignments
- preserve side-effecting filesystem and git operations while discarding only their unused results
- eliminate the `@typescript-eslint/no-unused-vars` category and reduce the ESLint baseline from 201 warnings to 154

Part of #403.

## Validation

- `pnpm lint` — blocking lint and Knip pass; anti-slop remains at zero
- `pnpm typecheck`
- `pnpm --filter main exec vitest run` — 596 passed
- `pnpm --filter frontend exec vitest run` — 163 passed
- `pnpm build:main`
- `pnpm --filter frontend build`
- ESLint JSON audit — 154 warnings, 0 errors, 0 unused-variable findings

Delivery lane: medium, using the approved zero-findings campaign plan with current-head implementation review and required PR CI/review gates before merge.
