### PR TITLE
Keep event refs aligned with committed state

### DIFF
--- a/frontend/src/hooks/useCommittedRef.ts
+++ b/frontend/src/hooks/useCommittedRef.ts
@@ -1,0 +1,12 @@
+import { useLayoutEffect, useRef, type RefObject } from 'react';
+
+/** Keep the latest committed value available to stable event callbacks. */
+export function useCommittedRef<T>(value: T): RefObject<T> {
+  const ref = useRef(value);
+
+  useLayoutEffect(() => {
+    ref.current = value;
+  });
+
+  return ref;
+}

--- a/frontend/src/hooks/useHotkey.ts
+++ b/frontend/src/hooks/useHotkey.ts
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useHotkeyStore, type HotkeyDefinition } from '../stores/hotkeyStore';
+import { useCommittedRef } from './useCommittedRef';
 
 /**
  * Register a global hotkey. The shortcut is active while the component is mounted.
@@ -23,15 +24,12 @@ export function useHotkey(def: HotkeyDefinition): void {
   const unregister = useHotkeyStore((s) => s.unregister);
 
   // Keep action ref stable to avoid re-registering on every render
-  const actionRef = useRef(def.action);
-  actionRef.current = def.action;
+  const actionRef = useCommittedRef(def.action);
 
   // Same for enabled
-  const enabledRef = useRef(def.enabled);
-  enabledRef.current = def.enabled;
+  const enabledRef = useCommittedRef(def.enabled);
 
-  const disabledReasonRef = useRef(def.disabledReason);
-  disabledReasonRef.current = def.disabledReason;
+  const disabledReasonRef = useCommittedRef(def.disabledReason);
 
   useEffect(() => {
     register({

--- a/frontend/src/hooks/useScrollSurface.ts
+++ b/frontend/src/hooks/useScrollSurface.ts
@@ -4,6 +4,7 @@ import {
   type FocusedScrollSurface,
   type ScrollDirection,
 } from '../services/focusedSurfaceScroll';
+import { useCommittedRef } from './useCommittedRef';
 
 interface UseScrollSurfaceOptions {
   id: string;
@@ -35,8 +36,10 @@ export function useScrollSurface<T extends HTMLElement>({
   scrollPage,
   focus,
 }: UseScrollSurfaceOptions): (element: T | null) => void {
-  const optionsRef = useRef({ ownerElement, scrollByLines, scrollPage, focus });
-  optionsRef.current = { ownerElement, scrollByLines, scrollPage, focus };
+  const ownerElementRef = useCommittedRef(ownerElement);
+  const scrollByLinesRef = useCommittedRef(scrollByLines);
+  const scrollPageRef = useCommittedRef(scrollPage);
+  const focusRef = useCommittedRef(focus);
   const unregisterRef = useRef<(() => void) | null>(null);
 
   return useCallback((element: T | null) => {
@@ -46,31 +49,31 @@ export function useScrollSurface<T extends HTMLElement>({
 
     const surface: FocusedScrollSurface = {
       id,
-      element: optionsRef.current.ownerElement?.() ?? element,
+      element: ownerElementRef.current?.() ?? element,
       sessionId,
       priority,
       scrollByLines: (lines) => {
-        if (optionsRef.current.scrollByLines) {
-          optionsRef.current.scrollByLines(lines);
+        if (scrollByLinesRef.current) {
+          scrollByLinesRef.current(lines);
         } else {
           element.scrollTop += lines * lineStep(element);
         }
       },
       scrollPage: (direction) => {
-        if (optionsRef.current.scrollPage) {
-          optionsRef.current.scrollPage(direction);
+        if (scrollPageRef.current) {
+          scrollPageRef.current(direction);
         } else {
           element.scrollTop += direction * element.clientHeight * PAGE_RATIO;
         }
       },
       focus: () => {
-        if (optionsRef.current.focus) {
-          optionsRef.current.focus();
+        if (focusRef.current) {
+          focusRef.current();
         } else {
           element.focus({ preventScroll: true });
         }
       },
     };
     unregisterRef.current = focusedSurfaceScroll.register(surface);
-  }, [enabled, id, priority, sessionId]);
+  }, [enabled, focusRef, id, ownerElementRef, priority, scrollByLinesRef, scrollPageRef, sessionId]);
 }

--- a/frontend/src/hooks/useSessionNavigationHotkeys.ts
+++ b/frontend/src/hooks/useSessionNavigationHotkeys.ts
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useHotkey } from './useHotkey';
+import { useCommittedRef } from './useCommittedRef';
 import { useHotkeyStore } from '../stores/hotkeyStore';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
@@ -67,22 +68,14 @@ export function useSessionNavigationHotkeys({
     return getPinnedSessions(sessions, projectById).map(item => item.session);
   }, [sessions, projectById]);
 
-  const allActiveSessionsRef = useRef(allActiveSessions);
-  allActiveSessionsRef.current = allActiveSessions;
-  const visibleSessionsRef = useRef(visibleSessions);
-  visibleSessionsRef.current = visibleSessions;
-  const pinnedSessionsRef = useRef(pinnedSessions);
-  pinnedSessionsRef.current = pinnedSessions;
-  const activeSessionIdRef = useRef(activeSessionId);
-  activeSessionIdRef.current = activeSessionId;
-  const sidebarNavigationScopeRef = useRef(sidebarNavigationScope);
-  sidebarNavigationScopeRef.current = sidebarNavigationScope;
-  const setActiveSessionRef = useRef(setActiveSession);
-  setActiveSessionRef.current = setActiveSession;
-  const setSidebarNavigationScopeRef = useRef(setSidebarNavigationScope);
-  setSidebarNavigationScopeRef.current = setSidebarNavigationScope;
-  const navigateToSessionsRef = useRef(navigateToSessions);
-  navigateToSessionsRef.current = navigateToSessions;
+  const allActiveSessionsRef = useCommittedRef(allActiveSessions);
+  const visibleSessionsRef = useCommittedRef(visibleSessions);
+  const pinnedSessionsRef = useCommittedRef(pinnedSessions);
+  const activeSessionIdRef = useCommittedRef(activeSessionId);
+  const sidebarNavigationScopeRef = useCommittedRef(sidebarNavigationScope);
+  const setActiveSessionRef = useCommittedRef(setActiveSession);
+  const setSidebarNavigationScopeRef = useCommittedRef(setSidebarNavigationScope);
+  const navigateToSessionsRef = useCommittedRef(navigateToSessions);
 
   const cycleSession = useCallback((direction: 'next' | 'prev') => {
     const sessions = allActiveSessionsRef.current;
@@ -95,7 +88,7 @@ export function useSessionNavigationHotkeys({
 
     setActiveSessionRef.current(sessions[nextIndex].id);
     navigateToSessionsRef.current();
-  }, []);
+  }, [activeSessionIdRef, allActiveSessionsRef, navigateToSessionsRef, setActiveSessionRef]);
 
   const cycleVisibleOrAllSessions = useCallback((direction: 'next' | 'prev') => {
     const currentId = activeSessionIdRef.current;
@@ -114,7 +107,15 @@ export function useSessionNavigationHotkeys({
 
     setActiveSessionRef.current(sessions[nextIndex].id);
     navigateToSessionsRef.current();
-  }, []);
+  }, [
+    activeSessionIdRef,
+    allActiveSessionsRef,
+    navigateToSessionsRef,
+    pinnedSessionsRef,
+    setActiveSessionRef,
+    sidebarNavigationScopeRef,
+    visibleSessionsRef,
+  ]);
 
   useHotkey({
     id: 'cycle-session-next-0',
@@ -170,8 +171,7 @@ export function useSessionNavigationHotkeys({
     action: () => cycleVisibleOrAllSessions('prev'),
   });
 
-  const projectByIdRef = useRef(projectById);
-  projectByIdRef.current = projectById;
+  const projectByIdRef = useCommittedRef(projectById);
 
   const register = useHotkeyStore(s => s.register);
   const unregister = useHotkeyStore(s => s.unregister);
@@ -211,5 +211,14 @@ export function useSessionNavigationHotkeys({
       });
     }
     return () => ids.forEach(id => unregister(id));
-  }, [register, unregister, sessionLabelKey]);
+  }, [
+    navigateToSessionsRef,
+    projectByIdRef,
+    register,
+    sessionLabelKey,
+    setActiveSessionRef,
+    setSidebarNavigationScopeRef,
+    unregister,
+    visibleSessionsRef,
+  ]);
 }


### PR DESCRIPTION
## Summary

- add a small `useCommittedRef` hook that updates stable event refs during the commit phase
- keep global hotkey handlers synchronized without mutating refs during render
- apply the same committed-value pattern to focused scrolling and session navigation hotkeys

Part of #403.

## React Doctor

- before: 24 errors, 333 warnings, 357 total
- after: 11 errors, 333 warnings, 344 total
- removes 13 `no-ref-current-in-render` errors without adding warnings
- the remaining 11 errors are isolated to component-level refs for the next task

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test` (165 tests)
- `pnpm build` (including signed universal DMG/ZIP packaging)
- `pnpm dlx react-doctor@0.9.2 frontend --no-score --json`
