### PR TITLE
Remove render-time component ref mutations

### DIFF
--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -3,6 +3,7 @@ import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
 import { useSessionHistoryStore } from '../stores/sessionHistoryStore';
 import { useHotkey } from '../hooks/useHotkey';
+import { useCommittedRef } from '../hooks/useCommittedRef';
 import { useHotkeyStore } from '../stores/hotkeyStore';
 import { HomePage } from './HomePage';
 import { PaneChatView } from './PaneChatView';
@@ -1131,10 +1132,8 @@ export const SessionView = memo(() => {
     const keys = hotkeys.get(id)?.keys;
     return keys ? formatKeyDisplay(keys) : null;
   }, [hotkeys]);
-  const handlePanelCreateRef = useRef(handlePanelCreate);
-  handlePanelCreateRef.current = handlePanelCreate;
-  const isInSessionViewRef = useRef(isInSessionView);
-  isInSessionViewRef.current = isInSessionView;
+  const handlePanelCreateRef = useCommittedRef(handlePanelCreate);
+  const isInSessionViewRef = useCommittedRef(isInSessionView);
 
   useEffect(() => {
     const ids: string[] = [];
@@ -1153,7 +1152,7 @@ export const SessionView = memo(() => {
       });
     }
     return () => { ids.forEach(id => unregisterHotkey(id)); };
-  }, [agentPresets, registerHotkey, unregisterHotkey]);
+  }, [agentPresets, handlePanelCreateRef, isInSessionViewRef, registerHotkey, unregisterHotkey]);
 
   useEffect(() => {
     const CUSTOM_CMD_START = 6; // mod+alt+3-5 stay reserved for built-in agents on every platform
@@ -1178,7 +1177,7 @@ export const SessionView = memo(() => {
     }
 
     return () => { ids.forEach(id => unregisterHotkey(id)); };
-  }, [customCommands, registerHotkey, unregisterHotkey]);
+  }, [customCommands, handlePanelCreateRef, isInSessionViewRef, registerHotkey, unregisterHotkey]);
 
   // Load project data for active session
   useEffect(() => {

--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -9,6 +9,7 @@ import { RefreshCw } from 'lucide-react';
 import { panelApi } from '../../../services/panelApi';
 import { usePanelStore } from '../../../stores/panelStore';
 import { clearPendingViewCommit, takePendingViewCommit } from './pendingViewCommit';
+import { useCommittedRef } from '../../../hooks/useCommittedRef';
 
 const HISTORY_LIMIT = 50;
 
@@ -79,13 +80,10 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
   const executionsRequestIdRef = useRef(0);
   const combinedDiffRequestIdRef = useRef(0);
   const commitDiffRequestIdRef = useRef(0);
-  const executionsRef = useRef(executions);
-  const selectedExecutionsRef = useRef(selectedExecutions);
-  const viewingCommitHashRef = useRef(viewingCommitHash);
+  const executionsRef = useCommittedRef(executions);
+  const selectedExecutionsRef = useCommittedRef(selectedExecutions);
+  const viewingCommitHashRef = useCommittedRef(viewingCommitHash);
   const mountedRef = useRef(true);
-  executionsRef.current = executions;
-  selectedExecutionsRef.current = selectedExecutions;
-  viewingCommitHashRef.current = viewingCommitHash;
 
   // Resizable sidebar state
   const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
@@ -289,7 +287,17 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
         setExecutionsLoading(false);
       }
     }
-  }, [getDefaultSelection, getSelectedHashes, isVisible, processExecutions, reconcileSelection, sessionId]);
+  }, [
+    executionsRef,
+    getDefaultSelection,
+    getSelectedHashes,
+    isVisible,
+    processExecutions,
+    reconcileSelection,
+    selectedExecutionsRef,
+    sessionId,
+    viewingCommitHashRef,
+  ]);
 
   const triggerSoftRefresh = useCallback(() => {
     diffCacheRef.current.clear();
@@ -367,11 +375,10 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [executionRefreshNonce, isVisible, refreshExecutions]);
+  }, [executionRefreshNonce, isVisible, refreshExecutions, selectedExecutionsRef]);
 
   // Keep refs to avoid stale closures in event handlers
-  const executionsLengthRef = useRef(executions.length);
-  executionsLengthRef.current = executions.length;
+  const executionsLengthRef = useCommittedRef(executions.length);
 
   // Load combined diff when selection changes (with caching)
   useEffect(() => {
@@ -445,7 +452,7 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [selectedExecutions, sessionId, viewingCommitHash]);
+  }, [executionsLengthRef, selectedExecutions, sessionId, viewingCommitHash]);
 
   const handleSelectionChange = (newSelection: number[]) => {
     commitDiffRequestIdRef.current += 1;

--- a/frontend/src/components/panels/editor/EditorPanel.tsx
+++ b/frontend/src/components/panels/editor/EditorPanel.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { FileEditor } from './FileEditor';
 import { ExplorerPanelState, ToolPanel } from '../../../../../shared/types/panels';
 import { panelApi } from '../../../services/panelApi';
-import { debounce, type DebouncedFunction } from '../../../utils/debounce';
+import { debounce } from '../../../utils/debounce';
 import { devLog } from '../../../utils/console';
 import { usePanelStore } from '../../../stores/panelStore';
 
@@ -51,67 +51,61 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
     }
   }, [isActive, isInitialized]);
   
-  // Use ref to store the debounced function so it doesn't get recreated
-  const debouncedUpdateRef = useRef<DebouncedFunction<(panelId: string, sessionId: string, newState: Partial<ExplorerPanelState>) => void> | null>(null);
+  const [debouncedUpdate] = useState(() => debounce((panelId: string, sessionId: string, newState: Partial<ExplorerPanelState>) => {
+    devLog.debug('[ExplorerPanel] Saving state to database:', {
+      panelId,
+      newState
+    });
 
-  // Initialize debounced function immediately to prevent warning
-  if (!debouncedUpdateRef.current) {
-    debouncedUpdateRef.current = debounce((panelId: string, sessionId: string, newState: Partial<ExplorerPanelState>) => {
-      devLog.debug('[ExplorerPanel] Saving state to database:', {
-        panelId,
-        newState
-      });
+    // Get the CURRENT panel state from the store (not stale closure!)
+    const panels = usePanelStore.getState().getSessionPanels(sessionId);
+    const currentPanel = panels.find(p => p.id === panelId);
 
-      // Get the CURRENT panel state from the store (not stale closure!)
-      const panels = usePanelStore.getState().getSessionPanels(sessionId);
-      const currentPanel = panels.find(p => p.id === panelId);
+    if (!currentPanel) {
+      console.error('[ExplorerPanel] Panel not found in store:', panelId);
+      return;
+    }
 
-      if (!currentPanel) {
-        console.error('[ExplorerPanel] Panel not found in store:', panelId);
-        return;
+    // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
+    const currentCustomState = (currentPanel.state?.customState || {}) as ExplorerPanelState;
+
+    const stateToSave = {
+      isActive: currentPanel.state?.isActive || false,
+      isPinned: currentPanel.state?.isPinned,
+      hasBeenViewed: currentPanel.state?.hasBeenViewed,
+      customState: {
+        ...currentCustomState,  // Merge with existing state
+        ...newState             // Apply new state on top
       }
+    };
 
-      // SAFETY: The panel type discriminator determines the corresponding custom-state shape.
-      const currentCustomState = (currentPanel.state?.customState || {}) as ExplorerPanelState;
+    devLog.debug('[ExplorerPanel] Full state being saved:', stateToSave);
 
-      const stateToSave = {
-        isActive: currentPanel.state?.isActive || false,
-        isPinned: currentPanel.state?.isPinned,
-        hasBeenViewed: currentPanel.state?.hasBeenViewed,
-        customState: {
-          ...currentCustomState,  // Merge with existing state
-          ...newState             // Apply new state on top
-        }
-      };
-
-      devLog.debug('[ExplorerPanel] Full state being saved:', stateToSave);
-
-      panelApi.updatePanel(panelId, {
-        state: stateToSave
-      }).then(() => {
-        devLog.debug('[ExplorerPanel] State saved successfully');
-      }).catch(err => {
-        console.error('[ExplorerPanel] Failed to update explorer panel state:', err);
-      });
-    }, 500);
-  }
+    panelApi.updatePanel(panelId, {
+      state: stateToSave
+    }).then(() => {
+      devLog.debug('[ExplorerPanel] State saved successfully');
+    }).catch(err => {
+      console.error('[ExplorerPanel] Failed to update explorer panel state:', err);
+    });
+  }, 500));
   
   // Cleanup effect for debounced function - flush pending saves on unmount
   useEffect(() => {
     return () => {
-      if (debouncedUpdateRef.current?.flush) {
+      if (debouncedUpdate.flush) {
         devLog.debug('[ExplorerPanel] Flushing pending saves on unmount');
-        debouncedUpdateRef.current.flush(); // Save any pending changes before unmount
+        debouncedUpdate.flush(); // Save any pending changes before unmount
       }
     };
-  }, []); // Empty deps - only create once
+  }, [debouncedUpdate]);
 
   // Also flush pending saves when switching sessions
   useEffect(() => {
     const handleSessionSwitch = () => {
-      if (debouncedUpdateRef.current?.flush) {
+      if (debouncedUpdate.flush) {
         devLog.debug('[ExplorerPanel] Flushing pending saves on session switch');
-        debouncedUpdateRef.current.flush(); // Save before switching sessions
+        debouncedUpdate.flush(); // Save before switching sessions
       }
     };
 
@@ -119,28 +113,24 @@ const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
     return () => {
       window.removeEventListener('session-switched', handleSessionSwitch);
     };
-  }, []); // Empty deps - only create once
+  }, [debouncedUpdate]);
 
   // Flush pending saves when panel becomes inactive
   useEffect(() => {
-    if (!isActive && debouncedUpdateRef.current?.flush) {
+    if (!isActive && debouncedUpdate.flush) {
       devLog.debug('[ExplorerPanel] Panel became inactive, flushing pending saves');
-      debouncedUpdateRef.current.flush(); // Save immediately when switching away
+      debouncedUpdate.flush(); // Save immediately when switching away
     }
-  }, [isActive]);
+  }, [debouncedUpdate, isActive]);
 
   // Save state changes to the panel
   const handleStateChange = useCallback((newState: Partial<ExplorerPanelState>) => {
     devLog.debug('[ExplorerPanel] handleStateChange called with:', newState);
 
     // Call debounced update - it will fetch fresh state from the store
-    if (debouncedUpdateRef.current) {
-      devLog.debug('[ExplorerPanel] Calling debounced update');
-      debouncedUpdateRef.current(panel.id, panel.sessionId, newState);
-    } else {
-      console.error('[ExplorerPanel] No debounced update function!');
-    }
-  }, [panel.id, panel.sessionId]);
+    devLog.debug('[ExplorerPanel] Calling debounced update');
+    debouncedUpdate(panel.id, panel.sessionId, newState);
+  }, [debouncedUpdate, panel.id, panel.sessionId]);
   
   // Update panel title when file changes
   const handleFileChange = useCallback((filePath: string | undefined, isDirty: boolean) => {

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -12,6 +12,7 @@ import { devLog } from '../../../utils/console';
 import { MarkdownPreview } from '../../MarkdownPreview';
 import { NotebookPreview } from './NotebookPreview';
 import { useResizablePanel } from '../../../hooks/useResizablePanel';
+import { useCommittedRef } from '../../../hooks/useCommittedRef';
 import { ExplorerPanelState } from '../../../../../shared/types/panels';
 import { isMac, isWindows } from '../../../utils/platformUtils';
 import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
@@ -65,12 +66,10 @@ function HeadlessFileTree({
   const filesCacheRef = useRef(new Map<string, FileItem[]>());
 
   // Refs for values used in dataLoader (avoids stale closures)
-  const sessionIdRef = useRef(sessionId);
-  sessionIdRef.current = sessionId;
+  const sessionIdRef = useCommittedRef(sessionId);
 
   const [error, setError] = useState<string | null>(null);
-  const setErrorRef = useRef(setError);
-  setErrorRef.current = setError;
+  const setErrorRef = useCommittedRef(setError);
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery || '');
   const [showSearch, setShowSearch] = useState(initialShowSearch || false);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -156,7 +155,7 @@ function HeadlessFileTree({
       }
       return [];
     },
-  }), []); // Empty deps — uses refs internally
+  }), [sessionIdRef, setErrorRef]);
 
   const tree = useTree<FileItem>({
     rootItemId: ROOT_ID,
@@ -553,7 +552,7 @@ function HeadlessFileTree({
       reader.onerror = () => resolve({ success: false, name: file.name, error: 'Failed to read file' });
       reader.readAsDataURL(file);
     });
-  }, []);
+  }, [sessionIdRef]);
 
   const handleMoveToDirectory = useCallback(async (files: FileItem[], targetDir: string) => {
     const movingFiles = files.filter(file => file.path !== targetDir && !targetDir.startsWith(`${file.path}/`));

--- a/frontend/src/components/settings/RemoteAccessWorkflows.tsx
+++ b/frontend/src/components/settings/RemoteAccessWorkflows.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { ArrowLeft, Copy, ExternalLink, Plus, Terminal, Trash2 } from 'lucide-react';
 import { Button, IconButton } from '../ui/Button';
 import { Checkbox, Input, Textarea } from '../ui/Input';
@@ -10,6 +10,7 @@ import type { RemoteAccessSubviewId } from '../../types/settings';
 import type { RemoteAccessController } from './useRemoteAccessSettings';
 import type { RemoteSetupTunnelPreference } from '../../../../shared/types/remoteDaemon';
 import { getRemoteExecutableHealthPresentation } from '../../utils/remoteRuntimePresentation';
+import { useCommittedRef } from '../../hooks/useCommittedRef';
 
 interface RemoteAccessWorkflowsProps {
   subview: RemoteAccessSubviewId;
@@ -19,8 +20,7 @@ interface RemoteAccessWorkflowsProps {
 }
 
 export function RemoteAccessWorkflows({ subview, controller, onBack, onDirtyChange }: RemoteAccessWorkflowsProps) {
-  const resetDraftRef = useRef(controller.resetSubviewDraft);
-  resetDraftRef.current = controller.resetSubviewDraft;
+  const resetDraftRef = useCommittedRef(controller.resetSubviewDraft);
   const configuredBaseUrl = formatRemoteBaseUrl(
     controller.config.host.config.listenHost,
     controller.config.host.config.listenPort,
@@ -38,7 +38,7 @@ export function RemoteAccessWorkflows({ subview, controller, onBack, onDirtyChan
   useEffect(() => () => {
     onDirtyChange(false);
     resetDraftRef.current(subview);
-  }, [onDirtyChange, subview]);
+  }, [onDirtyChange, resetDraftRef, subview]);
 
   return (
     <div className="mx-auto w-full max-w-3xl pb-8">

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../utils/cn';
 import { X } from 'lucide-react';
 import { PortalContainerProvider } from '../../contexts/PortalContainerContext';
 import { useScrollSurface } from '../../hooks/useScrollSurface';
+import { useCommittedRef } from '../../hooks/useCommittedRef';
 
 export interface ModalProps {
   isOpen: boolean;
@@ -41,10 +42,8 @@ export const Modal: React.FC<ModalProps> = ({
   const contentRef = useRef<HTMLDivElement>(null);
   const openerRef = useRef<HTMLElement | null>(null);
   const didRestoreRef = useRef(false);
-  const restoreFocusRef = useRef(restoreFocusOnClose);
+  const restoreFocusRef = useCommittedRef(restoreFocusOnClose);
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
-
-  restoreFocusRef.current = restoreFocusOnClose;
 
   const restoreOpener = () => {
     if (didRestoreRef.current || !restoreFocusRef.current) return;


### PR DESCRIPTION
## Summary

- move the final component-level latest-value refs onto the commit-phase helper introduced in #452
- keep diff refresh, editor tree, modal focus, settings cleanup, and dynamic hotkey callbacks aligned with committed UI state
- replace the editor panel's render-time debouncer ref initialization with one lazy stable instance while preserving every flush path

Part of #403.

## React Doctor

- before: 11 errors, 333 warnings, 344 total
- after: 0 errors, 333 warnings, 333 total
- removes the final 11 `no-ref-current-in-render` errors without adding warnings
- Phase 4 error count is now zero (down from 39 at the phase baseline)

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test` (165 tests)
- `pnpm build` (including signed universal DMG/ZIP packaging)
- `pnpm dlx react-doctor@0.9.2 frontend --no-score --json`
