### PR TITLE
Prevent packaged startup regressions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,6 +49,16 @@ jobs:
     - name: Rebuild native modules for Electron smoke tests
       run: pnpm run electron:rebuild
 
+    - name: Configure Electron sandbox
+      run: |
+        electron_path="$(node -p "require('electron')")"
+        electron_dir="$(dirname "${electron_path}")"
+        sudo chown root "${electron_dir}/chrome-sandbox"
+        sudo chmod 4755 "${electron_dir}/chrome-sandbox"
+
+    - name: Verify sandboxed Electron preload
+      run: pnpm build:main && xvfb-run -a pnpm exec electron scripts/smoke-sandboxed-preload.cjs
+
     - name: Run maintained functional smoke tests
       run: xvfb-run -a pnpm test:ci:minimal
       env:

--- a/NOTICES
+++ b/NOTICES
@@ -10484,7 +10484,7 @@ For more information, please refer to <http://unlicense.org>
 ================================================================================
 
 Package: Pane
-Version: 2.4.52
+Version: 2.4.61
 Author: [object Object]
 License: AGPL-3.0
 

--- a/frontend/src/components/BrowserFallback.test.tsx
+++ b/frontend/src/components/BrowserFallback.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { BrowserFallback } from './BrowserFallback';
+
+describe('BrowserFallback', () => {
+  it('keeps the Remote Pane entry relative to the packaged frontend directory', () => {
+    const markup = renderToStaticMarkup(<BrowserFallback />);
+
+    expect(markup).toContain('href="./remote.html"');
+    expect(markup).not.toContain('href="/remote.html"');
+  });
+});

--- a/frontend/src/components/BrowserFallback.tsx
+++ b/frontend/src/components/BrowserFallback.tsx
@@ -9,7 +9,7 @@ export function BrowserFallback() {
         </p>
         <a
           className="mt-6 inline-flex rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary-hover"
-          href="/remote.html"
+          href="./remote.html"
         >
           Open Remote Pane
         </a>

--- a/main/package.json
+++ b/main/package.json
@@ -6,9 +6,10 @@
   "type": "commonjs",
   "scripts": {
     "dev": "tsc -w",
-    "build": "rimraf dist && tsc && npm run copy:assets && npm run bundle:mcp",
+    "build": "rimraf dist && tsc && npm run bundle:preload && npm run copy:assets && npm run bundle:mcp",
     "headless": "npm run build && electron dist/main/src/daemon/headless.js",
     "bundle:mcp": "node build-mcp-bridge.js",
+    "bundle:preload": "esbuild src/preload.ts --bundle --platform=node --format=cjs --target=node24 --external:electron --sourcemap --outfile=dist/main/src/preload.js && node ../scripts/verify-sandboxed-preload.js",
     "copy:assets": "mkdirp dist/main/src/database/migrations && shx cp src/database/*.sql dist/main/src/database/ && shx cp src/database/migrations/*.sql dist/main/src/database/migrations/",
     "lint": "pnpm --dir .. run lint:ox:main && pnpm run lint:eslint",
     "lint:eslint": "eslint src --ext .ts",

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -28,6 +28,8 @@ import type {
   PanePermissionResponse as PermissionResponse,
   PanePermissionResolvedEvent as PermissionResolvedEvent,
 } from '../../shared/types/permissions';
+// The main build bundles this runtime dependency into preload.js; the sandbox
+// verification step rejects any remaining require other than Electron itself.
 import { boundary, decodeBoundary, type JsonObject } from '../../shared/validation/boundaryDecoder';
 
 interface LogEntry {
@@ -171,8 +173,7 @@ const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
   'terminal:clipboard-paste-image',
 ]);
 
-// Sandboxed Electron preload scripts cannot reliably require local runtime
-// modules, so the daemon-owned channel classifier stays inline here.
+// Keep the security-sensitive channel classifier visible at the bridge boundary.
 function isDaemonOwnedChannel(channel: string): boolean {
   if (ELECTRON_ADAPTER_ONLY_CHANNELS.has(channel)) {
     return false;

--- a/main/src/services/cliManagerFactory.test.ts
+++ b/main/src/services/cliManagerFactory.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { decodePermissionIpcPath } from './cliManagerFactory';
+
+describe('decodePermissionIpcPath', () => {
+  it('preserves the degraded startup path for missing and null endpoints', () => {
+    expect(decodePermissionIpcPath()).toBeNull();
+    expect(decodePermissionIpcPath({ permissionIpcPath: null })).toBeNull();
+  });
+
+  it('accepts a valid IPC endpoint', () => {
+    expect(decodePermissionIpcPath({ permissionIpcPath: '\\\\.\\pipe\\pane-permissions-42' }))
+      .toBe('\\\\.\\pipe\\pane-permissions-42');
+  });
+
+  it('rejects a non-string, non-null endpoint', () => {
+    expect(() => decodePermissionIpcPath({ permissionIpcPath: 42 })).toThrow('expected string');
+  });
+});

--- a/main/src/services/cliManagerFactory.ts
+++ b/main/src/services/cliManagerFactory.ts
@@ -11,6 +11,14 @@ import {
 } from './cliToolRegistry';
 import { boundary, decodeBoundary, type JsonObject } from '../../../shared/validation/boundaryDecoder';
 
+export function decodePermissionIpcPath(additionalOptions?: JsonObject): string | null {
+  const candidate = additionalOptions?.permissionIpcPath;
+  if (candidate === undefined || candidate === null) {
+    return null;
+  }
+  return decodeBoundary(candidate, boundary.string);
+}
+
 /**
  * Factory configuration for CLI manager creation
  */
@@ -199,10 +207,7 @@ export class CliManagerFactory {
       configManager?: ConfigManager,
       additionalOptions?: JsonObject
     ) => {
-      let permissionIpcPath: string | null = null;
-      if (additionalOptions?.permissionIpcPath !== undefined && additionalOptions?.permissionIpcPath !== null) {
-        permissionIpcPath = decodeBoundary(additionalOptions.permissionIpcPath, boundary.string);
-      }
+      const permissionIpcPath = decodePermissionIpcPath(additionalOptions);
 
       // SAFETY: A null manager is created only for the availability probe,
       // which calls no session-dependent operations before disposal.

--- a/main/src/services/permissionIpcServer.test.ts
+++ b/main/src/services/permissionIpcServer.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getPermissionIpcEndpoint, PermissionIpcServer } from './permissionIpcServer';
+
+describe('PermissionIpcServer', () => {
+  let server: PermissionIpcServer | null = null;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = null;
+  });
+
+  it('uses a Windows named pipe instead of a filesystem socket path', () => {
+    expect(getPermissionIpcEndpoint('win32', 42, 'C:\\Users\\test\\.pane\\sockets'))
+      .toBe('\\\\.\\pipe\\pane-permissions-42');
+  });
+
+  it('uses a socket file on Unix platforms', () => {
+    expect(getPermissionIpcEndpoint('linux', 42, '/tmp/pane-sockets'))
+      .toBe('/tmp/pane-sockets/pane-permissions-42.sock');
+  });
+
+  it('starts and stops the platform endpoint', async () => {
+    server = new PermissionIpcServer();
+
+    await server.start();
+
+    if (process.platform === 'win32') {
+      expect(server.getSocketPath()).toMatch(/^\\\\\.\\pipe\\pane-permissions-\d+$/);
+    } else {
+      expect(server.getSocketPath()).toMatch(/pane-permissions-\d+\.sock$/);
+    }
+  });
+});

--- a/main/src/services/permissionIpcServer.ts
+++ b/main/src/services/permissionIpcServer.ts
@@ -5,12 +5,28 @@ import os from 'os';
 import { PermissionManager } from './permissionManager';
 import { getAppSubdirectory } from '../utils/appDirectory';
 
+export function getPermissionIpcEndpoint(
+  platform: NodeJS.Platform,
+  processId: number,
+  socketDirectory: string,
+): string {
+  return platform === 'win32'
+    ? `\\\\.\\pipe\\pane-permissions-${processId}`
+    : path.posix.join(socketDirectory, `pane-permissions-${processId}.sock`);
+}
+
 export class PermissionIpcServer {
   private server: net.Server | null = null;
   private clients: Map<string, net.Socket> = new Map();
   private socketPath: string;
+  private readonly usesFilesystemSocket = process.platform !== 'win32';
 
   constructor() {
+    if (!this.usesFilesystemSocket) {
+      this.socketPath = getPermissionIpcEndpoint(process.platform, process.pid, '');
+      return;
+    }
+
     // Use a directory without spaces for better compatibility
     // DMG apps can write to user's home directory
     let socketDir: string;
@@ -31,15 +47,13 @@ export class PermissionIpcServer {
       socketDir = os.tmpdir();
     }
     
-    this.socketPath = process.platform === 'win32'
-      ? `\\\\.\\pipe\\pane-permissions-${process.pid}`
-      : path.join(socketDir, `pane-permissions-${process.pid}.sock`);
+    this.socketPath = getPermissionIpcEndpoint(process.platform, process.pid, socketDir);
   }
 
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
       // Clean up any existing socket file (skip on Windows: named pipes are not filesystem entries)
-      if (process.platform !== 'win32' && fs.existsSync(this.socketPath)) {
+      if (this.usesFilesystemSocket && fs.existsSync(this.socketPath)) {
         fs.unlinkSync(this.socketPath);
       }
 
@@ -119,7 +133,7 @@ export class PermissionIpcServer {
       if (this.server) {
         this.server.close(() => {
           // Clean up socket file (skip on Windows: named pipes are not filesystem entries)
-          if (process.platform !== 'win32' && fs.existsSync(this.socketPath)) {
+          if (this.usesFilesystemSocket && fs.existsSync(this.socketPath)) {
             fs.unlinkSync(this.socketPath);
           }
           resolve();

--- a/main/src/services/versionChecker.test.ts
+++ b/main/src/services/versionChecker.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ConfigManager } from './configManager';
+import type { Logger } from '../utils/logger';
+import { VersionChecker } from './versionChecker';
+
+function partialMock<Contract>(implementation: Partial<Contract>): Contract {
+  // SAFETY: Each test supplies every dependency method reached by its scenario.
+  return implementation as Contract;
+}
+
+describe('VersionChecker', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts GitHub releases with nullable name and body fields', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      tag_name: 'v2.4.62',
+      name: null,
+      body: null,
+      html_url: 'https://github.com/dcouple/Pane/releases/tag/v2.4.62',
+      published_at: '2026-08-18T00:00:00Z',
+      prerelease: false,
+      draft: false,
+      assets: [],
+    }), { status: 200 })));
+    const logger = partialMock<Logger>({ error: vi.fn() });
+    const checker = new VersionChecker(partialMock<ConfigManager>({}), logger);
+
+    const result = await checker.checkForUpdates();
+
+    expect(result.latest).toBe('2.4.62');
+    expect(result.hasUpdate).toBe(true);
+    expect(result.releaseNotes).toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/main/src/services/versionChecker.ts
+++ b/main/src/services/versionChecker.ts
@@ -20,8 +20,8 @@ interface GitHubReleaseAsset {
 
 export interface GitHubRelease {
   tag_name: string;
-  name: string;
-  body: string;
+  name: string | null;
+  body: string | null;
   html_url: string;
   published_at: string;
   prerelease: boolean;
@@ -53,8 +53,8 @@ export class VersionChecker {
 
       const release = decodeBoundary(await response.json(), boundary.object({
         tag_name: boundary.string,
-        name: boundary.string,
-        body: boundary.string,
+        name: boundary.nullable(boundary.string),
+        body: boundary.nullable(boundary.string),
         html_url: boundary.string,
         published_at: boundary.string,
         prerelease: boundary.boolean,
@@ -83,7 +83,7 @@ export class VersionChecker {
         hasUpdate,
         releaseUrl: release.html_url,
         downloadUrl: this.findMacDmgDownloadUrl(release),
-        releaseNotes: release.body,
+        releaseNotes: release.body ?? undefined,
         publishedAt: release.published_at
       };
     } catch (error) {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "electron": "41.10.3",
     "electron-builder": "26.7.0",
     "electron-builder-squirrel-windows": "26.7.0",
+    "esbuild": "0.25.7",
     "js-yaml": "^4.1.1",
     "knip": "6.29.0",
     "oxlint": "1.76.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       electron-builder-squirrel-windows:
         specifier: 26.7.0
         version: 26.7.0(dmg-builder@26.7.0)
+      esbuild:
+        specifier: 0.25.7
+        version: 0.25.7
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1

--- a/scripts/smoke-sandboxed-preload.cjs
+++ b/scripts/smoke-sandboxed-preload.cjs
@@ -1,0 +1,52 @@
+const path = require('path');
+process.env.NODE_ENV = 'production';
+const { app, BrowserWindow } = require('electron');
+
+const preloadPath = path.resolve(__dirname, '..', 'main', 'dist', 'main', 'src', 'preload.js');
+const timeout = setTimeout(() => {
+  console.error('Sandboxed preload smoke test timed out');
+  app.exit(1);
+}, 15_000);
+
+async function run() {
+  const window = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  let preloadFailure = null;
+  window.webContents.on('preload-error', (_event, _preload, error) => {
+    preloadFailure = error;
+  });
+
+  await window.loadURL('data:text/html,<html><body>preload-smoke</body></html>');
+  const apiAvailable = await window.webContents.executeJavaScript(
+    'typeof window.electronAPI === "object" && typeof window.electronAPI.getAppVersion === "function"',
+  );
+
+  if (preloadFailure) {
+    throw preloadFailure;
+  }
+  if (!apiAvailable) {
+    throw new Error('Sandboxed preload did not expose window.electronAPI');
+  }
+
+  console.log('Sandboxed preload smoke test passed');
+  window.destroy();
+}
+
+app.whenReady()
+  .then(run)
+  .then(() => {
+    clearTimeout(timeout);
+    app.quit();
+  })
+  .catch((error) => {
+    clearTimeout(timeout);
+    console.error(error);
+    app.exit(1);
+  });

--- a/scripts/verify-sandboxed-preload.js
+++ b/scripts/verify-sandboxed-preload.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const preloadPath = path.join(repoRoot, 'main', 'dist', 'main', 'src', 'preload.js');
+
+if (!fs.existsSync(preloadPath)) {
+  throw new Error(`Sandboxed preload bundle was not created: ${preloadPath}`);
+}
+
+const source = fs.readFileSync(preloadPath, 'utf8');
+const requireCallCount = source.match(/\brequire\s*\(/g)?.length ?? 0;
+const runtimeRequires = [...source.matchAll(/\brequire\((['"])([^'"]+)\1\)/g)]
+  .map((match) => match[2]);
+const unsupportedRequires = [...new Set(runtimeRequires.filter((specifier) => specifier !== 'electron'))];
+
+if (runtimeRequires.length !== requireCallCount) {
+  throw new Error('Sandboxed preload has a dynamic runtime require');
+}
+
+if (unsupportedRequires.length > 0) {
+  throw new Error(`Sandboxed preload has unsupported runtime requires: ${unsupportedRequires.join(', ')}`);
+}
+
+if (!source.includes('exposeInMainWorld')) {
+  throw new Error('Sandboxed preload bundle does not expose the renderer API');
+}
+
+console.log(`Sandboxed preload bundle verified (${runtimeRequires.length} Electron require).`);


### PR DESCRIPTION
## Summary

- bundle the Electron preload so sandboxed packaged builds have no local runtime `require`
- verify the bundle statically and with a real sandboxed Electron window in CI
- add cross-platform permission IPC coverage on top of #462, including a real endpoint start/stop test
- accept nullable GitHub release name/body fields and keep update checks operational
- resolve Remote Pane relative to the packaged frontend directory

Follows #462 and adds regression coverage for #460.
Closes #464.
Closes #465.

## Root-cause prevention

- `verify-sandboxed-preload.js` rejects every runtime require except `electron`, including dynamic requires
- `smoke-sandboxed-preload.cjs` launches a sandboxed BrowserWindow and asserts `window.electronAPI` is exposed
- the Windows CI main-test job now exercises a real `\\.\pipe\pane-permissions-*` endpoint

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter main exec vitest run` (66 files / 609 tests)
- `pnpm --filter frontend test` (24 files / 246 tests)
- `pnpm build` (signed universal DMG/ZIP)
- `pnpm exec electron scripts/smoke-sandboxed-preload.cjs`
- React Doctor: 0 errors / 317 warnings, unchanged from main
