### PR TITLE
Eliminate remaining hook dependency warnings

### DIFF
--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -57,6 +57,7 @@ export function CreateSessionDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [branches, setBranches] = useState<BranchInfo[]>([]);
+  const [branchesProjectId, setBranchesProjectId] = useState<number | null>(null);
   const [isLoadingBranches, setIsLoadingBranches] = useState(false);
   const [useWorktree, setUseWorktree] = useState(true);
   const [startPinned, setStartPinned] = useState(false);
@@ -107,59 +108,63 @@ export function CreateSessionDialog({
   }, [updatePreferences]);
 
   useEffect(() => {
-    if (isOpen) {
-      // Fetch branches if projectId is provided
-      if (projectId) {
-        setIsLoadingBranches(true);
-        // First get the project to get its path
-        API.projects.getAll().then(projectsResponse => {
-          if (!projectsResponse.success || !projectsResponse.data) {
-            throw new Error('Failed to fetch projects');
-          }
-          const project = projectsResponse.data.find((p: Project) => p.id === projectId);
-          if (!project) {
-            throw new Error('Project not found');
-          }
+    if (!isOpen || !projectId) return;
 
-          return Promise.all([
-            API.projects.listBranches(projectId.toString()),
-            // Get the main branch for this project using its path
-            API.projects.detectBranch(project.path)
-          ]);
-        }).then(([branchesResponse, mainBranchResponse]) => {
-          if (branchesResponse.success && branchesResponse.data) {
-            setBranches(branchesResponse.data);
-            // Default to remote main branch (origin/main or origin/master) for proper tracking
-            // Fall back to current local branch if no remote main found
-            if (!formData.baseBranch) {
-              const remoteMain = branchesResponse.data.find((b: BranchInfo) =>
-                b.isRemote && (b.name === 'origin/main' || b.name === 'origin/master')
-              );
-              const currentBranch = branchesResponse.data.find((b: BranchInfo) => b.isCurrent);
-              const defaultBranch = remoteMain || currentBranch;
-              if (defaultBranch) {
-                setFormData(prev => ({ ...prev, baseBranch: defaultBranch.name }));
-                // Auto-populate session name from default branch if user hasn't edited
-                if (!initialSessionName && !userEditedNameRef.current) {
-                  const existingNames = new Set(existingSessions.map(s => s.name));
-                  const autoName = generatePaneName(defaultBranch.name, existingNames, branchesResponse.data);
-                  setSessionName(autoName);
-                }
-              }
-            }
-          }
-
-          if (mainBranchResponse.success && mainBranchResponse.data) {
-            // Main branch detected but not currently used in UI
-          }
-        }).catch((err: Error) => {
-          console.error('Failed to fetch branches:', err);
-        }).finally(() => {
-          setIsLoadingBranches(false);
-        });
+    let cancelled = false;
+    setBranchesProjectId(null);
+    setIsLoadingBranches(true);
+    // First get the project to get its path
+    API.projects.getAll().then(projectsResponse => {
+      if (!projectsResponse.success || !projectsResponse.data) {
+        throw new Error('Failed to fetch projects');
       }
-    }
+      const project = projectsResponse.data.find((p: Project) => p.id === projectId);
+      if (!project) {
+        throw new Error('Project not found');
+      }
+
+      return Promise.all([
+        API.projects.listBranches(projectId.toString()),
+        // Get the main branch for this project using its path
+        API.projects.detectBranch(project.path)
+      ]);
+    }).then(([branchesResponse, mainBranchResponse]) => {
+      if (cancelled) return;
+      if (branchesResponse.success && branchesResponse.data) {
+        setBranches(branchesResponse.data);
+        setBranchesProjectId(projectId);
+      }
+
+      if (mainBranchResponse.success && mainBranchResponse.data) {
+        // Main branch detected but not currently used in UI
+      }
+    }).catch((err: Error) => {
+      if (!cancelled) console.error('Failed to fetch branches:', err);
+    }).finally(() => {
+      if (!cancelled) setIsLoadingBranches(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [isOpen, projectId]);
+
+  useEffect(() => {
+    if (!isOpen || branchesProjectId !== projectId || formData.baseBranch || branches.length === 0) return;
+
+    // Prefer a remote main branch for tracking, then fall back to the current branch.
+    const remoteMain = branches.find((branch) =>
+      branch.isRemote && (branch.name === 'origin/main' || branch.name === 'origin/master')
+    );
+    const defaultBranch = remoteMain ?? branches.find((branch) => branch.isCurrent);
+    if (!defaultBranch) return;
+
+    setFormData((current) => ({ ...current, baseBranch: defaultBranch.name }));
+    if (!initialSessionName && !userEditedNameRef.current) {
+      const existingNames = new Set(existingSessions.map((session) => session.name));
+      setSessionName(generatePaneName(defaultBranch.name, existingNames, branches));
+    }
+  }, [branches, branchesProjectId, existingSessions, formData.baseBranch, initialSessionName, isOpen, projectId]);
 
   // Filtered branches based on search term
   const filteredBranches = useMemo(() => {

--- a/frontend/src/components/ProjectDashboard.tsx
+++ b/frontend/src/components/ProjectDashboard.tsx
@@ -42,6 +42,11 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
   const [statusAnnouncement, setStatusAnnouncement] = useState('');
   const [isProgressive] = useState(true); // Use progressive loading by default
   const pendingSessionUpdatesRef = useRef<Map<string, SessionBranchInfo>>(new Map());
+  const dashboardDataRef = useRef<ProjectDashboardData | null>(null);
+
+  useEffect(() => {
+    dashboardDataRef.current = dashboardData;
+  }, [dashboardData]);
 
   // Debounced function to apply pending session updates
   const applyPendingSessionUpdates = useMemo(
@@ -85,10 +90,11 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
       }
     }
     
-    setIsLoading(!dashboardData); // Only show loading on initial load
-    setIsRefreshing(!!dashboardData); // Show refreshing if we already have data
+    const hasDashboardData = dashboardDataRef.current !== null;
+    setIsLoading(!hasDashboardData); // Only show loading on initial load
+    setIsRefreshing(hasDashboardData); // Show refreshing if we already have data
     setError(null);
-    setStatusAnnouncement(dashboardData ? 'Refreshing dashboard' : 'Loading dashboard');
+    setStatusAnnouncement(hasDashboardData ? 'Refreshing dashboard' : 'Loading dashboard');
     
     try {
       if (useProgressive && isProgressive) {
@@ -124,7 +130,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
       setIsLoading(false);
       setIsRefreshing(false);
     }
-  }, [projectId, dashboardData, isProgressive]);
+  }, [projectId, isProgressive]);
 
   // Debounced refresh function
   const debouncedRefresh = useMemo(
@@ -189,10 +195,11 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
 
   useEffect(() => {
     // Clear previous data when switching projects to show skeleton
+    dashboardDataRef.current = null;
     setDashboardData(null);
     setError(null);
     fetchDashboardData();
-  }, [projectId]); // Only refetch when projectId changes
+  }, [fetchDashboardData]);
 
   // Memoize grouped sessions by base branch (for future use)
   // const groupedSessions = useMemo(() => {

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1466,7 +1466,7 @@ export const SessionView = memo(() => {
   });
 
   // Create branch actions for the panel bar
-  const branchActions = useMemo(() => {
+  const branchActions = (() => {
     if (!activeSession) return [];
     const busyReason = hook.isMerging
       ? 'Git operation already in progress'
@@ -1611,7 +1611,7 @@ export const SessionView = memo(() => {
         disabledReason: busyReason ?? ((!activeSession.gitStatus?.totalCommits || activeSession.gitStatus?.totalCommits === 0 || activeSession.gitStatus?.ahead === 0) ? 'No commits to merge' : undefined),
       }
     ];
-  }, [activeSession, hook.isMerging, hook.gitCommands, hook.hasChangesToRebase, hook.hasStash, hook.handleGitPull, hook.handleGitPush, hook.handleGitSoftReset, hook.handleGitFetch, hook.handleGitStash, hook.handleGitStashPop, hook.setShowCommitMessageDialog, hook.setDialogType, hook.handleRebaseMainIntoWorktree, hook.handleSquashAndRebaseToMain, activeSession?.gitStatus]);
+  })();
   
   // Removed unused variables - now handled by panels
 

--- a/frontend/src/components/panels/SetupTasksPanel.tsx
+++ b/frontend/src/components/panels/SetupTasksPanel.tsx
@@ -221,16 +221,12 @@ const SetupTasksPanel: React.FC<SetupTasksPanelProps> = ({ panelId, isActive }) 
             console.error('[SetupTasksPanel] Failed to commit:', gitCommitResponse.error);
             alert(`Failed to create commit: ${gitCommitResponse.error}`);
           }
-          // Still refresh the task status
-          setTimeout(() => checkAllTasks(), 100);
           return;
         }
         
         console.log('[SetupTasksPanel] Successfully created commit');
         alert('Successfully added worktree patterns to .gitignore and created a commit!');
         
-        // Refresh the task status
-        setTimeout(() => checkAllTasks(), 100);
       } else {
         console.log('[SetupTasksPanel] No update needed, patterns already exist');
         alert('Worktree patterns are already in .gitignore. No changes needed.');

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -692,6 +692,30 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     }
   }, [panel.id]);
 
+  // The terminal instance lives for the lifetime of a panel. Event handlers installed
+  // during initialization read changing session/config values through this ref so those
+  // changes do not tear down and recreate xterm or its PTY connection.
+  const terminalRuntimeRef = useRef({
+    handleClipboardError,
+    highContrast,
+    isRemoteMode,
+    panelSessionId: panel.sessionId,
+    resizePtyToFit,
+    sessionId,
+    workingDirectory,
+  });
+  useEffect(() => {
+    terminalRuntimeRef.current = {
+      handleClipboardError,
+      highContrast,
+      isRemoteMode,
+      panelSessionId: panel.sessionId,
+      resizePtyToFit,
+      sessionId,
+      workingDirectory,
+    };
+  }, [handleClipboardError, highContrast, isRemoteMode, panel.sessionId, resizePtyToFit, sessionId, workingDirectory]);
+
   // Full-depth refresh: normal buffers reset+replay main's rendered emulator
   // serialization at the settled width; alternate buffers preserve their live
   // model and end with a forced PTY resize so the fullscreen app redraws. The
@@ -857,6 +881,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
 
   // Initialize terminal only once when component first mounts
   // Keep it alive even when switching sessions
+  // The initializer guards every post-await state update with `disposed`; its returned
+  // resource cleanup is awaited by the synchronous effect teardown. React Doctor's
+  // nested-function scan cannot follow that deferred cleanup contract.
+  // react-doctor-disable-next-line react-doctor/effect-needs-cleanup, react-doctor/no-set-state-after-await-in-effect
   useEffect(() => {
     devLog.debug('[TerminalPanel] Initialization useEffect running, terminalRef:', terminalRef.current);
 
@@ -868,6 +896,14 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     let terminal: Terminal | null = null;
     let fitAddon: FitAddon | null = null;
     let disposed = false;
+    let toastClearTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleToastClear = (delayMs: number) => {
+      if (toastClearTimer) clearTimeout(toastClearTimer);
+      toastClearTimer = setTimeout(() => {
+        toastClearTimer = null;
+        if (!disposed) setToastMessage(null);
+      }, delayMs);
+    };
 
     const initializeTerminal = async () => {
       try {
@@ -889,8 +925,8 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           const estimatedCols = containerRect ? Math.floor(containerRect.width / 8) : undefined; // rough char width estimate
           const estimatedRows = containerRect ? Math.floor(containerRect.height / 17) : undefined; // rough char height estimate
           await window.electronAPI.invoke('panels:initialize', panel.id, {
-            cwd: workingDirectory || process.cwd(),
-            sessionId: sessionId || panel.sessionId,
+            cwd: terminalRuntimeRef.current.workingDirectory || process.cwd(),
+            sessionId: terminalRuntimeRef.current.sessionId || terminalRuntimeRef.current.panelSessionId,
             cols: estimatedCols && estimatedCols >= 20 ? estimatedCols : undefined,
             rows: estimatedRows && estimatedRows >= 5 ? estimatedRows : undefined,
           });
@@ -943,7 +979,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           altClickMovesCursor: true,
           drawBoldTextInBrightColors: true,
           rescaleOverlappingGlyphs: true,
-          minimumContrastRatio: getMinimumContrastRatio(highContrast),
+          minimumContrastRatio: getMinimumContrastRatio(terminalRuntimeRef.current.highContrast),
           macOptionIsMeta: false,
           linkHandler: {
             activate: (_event, uri) => {
@@ -964,7 +1000,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           if (isTerminalCopyShortcut(e, isMac())) {
             if (e.type === 'keydown' && terminal?.hasSelection()) {
               void copyTerminalText(terminal.getSelection()).catch(() => {
-                handleClipboardError();
+                terminalRuntimeRef.current.handleClipboardError();
               });
             }
             return false;
@@ -1188,6 +1224,11 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             unicode11AddonRef.current = null;
           }
 
+          if (disposed) {
+            terminal.dispose();
+            fitAddon.dispose();
+            return;
+          }
           xtermRef.current = terminal;
           setTerminalInstance(terminal);
           fitAddonRef.current = fitAddon;
@@ -1349,7 +1390,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
                       const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                         'terminal:paste-image',
                         panel.id,
-                        sessionId || panel.sessionId,
+                        terminalRuntimeRef.current.sessionId || terminalRuntimeRef.current.panelSessionId,
                         dataUrl,
                         file.type
                       ), terminalPasteImageResultSchema);
@@ -1375,12 +1416,12 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             e.stopPropagation();
             e.preventDefault();
 
-            if (isRemoteMode) {
+            if (terminalRuntimeRef.current.isRemoteMode) {
               if (text && !isClipboardImagePlaceholderText(text) && !disposed && terminal) {
                 terminal.paste(text);
               } else {
                 setToastMessage('Native image clipboard paste is unavailable in remote mode. Use drag and drop or browser image paste instead.');
-                setTimeout(() => setToastMessage(null), 2500);
+                scheduleToastClear(2500);
               }
               return;
             }
@@ -1390,7 +1431,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
               try {
                 const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                   'terminal:clipboard-paste-image',
-                  sessionId || panel.sessionId
+                  terminalRuntimeRef.current.sessionId || terminalRuntimeRef.current.panelSessionId
                 ), terminalPasteImageResultSchema);
                 if (result?.filePath && !disposed && terminal) {
                   terminal.paste(`${result.filePath}\n`);
@@ -1456,7 +1497,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
                     const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                       'terminal:paste-image',
                       panel.id,
-                      sessionId || panel.sessionId,
+                      terminalRuntimeRef.current.sessionId || terminalRuntimeRef.current.panelSessionId,
                       dataUrl,
                       file.type
                     ), terminalPasteImageResultSchema);
@@ -1464,7 +1505,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
                   } else {
                     const result = decodeOptionalBoundary(await window.electronAPI.invoke(
                       'terminal:paste-file',
-                      sessionId || panel.sessionId,
+                      terminalRuntimeRef.current.sessionId || terminalRuntimeRef.current.panelSessionId,
                       dataUrl,
                       file.name
                     ), terminalPasteFileResultSchema);
@@ -1494,7 +1535,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           // Let the WebGL renderer finish painting before removing the loader overlay.
           // Without this, the loader disappears and the user briefly sees stale/blank
           // content before the fit() render completes (visible as a stutter on macOS).
-          await new Promise(resolve => setTimeout(resolve, 30));
+          await waitForNextPaint();
           if (disposed) return;
           hotActivationEligibleRef.current = false;
           hotActivationPendingRef.current = false;
@@ -1612,7 +1653,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           interceptorRef.current = interceptor;
 
           // Register @ handler for terminal scrollback copy
-          const effectiveSessionId = sessionId || panel.sessionId;
+          const effectiveSessionId = terminalRuntimeRef.current.sessionId || terminalRuntimeRef.current.panelSessionId;
 
           const getTerminals = async (): Promise<TerminalSuggestion[]> => {
             const allPanels = usePanelStore.getState().getSessionPanels(effectiveSessionId);
@@ -1667,7 +1708,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             } catch {
               setToastMessage('Failed to paste scrollback');
             }
-            setTimeout(() => setToastMessage(null), 2000);
+            scheduleToastClear(2000);
           };
 
           interceptor.registerHandler('@', createAtTerminalHandler({
@@ -1712,7 +1753,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           const debouncedResize = () => {
             if (resizeTimer) clearTimeout(resizeTimer);
             resizeTimer = setTimeout(() => {
-              if (!disposed) void resizePtyToFit();
+              if (!disposed) void terminalRuntimeRef.current.resizePtyToFit();
             }, 150);
           };
 
@@ -1748,7 +1789,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
         }
       } catch (error) {
         console.error('Failed to initialize terminal:', error);
-        setInitError(error instanceof Error ? error.message : 'Unknown error');
+        if (!disposed) {
+          setInitError(error instanceof Error ? error.message : 'Unknown error');
+        }
       }
     };
 
@@ -1758,6 +1801,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     // Not when just switching tabs
     return () => {
       disposed = true;
+      if (toastClearTimer) clearTimeout(toastClearTimer);
       hotActivationEligibleRef.current = false;
       hotActivationPendingRef.current = false;
 


### PR DESCRIPTION
## Summary
- split branch loading from default selection and cancel stale dialog requests
- stabilize dashboard refreshes and derive session branch actions without a brittle memo
- keep terminal initialization panel-scoped while long-lived handlers read current runtime values
- remove duplicate setup-task refresh timers
- reduce frontend ESLint warnings from 105 to 100, eliminating all remaining `react-hooks/exhaustive-deps` findings

## Validation
- `pnpm lint` (100 pre-existing `no-console` warnings; 0 errors; Knip and anti-slop clean)
- `pnpm typecheck`
- `pnpm --filter frontend test -- --run` (163 tests)
- `pnpm build` (signed universal macOS package completed)