### PR TITLE
Remove low-risk renderer debug logs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -780,7 +780,6 @@ function App() {
     if (!window.electronAPI?.events) return;
 
     const handleVersionUpdate = (versionInfo: VersionUpdateInfo) => {
-      console.log('[App] Version update available:', versionInfo);
       setUpdateVersionInfo(versionInfo);
       setIsUpdateDialogOpen(true);
       showNotification(

--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -344,21 +344,12 @@ export function CreateSessionDialog({
           const folderResponse = await API.folders.create(cleanedName, projectId);
           if (folderResponse.success && folderResponse.data) {
             folderId = folderResponse.data.id;
-            console.log(`[CreateSessionDialog] Created folder: ${cleanedName} (${folderId})`);
           }
         } catch (error) {
           console.error('[CreateSessionDialog] Failed to create folder:', error);
           // Continue without folder - sessions will be created at project level
         }
       }
-
-      console.log('[CreateSessionDialog] Creating session with:', {
-        sessionName: cleanedName,
-        count: sessionCount,
-        toolType: 'none',
-        folderId,
-        startPinned
-      });
 
       const response = await API.sessions.create({
         prompt: '',

--- a/frontend/src/components/DiscordPopup.tsx
+++ b/frontend/src/components/DiscordPopup.tsx
@@ -21,16 +21,13 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
     const loadPreference = async () => {
       if (window.electron?.invoke) {
         try {
-          console.log('[Discord] Loading hide_discord preference...');
           // SAFETY: The named IPC/API channel contract establishes this response payload type.
           const result = await window.electron.invoke('preferences:get', 'hide_discord') as IPCResponse<string>;
-          console.log('[Discord] Preference result:', result);
           
           if (result?.success) {
             // Handle null (preference doesn't exist) as false
             const shouldHide = result.data === 'true';
             setDontShowAgain(shouldHide);
-            console.log('[Discord] Set dontShowAgain to:', shouldHide);
           } else {
             console.error('[Discord] Failed to load preference:', result?.error);
           }
@@ -158,9 +155,7 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
                   try {
                     // SAFETY: The named IPC/API channel contract establishes this response payload type.
                     const result = await window.electron.invoke('preferences:set', 'hide_discord', newValue ? 'true' : 'false') as IPCResponse;
-                    if (result?.success) {
-                      console.log('[Discord] Successfully set hide_discord preference to', newValue);
-                    } else {
+                    if (!result?.success) {
                       console.error('[Discord] Failed to set preference:', result?.error);
                     }
                   } catch (error) {

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -35,14 +35,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       url: window.location.href,
     }).catch(() => {});
 
-    // Log to file in development mode for debugging
-    if (process.env.NODE_ENV === 'development') {
-      console.log('[ErrorBoundary] Full error details:', {
-        message: error.message,
-        stack: error.stack,
-        componentStack: errorInfo.componentStack
-      });
-    }
   }
 
   render() {

--- a/frontend/src/components/MainProcessLogger.tsx
+++ b/frontend/src/components/MainProcessLogger.tsx
@@ -13,9 +13,11 @@ export function MainProcessLogger() {
           console.warn(prefix, message);
           break;
         case 'info':
+          // eslint-disable-next-line no-console -- this component intentionally mirrors main-process logs.
           console.info(prefix, message);
           break;
         default:
+          // eslint-disable-next-line no-console -- this component intentionally mirrors main-process logs.
           console.log(prefix, message);
       }
     });

--- a/frontend/src/components/ProjectDashboard.tsx
+++ b/frontend/src/components/ProjectDashboard.tsx
@@ -221,12 +221,9 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
     const staleClass = session.isStale ? 'bg-status-warning/10' : '';
     
     const handleSessionClick = async () => {
-      console.log('[ProjectDashboard] Session clicked:', session.sessionId, session.sessionName);
       try {
         await useSessionStore.getState().setActiveSession(session.sessionId);
-        console.log('[ProjectDashboard] Session set, now navigating to sessions view');
         useNavigationStore.getState().navigateToSessions();
-        console.log('[ProjectDashboard] Navigation completed');
       } catch (error) {
         console.error('[ProjectDashboard] Error in handleSessionClick:', error);
       }
@@ -391,7 +388,7 @@ export const ProjectDashboard: React.FC<ProjectDashboardProps> = React.memo(({ p
               mainBranch={dashboardData.mainBranch}
               mainBranchStatus={dashboardData.mainBranchStatus}
               remotes={dashboardData.remotes}
-              onReviewUpdates={() => console.log('Review updates clicked')}
+              onReviewUpdates={() => {}}
             />
           )}
           

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -81,10 +81,7 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
   // Load panels when main repo session changes (no auto-creation, matches worktree session behavior)
   useEffect(() => {
     if (mainRepoSessionId) {
-      console.log('[ProjectView] Loading panels for project session:', mainRepoSessionId);
       panelApi.loadPanelsForSession(mainRepoSessionId).then(async (loadedPanels) => {
-        console.log('[ProjectView] Loaded panels:', loadedPanels);
-
         setPanels(mainRepoSessionId, loadedPanels);
 
         // Pick default active: prefer diff, then explorer, then first panel
@@ -208,16 +205,6 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
     [mainRepoSessionId, addPanel, setActivePanelInStore]
   );
   
-  // Debug logging
-  useEffect(() => {
-    console.log('[ProjectView] Session state:', { 
-      mainRepoSessionId, 
-      mainRepoSession: mainRepoSession?.id,
-      activePanelType: currentActivePanel?.type,
-      activeSessionInStore: useSessionStore.getState().activeSessionId
-    });
-  }, [mainRepoSessionId, mainRepoSession, currentActivePanel]);
-
   // Get or create main repo session when panels are needed
   useEffect(() => {
     const requestGeneration = ++sessionRequestGeneration.current;
@@ -288,8 +275,6 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
 
     // Handle panel creation events (for auto-created panels like logs)
     const handlePanelCreated = (panel: ToolPanel) => {
-      console.log('[ProjectView] Received panel:created event:', panel);
-
       // Only add if it's for the current session
       if (panel.sessionId === mainRepoSessionId) {
         // The store's addPanel now checks for duplicates, so we can safely call it

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1362,7 +1362,6 @@ export const SessionView = memo(() => {
     // Check if user has previously closed terminal panel for this session
     window.electronAPI?.invoke('panels:shouldAutoCreate', activeSession.id, 'terminal').then(shouldCreate => {
       if (!shouldCreate) {
-        console.log('[SessionView] Skipping terminal auto-create - user previously closed it');
         return;
       }
       panelApi.createPanel({

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -138,27 +138,22 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
   const hydrateExpandedProjects = useNavigationStore(s => s.hydrateExpandedProjects);
 
   useEffect(() => {
+    let cancelled = false;
+
     // Fetch version info and UI state on component mount
     const fetchVersion = async () => {
       try {
-        console.log('[Sidebar Debug] Fetching version info...');
         const result = await window.electronAPI.getVersionInfo();
-        console.log('[Sidebar Debug] Version info result:', result);
+        if (cancelled) return;
         if (result.success && result.data) {
-          console.log('[Sidebar Debug] Version data:', result.data);
           if (result.data.current) {
             setVersion(result.data.current);
-            console.log('[Sidebar Debug] Set version:', result.data.current);
           }
           if (result.data.gitCommit) {
             setGitCommit(result.data.gitCommit);
-            console.log('[Sidebar Debug] Set gitCommit:', result.data.gitCommit);
           }
           if (result.data.worktreeName) {
             setWorktreeName(result.data.worktreeName);
-            console.log('[Sidebar Debug] Set worktreeName:', result.data.worktreeName);
-          } else {
-            console.log('[Sidebar Debug] No worktreeName in response');
           }
         }
       } catch (error) {
@@ -169,6 +164,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
     const loadUIState = async () => {
       try {
         const result = await window.electronAPI.uiState.getExpanded();
+        if (cancelled) return;
         if (result.success && result.data) {
           setSessionSortAscending(result.data.sessionSortAscending ?? true);
           hydrateExpandedProjects(result.data.expandedProjects ?? []);
@@ -182,8 +178,12 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
       }
     };
 
-    fetchVersion();
-    loadUIState();
+    void fetchVersion();
+    void loadUIState();
+
+    return () => {
+      cancelled = true;
+    };
   }, [hydrateExpandedProjects]);
 
   useEffect(() => {

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -68,7 +68,6 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     // Check if app is packaged (auto-update only works in packaged apps)
     if (window.electronAPI?.isPackaged) {
       window.electronAPI.isPackaged().then((packaged) => {
-        console.log('[UpdateDialog] App packaged state:', packaged);
         setIsPackaged(packaged);
       });
     }
@@ -144,8 +143,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     );
 
     cleanupFns.push(
-      window.electronAPI.events.onUpdaterUpdateAvailable((info) => {
-        console.log('Update available:', info);
+      window.electronAPI.events.onUpdaterUpdateAvailable(() => {
         setUpdateState('available');
         if (userStartedUpdateRef.current && !isMac()) {
           void startDownloadUpdate();
@@ -154,8 +152,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     );
 
     cleanupFns.push(
-      window.electronAPI.events.onUpdaterUpdateNotAvailable((info) => {
-        console.log('No update available:', info);
+      window.electronAPI.events.onUpdaterUpdateNotAvailable(() => {
         userStartedUpdateRef.current = false;
         setUpdateState('idle');
       })
@@ -169,8 +166,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     );
 
     cleanupFns.push(
-      window.electronAPI.events.onUpdaterUpdateDownloaded((info) => {
-        console.log('Update downloaded:', info);
+      window.electronAPI.events.onUpdaterUpdateDownloaded(() => {
         setUpdateState('downloaded');
         setDownloadProgress(null);
         if (userStartedUpdateRef.current && !isMac()) {

--- a/frontend/src/devtools/reactScan.ts
+++ b/frontend/src/devtools/reactScan.ts
@@ -22,6 +22,7 @@ function flushRenderEvidence(): void {
       }));
 
     summaries.clear();
+    // eslint-disable-next-line no-console -- perf:scan consumes this structured console evidence.
     console.info(`[render-evidence] ${JSON.stringify({
       surface: window.location.pathname.endsWith('remote.html') ? 'remote-pwa' : 'desktop',
       intervalMs: 1000,

--- a/frontend/src/hooks/useSessionView.ts
+++ b/frontend/src/hooks/useSessionView.ts
@@ -1530,8 +1530,6 @@ export const useSessionView = (
     if (!activeSession) return;
     
     try {
-      console.log('[Context Compaction] Starting compaction for session:', activeSession.id);
-      
       // Generate the compacted context
       const response = await API.sessions.generateCompactedContext(activeSession.id);
       
@@ -1539,7 +1537,6 @@ export const useSessionView = (
         const summary = response.data.summary;
         setCompactedContext(summary);
         setContextCompacted(true);
-        console.log('[Context Compaction] Context successfully compacted');
       } else {
         console.error('[Context Compaction] Failed to compact context:', response.error);
       }

--- a/frontend/src/utils/console.ts
+++ b/frontend/src/utils/console.ts
@@ -17,6 +17,7 @@ const isVerboseEnabled = () => {
 export const devLog = {
   log: (...args: unknown[]) => {
     if (isDevelopment || isVerboseEnabled()) {
+      // eslint-disable-next-line no-console -- this module is the centralized console adapter.
       console.log(...args);
     }
   },
@@ -34,12 +35,14 @@ export const devLog = {
   
   debug: (...args: unknown[]) => {
     if (isDevelopment && isVerboseEnabled()) {
+      // eslint-disable-next-line no-console -- this module is the centralized console adapter.
       console.debug(...args);
     }
   },
   
   info: (...args: unknown[]) => {
     if (isDevelopment || isVerboseEnabled()) {
+      // eslint-disable-next-line no-console -- this module is the centralized console adapter.
       console.info(...args);
     }
   }
@@ -51,6 +54,7 @@ export const devLog = {
  */
 export const renderLog = (...args: unknown[]) => {
   if (isDevelopment && isVerboseEnabled()) {
+    // eslint-disable-next-line no-console -- this module is the centralized console adapter.
     console.log(...args);
   }
 };


### PR DESCRIPTION
## Summary
- remove transient renderer click, state, updater, and preference debug output
- preserve existing error reporting and UI behavior
- document narrow `no-console` exemptions in intentional console adapters
- reduce frontend ESLint warnings from 100 to 63

## Validation
- `pnpm lint` (63 remaining `no-console` warnings; 0 errors; Knip and anti-slop clean)
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend test -- --run` (163 tests)
- `pnpm --filter frontend build`