### PR TITLE
Fix Windows startup crash: permission IPC pipe path and null guard (#…

### DIFF
--- a/main/src/services/cliManagerFactory.ts
+++ b/main/src/services/cliManagerFactory.ts
@@ -200,7 +200,7 @@ export class CliManagerFactory {
       additionalOptions?: JsonObject
     ) => {
       let permissionIpcPath: string | null = null;
-      if (additionalOptions?.permissionIpcPath !== undefined) {
+      if (additionalOptions?.permissionIpcPath !== undefined && additionalOptions?.permissionIpcPath !== null) {
         permissionIpcPath = decodeBoundary(additionalOptions.permissionIpcPath, boundary.string);
       }
 

--- a/main/src/services/permissionIpcServer.ts
+++ b/main/src/services/permissionIpcServer.ts
@@ -31,13 +31,15 @@ export class PermissionIpcServer {
       socketDir = os.tmpdir();
     }
     
-    this.socketPath = path.join(socketDir, `pane-permissions-${process.pid}.sock`);
+    this.socketPath = process.platform === 'win32'
+      ? `\\\\.\\pipe\\pane-permissions-${process.pid}`
+      : path.join(socketDir, `pane-permissions-${process.pid}.sock`);
   }
 
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
-      // Clean up any existing socket file
-      if (fs.existsSync(this.socketPath)) {
+      // Clean up any existing socket file (skip on Windows: named pipes are not filesystem entries)
+      if (process.platform !== 'win32' && fs.existsSync(this.socketPath)) {
         fs.unlinkSync(this.socketPath);
       }
 
@@ -116,8 +118,8 @@ export class PermissionIpcServer {
 
       if (this.server) {
         this.server.close(() => {
-          // Clean up socket file
-          if (fs.existsSync(this.socketPath)) {
+          // Clean up socket file (skip on Windows: named pipes are not filesystem entries)
+          if (process.platform !== 'win32' && fs.existsSync(this.socketPath)) {
             fs.unlinkSync(this.socketPath);
           }
           resolve();


### PR DESCRIPTION
## Description

Fixes two bugs causing Pane to crash on startup on Windows (2.4.60 regression).

Closes #460.

**Bug 1 — `permissionIpcServer.ts` uses a filesystem path for the socket on Windows.**
On Windows, `net.Server.listen(path)` expects a named pipe (`\\.\pipe\<name>`), not a filesystem path. The existing code passes a path like `C:\Users\<user>\.pane\sockets\pane-permissions-<pid>.sock`, which fails with EACCES on every launch. Fixed by platform-branching the socket path to use a named pipe on Windows, and skipping the `fs.existsSync`/`fs.unlinkSync` socket cleanup since Windows named pipes are not filesystem entries.

**Bug 2 — `cliManagerFactory.ts` null guard passes null into `decodeBoundary`.**
When Bug 1 causes the permission IPC server to fail, `permissionIpcPath` stays `null`. The guard checks `!== undefined`, which passes `null` through to `decodeBoundary`, throwing `input: expected string` and crashing service initialization. Fixed by adding a `!== null` check to match the codebase's prevailing convention. (`typeof === 'string'` was the obvious fix but the repo's `no-runtime-typeof` oxlint rule blocks it.)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified

- [x] State management/IPC events

## Screenshots (if applicable)

Before fix (2.4.60 on Windows):

[Permission IPC] Server error: listen EACCES: permission denied C:\Users<user>.pane\sockets\pane-permissions-<pid>.sock
[CliToolRegistry] Failed to create manager for tool 'claude': Error: input: expected string
UnhandledPromiseRejectionWarning: Error: Failed to create manager for CLI tool 'claude'


After fix:

[Main] Permission IPC server started successfully
[Main] Permission IPC socket path: \.\pipe\pane-permissions-<pid>
[CliManagerFactory] Created claude manager successfully
[Main] Services initialized, creating window...
[Main] Window created successfully


## Additional Notes

Two files changed, 8 insertions, 6 deletions. No new tests added — both fixes are guard/path changes in existing initialization code. The `PaneDaemonServer` in the same codebase already handles Windows named pipes correctly; `permissionIpcServer` was the one place that kept the Unix socket assumption.

Two files changed, 8 insertions, 6 deletions. No new tests added — both fixes are guard/path changes in existing initialization code. The `PaneDaemonServer` in the same codebase already handles Windows named pipes correctly; `permissionIpcServer` was the one place that kept the Unix socket assumption.

Note: When testing locally with `npx electron .` (running the main, frontend, and electron processes separately — `pnpm run electron-dev` doesn't work on Windows due to bash variable expansion in the script), the app initializes fully and reaches "Window created successfully" but the renderer shows a "Open Pane from the desktop app" fallback instead of the full UI. This happens on upstream/main without my changes as well — it appears to be a pre-existing dev environment issue where `window.electronAPI` is not injected in the dev build on Windows. The preload script exists at the expected path and the main process logs confirm all services initialize correctly. Flagging this in case others have a known workaround for local dev testing on Windows.