### PR TITLE
Keep UI state updaters side-effect free

### DIFF
--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -102,7 +102,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   const [showCustomInput, setShowCustomInput] = useState(false);
   const [customCommand, setCustomCommand] = useState('');
   const customInputRef = useRef<HTMLInputElement>(null);
-  const [, setFocusedDropdownIndex] = useState(-1);
+  const [focusedDropdownIndex, setFocusedDropdownIndex] = useState(-1);
   const dropdownItemsRef = useRef<(HTMLButtonElement | HTMLInputElement | null)[]>([]);
 
   // Activity status moved to PanelTabStrip
@@ -249,15 +249,17 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   useEffect(() => {
     if (showDropdown) {
       setFocusedDropdownIndex(0);
-      // Focus first item after render
-      requestAnimationFrame(() => {
-        dropdownItemsRef.current[0]?.focus();
-      });
     } else {
       setFocusedDropdownIndex(-1);
       dropdownItemsRef.current = [];
     }
   }, [showDropdown]);
+
+  useEffect(() => {
+    if (showDropdown && focusedDropdownIndex >= 0) {
+      dropdownItemsRef.current[focusedDropdownIndex]?.focus();
+    }
+  }, [focusedDropdownIndex, showDropdown]);
 
   // Handle keyboard navigation in dropdown
   const handleDropdownKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -270,17 +272,13 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
       case 'ArrowDown':
         e.preventDefault();
         setFocusedDropdownIndex(prev => {
-          const next = prev < itemCount - 1 ? prev + 1 : 0;
-          items[next]?.focus();
-          return next;
+          return prev < itemCount - 1 ? prev + 1 : 0;
         });
         break;
       case 'ArrowUp':
         e.preventDefault();
         setFocusedDropdownIndex(prev => {
-          const next = prev > 0 ? prev - 1 : itemCount - 1;
-          items[next]?.focus();
-          return next;
+          return prev > 0 ? prev - 1 : itemCount - 1;
         });
         break;
       case 'Escape':

--- a/frontend/src/remote/components/RemoteTerminalInputBar.tsx
+++ b/frontend/src/remote/components/RemoteTerminalInputBar.tsx
@@ -271,12 +271,11 @@ export function RemoteTerminalInputBar({
         <button
           type="button"
           onClick={() => {
-            setShowShortcuts(value => {
-              if (!value) {
-                onOpenShortcuts?.();
-              }
-              return !value;
-            });
+            const next = !showShortcuts;
+            if (next) {
+              onOpenShortcuts?.();
+            }
+            setShowShortcuts(next);
           }}
           disabled={disabled}
           className="flex h-8 shrink-0 items-center gap-1 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"


### PR DESCRIPTION
## Summary

- keep PanelTabBar arrow-key state updaters pure and focus the committed dropdown index from an effect
- invoke the Remote PWA shortcuts callback from the click event before committing the next visibility state
- preserve wraparound navigation and call the open callback only when opening the shortcuts panel

Part of #403.

## React Doctor

- before: 0 errors, 333 warnings, 333 total
- after: 0 errors, 330 warnings, 330 total
- removes all three `no-side-effect-in-state-updater-function` warnings

## Validation

- rebased onto v2.4.60 / current `main`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test` (172 tests)
- `pnpm build` (including signed universal DMG/ZIP packaging)
- `pnpm dlx react-doctor@0.9.2 frontend --no-score --json`
