### PR TITLE
Phase 4a: clean up React resource ownership

### DIFF
--- a/frontend/src/components/CommitDialog.tsx
+++ b/frontend/src/components/CommitDialog.tsx
@@ -32,12 +32,14 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
       setCommitMessage(defaultMessage);
       setError(null);
       // Focus and select all text after a short delay
-      setTimeout(() => {
+      const focusTimer = window.setTimeout(() => {
         if (textareaRef.current) {
           textareaRef.current.focus();
           textareaRef.current.select();
         }
       }, 100);
+
+      return () => window.clearTimeout(focusTimer);
     }
   }, [isOpen, fileCount]);
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -896,6 +896,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     let terminal: Terminal | null = null;
     let fitAddon: FitAddon | null = null;
     let disposed = false;
+    let resizeObserver: ResizeObserver | null = null;
     let toastClearTimer: ReturnType<typeof setTimeout> | null = null;
     const scheduleToastClear = (delayMs: number) => {
       if (toastClearTimer) clearTimeout(toastClearTimer);
@@ -1757,7 +1758,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             }, 150);
           };
 
-          const resizeObserver = new ResizeObserver(() => {
+          resizeObserver = new ResizeObserver(() => {
             if (isActiveRef.current) {  // Only resize when panel is active
               debouncedResize();
             }
@@ -1774,7 +1775,8 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             outputConsumerRef.current = null;
             flushAck();
             if (ackFlushTimer) clearTimeout(ackFlushTimer);
-            resizeObserver.disconnect();
+            resizeObserver?.disconnect();
+            resizeObserver = null;
             if (resizeTimer) clearTimeout(resizeTimer);
             unsubscribeOutput();
             unsubscribeAltScreen();
@@ -1802,6 +1804,8 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     return () => {
       disposed = true;
       if (toastClearTimer) clearTimeout(toastClearTimer);
+      resizeObserver?.disconnect();
+      resizeObserver = null;
       hotActivationEligibleRef.current = false;
       hotActivationPendingRef.current = false;
 


### PR DESCRIPTION
## Summary
- cancel CommitDialog's delayed focus timer when the dialog closes or the effect reruns
- make the terminal ResizeObserver effect-owned and disconnect it synchronously during teardown
- reduce the full React Doctor baseline from 385 to 382 diagnostics and errors from 39 to 37

Advances #403.

## Validation
- `pnpm lint` (0 ESLint, Knip, or anti-slop findings)
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend test -- --run` (163 tests)
- `pnpm --filter frontend build`
- React Doctor 0.9.2 changed-scope scan: 0 errors, 0 warnings, 3 fixed diagnostics
- React Doctor 0.9.2 full scan: 37 errors, 345 warnings, 382 total

## Review notes
- terminal cleanup remains idempotent: the synchronous effect teardown disconnects first, and the deferred initializer cleanup safely sees a null observer
- no terminal initialization, resize cadence, or dialog submission behavior changed
