### PR TITLE
Phase 4b: make git status queues immutable

### DIFF
--- a/frontend/src/stores/sessionStore.test.ts
+++ b/frontend/src/stores/sessionStore.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from 'vitest';
-import type { Session } from '../types/session';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitStatus, Session } from '../types/session';
 import { useSessionStore } from './sessionStore';
 
 function session(overrides: Partial<Session> = {}): Session {
@@ -18,6 +18,7 @@ function session(overrides: Partial<Session> = {}): Session {
 
 describe('sessionStore', () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     useSessionStore.setState({
       sessions: [],
       activeSessionId: null,
@@ -31,6 +32,12 @@ describe('sessionStore', () => {
       gitStatusBatchTimer: null,
       activeSpotlights: new Map(),
     });
+  });
+
+  afterEach(() => {
+    const timer = useSessionStore.getState().gitStatusBatchTimer;
+    if (timer) clearTimeout(timer);
+    vi.useRealTimers();
   });
 
   it('keeps the current active pane when a background-created session arrives', () => {
@@ -54,5 +61,47 @@ describe('sessionStore', () => {
     }));
 
     expect(useSessionStore.getState().activeSessionId).toBe('session-foreground');
+  });
+
+  it('queues and flushes git status updates without mutating map snapshots', () => {
+    const originalQueue = useSessionStore.getState().pendingGitStatusUpdates;
+    const gitStatus: GitStatus = { state: 'modified', filesChanged: 2 };
+    useSessionStore.setState({ sessions: [session({ id: 'session-status' })] });
+
+    useSessionStore.getState().updateSessionGitStatus('session-status', gitStatus);
+
+    const queuedState = useSessionStore.getState();
+    expect(originalQueue.size).toBe(0);
+    expect(queuedState.pendingGitStatusUpdates).not.toBe(originalQueue);
+    expect(queuedState.pendingGitStatusUpdates.get('session-status')).toBe(gitStatus);
+
+    const queuedSnapshot = queuedState.pendingGitStatusUpdates;
+    vi.advanceTimersByTime(50);
+
+    const flushedState = useSessionStore.getState();
+    expect(queuedSnapshot.get('session-status')).toBe(gitStatus);
+    expect(flushedState.pendingGitStatusUpdates).not.toBe(queuedSnapshot);
+    expect(flushedState.pendingGitStatusUpdates.size).toBe(0);
+    expect(flushedState.sessions[0].gitStatus).toEqual(gitStatus);
+  });
+
+  it('queues and flushes loading updates without mutating map snapshots', () => {
+    const originalQueue = useSessionStore.getState().pendingGitStatusLoading;
+
+    useSessionStore.getState().setGitStatusLoading('session-loading', true);
+
+    const queuedState = useSessionStore.getState();
+    expect(originalQueue.size).toBe(0);
+    expect(queuedState.pendingGitStatusLoading).not.toBe(originalQueue);
+    expect(queuedState.pendingGitStatusLoading.get('session-loading')).toBe(true);
+
+    const queuedSnapshot = queuedState.pendingGitStatusLoading;
+    vi.advanceTimersByTime(50);
+
+    const flushedState = useSessionStore.getState();
+    expect(queuedSnapshot.get('session-loading')).toBe(true);
+    expect(flushedState.pendingGitStatusLoading).not.toBe(queuedSnapshot);
+    expect(flushedState.pendingGitStatusLoading.size).toBe(0);
+    expect(flushedState.gitStatusLoading.has('session-loading')).toBe(true);
   });
 });

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -527,9 +527,8 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
 
   updateSessionGitStatus: (sessionId, gitStatus) => {
     const state = get();
-    
-    // Add to pending updates
-    state.pendingGitStatusUpdates.set(sessionId, gitStatus);
+    const pendingGitStatusUpdates = new Map(state.pendingGitStatusUpdates);
+    pendingGitStatusUpdates.set(sessionId, gitStatus);
     
     // Clear existing timer
     if (state.gitStatusBatchTimer) {
@@ -541,14 +540,13 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       get().processPendingGitStatusUpdates();
     }, 50); // 50ms batch window
     
-    set({ gitStatusBatchTimer: timer });
+    set({ pendingGitStatusUpdates, gitStatusBatchTimer: timer });
   },
   
   setGitStatusLoading: (sessionId, loading) => {
     const state = get();
-    
-    // Add to pending updates
-    state.pendingGitStatusLoading.set(sessionId, loading);
+    const pendingGitStatusLoading = new Map(state.pendingGitStatusLoading);
+    pendingGitStatusLoading.set(sessionId, loading);
     
     // Clear existing timer
     if (state.gitStatusBatchTimer) {
@@ -560,7 +558,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       get().processPendingGitStatusUpdates();
     }, 50); // 50ms batch window
     
-    set({ gitStatusBatchTimer: timer });
+    set({ pendingGitStatusLoading, gitStatusBatchTimer: timer });
   },
   
   isGitStatusLoading: (sessionId) => {
@@ -655,29 +653,34 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   
   processPendingGitStatusUpdates: () => {
     const state = get();
-    
-    // Clear timer
+
     if (state.gitStatusBatchTimer) {
       clearTimeout(state.gitStatusBatchTimer);
-      set({ gitStatusBatchTimer: null });
     }
-    
-    // Process loading state updates
-    if (state.pendingGitStatusLoading.size > 0) {
-      const loadingUpdates = Array.from(state.pendingGitStatusLoading.entries()).map(
-        ([sessionId, loading]) => ({ sessionId, loading })
-      );
+
+    const loadingUpdates = Array.from(state.pendingGitStatusLoading, ([sessionId, loading]) => ({
+      sessionId,
+      loading,
+    }));
+    const statusUpdates = Array.from(state.pendingGitStatusUpdates, ([sessionId, status]) => ({
+      sessionId,
+      status,
+    }));
+
+    // Reset the queues before publishing their snapshots so every observable
+    // collection gets a new identity and subsequent updates start a fresh batch.
+    set({
+      gitStatusBatchTimer: null,
+      pendingGitStatusLoading: new Map(),
+      pendingGitStatusUpdates: new Map(),
+    });
+
+    if (loadingUpdates.length > 0) {
       get().setGitStatusLoadingBatch(loadingUpdates);
-      state.pendingGitStatusLoading.clear();
     }
-    
-    // Process status updates
-    if (state.pendingGitStatusUpdates.size > 0) {
-      const statusUpdates = Array.from(state.pendingGitStatusUpdates.entries()).map(
-        ([sessionId, status]) => ({ sessionId, status })
-      );
+
+    if (statusUpdates.length > 0) {
       get().updateSessionGitStatusBatch(statusUpdates);
-      state.pendingGitStatusUpdates.clear();
     }
   },
   


### PR DESCRIPTION
## Summary
- publish new pending git-status Map identities instead of mutating Zustand state in place
- snapshot and reset both batching queues before applying their accumulated updates
- add regression tests proving old queue snapshots stay unchanged and queued status/loading values still flush
- reduce full React Doctor errors from 37 to 33 and total diagnostics from 382 to 378

Advances #403.

## Validation
- `pnpm lint` (0 ESLint, Knip, or anti-slop findings)
- `pnpm --filter frontend typecheck`
- `pnpm --filter frontend test -- --run` (165 tests)
- `pnpm --filter frontend build`
- React Doctor 0.9.2 changed-scope scan: 0 errors, 0 warnings, 4 fixed diagnostics
- React Doctor 0.9.2 full scan: 33 errors, 345 warnings, 378 total

## Review notes
- the 50 ms batching window and last-update-wins behavior are unchanged
- queue resets happen synchronously before batch publication, so later batches cannot mutate snapshots held by subscribers
