### PR TITLE
Keep async loading state request-owned

### DIFF
--- a/frontend/src/components/panels/diff/CombinedDiffView.tsx
+++ b/frontend/src/components/panels/diff/CombinedDiffView.tsx
@@ -18,6 +18,25 @@ const DEFAULT_SIDEBAR_WIDTH = 300;
 const MIN_SIDEBAR_WIDTH = 150;
 const MAX_SIDEBAR_WIDTH = 600;
 
+type CommitDiffLoadResult =
+  | { success: true; data: GitDiffResult }
+  | { success: false; error: string };
+
+async function loadCommitDiff(sessionId: string, commitHash: string): Promise<CommitDiffLoadResult> {
+  try {
+    const response = await API.sessions.getCommitDiffByHash(sessionId, commitHash);
+    if (!response.success) {
+      return { success: false, error: response.error ?? 'Failed to load commit diff' };
+    }
+    return { success: true, data: response.data };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to load commit diff',
+    };
+  }
+}
+
 // --- Unified diff parser (single pass, shared between FileList and DiffViewer) ---
 
 function parseUnifiedDiffToFiles(diff: string): FileDiff[] {
@@ -283,9 +302,8 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
         setError(err instanceof Error ? err.message : 'Failed to load executions');
       }
     } finally {
-      if (mountedRef.current && requestId === executionsRequestIdRef.current) {
-        setExecutionsLoading(false);
-      }
+      const ownsLoadingState = mountedRef.current && requestId === executionsRequestIdRef.current;
+      setExecutionsLoading(current => ownsLoadingState ? false : current);
     }
   }, [
     executionsRef,
@@ -343,24 +361,22 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
     if (!viewingCommitHash) return;
     const requestId = ++commitDiffRequestIdRef.current;
     let cancelled = false;
-    const load = async () => {
-      setCommitDiffLoading(true);
-      setError(null);
-      try {
-        const response = await API.sessions.getCommitDiffByHash(sessionId, viewingCommitHash);
+    setCommitDiffLoading(true);
+    setError(null);
+    void loadCommitDiff(sessionId, viewingCommitHash)
+      .then(result => {
         if (cancelled || requestId !== commitDiffRequestIdRef.current) return;
-        if (!response.success) throw new Error(response.error);
-        setCombinedDiff(response.data);
-      } catch (err) {
-        if (!cancelled && requestId === commitDiffRequestIdRef.current) {
-          setError(err instanceof Error ? err.message : 'Failed to load commit diff');
+        if (result.success) {
+          setCombinedDiff(result.data);
+        } else {
+          setError(result.error);
           setCombinedDiff(null);
         }
-      } finally {
-        if (!cancelled && requestId === commitDiffRequestIdRef.current) setCommitDiffLoading(false);
-      }
-    };
-    load();
+      })
+      .finally(() => {
+        const ownsLoadingState = !cancelled && requestId === commitDiffRequestIdRef.current;
+        setCommitDiffLoading(current => ownsLoadingState ? false : current);
+      });
     return () => { cancelled = true; };
   }, [viewingCommitHash, sessionId]);
 
@@ -439,9 +455,8 @@ const CombinedDiffView = memo(forwardRef<CombinedDiffViewHandle, CombinedDiffVie
             setError(err instanceof Error ? err.message : 'Failed to load combined diff');
           }
         } finally {
-          if (!cancelled && requestId === combinedDiffRequestIdRef.current) {
-            setDiffLoading(false);
-          }
+          const ownsLoadingState = !cancelled && requestId === combinedDiffRequestIdRef.current;
+          setDiffLoading(current => ownsLoadingState ? false : current);
         }
       };
 

--- a/frontend/src/hooks/useAgentUsage.ts
+++ b/frontend/src/hooks/useAgentUsage.ts
@@ -28,7 +28,8 @@ export function useAgentUsage() {
       setSnapshot(null);
       setError(requestError instanceof Error ? requestError.message : 'Codex usage is unavailable');
     } finally {
-      if (generation === requestGeneration.current) setIsLoading(false);
+      const ownsLoadingState = generation === requestGeneration.current;
+      setIsLoading(current => ownsLoadingState ? false : current);
     }
   }, []);
 

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -10,6 +10,7 @@ import type { RemoteBranchInfo, RemoteProjectWithSessions, RemoteRuntimeAdapter 
  * desktop session preference store because it writes through window.electronAPI.
  */
 const REMOTE_START_PINNED_PREFERENCE_KEY = 'pane.remoteCreateSession.startPinned';
+const EMPTY_REMOTE_BRANCHES: RemoteBranchInfo[] = [];
 
 interface RemoteCreateSessionDialogProps {
   adapter: RemoteRuntimeAdapter;
@@ -28,13 +29,12 @@ export function RemoteCreateSessionDialog({
   onClose,
   onCreated,
 }: RemoteCreateSessionDialogProps) {
-  const [branches, setBranches] = useState<RemoteBranchInfo[]>([]);
+  const [loadedBranches, setLoadedBranches] = useState<RemoteBranchInfo[] | null>(null);
   const [baseBranch, setBaseBranch] = useState('');
   const [paneName, setPaneName] = useState('');
   const [branchSearch, setBranchSearch] = useState('');
   const [useWorktree, setUseWorktree] = useState(true);
   const [startPinned, setStartPinned] = useState(() => loadRemoteStartPinnedPreference());
-  const [loadingBranches, setLoadingBranches] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [branchOpen, setBranchOpen] = useState(false);
@@ -49,6 +49,8 @@ export function RemoteCreateSessionDialog({
   const nameHelpId = useId();
   const errorId = useId();
   const paneNameInvalid = error === 'Pane name is required.';
+  const branches = loadedBranches ?? EMPTY_REMOTE_BRANCHES;
+  const loadingBranches = loadedBranches === null;
 
   const existingNames = useMemo(() => new Set((project.sessions ?? []).map(session => session.name)), [project.sessions]);
 
@@ -87,7 +89,7 @@ export function RemoteCreateSessionDialog({
     let cancelled = false;
 
     async function loadBranches() {
-      setLoadingBranches(true);
+      setLoadedBranches(null);
       setError(null);
       try {
         const [branchList, detectedBranch] = await Promise.all([
@@ -96,7 +98,7 @@ export function RemoteCreateSessionDialog({
         ]);
         if (cancelled) return;
 
-        setBranches(branchList);
+        setLoadedBranches(branchList);
         const remoteMain = branchList.find(branch => branch.isRemote && (branch.name === 'origin/main' || branch.name === 'origin/master'));
         const detected = branchList.find(branch => branch.name === detectedBranch || branch.name === `origin/${detectedBranch}`);
         const current = branchList.find(branch => branch.isCurrent);
@@ -108,11 +110,8 @@ export function RemoteCreateSessionDialog({
         }
       } catch (loadError) {
         if (!cancelled) {
+          setLoadedBranches([]);
           setError(loadError instanceof Error ? loadError.message : 'Failed to load branches');
-        }
-      } finally {
-        if (!cancelled) {
-          setLoadingBranches(false);
         }
       }
     }


### PR DESCRIPTION
## Summary

- clear diff and agent-usage loading flags only when the completing request still owns that state
- keep stale request completions as pure no-op updates so they cannot hide newer in-flight work
- derive Remote PWA branch loading from unresolved branch data and settle it on both success and failure
- normalize commit-diff failures into a typed result before guarded effect updates

Part of #403.

## React Doctor

- current-main baseline: 0 errors, 323 warnings, 323 total
- after: 0 errors, 317 warnings, 317 total
- removes all five `no-loading-flag-reset-outside-finally` warnings and the review-detected stale-effect fingerprint without replacement findings

## Validation

- rebased onto v2.4.61 / current `main`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test` (245 tests)
- `pnpm build` (including signed universal DMG/ZIP packaging)
- `pnpm dlx react-doctor@0.9.2 frontend --no-score --json`
