### PR TITLE
Replace legacy require imports

### DIFF
--- a/main/src/autoUpdater.ts
+++ b/main/src/autoUpdater.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { setupTestUpdater } from './test-updater';
 
 export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): void {
   // Only setup auto-updater for packaged apps (not development)
@@ -10,7 +11,6 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
 
   // TEST MODE: Use local server for testing
   if (process.env.TEST_UPDATES === 'true') {
-    const { setupTestUpdater } = require('./test-updater');
     setupTestUpdater();
     console.log('[AutoUpdater] Using test update server at:', process.env.UPDATE_SERVER_URL || 'http://localhost:8080');
   } else {
@@ -74,4 +74,4 @@ export function setupAutoUpdater(getMainWindow: () => BrowserWindow | null): voi
       // Let the renderer handle the UI - no native dialog
     }
   });
-} 
+}

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -1,6 +1,8 @@
 import Database from "better-sqlite3-multiple-ciphers";
 import { readFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
+import { v4 as uuidv4 } from "uuid";
+import { createRequire } from "node:module";
 import type {
   Project,
   ProjectRunCommand,
@@ -27,6 +29,8 @@ import {
   decodeBoundary,
   type JsonObject,
 } from "../../../shared/validation/boundaryDecoder";
+
+const loadDatabaseDependency = createRequire(__filename);
 
 // Interface for legacy claude_panel_settings during migration
 interface ClaudePanelSetting {
@@ -571,7 +575,7 @@ export class DatabaseService {
         // Import existing config as default project if it exists
         try {
           const configManager =
-            require("../services/configManager").configManager;
+            loadDatabaseDependency("../services/configManager").configManager;
           const gitRepoPath = configManager.getGitRepoPath();
 
           if (gitRepoPath) {
@@ -1934,7 +1938,7 @@ export class DatabaseService {
             );
 
           // Create Claude panel settings with default model from config
-          const { configManager } = require("../services/configManager");
+          const { configManager } = loadDatabaseDependency("../services/configManager");
           const defaultModel =
             configManager.getDefaultModel() || "claude-3-opus-20240229";
           this.db
@@ -2049,7 +2053,7 @@ export class DatabaseService {
 
           if (!hasDiffPanel) {
             // Create diff panel for this session
-            const panelId = require("uuid").v4();
+            const panelId = uuidv4();
             const now = new Date().toISOString();
 
             this.db

--- a/main/src/ipc/project.ts
+++ b/main/src/ipc/project.ts
@@ -15,6 +15,9 @@ import { ensureProjectAgentContext } from '../services/agentContextManager';
 import type { ConfigManager } from '../services/configManager';
 import type { Project } from '../database/models';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+import { createRequire } from 'node:module';
+
+const loadProjectDependency = createRequire(__filename);
 
 // Helper function to stop a running project script
 async function stopProjectScriptInternal(projectId?: number): Promise<{ success: boolean; error?: string }> {
@@ -33,8 +36,7 @@ async function stopProjectScriptInternal(projectId?: number): Promise<{ success:
       // Mark as closing
       scriptExecutionTracker.markClosing('project', projectIdToStop);
 
-      const { panelManager } = require('../services/panelManager');
-      const { logsManager } = require('../services/panels/logPanel/logsManager');
+      const { logsManager } = loadProjectDependency('../services/panels/logPanel/logsManager');
 
       const panels = await panelManager.getPanelsForSession(runningScript.sessionId);
       const logsPanel = panels?.find((p: { type: string }) => p.type === 'logs');
@@ -724,7 +726,7 @@ export function registerProjectHandlers(
           const panels = await panelManager.getPanelsForSession(sessionIdToStop);
           const logsPanel = panels?.find((p: { type: string }) => p.type === 'logs');
           if (logsPanel) {
-            const { logsManager } = require('../services/panels/logPanel/logsManager');
+            const { logsManager } = loadProjectDependency('../services/panels/logPanel/logsManager');
             await logsManager.stopScript(logsPanel.id);
           }
           // Also try old mechanism as fallback
@@ -743,7 +745,7 @@ export function registerProjectHandlers(
       const sessionId = mainRepoSession.id;
 
       // Run the script in the project root using logsManager
-      const { logsManager } = require('../services/panels/logPanel/logsManager');
+      const { logsManager } = loadProjectDependency('../services/panels/logPanel/logsManager');
       const ctx = sessionManager.getProjectContextByProjectId(projectId);
       const wslContext = ctx ? ctx.commandRunner.wslContext : null;
       await logsManager.runScript(sessionId, runScript, project.path, wslContext);

--- a/main/src/ipc/script.ts
+++ b/main/src/ipc/script.ts
@@ -5,7 +5,7 @@ import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDec
 import { getShellPath, findExecutableInPath } from '../utils/shellPath';
 import { logsManager } from '../services/panels/logPanel/logsManager';
 import { panelManager } from '../services/panelManager';
-import type { ExecException } from 'child_process';
+import { exec, type ExecException } from 'child_process';
 import { scriptExecutionTracker } from '../services/scriptExecutionTracker';
 
 const DAEMON_SCRIPT_CHANNELS = [
@@ -255,8 +255,6 @@ export function registerScriptHandlers(
       }
 
       // Execute the IDE command in the worktree directory
-      const { exec } = require('child_process');
-
       // Get enhanced shell PATH for packaged apps
       const shellPath = getShellPath();
 
@@ -270,7 +268,6 @@ export function registerScriptHandlers(
           ideCommand,
           {
             cwd: session.worktreePath,
-            shell: true,
             env: {
               ...process.env,
               PATH: shellPath  // Use enhanced PATH that includes user's shell PATH

--- a/main/src/polyfills/readablestream.ts
+++ b/main/src/polyfills/readablestream.ts
@@ -3,11 +3,15 @@
  * This ensures the Web Streams API is available as a global
  */
 
+import { createRequire } from 'node:module';
+
+const loadStreamModule = createRequire(__filename);
+
 // Check if ReadableStream is already available
 if (!globalThis.ReadableStream) {
   try {
     // Try to import from Node.js built-in stream/web module (Node 16.5+)
-    const { ReadableStream, WritableStream, TransformStream } = require('stream/web');
+    const { ReadableStream, WritableStream, TransformStream } = loadStreamModule('stream/web');
     
     // Make them available globally
     globalThis.ReadableStream = ReadableStream;
@@ -18,7 +22,7 @@ if (!globalThis.ReadableStream) {
   } catch {
     // If stream/web is not available, use the web-streams-polyfill package
     try {
-      const streams = require('web-streams-polyfill/ponyfill');
+      const streams = loadStreamModule('web-streams-polyfill/ponyfill');
       
       globalThis.ReadableStream = streams.ReadableStream;
       globalThis.WritableStream = streams.WritableStream;

--- a/main/src/ptyHost/ptyHostMain.ts
+++ b/main/src/ptyHost/ptyHostMain.ts
@@ -32,19 +32,22 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { boundary, decodeBoundary, type JsonValue } from '../../../shared/validation/boundaryDecoder';
+
+const loadHostModule = createRequire(__filename);
 
 // node-pty's CommonJS export shape matches what main uses at
 // `terminalPanelManager.ts:1`. We use a typed `require` here because this
 // UtilityProcess entry is deliberately self-contained; importing via
 // `import * as pty` would couple to main's module graph.
 // SAFETY: This package's CommonJS entry exports the same typed node-pty API.
-const pty = require('@lydell/node-pty') as typeof import('@lydell/node-pty');
+const pty = loadHostModule('@lydell/node-pty') as typeof import('@lydell/node-pty');
 
 // Electron exposes UtilityProcess parentPort on `process.parentPort` in this
 // runtime. Keep the module export as a compatibility fallback.
 // SAFETY: Electron's UtilityProcess runtime exposes the documented HostPort surface.
-const electron = require('electron') as { parentPort?: typeof process.parentPort };
+const electron = loadHostModule('electron') as { parentPort?: typeof process.parentPort };
 
 import type {
   PtyHostRequest,

--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -19,10 +19,14 @@ import { withLock } from '../../../utils/mutex';
 import { getAppDirectory } from '../../../utils/appDirectory';
 import { escapeForBash } from '../../../utils/wslUtils';
 import { boundary, decodeBoundary, type JsonObject } from '../../../../../shared/validation/boundaryDecoder';
+import { createRequire } from 'node:module';
+import { logValidationFailure, validatePanelSessionOwnership } from '../../../utils/sessionValidation';
+
+const loadClaudeDependency = createRequire(__filename);
 
 function getPanelManagerModule(): typeof import('../../panelManager') {
   // SAFETY: CommonJS require returns the statically typed local panelManager module.
-  return require('../../panelManager') as typeof import('../../panelManager');
+  return loadClaudeDependency('../../panelManager') as typeof import('../../panelManager');
 }
 
 // Extend global object for MCP configuration storage  
@@ -608,7 +612,6 @@ export class ClaudeCodeManager extends AbstractCliManager {
   async startPanel(panelId: string, sessionId: string, worktreePath: string, prompt: string, permissionMode?: 'approve' | 'ignore', model?: string): Promise<void> {
     // Validate panel ownership before starting (skip for virtual session-based panel IDs)
     if (!panelId.startsWith('session-')) {
-      const { validatePanelSessionOwnership, logValidationFailure } = require('../../../utils/sessionValidation');
       const validation = validatePanelSessionOwnership(panelId, sessionId);
       if (!validation.valid) {
         logValidationFailure('ClaudeCodeManager.startPanel', validation);
@@ -667,7 +670,6 @@ export class ClaudeCodeManager extends AbstractCliManager {
     return await withLock(`claude-continue-${panelId}`, async () => {
       // Validate panel ownership before continuing (skip for virtual session-based panel IDs)
       if (!panelId.startsWith('session-')) {
-        const { validatePanelSessionOwnership, logValidationFailure } = require('../../../utils/sessionValidation');
         const validation = validatePanelSessionOwnership(panelId, sessionId);
         if (!validation.valid) {
           logValidationFailure('ClaudeCodeManager.continuePanel', validation);

--- a/main/src/services/resourceMonitorService.ts
+++ b/main/src/services/resourceMonitorService.ts
@@ -10,6 +10,9 @@ import type {
   ResourceSnapshot,
 } from '../../../shared/types/resourceMonitor';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+import { createRequire } from 'node:module';
+
+const loadResourceDependency = createRequire(__filename);
 
 const execFileAsync = promisify(execFile);
 
@@ -366,9 +369,9 @@ export class ResourceMonitorService extends EventEmitter {
 
     // Lazy imports to avoid circular dependency at module load time
     // SAFETY: This require targets the statically typed local module and selects its exported singleton.
-    const { terminalPanelManager } = require('./terminalPanelManager') as { terminalPanelManager: { getSessionPids(): Map<string, number[]> } };
+    const { terminalPanelManager } = loadResourceDependency('./terminalPanelManager') as { terminalPanelManager: { getSessionPids(): Map<string, number[]> } };
     // SAFETY: This require targets the statically typed local module and selects its exported registry class.
-    const { CliToolRegistry } = require('./cliToolRegistry') as { CliToolRegistry: { getInstance(): { getAllManagers(): { getSessionPids(): Map<string, number[]> }[] } } };
+    const { CliToolRegistry } = loadResourceDependency('./cliToolRegistry') as { CliToolRegistry: { getInstance(): { getAllManagers(): { getSessionPids(): Map<string, number[]> }[] } } };
 
     // Collect PIDs from all sources: terminal panels + CLI managers (Claude, Codex, etc.)
     const sessionPids = new Map<string, number[]>();

--- a/main/src/services/runCommandManager.ts
+++ b/main/src/services/runCommandManager.ts
@@ -7,7 +7,7 @@ import type { ProjectRunCommand } from '../database/models';
 import { getShellPath } from '../utils/shellPath';
 import { ShellDetector } from '../utils/shellDetector';
 import * as os from 'os';
-import { exec } from 'child_process';
+import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
 import { getGitAttributionEnv } from '../utils/attribution';
 
@@ -400,7 +400,7 @@ export class RunCommandManager extends EventEmitter {
     try {
       if (platform === 'win32') {
         // Windows: Use WMIC to get child processes
-        const result = require('child_process').execSync(
+        const result = execSync(
           `wmic process where (ParentProcessId=${parentPid}) get ProcessId`,
           { encoding: 'utf8' }
         );
@@ -416,7 +416,7 @@ export class RunCommandManager extends EventEmitter {
         }
       } else {
         // Unix/Linux/macOS: Use ps command
-        const result = require('child_process').execSync(
+        const result = execSync(
           `ps -o pid= --ppid ${parentPid} 2>/dev/null || true`,
           { encoding: 'utf8' }
         );

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -7,6 +7,7 @@
 import { randomUUID } from 'crypto';
 import { EventEmitter } from 'events';
 import { spawn, ChildProcess, exec, execSync } from 'child_process';
+import { promisify } from 'util';
 import { getRuntimeConfigManager } from '../core/runtime';
 import { ShellDetector } from '../utils/shellDetector';
 import type { Session, SessionUpdate, SessionOutput } from '../types/session';
@@ -1470,8 +1471,6 @@ export class SessionManager extends EventEmitter {
   }
   
   private async execWithShellPath(command: string, options?: { cwd?: string }): Promise<{ stdout: string; stderr: string }> {
-    const { exec } = require('child_process');
-    const { promisify } = require('util');
     const execAsync = promisify(exec);
     
     const shellPath = getShellPath();

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -3,6 +3,7 @@ import { ToolPanel, TerminalPanelState } from '../../../shared/types/panels';
 import { getPaneDaemonEventSink, getPaneEventSink, getPtyHostRuntime, getRuntimeConfigManager, type PtyHandleLike, type PtyHostRuntime } from '../core/runtime';
 import { panelManager } from './panelManager';
 import * as path from 'path';
+import { promises as fs } from 'fs';
 import { randomUUID } from 'crypto';
 import { getShellPath } from '../utils/shellPath';
 import { ShellDetector } from '../utils/shellDetector';
@@ -1572,7 +1573,6 @@ export class TerminalPanelManager {
     // In production, you'd use more robust methods
     if (process.platform === 'darwin' || process.platform === 'linux') {
       try {
-        const fs = require('fs').promises;
         const cwdLink = `/proc/${pid}/cwd`;
         return await fs.readlink(cwdLink);
       } catch {

--- a/main/src/services/terminalSessionManager.ts
+++ b/main/src/services/terminalSessionManager.ts
@@ -4,7 +4,7 @@ import { getPtyHostRuntime, getRuntimeConfigManager, type PtyHandleLike, type Pt
 import { getShellPath } from '../utils/shellPath';
 import { ShellDetector } from '../utils/shellDetector';
 import * as os from 'os';
-import { exec } from 'child_process';
+import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
 import { getGitAttributionEnv } from '../utils/attribution';
 
@@ -298,7 +298,7 @@ export class TerminalSessionManager extends EventEmitter {
     try {
       if (platform === 'win32') {
         // Windows: Use WMIC to get child processes
-        const result = require('child_process').execSync(
+        const result = execSync(
           `wmic process where (ParentProcessId=${parentPid}) get ProcessId`,
           { encoding: 'utf8' }
         );
@@ -314,7 +314,7 @@ export class TerminalSessionManager extends EventEmitter {
         }
       } else {
         // Unix/Linux/macOS: Use ps command
-        const result = require('child_process').execSync(
+        const result = execSync(
           `ps -o pid= --ppid ${parentPid} 2>/dev/null || true`,
           { encoding: 'utf8' }
         );

--- a/main/src/utils/shellPath.ts
+++ b/main/src/utils/shellPath.ts
@@ -3,11 +3,14 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import { ShellDetector } from './shellDetector';
+import { createRequire } from 'node:module';
+
+const loadShellDependency = createRequire(__filename);
 
 // Try to import app from electron (might not be available in all contexts)
 let app: typeof import('electron').app | undefined;
 try {
-  app = require('electron').app;
+  app = loadShellDependency('electron').app;
 } catch {
   // Electron not available (e.g., in worker threads)
   app = undefined;
@@ -19,7 +22,7 @@ try {
   // Lazy import to avoid circular dependencies
   const getConfigManager = () => {
     try {
-      const { configManager } = require('../services/configManager');
+      const { configManager } = loadShellDependency('../services/configManager');
       return configManager;
     } catch {
       return null;

--- a/main/src/utils/toolFormatter.ts
+++ b/main/src/utils/toolFormatter.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { formatJsonForOutput } from './formatters';
 import type { ClaudeJsonMessage } from '../types/session';
 import { boundary, decodeBoundary, type JsonObject, type JsonValue } from '../../../shared/validation/boundaryDecoder';
+import { formatForDisplay, isValidTimestamp } from './timestampUtils';
 
 interface ToolCall {
   type: 'tool_use';
@@ -281,7 +282,6 @@ function formatToolInteraction(
     let resultTime = '';
     if (resultTimestamp) {
       try {
-        const { formatForDisplay, isValidTimestamp } = require('./timestampUtils');
         if (isValidTimestamp(resultTimestamp)) {
           resultTime = ` (${formatForDisplay(resultTimestamp)})`;
         }


### PR DESCRIPTION
## Summary

- replace 28 legacy `require()` calls with static imports where module timing is ordinary
- preserve conditional, circular, and CommonJS runtime behavior with named `createRequire` loaders where lazy loading is intentional
- eliminate the main-process ESLint surface and reduce the repository baseline from 154 warnings to 126

Part of #403.

## Validation

- `pnpm lint` — blocking lint and Knip pass; anti-slop remains at zero
- `pnpm typecheck`
- `pnpm --filter main exec vitest run` — 596 passed
- `pnpm --filter frontend exec vitest run` — 163 passed
- `pnpm build:main`
- `pnpm --filter frontend build`
- ESLint JSON audit — main process 0 warnings/0 errors; repository 126 warnings/0 errors

Delivery lane: medium, using the approved zero-findings campaign plan with current-head implementation review and required PR CI/review gates before merge.
