### PR TITLE
Fix stable React hook dependencies

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -303,7 +303,7 @@ function App() {
         'Your OS may have been overloaded. Check RAM usage if this keeps happening.'
       );
     });
-  }, []);
+  }, [showNotification]);
 
   // Fetch projects for global shortcuts
   useEffect(() => {

--- a/frontend/src/components/CloudOverlay.tsx
+++ b/frontend/src/components/CloudOverlay.tsx
@@ -9,20 +9,21 @@ import { useCloudStore } from '../stores/cloudStore';
 export function CloudOverlay() {
   const { vmState, showCloudView, iframeReady, setIframeReady } = useCloudStore();
   const [hasEverBeenRunning, setHasEverBeenRunning] = useState(false);
+  const vmStatus = vmState?.status;
 
   // Once the VM is running and the user opens cloud view, mount the iframe permanently
   useEffect(() => {
-    if (vmState?.status === 'running' && showCloudView && !hasEverBeenRunning) {
+    if (vmStatus === 'running' && showCloudView && !hasEverBeenRunning) {
       setHasEverBeenRunning(true);
     }
-  }, [vmState?.status, showCloudView, hasEverBeenRunning]);
+  }, [vmStatus, showCloudView, hasEverBeenRunning]);
 
   // Reset when VM stops
   useEffect(() => {
-    if (vmState && vmState.status !== 'running' && vmState.status !== 'starting' && vmState.status !== 'initializing') {
+    if (vmStatus && vmStatus !== 'running' && vmStatus !== 'starting' && vmStatus !== 'initializing') {
       setHasEverBeenRunning(false);
     }
-  }, [vmState?.status]);
+  }, [vmStatus]);
 
   const noVncUrl = vmState?.noVncUrl;
 

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -115,7 +115,7 @@ export const SessionView = memo(() => {
     setSessionStatusAnnouncement(
       `${activeSession.name || 'Pane'} is ${activeSession.status}${activeSession.statusMessage ? `: ${activeSession.statusMessage}` : ''}`,
     );
-  }, [activeSession?.id, activeSession?.name, activeSession?.status, activeSession?.statusMessage]);
+  }, [activeSession]);
 
   // Panel store state and actions
   const {

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -129,12 +129,12 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
     return () => window.removeEventListener('project-settings-updated', handler);
   }, []);
   useEffect(() => {
-    if (!session) {
+    const currentSessionId = session?.id;
+    if (!currentSessionId) {
       setResolvedRunScript(null);
       return;
     }
     let cancelled = false;
-    const currentSessionId = session.id;
     window.electronAPI?.projects.resolveRunScript(currentSessionId).then((result: { success: boolean; data?: { command: string; source: string } | null }) => {
       if (cancelled) return;
       if (result?.success) {

--- a/frontend/src/components/panels/browser/BrowserPanel.tsx
+++ b/frontend/src/components/panels/browser/BrowserPanel.tsx
@@ -283,7 +283,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
     };
     window.addEventListener('browser-panel:popup-requested', handler);
     return () => window.removeEventListener('browser-panel:popup-requested', handler);
-  }, [panel.sessionId, addPanel, setActivePanelInStore]);
+  }, [panel.id, panel.sessionId, addPanel, setActivePanelInStore]);
 
   // Listen for browser-panel:navigate CustomEvents (e.g., from SelectionPopover "Open in Browser")
   // Uses stopImmediatePropagation so only the first browser panel for a session handles the event,

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -1486,8 +1486,8 @@ export function FileEditor({
   };
 
   // Auto-save functionality
-  const autoSave = useCallback(
-    debounce(async () => {
+  const autoSave = useMemo(
+    () => debounce(async () => {
       if (!selectedFile || selectedFile.isDirectory || fileContent === originalContent) return;
       
       try {
@@ -1528,6 +1528,8 @@ export function FileEditor({
     }, 1000), // Auto-save after 1 second of inactivity
     [sessionId, selectedFile, fileContent, originalContent, onFileChange, onStateChange]
   );
+
+  useEffect(() => () => autoSave.cancel(), [autoSave]);
 
   // Trigger auto-save when content changes
   useEffect(() => {

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useLayoutEffect, useId, ReactNode, CSSProperties } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, useId, useCallback, ReactNode, CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { Slot } from '@radix-ui/react-slot';
 import { cn } from '../../utils/cn';
@@ -109,7 +109,7 @@ export function Dropdown({
     onOpenChange?.(newState);
   };
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     // Focus inside the menu would land on <body> when it unmounts, so hand it back to
     // the trigger. Focus already moved elsewhere (a click on another control) is left alone.
     const focusWasInMenu = !!contentRef.current?.contains(document.activeElement);
@@ -120,7 +120,7 @@ export function Dropdown({
     if (focusWasInMenu) {
       triggerRef.current?.focus();
     }
-  };
+  }, [onOpenChange]);
 
   const handleItemClick = (item: DropdownItem) => {
     if (item.disabled) return;
@@ -292,7 +292,7 @@ export function Dropdown({
       clearTimeout(timer);
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [isOpen]);
+  }, [isOpen, handleClose]);
 
   // Handle escape key
   useEffect(() => {
@@ -306,7 +306,7 @@ export function Dropdown({
 
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen]);
+  }, [isOpen, handleClose]);
 
   return (
     <div ref={dropdownRef} className={cn('relative', className)} style={style}>

--- a/frontend/src/hooks/useIPCEvents.ts
+++ b/frontend/src/hooks/useIPCEvents.ts
@@ -434,7 +434,7 @@ export function useIPCEvents() {
       // Clean up all event listeners
       unsubscribeFunctions.forEach(unsubscribe => unsubscribe());
     };
-  }, [setSessions, loadSessions, addSession, updateSession, deleteSession, showError]);
+  }, [setSessions, loadSessions, addSession, updateSession, deleteSession, showError, gitStatusLoadingRef, gitStatusUpdatedRef]);
   
   // Return a mock socket object for compatibility
   return {

--- a/frontend/src/hooks/useResizable.ts
+++ b/frontend/src/hooks/useResizable.ts
@@ -72,7 +72,7 @@ export function useResizable({
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
     };
-  }, [isResizing, minWidth, maxWidth]);
+  }, [isResizing, minWidth, maxWidth, side]);
 
   return {
     width,

--- a/frontend/src/remote/RemotePwaApp.tsx
+++ b/frontend/src/remote/RemotePwaApp.tsx
@@ -102,7 +102,10 @@ export function RemotePwaApp() {
     return null;
   }, [projects, selectedSessionId]);
 
-  const selectedPanels = selectedSessionId ? panelsBySessionId[selectedSessionId] ?? [] : [];
+  const selectedPanels = useMemo(
+    () => selectedSessionId ? panelsBySessionId[selectedSessionId] ?? [] : [],
+    [panelsBySessionId, selectedSessionId],
+  );
   const terminalPanels = useMemo(
     () => selectedPanels.filter(panel => panel.type === 'terminal'),
     [selectedPanels],


### PR DESCRIPTION
## Summary

- fix 11 low-risk React hook dependency findings across app notifications, cloud state, panel events, dropdowns, IPC, resizing, and remote panel selection
- replace the file editor's opaque debounced `useCallback` with a memoized debouncer and cancel pending work during lifecycle changes
- reduce the repository ESLint baseline from 126 warnings to 115 while preserving the higher-risk terminal/session effects for a focused follow-up

Part of #403.

## Validation

- `pnpm lint` — blocking lint and Knip pass; anti-slop remains at zero
- `pnpm typecheck`
- `pnpm --filter frontend exec vitest run` — 163 passed
- `pnpm --filter frontend build`
- ESLint JSON audit — 115 warnings/0 errors; exhaustive-deps reduced from 26 to 15

Delivery lane: medium, using the approved zero-findings campaign plan with current-head implementation review and required PR CI/review gates before merge.
