### PR TITLE
Keep React state updaters side-effect free

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -821,14 +821,12 @@ export function ArchivedSessions() {
   }, []);
 
   const toggleArchived = useCallback(() => {
-    setShowArchived(prev => {
-      const next = !prev;
-      if (next && !hasLoadedArchived) {
-        loadArchivedSessions();
-      }
-      return next;
-    });
-  }, [hasLoadedArchived, loadArchivedSessions]);
+    const next = !showArchived;
+    if (next && !hasLoadedArchived) {
+      void loadArchivedSessions();
+    }
+    setShowArchived(next);
+  }, [hasLoadedArchived, loadArchivedSessions, showArchived]);
 
   const toggleArchivedProject = (id: number) => {
     setExpandedArchivedProjects(prev => {

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1410,12 +1410,12 @@ export const SessionView = memo(() => {
     return stored === null ? false : stored === 'true';
   });
 
+  useEffect(() => {
+    localStorage.setItem('pane-detail-collapsed', String(isDetailCollapsed));
+  }, [isDetailCollapsed]);
+
   const toggleDetailCollapse = useCallback(() => {
-    setIsDetailCollapsed(prev => {
-      const newValue = !prev;
-      localStorage.setItem('pane-detail-collapsed', String(newValue));
-      return newValue;
-    });
+    setIsDetailCollapsed(prev => !prev);
   }, []);
 
   // Layout-aware detail panel toggle that also handles immersive mode override
@@ -1436,12 +1436,12 @@ export const SessionView = memo(() => {
     return stored === null ? true : stored === 'true';
   });
 
+  useEffect(() => {
+    localStorage.setItem('pane-terminal-collapsed', String(isTerminalCollapsed));
+  }, [isTerminalCollapsed]);
+
   const toggleTerminalCollapse = useCallback(() => {
-    setIsTerminalCollapsed(prev => {
-      const newValue = !prev;
-      localStorage.setItem('pane-terminal-collapsed', String(newValue));
-      return newValue;
-    });
+    setIsTerminalCollapsed(prev => !prev);
   }, []);
 
   // Ctrl+`: toggle bottom terminal

--- a/frontend/src/remote/RemotePwaApp.tsx
+++ b/frontend/src/remote/RemotePwaApp.tsx
@@ -72,6 +72,10 @@ export function RemotePwaApp() {
   const sidebarOpenerRef = useRef<HTMLElement | null>(null);
   const createSessionOpenerRef = useRef<HTMLElement | null>(null);
 
+  useEffect(() => {
+    window.localStorage.setItem(SAVED_PROFILES_KEY, JSON.stringify(savedProfiles));
+  }, [savedProfiles]);
+
   const openSidebar = useCallback(() => {
     sidebarOpenerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     setSidebarOpen(true);
@@ -228,11 +232,7 @@ export function RemotePwaApp() {
   }, [adapter, selectSession, setProjects]);
 
   const forgetProfile = useCallback((profileId: string) => {
-    setSavedProfiles(previous => {
-      const next = previous.filter(profile => profile.id !== profileId);
-      window.localStorage.setItem(SAVED_PROFILES_KEY, JSON.stringify(next));
-      return next;
-    });
+    setSavedProfiles(previous => previous.filter(profile => profile.id !== profileId));
   }, []);
 
   const createTerminal = useCallback(async (options?: RemoteTerminalCreateOptions) => {
@@ -567,11 +567,9 @@ function saveProfile(
   setSavedProfiles: (updater: (profiles: RemotePaneConnectionProfile[]) => RemotePaneConnectionProfile[]) => void,
 ): void {
   setSavedProfiles(previous => {
-    const next = [profile, ...previous.filter(candidate => (
+    return [profile, ...previous.filter(candidate => (
       candidate.id !== profile.id && candidate.baseUrl !== profile.baseUrl
     ))];
-    window.localStorage.setItem(SAVED_PROFILES_KEY, JSON.stringify(next));
-    return next;
   });
 }
 
@@ -580,10 +578,6 @@ function forgetProfilesForBaseUrl(
   setSavedProfiles: (updater: (profiles: RemotePaneConnectionProfile[]) => RemotePaneConnectionProfile[]) => void,
 ): void {
   setSavedProfiles(previous => {
-    const next = previous.filter(profile => profile.baseUrl !== baseUrl);
-    if (next.length !== previous.length) {
-      window.localStorage.setItem(SAVED_PROFILES_KEY, JSON.stringify(next));
-    }
-    return next;
+    return previous.filter(profile => profile.baseUrl !== baseUrl);
   });
 }


### PR DESCRIPTION
## Summary

- keep archived-session loading outside the `showArchived` state updater
- persist detail and terminal collapse preferences from committed state effects
- centralize remote-profile persistence and keep profile collection updaters pure

Part of #403.

## React Doctor

- before: 28 errors, 340 warnings, 368 total
- after: 24 errors, 333 warnings, 357 total
- removes all remaining `no-impure-state-updater` errors and seven related updater-side-effect warnings
- the remaining 24 errors are the next, separate `no-ref-current-in-render` family

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test` (165 tests)
- `pnpm build`
- `pnpm dlx react-doctor@0.9.2 frontend --no-score --json`
