### PR TITLE
Harden browser response boundaries

### DIFF
--- a/frontend/src/components/DiscordPopup.tsx
+++ b/frontend/src/components/DiscordPopup.tsx
@@ -78,7 +78,7 @@ export const DiscordPopup: React.FC<DiscordPopupProps> = ({ isOpen, onClose }) =
       window.electronAPI.openExternal('https://discord.gg/BdMyubeAZn');
     } else {
       // Fallback for web/development mode
-      window.open('https://discord.gg/BdMyubeAZn', '_blank');
+      window.open('https://discord.gg/BdMyubeAZn', '_blank', 'noopener,noreferrer');
     }
     if (dontShowAgain && window.electron?.invoke) {
       try {

--- a/frontend/src/components/panels/editor/NotebookPreview.test.tsx
+++ b/frontend/src/components/panels/editor/NotebookPreview.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NotebookPreview } from './NotebookPreview';
+
+describe('NotebookPreview', () => {
+  it('renders application/json output as escaped text', () => {
+    const content = JSON.stringify({
+      cells: [{
+        cell_type: 'code',
+        source: [],
+        outputs: [{
+          output_type: 'display_data',
+          data: {
+            'application/json': JSON.stringify({ value: '<script>alert("unsafe")</script>' }),
+          },
+        }],
+      }],
+    });
+
+    const markup = renderToStaticMarkup(<NotebookPreview content={content} />);
+
+    expect(markup).toContain('&lt;script&gt;alert(');
+    expect(markup).toContain('&lt;/script&gt;');
+    expect(markup).not.toContain('<script>');
+  });
+});

--- a/frontend/src/components/panels/editor/NotebookPreview.tsx
+++ b/frontend/src/components/panels/editor/NotebookPreview.tsx
@@ -6,6 +6,7 @@ import {
   decodeOptionalBoundary,
   type BoundarySchema,
   type JsonObject,
+  type JsonValue,
 } from '../../../../../shared/validation/boundaryDecoder';
 
 // --- Notebook JSON types ---
@@ -111,6 +112,18 @@ function getMimeData(data: JsonObject, mime: string): string | undefined {
   return JSON.stringify(val, null, 2);
 }
 
+function formatJsonOutput(value: JsonValue): string {
+  const jsonText = decodeOptionalBoundary(value, boundary.string);
+  if (jsonText !== undefined) {
+    try {
+      return JSON.stringify(JSON.parse(jsonText), null, 2);
+    } catch {
+      return jsonText;
+    }
+  }
+  return JSON.stringify(value, null, 2);
+}
+
 // --- Sub-components ---
 
 function CellOutputRenderer({ output, index }: { output: NotebookCellOutput; index: number }) {
@@ -183,18 +196,7 @@ function CellOutputRenderer({ output, index }: { output: NotebookCellOutput; ind
 
     const jsonVal = data['application/json'];
     if (jsonVal !== undefined) {
-      let formatted: string;
-      const jsonText = decodeOptionalBoundary(jsonVal, boundary.string);
-      if (jsonText !== undefined) {
-        try {
-          formatted = JSON.stringify(JSON.parse(jsonText), null, 2);
-        } catch {
-          formatted = jsonText;
-        }
-      } else {
-        formatted = JSON.stringify(jsonVal, null, 2);
-      }
-      return <pre className="nb-output-stream">{formatted}</pre>;
+      return <pre className="nb-output-stream">{formatJsonOutput(jsonVal)}</pre>;
     }
 
     const plain = getMimeData(data, 'text/plain');

--- a/frontend/src/components/panels/editor/NotebookPreview.tsx
+++ b/frontend/src/components/panels/editor/NotebookPreview.tsx
@@ -104,10 +104,8 @@ function stripAnsi(str: string): string {
 function getMimeData(data: JsonObject, mime: string): string | undefined {
   const val = data[mime];
   if (val === undefined) return undefined;
-  const text = decodeOptionalBoundary(val, boundary.string);
-  if (text !== undefined) return text;
-  const lines = decodeOptionalBoundary(val, boundary.array(boundary.string));
-  if (lines) return lines.join('');
+  const text = decodeOptionalBoundary(val, stringOrLinesSchema);
+  if (text !== undefined) return Array.isArray(text) ? text.join('') : text;
   // For non-string values (e.g. application/json stored as object), stringify
   return JSON.stringify(val, null, 2);
 }

--- a/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
+++ b/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
@@ -119,22 +119,9 @@ export class RemoteDaemonBrowserClient {
           request.signal = signal;
         }
 
-        const response = await fetch(this.endpoint('invoke'), {
-          ...request,
-        });
+        const response = await fetch(this.endpoint('invoke'), request);
 
-        if (!response.ok) {
-          const isAuthFailure = isAuthFailureResponse(response.status);
-          const isRetryable = isRetryableResponse(response.status);
-          const message = await readInvokeErrorMessage(response) ?? 'Remote request failed';
-          if (isAuthFailure) {
-            throw new RemoteAuthInvalidError(getRemoteAuthFailureMessage(message));
-          }
-          if (!isRetryable) {
-            throw new NonRetryableRemoteError(message);
-          }
-          lastError = new Error(message);
-        } else {
+        if (response.ok) {
           // SAFETY: The named IPC/API channel contract establishes this success payload type.
           const payload = await response.json() as InvokeSuccessPayload<T> | InvokeErrorPayload;
           if (!payload.ok) {
@@ -142,6 +129,17 @@ export class RemoteDaemonBrowserClient {
           }
           return payload.result;
         }
+
+        const isAuthFailure = isAuthFailureResponse(response.status);
+        const isRetryable = isRetryableResponse(response.status);
+        const message = await readInvokeErrorMessage(response) ?? 'Remote request failed';
+        if (isAuthFailure) {
+          throw new RemoteAuthInvalidError(getRemoteAuthFailureMessage(message));
+        }
+        if (!isRetryable) {
+          throw new NonRetryableRemoteError(message);
+        }
+        lastError = new Error(message);
       } catch (error) {
         if (error instanceof RemoteAuthInvalidError || error instanceof NonRetryableRemoteError || signal?.aborted) {
           throw error;

--- a/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
+++ b/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
@@ -1,6 +1,7 @@
 import {
   decodeRemoteDaemonEventEnvelope,
   decodeRemoteHeartbeatPayload,
+  decodeRemoteInvokeResponsePayload,
   type RemoteDaemonEventEnvelope,
   type RemoteDaemonHeartbeatPayload,
   type RemotePaneConnectionProfile,
@@ -19,19 +20,6 @@ export interface RemoteBrowserConnectionState {
   status: RemotePaneConnectionStatus;
   lastError: string | null;
   lastSeenAt: string | null;
-}
-
-interface InvokeSuccessPayload<T> {
-  ok: true;
-  result: T;
-}
-
-interface InvokeErrorPayload {
-  ok: false;
-  error?: {
-    message?: string;
-    code?: string;
-  };
 }
 
 const INITIAL_RECONNECT_DELAY_MS = 1_000;
@@ -122,12 +110,12 @@ export class RemoteDaemonBrowserClient {
         const response = await fetch(this.endpoint('invoke'), request);
 
         if (response.ok) {
-          // SAFETY: The named IPC/API channel contract establishes this success payload type.
-          const payload = await response.json() as InvokeSuccessPayload<T> | InvokeErrorPayload;
+          const payload = decodeRemoteInvokeResponsePayload(await response.json());
           if (!payload.ok) {
-            throw new NonRetryableRemoteError(payload.error?.message ?? 'Remote request failed');
+            throw new NonRetryableRemoteError(payload.error.message);
           }
-          return payload.result;
+          // SAFETY: The channel-specific adapter method establishes the decoded JSON result type.
+          return payload.result as T;
         }
 
         const isAuthFailure = isAuthFailureResponse(response.status);
@@ -540,9 +528,8 @@ function isAuthFailureResponse(status: number): boolean {
 
 async function readInvokeErrorMessage(response: Response): Promise<string | undefined> {
   try {
-    // SAFETY: The named IPC/API channel contract establishes this error payload type.
-    const payload = await response.json() as InvokeSuccessPayload<unknown> | InvokeErrorPayload;
-    return payload.ok ? undefined : payload.error?.message;
+    const payload = decodeRemoteInvokeResponsePayload(await response.json());
+    return payload.ok ? undefined : payload.error.message;
   } catch {
     return undefined;
   }

--- a/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
+++ b/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
@@ -123,23 +123,27 @@ export class RemoteDaemonBrowserClient {
           ...request,
         });
 
-        // SAFETY: The named IPC/API channel contract establishes this response payload type.
-        const payload = await response.json() as InvokeSuccessPayload<T> | InvokeErrorPayload;
-        if (response.ok && payload.ok) {
+        if (!response.ok) {
+          // SAFETY: The named IPC/API channel contract establishes this error payload type.
+          const payload = await response.json() as InvokeSuccessPayload<T> | InvokeErrorPayload;
+          const message = payload.ok
+            ? `Remote request failed with ${response.status}`
+            : payload.error?.message ?? 'Remote request failed';
+          if (isAuthFailureResponse(response.status)) {
+            throw new RemoteAuthInvalidError(getRemoteAuthFailureMessage(message));
+          }
+          if (!isRetryableResponse(response.status)) {
+            throw new NonRetryableRemoteError(message);
+          }
+          lastError = new Error(message);
+        } else {
+          // SAFETY: The named IPC/API channel contract establishes this success payload type.
+          const payload = await response.json() as InvokeSuccessPayload<T> | InvokeErrorPayload;
+          if (!payload.ok) {
+            throw new NonRetryableRemoteError(payload.error?.message ?? 'Remote request failed');
+          }
           return payload.result;
         }
-
-        const message = payload.ok
-          ? `Remote request failed with ${response.status}`
-          : payload.error?.message ?? 'Remote request failed';
-        const error = new Error(message);
-        if (isAuthFailureResponse(response.status)) {
-          throw new RemoteAuthInvalidError(getRemoteAuthFailureMessage(message));
-        }
-        if (!isRetryableResponse(response.status)) {
-          throw new NonRetryableRemoteError(message);
-        }
-        lastError = error instanceof Error ? error : new Error('Remote request failed');
       } catch (error) {
         if (error instanceof RemoteAuthInvalidError || error instanceof NonRetryableRemoteError || signal?.aborted) {
           throw error;

--- a/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
+++ b/frontend/src/remote/runtime/remoteDaemonBrowserClient.ts
@@ -124,15 +124,13 @@ export class RemoteDaemonBrowserClient {
         });
 
         if (!response.ok) {
-          // SAFETY: The named IPC/API channel contract establishes this error payload type.
-          const payload = await response.json() as InvokeSuccessPayload<T> | InvokeErrorPayload;
-          const message = payload.ok
-            ? `Remote request failed with ${response.status}`
-            : payload.error?.message ?? 'Remote request failed';
-          if (isAuthFailureResponse(response.status)) {
+          const isAuthFailure = isAuthFailureResponse(response.status);
+          const isRetryable = isRetryableResponse(response.status);
+          const message = await readInvokeErrorMessage(response) ?? 'Remote request failed';
+          if (isAuthFailure) {
             throw new RemoteAuthInvalidError(getRemoteAuthFailureMessage(message));
           }
-          if (!isRetryableResponse(response.status)) {
+          if (!isRetryable) {
             throw new NonRetryableRemoteError(message);
           }
           lastError = new Error(message);
@@ -540,6 +538,16 @@ function isRetryableResponse(status: number): boolean {
 
 function isAuthFailureResponse(status: number): boolean {
   return status === 401 || status === 403;
+}
+
+async function readInvokeErrorMessage(response: Response): Promise<string | undefined> {
+  try {
+    // SAFETY: The named IPC/API channel contract establishes this error payload type.
+    const payload = await response.json() as InvokeSuccessPayload<unknown> | InvokeErrorPayload;
+    return payload.ok ? undefined : payload.error?.message;
+  } catch {
+    return undefined;
+  }
 }
 
 function getRemoteAuthFailureMessage(serverMessage?: string): string {

--- a/main/src/daemon/client/remotePaneClient.ts
+++ b/main/src/daemon/client/remotePaneClient.ts
@@ -12,6 +12,7 @@ import { isPaneDaemonEventChannel } from '../server';
 import {
   createDefaultRemotePaneConnectionState,
   normalizeRemoteDaemonConfig,
+  remoteInvokeResponseSchema,
   type RemoteDaemonHeartbeatPayload,
   type RemotePaneConnectionProfile,
   type RemotePaneConnectionState,
@@ -45,21 +46,6 @@ interface RemotePaneClientConnectOptions {
   retryOnInitialFailure?: boolean;
 }
 
-interface RemoteInvokeSuccessPayload {
-  ok: true;
-  result?: JsonValue;
-}
-
-interface RemoteInvokeErrorPayload {
-  ok: false;
-  error: {
-    message: string;
-    code?: string;
-  };
-}
-
-type RemoteInvokeResponsePayload = RemoteInvokeSuccessPayload | RemoteInvokeErrorPayload;
-
 interface JsonResponse {
   statusCode: number;
   body: string;
@@ -71,19 +57,6 @@ interface RemoteReadyEventPayload {
   timestamp: string;
 }
 
-const remoteInvokeResponseSchema: BoundarySchema<RemoteInvokeResponsePayload> = boundary.union(
-  boundary.object({
-    ok: boundary.literal(true),
-    result: boundary.optional(boundary.json),
-  }),
-  boundary.object({
-    ok: boundary.literal(false),
-    error: boundary.object({
-      message: boundary.string,
-      code: boundary.optional(boundary.string),
-    }),
-  }),
-);
 const remoteErrorResponseSchema = boundary.object({
   error: boundary.object({ message: boundary.string }),
 });

--- a/main/src/daemon/httpApiServer.ts
+++ b/main/src/daemon/httpApiServer.ts
@@ -19,7 +19,9 @@ import {
   type RemoteDaemonConfig,
   type RemoteDaemonEventEnvelope,
   type RemoteDaemonHeartbeatPayload,
+  type RemoteInvokeErrorPayload,
   type RemoteInvokeRequest,
+  type RemoteInvokeSuccessPayload,
 } from '../../../shared/types/remoteDaemon';
 import { remoteHostRuntimeStateStore } from './remoteHostRuntimeState';
 import { getRemotePwaAssetResponse } from './pwaStaticAssets';
@@ -52,19 +54,6 @@ interface ConnectedRemoteEventClient {
   connectedAt: string;
   lastSeenAt: string;
   heartbeatTimer: NodeJS.Timeout;
-}
-
-interface RemoteInvokeSuccessPayload {
-  ok: true;
-  result: unknown;
-}
-
-interface RemoteInvokeErrorPayload {
-  ok: false;
-  error: {
-    message: string;
-    code: string;
-  };
 }
 
 interface RemoteReadyEventPayload {
@@ -531,7 +520,7 @@ export class PaneRemoteHttpApiServer {
       this.writeJson(response, 200, {
         ok: true,
         result,
-      } satisfies RemoteInvokeSuccessPayload);
+      } satisfies RemoteInvokeSuccessPayload<unknown>);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const code = message.includes('No Pane daemon command registered')

--- a/main/src/daemon/remotePwaBrowserRuntime.test.ts
+++ b/main/src/daemon/remotePwaBrowserRuntime.test.ts
@@ -328,6 +328,39 @@ describe('Remote PWA browser runtime', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects malformed successful invoke response envelopes', async () => {
+    vi.useFakeTimers();
+    try {
+      installBrowserGlobals();
+      const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+        ok: 'yes',
+        result: { projects: [] },
+      }), {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const client = new RemoteDaemonBrowserClient({
+        id: 'profile-1',
+        baseUrl: 'https://host.example.test',
+        label: 'Remote Host',
+        token: 'secret-token',
+        transport: 'http+sse',
+      });
+
+      const invoke = client.invoke('sessions:get-all-with-projects', []).catch((cause: unknown) => cause);
+      await vi.runAllTimersAsync();
+
+      const error = await invoke;
+      if (!(error instanceof Error)) throw new Error('Expected invoke to reject with Error');
+      expect(error.message).toMatch(/did not match any allowed shape/);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('shows a Safari Tailscale hint when health checks fail before HTTP', async () => {
     vi.useFakeTimers();
     try {

--- a/main/src/daemon/remotePwaBrowserRuntime.test.ts
+++ b/main/src/daemon/remotePwaBrowserRuntime.test.ts
@@ -306,6 +306,28 @@ describe('Remote PWA browser runtime', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('classifies an auth failure before parsing a non-JSON response body', async () => {
+    installBrowserGlobals();
+    const fetchMock = vi.fn(async () => new Response('<h1>Unauthorized</h1>', {
+      headers: { 'Content-Type': 'text/html' },
+      status: 401,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new RemoteDaemonBrowserClient({
+      id: 'profile-1',
+      baseUrl: 'https://host.example.test',
+      label: 'Remote Host',
+      token: 'secret-token',
+      transport: 'http+sse',
+    });
+
+    await expect(client.invoke('sessions:get-all-with-projects', [])).rejects.toThrow(
+      /connection code is not accepted/,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('shows a Safari Tailscale hint when health checks fail before HTTP', async () => {
     vi.useFakeTimers();
     try {

--- a/shared/types/remoteDaemon.ts
+++ b/shared/types/remoteDaemon.ts
@@ -262,6 +262,23 @@ export interface RemoteInvokeRequest {
   clientLabel?: string;
 }
 
+export interface RemoteInvokeSuccessPayload<Result = JsonValue | undefined> {
+  ok: true;
+  result?: Result;
+}
+
+export interface RemoteInvokeErrorPayload {
+  ok: false;
+  error: {
+    message: string;
+    code?: string;
+  };
+}
+
+export type RemoteInvokeResponsePayload<Result = JsonValue | undefined> =
+  | RemoteInvokeSuccessPayload<Result>
+  | RemoteInvokeErrorPayload;
+
 export interface RemoteDaemonHeartbeatPayload {
   timestamp: string;
 }
@@ -276,6 +293,20 @@ const remoteHeartbeatPayloadSchema: BoundarySchema<RemoteDaemonHeartbeatPayload>
   timestamp: boundary.nonEmptyString,
 });
 
+export const remoteInvokeResponseSchema: BoundarySchema<RemoteInvokeResponsePayload> = boundary.union(
+  boundary.object({
+    ok: boundary.literal(true),
+    result: boundary.optional(boundary.json),
+  }),
+  boundary.object({
+    ok: boundary.literal(false),
+    error: boundary.object({
+      message: boundary.string,
+      code: boundary.optional(boundary.string),
+    }),
+  }),
+);
+
 const remoteDaemonEventEnvelopeSchema = boundary.object({
   channel: boundary.string,
   args: boundary.array(boundary.json),
@@ -284,6 +315,10 @@ const remoteDaemonEventEnvelopeSchema = boundary.object({
 
 export function decodeRemoteHeartbeatPayload<Value>(value: Value): RemoteDaemonHeartbeatPayload {
   return decodeBoundary(value, remoteHeartbeatPayloadSchema);
+}
+
+export function decodeRemoteInvokeResponsePayload<Value>(value: Value): RemoteInvokeResponsePayload {
+  return decodeBoundary(value, remoteInvokeResponseSchema);
 }
 
 export function decodeRemoteDaemonEventEnvelope<Value>(value: Value): RemoteDaemonEventEnvelope {


### PR DESCRIPTION
## Summary

- isolate the web fallback Discord window from its opener
- branch on remote-daemon HTTP status before decoding success or error payloads
- separate notebook JSON text formatting from the component sanitized HTML render paths

Part of #403.

## React Doctor

- current-main baseline: 0 errors, 317 warnings, 317 total
- after: 0 errors, 314 warnings, 314 total
- removes `window-open-without-noopener`, `no-fetch-response-used-without-status-check`, and the false-positive `unsafe-json-in-html` finding without replacements

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test` (245 tests)
- `pnpm build` (including signed universal DMG/ZIP packaging)
- `pnpm dlx react-doctor@0.9.2 frontend --no-score --no-supply-chain --no-dead-code --json`

<!-- pr-test-automation-summary:start -->
## Automated QA

- Status: pass at `4c4017cb`
- Remote invoke transport: 42/42 focused tests passed across browser, main client, and HTTP server, including non-JSON 401 and malformed 200 responses.
- Notebook JSON boundary: server-render proof confirms script-like JSON is emitted as escaped text, with no raw script element.
- Full gates: 267/267 frontend tests, root typecheck, root lint, and React Doctor all passed. React Doctor reported 0 errors and 315 warnings on current main; none are the three boundary findings addressed by this PR.
- Screenshots: omitted because the UI changes have no intended visual delta.
- Remaining human check: optionally open the Discord fallback in web mode and inspect that the new tab has no opener.
<!-- pr-test-automation-summary:end -->