### PR TITLE
Phase 3n: eliminate remaining frontend ESLint warnings

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -483,7 +483,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
         if (webglAddonRef.current !== addon) return;
         if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
       }));
-      console.log('[TerminalPanel] WebGL renderer loaded for panel', panel.id);
+      devLog.debug('[TerminalPanel] WebGL renderer loaded for panel', panel.id);
       forwardToMainLog('info', `[TerminalPanel] WebGL renderer loaded for panel ${panel.id} reason=${reason}`);
     } catch (e) {
       console.warn('[TerminalPanel] WebGL renderer failed for panel', panel.id, ', using DOM renderer:', e);
@@ -911,14 +911,14 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
 
         // Check if already initialized on backend
         const initialized = await window.electronAPI.invoke('panels:checkInitialized', panel.id);
-        console.log('[TerminalPanel] Panel already initialized?', initialized);
+        devLog.debug('[TerminalPanel] Panel already initialized?', initialized);
 
         // Store terminal state for THIS panel only (not in global variable)
         let terminalStateForThisPanel: TerminalRestoreState | null = null;
 
         if (!initialized) {
           // Initialize backend PTY process
-          console.log('[TerminalPanel] Initializing backend PTY process...');
+          devLog.debug('[TerminalPanel] Initializing backend PTY process...');
           // Use workingDirectory and sessionId if available, but don't require them
           // Use actual container dimensions for PTY spawn (falls back to 80x30 on backend)
           const containerRect = terminalRef.current?.getBoundingClientRect();
@@ -930,14 +930,14 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             cols: estimatedCols && estimatedCols >= 20 ? estimatedCols : undefined,
             rows: estimatedRows && estimatedRows >= 5 ? estimatedRows : undefined,
           });
-          console.log('[TerminalPanel] Backend PTY process initialized');
+          devLog.debug('[TerminalPanel] Backend PTY process initialized');
         } else {
           // Terminal is already initialized, get its state to restore scrollback
-          console.log('[TerminalPanel] Restoring terminal state from backend...');
+          devLog.debug('[TerminalPanel] Restoring terminal state from backend...');
           const terminalState = await window.electronAPI.invoke('terminal:getState', panel.id);
           if (terminalState && selectTerminalRestoreContent(terminalState)) {
             // We'll restore this to the terminal after it's created
-            console.log('[TerminalPanel] Found terminal restore state');
+            devLog.debug('[TerminalPanel] Found terminal restore state');
             // Store for restoration after terminal is created - LOCAL to this initialization
             terminalStateForThisPanel = terminalState;
           }
@@ -963,7 +963,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
         if (disposed) return;
 
         // Create XTerm instance
-        console.log('[TerminalPanel] Creating XTerm instance...');
+        devLog.debug('[TerminalPanel] Creating XTerm instance...');
         terminal = new Terminal({
           fontSize: terminalFontSize,
           fontFamily: buildTerminalFontFamily(terminalFontFamily),
@@ -989,11 +989,11 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             },
           },
         });
-        console.log('[TerminalPanel] XTerm instance created:', !!terminal);
+        devLog.debug('[TerminalPanel] XTerm instance created:', !!terminal);
 
         fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
-        console.log('[TerminalPanel] FitAddon loaded');
+        devLog.debug('[TerminalPanel] FitAddon loaded');
 
         // Intercept app-level shortcuts before xterm consumes them
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
@@ -1152,9 +1152,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
 
         // FIX: Additional check before DOM manipulation
         if (terminalRef.current && !disposed) {
-          console.log('[TerminalPanel] Opening terminal in DOM element:', terminalRef.current);
+          devLog.debug('[TerminalPanel] Opening terminal in DOM element:', terminalRef.current);
           terminal.open(terminalRef.current);
-          console.log('[TerminalPanel] Terminal opened in DOM');
+          devLog.debug('[TerminalPanel] Terminal opened in DOM');
 
           // Wait for fonts to load before fitting so xterm measures correct cell dimensions
           await Promise.all([
@@ -1168,10 +1168,10 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           // full activation refresh rebuilds anything that still parsed mismatched.
           if ((terminalRef.current?.getBoundingClientRect().width ?? 0) >= MIN_VIABLE_RECT_PX) {
             fitAddon.fit();
-            console.log('[TerminalPanel] FitAddon fitted');
+            devLog.debug('[TerminalPanel] FitAddon fitted');
           } else {
             needsFullActivationRefreshRef.current = true;
-            console.log('[TerminalPanel] Skipped mount fit (hidden container); armed full activation refresh');
+            devLog.debug('[TerminalPanel] Skipped mount fit (hidden container); armed full activation refresh');
           }
           terminal.options.theme = getTerminalTheme();
 
@@ -1188,7 +1188,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
               });
               terminal.loadAddon(webLinksAddon);
               webLinksAddonRef.current = webLinksAddon;
-              console.log('[TerminalPanel] WebLinksAddon loaded for panel', panel.id);
+              devLog.debug('[TerminalPanel] WebLinksAddon loaded for panel', panel.id);
             }
           } catch (e) {
             console.warn('[TerminalPanel] WebLinksAddon failed to load for panel', panel.id, ':', e);
@@ -1202,7 +1202,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
               const serializeAddon = new SerializeAddonImpl();
               terminal.loadAddon(serializeAddon);
               serializeAddonRef.current = serializeAddon;
-              console.log('[TerminalPanel] SerializeAddon loaded for panel', panel.id);
+              devLog.debug('[TerminalPanel] SerializeAddon loaded for panel', panel.id);
             }
           } catch (e) {
             console.warn('[TerminalPanel] SerializeAddon failed to load for panel', panel.id, ':', e);
@@ -1217,7 +1217,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
               terminal.loadAddon(unicode11Addon);
               terminal.unicode.activeVersion = '11';
               unicode11AddonRef.current = unicode11Addon;
-              console.log('[TerminalPanel] Unicode11Addon loaded for panel', panel.id);
+              devLog.debug('[TerminalPanel] Unicode11Addon loaded for panel', panel.id);
             }
           } catch (e) {
             console.warn('[TerminalPanel] Unicode11Addon failed to load for panel', panel.id, ':', e);
@@ -1307,7 +1307,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           if (terminalStateForThisPanel) {
             const restore = selectTerminalRestoreContent(terminalStateForThisPanel);
             if (restore) {
-              console.log('[TerminalPanel] Restoring', restore.content.length, 'chars from', restore.source);
+              devLog.debug('[TerminalPanel] Restoring', restore.content.length, 'chars from', restore.source);
               terminal.write(restore.content);
             }
             // Force WebGL renderer to redraw after buffer content changes.
@@ -1540,7 +1540,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           hotActivationEligibleRef.current = false;
           hotActivationPendingRef.current = false;
           setIsInitialized(true);
-          console.log('[TerminalPanel] Terminal initialization complete, isInitialized set to true');
+          devLog.debug('[TerminalPanel] Terminal initialization complete, isInitialized set to true');
 
           // Core write-and-ack: consume a raw output chunk (already filtered by
           // source/panelId on the dispatcher side). Installed into a ref so the
@@ -1582,7 +1582,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             // Ignore session terminal output, which has no panelId.
           };
           const unsubscribeOutput = window.electronAPI.events.onTerminalOutput(legacyOutputHandler);
-          console.log('[TerminalPanel] Subscribed to terminal output events for panel:', panel.id);
+          devLog.debug('[TerminalPanel] Subscribed to terminal output events for panel:', panel.id);
 
           // Detect full-screen TUI apps (vim, htop, etc.) via alternate screen buffer.
           // This is universal — all well-behaved TUI apps enter alternate screen via
@@ -1852,7 +1852,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
       if (xtermRef.current) {
         const terminalToDispose = xtermRef.current;
         try {
-          console.log('[TerminalPanel] Disposing terminal for panel:', panel.id);
+          devLog.debug('[TerminalPanel] Disposing terminal for panel:', panel.id);
           terminalToDispose.dispose();
         } catch (e) {
           console.warn('Error disposing terminal:', e);

--- a/frontend/src/components/panels/editor/EditorPanel.tsx
+++ b/frontend/src/components/panels/editor/EditorPanel.tsx
@@ -3,6 +3,7 @@ import { FileEditor } from './FileEditor';
 import { ExplorerPanelState, ToolPanel } from '../../../../../shared/types/panels';
 import { panelApi } from '../../../services/panelApi';
 import { debounce, type DebouncedFunction } from '../../../utils/debounce';
+import { devLog } from '../../../utils/console';
 import { usePanelStore } from '../../../stores/panelStore';
 
 interface ExplorerPanelProps {
@@ -23,7 +24,7 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
     [panel.state?.customState]
   );
   
-  console.log('[ExplorerPanel] Rendering with state:', {
+  devLog.debug('[ExplorerPanel] Rendering with state:', {
     panelId: panel.id,
     isActive,
     explorerState,
@@ -56,7 +57,7 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   // Initialize debounced function immediately to prevent warning
   if (!debouncedUpdateRef.current) {
     debouncedUpdateRef.current = debounce((panelId: string, sessionId: string, newState: Partial<ExplorerPanelState>) => {
-      console.log('[ExplorerPanel] Saving state to database:', {
+      devLog.debug('[ExplorerPanel] Saving state to database:', {
         panelId,
         newState
       });
@@ -83,12 +84,12 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
         }
       };
 
-      console.log('[ExplorerPanel] Full state being saved:', stateToSave);
+      devLog.debug('[ExplorerPanel] Full state being saved:', stateToSave);
 
       panelApi.updatePanel(panelId, {
         state: stateToSave
       }).then(() => {
-        console.log('[ExplorerPanel] State saved successfully');
+        devLog.debug('[ExplorerPanel] State saved successfully');
       }).catch(err => {
         console.error('[ExplorerPanel] Failed to update explorer panel state:', err);
       });
@@ -99,7 +100,7 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   useEffect(() => {
     return () => {
       if (debouncedUpdateRef.current?.flush) {
-        console.log('[ExplorerPanel] Flushing pending saves on unmount');
+        devLog.debug('[ExplorerPanel] Flushing pending saves on unmount');
         debouncedUpdateRef.current.flush(); // Save any pending changes before unmount
       }
     };
@@ -109,7 +110,7 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   useEffect(() => {
     const handleSessionSwitch = () => {
       if (debouncedUpdateRef.current?.flush) {
-        console.log('[ExplorerPanel] Flushing pending saves on session switch');
+        devLog.debug('[ExplorerPanel] Flushing pending saves on session switch');
         debouncedUpdateRef.current.flush(); // Save before switching sessions
       }
     };
@@ -123,18 +124,18 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
   // Flush pending saves when panel becomes inactive
   useEffect(() => {
     if (!isActive && debouncedUpdateRef.current?.flush) {
-      console.log('[ExplorerPanel] Panel became inactive, flushing pending saves');
+      devLog.debug('[ExplorerPanel] Panel became inactive, flushing pending saves');
       debouncedUpdateRef.current.flush(); // Save immediately when switching away
     }
   }, [isActive]);
 
   // Save state changes to the panel
   const handleStateChange = useCallback((newState: Partial<ExplorerPanelState>) => {
-    console.log('[ExplorerPanel] handleStateChange called with:', newState);
+    devLog.debug('[ExplorerPanel] handleStateChange called with:', newState);
 
     // Call debounced update - it will fetch fresh state from the store
     if (debouncedUpdateRef.current) {
-      console.log('[ExplorerPanel] Calling debounced update');
+      devLog.debug('[ExplorerPanel] Calling debounced update');
       debouncedUpdateRef.current(panel.id, panel.sessionId, newState);
     } else {
       console.error('[ExplorerPanel] No debounced update function!');

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -8,6 +8,7 @@ import type { ItemInstance } from '@headless-tree/core';
 import { MonacoErrorBoundary } from '../../MonacoErrorBoundary';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { debounce } from '../../../utils/debounce';
+import { devLog } from '../../../utils/console';
 import { MarkdownPreview } from '../../MarkdownPreview';
 import { NotebookPreview } from './NotebookPreview';
 import { useResizablePanel } from '../../../hooks/useResizablePanel';
@@ -18,7 +19,6 @@ import { TerminalPopover, PopoverButton } from '../../terminal/TerminalPopover';
 import { areKeyboardShortcutsEnabled, useConfigStore } from '../../../stores/configStore';
 import { LiveRegion } from '../../ui/LiveRegion';
 import { boundary, decodeBoundary } from '../../../../../shared/validation/boundaryDecoder';
-
 interface LanguageByExtension {
   [extension: string]: string;
 }
@@ -1193,7 +1193,7 @@ export function FileEditor({
   onFileChange,
   onStateChange 
 }: FileEditorProps) {
-  console.log('[FileEditor] Mounting with:', {
+  devLog.debug('[FileEditor] Mounting with:', {
     sessionId,
     initialFilePath,
     initialState,
@@ -1238,7 +1238,7 @@ export function FileEditor({
   
   // Wrap onResize callback to avoid recreating
   const handleTreeResize = useCallback((width: number) => {
-    console.log('[FileEditor] Tree resized to:', width);
+    devLog.debug('[FileEditor] Tree resized to:', width);
     if (onStateChange) {
       onStateChange({ fileTreeWidth: width });
     }
@@ -1581,16 +1581,16 @@ export function FileEditor({
 
   // Memoize the tree state change handler to prevent infinite loops
   const handleTreeStateChange = useCallback((treeState: { expandedDirs: string[]; searchQuery: string; showSearch: boolean }) => {
-    console.log('[FileEditor] handleTreeStateChange called with:', treeState);
+    devLog.debug('[FileEditor] handleTreeStateChange called with:', treeState);
     if (onStateChange) {
-      console.log('[FileEditor] Calling onStateChange');
+      devLog.debug('[FileEditor] Calling onStateChange');
       onStateChange({
         expandedDirs: treeState.expandedDirs,
         searchQuery: treeState.searchQuery,
         showSearch: treeState.showSearch
       });
     } else {
-      console.log('[FileEditor] No onStateChange callback');
+      devLog.debug('[FileEditor] No onStateChange callback');
     }
   }, [onStateChange]);
   
@@ -1601,7 +1601,7 @@ export function FileEditor({
       try {
         const model = editorRef.current?.getModel();
         if (model) {
-          console.log('[FileEditor] Disposing Monaco model');
+          devLog.debug('[FileEditor] Disposing Monaco model');
           model.dispose();
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- route the final terminal and editor debug diagnostics through the existing development logger
- preserve warning and error reporting while removing production console noise
- reduce frontend ESLint warnings from 35 to 0, completing Phase 3

Advances #403.

## Validation
- `pnpm lint` (0 ESLint, Knip, or anti-slop findings)
- `pnpm typecheck`
- `pnpm --filter frontend test -- --run` (163 tests)
- `pnpm --filter frontend build`
- focused ESLint on all three changed files
- React Doctor 0.9.2 changed-scope scan: no errors; two pre-existing `prefer-useReducer` diagnostics re-fingerprinted because their containing components changed (two old fingerprints simultaneously reported fixed)

## Review notes
- this is a logging-only change: no terminal or editor state, lifecycle, IPC, or error paths changed
- React Doctor is advisory for existing debt; the state-architecture findings belong to Phase 4 rather than this focused logging cleanup
