### PR TITLE
Fix/panel scrollback leak 457

### DIFF
--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -121,6 +121,17 @@ function readPersistedScrollback(customState: PersistedCustomState | undefined):
   }
 }
 
+async function readCleanTerminalScrollback(panelId: string, lines: number): Promise<string | null> {
+  const liveScrollback = await terminalPanelManager.getCleanTerminalScrollback(panelId, lines);
+  if (liveScrollback !== null) return liveScrollback;
+
+  const panel = panelManager.getPanel(panelId);
+  const persistedScrollback = readPersistedScrollback(panel?.state?.customState);
+  if (persistedScrollback === null || persistedScrollback === '') return null;
+
+  return sanitizeTerminalOutput(persistedScrollback).split('\n').slice(-lines).join('\n');
+}
+
 /**
  * Save file bytes for a session and return the path to pass to the CLI tool.
  *
@@ -718,33 +729,14 @@ export function registerPanelHandlers(
 
   commandRegistry.register('terminal:getScrollbackClean', async (panelId: string, lines: number) => {
     try {
-      // Prefer the live screen emulator: its rendered buffer applies cursor
-      // motions in place, so it never produces the overlapping-fragment
-      // corruption that ANSI-stripping the raw append log does for in-place
-      // repaints (spinners, progress bars, TUI status lines).
-      const clean = await terminalPanelManager.getCleanTerminalScrollback(panelId, lines);
-      if (clean !== null) {
-        const lastLines = clean.split('\n');
-        const panelTitle = panelManager.getPanel(panelId)?.title ?? panelId;
-        return { success: true, data: { content: clean, lineCount: lastLines.length, panelTitle } };
-      }
-
-      // Fall back to persisted scrollback for lazy/inactive terminals with no
-      // live emulator.
-      const panel = panelManager.getPanel(panelId);
-      const rawScrollback = readPersistedScrollback(panel?.state?.customState);
-
-      if (rawScrollback === null || rawScrollback === '') {
+      const content = await readCleanTerminalScrollback(panelId, lines);
+      if (content === null) {
         return { success: false, error: `No scrollback available for panel ${panelId}` };
       }
 
-      const stripped = sanitizeTerminalOutput(rawScrollback);
-      const allLines = stripped.split('\n');
-      const lastLines = allLines.slice(-lines);
-      const content = lastLines.join('\n');
+      const panel = panelManager.getPanel(panelId);
       const panelTitle = panel?.title ?? panelId;
-
-      return { success: true, data: { content, lineCount: lastLines.length, panelTitle } };
+      return { success: true, data: { content, lineCount: content.split('\n').length, panelTitle } };
     } catch (error) {
       console.error('[IPC] Failed to get clean scrollback:', error);
       return { success: false, error: error instanceof Error ? error.message : String(error) };
@@ -825,26 +817,10 @@ export function registerPanelHandlers(
     lines: number,
   ) => {
     try {
-      // Prefer the live screen emulator (corruption-free rendered buffer) and
-      // fall back to persisted state for lazy/inactive terminals. The raw append
-      // log is never used directly: ANSI-stripping it mangles in-place repaints.
-      let content: string | null = await terminalPanelManager.getCleanTerminalScrollback(panelId, lines);
-
-      if (content === null) {
-        const panelFallback = panelManager.getPanel(panelId);
-        const rawScrollback = readPersistedScrollback(panelFallback?.state?.customState);
-
-        if (rawScrollback !== null && rawScrollback !== '') {
-          const stripped = sanitizeTerminalOutput(rawScrollback);
-          content = stripped.split('\n').slice(-lines).join('\n');
-        }
-      }
-
+      const content = await readCleanTerminalScrollback(panelId, lines);
       if (content === null || content === '') {
         return { success: false, error: `No scrollback available for panel ${panelId}` };
       }
-
-      const lastLines = content.split('\n');
 
       const panel = panelManager.getPanel(panelId);
       const panelTitle = panel?.title ?? panelId;
@@ -856,7 +832,7 @@ export function registerPanelHandlers(
       // Save to .pane/files/ — routes to WSL-native path for WSL sessions so
       // Claude CLI inside WSL can read the file at a native Linux path.
       const resolvedPath = await saveFileForSession(sessionId, 'files', filename, Buffer.from(content, 'utf-8'));
-      return { success: true, data: { filePath: resolvedPath, lineCount: lastLines.length, panelTitle } };
+      return { success: true, data: { filePath: resolvedPath, lineCount: content.split('\n').length, panelTitle } };
     } catch (error) {
       console.error('[IPC] Failed to save scrollback:', error);
       return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -718,13 +718,29 @@ export function registerPanelHandlers(
 
   commandRegistry.register('terminal:getScrollbackClean', async (panelId: string, lines: number) => {
     try {
-      // Try live in-memory scrollback first (active terminals)
-      let rawScrollback = terminalPanelManager.getTerminalScrollback(panelId);
+      // Prefer the live screen emulator: its rendered buffer applies cursor
+      // motions in place, so it never produces the overlapping-fragment
+      // corruption that ANSI-stripping the raw append log does for in-place
+      // repaints (spinners, progress bars, TUI status lines).
+      const clean = await terminalPanelManager.getCleanTerminalScrollback(panelId, lines);
+      if (clean !== null) {
+        const lastLines = clean.split('\n');
+        const panelTitle = panelManager.getPanel(panelId)?.title ?? panelId;
+        return { success: true, data: { content: clean, lineCount: lastLines.length, panelTitle } };
+      }
 
-      // Fall back to persisted scrollback for lazy/inactive terminals
-      if (rawScrollback === null) {
-        const panel = panelManager.getPanel(panelId);
-        rawScrollback = readPersistedScrollback(panel?.state?.customState);
+      // Fall back to persisted scrollback for lazy/inactive terminals with no
+      // live emulator.
+      let rawScrollback: string | null = null;
+      const panel = panelManager.getPanel(panelId);
+      const customState = panel?.state?.customState;
+      if (customState && typeof customState === 'object' && 'scrollbackBuffer' in customState) {
+        const persisted = (customState as { scrollbackBuffer?: string | string[] }).scrollbackBuffer;
+        if (typeof persisted === 'string') {
+          rawScrollback = persisted;
+        } else if (Array.isArray(persisted)) {
+          rawScrollback = persisted.join('\n');
+        }
       }
 
       if (rawScrollback === null || rawScrollback === '') {
@@ -735,8 +751,6 @@ export function registerPanelHandlers(
       const allLines = stripped.split('\n');
       const lastLines = allLines.slice(-lines);
       const content = lastLines.join('\n');
-
-      const panel = panelManager.getPanel(panelId);
       const panelTitle = panel?.title ?? panelId;
 
       return { success: true, data: { content, lineCount: lastLines.length, panelTitle } };
@@ -820,22 +834,35 @@ export function registerPanelHandlers(
     lines: number,
   ) => {
     try {
-      // Get scrollback — try live buffer first, fall back to persisted state
-      let rawScrollback = terminalPanelManager.getTerminalScrollback(panelId);
+      // Prefer the live screen emulator (corruption-free rendered buffer) and
+      // fall back to persisted state for lazy/inactive terminals. The raw append
+      // log is never used directly: ANSI-stripping it mangles in-place repaints.
+      let content: string | null = await terminalPanelManager.getCleanTerminalScrollback(panelId, lines);
 
-      if (rawScrollback === null) {
-        const panel = panelManager.getPanel(panelId);
-        rawScrollback = readPersistedScrollback(panel?.state?.customState);
+      if (content === null) {
+        let rawScrollback: string | null = null;
+        const panelFallback = panelManager.getPanel(panelId);
+        const customState = panelFallback?.state?.customState;
+        if (customState && typeof customState === 'object' && 'scrollbackBuffer' in customState) {
+          const persisted = (customState as { scrollbackBuffer?: string | string[] }).scrollbackBuffer;
+          if (typeof persisted === 'string') {
+            rawScrollback = persisted;
+          } else if (Array.isArray(persisted)) {
+            rawScrollback = persisted.join('\n');
+          }
+        }
+
+        if (rawScrollback !== null && rawScrollback !== '') {
+          const stripped = sanitizeTerminalOutput(rawScrollback);
+          content = stripped.split('\n').slice(-lines).join('\n');
+        }
       }
 
-      if (rawScrollback === null || rawScrollback === '') {
+      if (content === null || content === '') {
         return { success: false, error: `No scrollback available for panel ${panelId}` };
       }
 
-      const stripped = sanitizeTerminalOutput(rawScrollback);
-      const allLines = stripped.split('\n');
-      const lastLines = allLines.slice(-lines);
-      const content = lastLines.join('\n');
+      const lastLines = content.split('\n');
 
       const panel = panelManager.getPanel(panelId);
       const panelTitle = panel?.title ?? panelId;

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -731,17 +731,8 @@ export function registerPanelHandlers(
 
       // Fall back to persisted scrollback for lazy/inactive terminals with no
       // live emulator.
-      let rawScrollback: string | null = null;
       const panel = panelManager.getPanel(panelId);
-      const customState = panel?.state?.customState;
-      if (customState && typeof customState === 'object' && 'scrollbackBuffer' in customState) {
-        const persisted = (customState as { scrollbackBuffer?: string | string[] }).scrollbackBuffer;
-        if (typeof persisted === 'string') {
-          rawScrollback = persisted;
-        } else if (Array.isArray(persisted)) {
-          rawScrollback = persisted.join('\n');
-        }
-      }
+      const rawScrollback = readPersistedScrollback(panel?.state?.customState);
 
       if (rawScrollback === null || rawScrollback === '') {
         return { success: false, error: `No scrollback available for panel ${panelId}` };
@@ -840,17 +831,8 @@ export function registerPanelHandlers(
       let content: string | null = await terminalPanelManager.getCleanTerminalScrollback(panelId, lines);
 
       if (content === null) {
-        let rawScrollback: string | null = null;
         const panelFallback = panelManager.getPanel(panelId);
-        const customState = panelFallback?.state?.customState;
-        if (customState && typeof customState === 'object' && 'scrollbackBuffer' in customState) {
-          const persisted = (customState as { scrollbackBuffer?: string | string[] }).scrollbackBuffer;
-          if (typeof persisted === 'string') {
-            rawScrollback = persisted;
-          } else if (Array.isArray(persisted)) {
-            rawScrollback = persisted.join('\n');
-          }
-        }
+        const rawScrollback = readPersistedScrollback(panelFallback?.state?.customState);
 
         if (rawScrollback !== null && rawScrollback !== '') {
           const stripped = sanitizeTerminalOutput(rawScrollback);

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -31,7 +31,6 @@ vi.spyOn(terminalPanelManager, 'initializeTerminal');
 vi.spyOn(terminalPanelManager, 'isTerminalInitialized');
 vi.spyOn(terminalPanelManager, 'getTerminalSnapshot');
 vi.spyOn(terminalPanelManager, 'waitForTerminalState');
-vi.spyOn(terminalPanelManager, 'getTerminalScrollback');
 vi.spyOn(terminalPanelManager, 'getCleanTerminalScrollback');
 vi.spyOn(terminalPanelManager, 'writeToTerminal');
 vi.spyOn(terminalPanelManager, 'getLastOutputAt');
@@ -293,7 +292,6 @@ describe('runpane IPC handlers', () => {
     vi.mocked(terminalPanelManager.initializeTerminal).mockReset();
     vi.mocked(terminalPanelManager.isTerminalInitialized).mockReset();
     vi.mocked(terminalPanelManager.getTerminalSnapshot).mockReset();
-    vi.mocked(terminalPanelManager.getTerminalScrollback).mockReset();
     vi.mocked(terminalPanelManager.getCleanTerminalScrollback).mockReset();
     vi.mocked(terminalPanelManager.writeToTerminal).mockReset();
     vi.mocked(terminalPanelManager.getLastOutputAt).mockReset();
@@ -327,7 +325,6 @@ describe('runpane IPC handlers', () => {
     );
     vi.mocked(terminalPanelManager.isTerminalInitialized).mockReturnValue(true);
     vi.mocked(terminalPanelManager.getTerminalSnapshot).mockReturnValue(null);
-    vi.mocked(terminalPanelManager.getTerminalScrollback).mockReturnValue(null);
     vi.mocked(terminalPanelManager.getCleanTerminalScrollback).mockResolvedValue(null);
   });
 
@@ -1269,7 +1266,7 @@ describe('runpane IPC handlers', () => {
   });
 
   it('reads live terminal scrollback before persisted output records', async () => {
-    vi.mocked(terminalPanelManager.getTerminalScrollback).mockReturnValue('first\nsecond\nthird\n');
+    vi.mocked(terminalPanelManager.getCleanTerminalScrollback).mockResolvedValue('first\nsecond\nthird\n');
     const services = createServices();
     const registry = createRegistry(services);
 
@@ -1295,30 +1292,18 @@ describe('runpane IPC handlers', () => {
     });
   });
 
-  it('prefers clean emulator scrollback over the raw append log', async () => {
-    // Emulator renders in-place repaints cleanly; the raw append log would
-    // sanitize into overlapping garbage. The emulator source must win.
-    vi.mocked(terminalPanelManager.getCleanTerminalScrollback).mockResolvedValue('alpha\nbeta\ngamma');
-    vi.mocked(terminalPanelManager.getTerminalScrollback).mockReturnValue('should-not-be-used');
-    const registry = createRegistry();
-
-    const result = await registry.invoke('runpane:panels:output', [{
-      panelId: terminalPanel.id,
-      limit: 2,
-    }]);
-
-    expect(terminalPanelManager.getCleanTerminalScrollback).toHaveBeenCalledWith(terminalPanel.id, 3);
-    expect(result).toMatchObject({
-      returnedCount: 1,
-      hasMore: true,
-      text: 'beta\ngamma',
-    });
-  });
-
-  it('strips terminal control sequences from live scrollback output', async () => {
-    vi.mocked(terminalPanelManager.getTerminalScrollback).mockReturnValue(
-      '\x1b[31mred\x1b[0m\n[?25h[?2004hprompt$ [?2004lecho next\nnext[?25l[?25h\n',
-    );
+  it('strips terminal control sequences from persisted scrollback output', async () => {
+    const panelWithPersistedScrollback: ToolPanel = {
+      ...terminalPanel,
+      state: {
+        ...terminalPanel.state,
+        customState: {
+          ...terminalPanel.state.customState,
+          scrollbackBuffer: '\x1b[31mred\x1b[0m\n[?25h[?2004hprompt$ [?2004lecho next\nnext[?25l[?25h\n',
+        },
+      },
+    };
+    vi.mocked(panelManager.getPanel).mockReturnValue(panelWithPersistedScrollback);
     const registry = createRegistry();
 
     const result = await registry.invoke('runpane:panels:output', [{

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -10,30 +10,6 @@ import type { AppServices } from './types';
 import type { CreatePanelRequest, TerminalPanelState, ToolPanel } from '../../../shared/types/panels';
 import type { RunpaneToolSpec } from '../../../shared/types/runpaneOrchestration';
 
-vi.mock('../services/panelManager', () => ({
-  panelManager: {
-    createPanel: vi.fn(),
-    getPanel: vi.fn(),
-    getPanelsForSession: vi.fn(),
-    updatePanel: vi.fn(),
-  },
-}));
-
-vi.mock('../services/terminalPanelManager', () => ({
-  terminalPanelManager: {
-    initializeTerminal: vi.fn(),
-    isTerminalInitialized: vi.fn(),
-    getTerminalSnapshot: vi.fn(),
-    waitForTerminalState: vi.fn(),
-    getTerminalScrollback: vi.fn(),
-    getCleanTerminalScrollback: vi.fn(),
-    writeToTerminal: vi.fn(),
-    getLastOutputAt: vi.fn(),
-    getOutputGeneration: vi.fn(),
-    deliverPendingInitialInput: vi.fn(),
-  },
-}));
-
 import { RUNPANE_CONTRACT } from '../../../shared/types/generatedRunpaneContract';
 import { panelManager } from '../services/panelManager';
 import { terminalPanelManager } from '../services/terminalPanelManager';
@@ -56,6 +32,7 @@ vi.spyOn(terminalPanelManager, 'isTerminalInitialized');
 vi.spyOn(terminalPanelManager, 'getTerminalSnapshot');
 vi.spyOn(terminalPanelManager, 'waitForTerminalState');
 vi.spyOn(terminalPanelManager, 'getTerminalScrollback');
+vi.spyOn(terminalPanelManager, 'getCleanTerminalScrollback');
 vi.spyOn(terminalPanelManager, 'writeToTerminal');
 vi.spyOn(terminalPanelManager, 'getLastOutputAt');
 vi.spyOn(terminalPanelManager, 'getOutputGeneration');
@@ -183,7 +160,7 @@ function createServices(overrides: Partial<AppServices> = {}): AppServices {
     app: {
       getVersion: vi.fn(() => '2.3.8'),
       isPackaged: false,
-    } as unknown as AppServices['app'],
+    } as AppServices['app'],
     getMainWindow: () => null,
     databaseService: {
       getAllProjects: vi.fn(() => [project]),
@@ -1838,6 +1815,7 @@ describe('runpane IPC handlers', () => {
         text: 'persisted ready\n',
       },
     });
+    // SAFETY: The wait handler resolves to a result object whose `state` mirrors the panel snapshot exercised here.
     expect((ready as { state: { isCliReady?: unknown } }).state.isCliReady).toBeUndefined();
     expect(initialized).toMatchObject({
       ok: false,
@@ -2538,6 +2516,7 @@ describe('runpane IPC handlers', () => {
       }],
     }]);
 
+    // SAFETY: The panes:create handler always resolves to a result object carrying an `ok` flag.
     expect((result as { ok: boolean }).ok).toBe(true);
     expect(createSessionAndWait).toHaveBeenCalledTimes(2);
     expect(maxActiveCreates).toBe(1);
@@ -3039,6 +3018,7 @@ describe('runpane IPC handlers', () => {
           let createdPanel: ToolPanel | undefined;
           vi.mocked(panelManager.createPanel).mockImplementation(async (request) => {
             createRequest = request;
+            // SAFETY: This mock stands in for a terminal panel, so initialState carries the terminal customState shape.
             const initialState = (request.initialState ?? {}) as TerminalPanelState;
             const customState: TerminalPanelState = { ...initialState };
             if (initialState.initialInputMode === 'argument') {
@@ -3077,6 +3057,7 @@ describe('runpane IPC handlers', () => {
             if (toolKind === 'codex' && inputCase.name === 'slash' && snapshotCalls >= 4) {
               return terminalSnapshot('Working\n›', 'active');
             }
+            // SAFETY: The `custom` kind is handled above, leaving only agent kinds the snapshot frames as claude/codex.
             return terminalSnapshot(
               toolKind === 'codex' && inputCase.name === 'slash' ? `› ${inputCase.input}` : 'ready',
               'idle',
@@ -3094,7 +3075,9 @@ describe('runpane IPC handlers', () => {
             panes: [{ name: `${toolKind}-${inputCase.name}`, tool }],
           }]);
           await vi.runAllTimersAsync();
+          // SAFETY: The panes:create handler resolves to a result object exposing the per-pane `items` array read below.
           const result = await resultPromise as { items: Array<{ ok?: boolean; initialInput?: unknown }> };
+          // SAFETY: createPanel was invoked for a terminal panel, so the captured initialState is the terminal customState.
           const initialState = createRequest?.initialState as TerminalPanelState | undefined;
           const useArgument = toolKind === 'claude'
             || toolKind === 'cursor'

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -7,8 +7,32 @@ import { PaneCommandRegistry } from '../daemon/commandRegistry';
 import type { Project } from '../database/models';
 import type { Session } from '../types/session';
 import type { AppServices } from './types';
-import type { CreatePanelRequest, ToolPanel } from '../../../shared/types/panels';
+import type { CreatePanelRequest, TerminalPanelState, ToolPanel } from '../../../shared/types/panels';
 import type { RunpaneToolSpec } from '../../../shared/types/runpaneOrchestration';
+
+vi.mock('../services/panelManager', () => ({
+  panelManager: {
+    createPanel: vi.fn(),
+    getPanel: vi.fn(),
+    getPanelsForSession: vi.fn(),
+    updatePanel: vi.fn(),
+  },
+}));
+
+vi.mock('../services/terminalPanelManager', () => ({
+  terminalPanelManager: {
+    initializeTerminal: vi.fn(),
+    isTerminalInitialized: vi.fn(),
+    getTerminalSnapshot: vi.fn(),
+    waitForTerminalState: vi.fn(),
+    getTerminalScrollback: vi.fn(),
+    getCleanTerminalScrollback: vi.fn(),
+    writeToTerminal: vi.fn(),
+    getLastOutputAt: vi.fn(),
+    getOutputGeneration: vi.fn(),
+    deliverPendingInitialInput: vi.fn(),
+  },
+}));
 
 import { RUNPANE_CONTRACT } from '../../../shared/types/generatedRunpaneContract';
 import { panelManager } from '../services/panelManager';
@@ -159,7 +183,7 @@ function createServices(overrides: Partial<AppServices> = {}): AppServices {
     app: {
       getVersion: vi.fn(() => '2.3.8'),
       isPackaged: false,
-    } as AppServices['app'],
+    } as unknown as AppServices['app'],
     getMainWindow: () => null,
     databaseService: {
       getAllProjects: vi.fn(() => [project]),
@@ -293,6 +317,7 @@ describe('runpane IPC handlers', () => {
     vi.mocked(terminalPanelManager.isTerminalInitialized).mockReset();
     vi.mocked(terminalPanelManager.getTerminalSnapshot).mockReset();
     vi.mocked(terminalPanelManager.getTerminalScrollback).mockReset();
+    vi.mocked(terminalPanelManager.getCleanTerminalScrollback).mockReset();
     vi.mocked(terminalPanelManager.writeToTerminal).mockReset();
     vi.mocked(terminalPanelManager.getLastOutputAt).mockReset();
     vi.mocked(terminalPanelManager.getOutputGeneration).mockReset();
@@ -326,6 +351,7 @@ describe('runpane IPC handlers', () => {
     vi.mocked(terminalPanelManager.isTerminalInitialized).mockReturnValue(true);
     vi.mocked(terminalPanelManager.getTerminalSnapshot).mockReturnValue(null);
     vi.mocked(terminalPanelManager.getTerminalScrollback).mockReturnValue(null);
+    vi.mocked(terminalPanelManager.getCleanTerminalScrollback).mockResolvedValue(null);
   });
 
   describe('runpane:panes:adopt', () => {
@@ -1292,6 +1318,26 @@ describe('runpane IPC handlers', () => {
     });
   });
 
+  it('prefers clean emulator scrollback over the raw append log', async () => {
+    // Emulator renders in-place repaints cleanly; the raw append log would
+    // sanitize into overlapping garbage. The emulator source must win.
+    vi.mocked(terminalPanelManager.getCleanTerminalScrollback).mockResolvedValue('alpha\nbeta\ngamma');
+    vi.mocked(terminalPanelManager.getTerminalScrollback).mockReturnValue('should-not-be-used');
+    const registry = createRegistry();
+
+    const result = await registry.invoke('runpane:panels:output', [{
+      panelId: terminalPanel.id,
+      limit: 2,
+    }]);
+
+    expect(terminalPanelManager.getCleanTerminalScrollback).toHaveBeenCalledWith(terminalPanel.id, 3);
+    expect(result).toMatchObject({
+      returnedCount: 1,
+      hasMore: true,
+      text: 'beta\ngamma',
+    });
+  });
+
   it('strips terminal control sequences from live scrollback output', async () => {
     vi.mocked(terminalPanelManager.getTerminalScrollback).mockReturnValue(
       '\x1b[31mred\x1b[0m\n[?25h[?2004hprompt$ [?2004lecho next\nnext[?25l[?25h\n',
@@ -1792,7 +1838,7 @@ describe('runpane IPC handlers', () => {
         text: 'persisted ready\n',
       },
     });
-    expect(ready.state.isCliReady).toBeUndefined();
+    expect((ready as { state: { isCliReady?: unknown } }).state.isCliReady).toBeUndefined();
     expect(initialized).toMatchObject({
       ok: false,
       condition: 'initialized',
@@ -2492,7 +2538,7 @@ describe('runpane IPC handlers', () => {
       }],
     }]);
 
-    expect(result.ok).toBe(true);
+    expect((result as { ok: boolean }).ok).toBe(true);
     expect(createSessionAndWait).toHaveBeenCalledTimes(2);
     expect(maxActiveCreates).toBe(1);
   });
@@ -2751,7 +2797,7 @@ describe('runpane IPC handlers', () => {
   it('does not retry on stale staged frames when no output arrives after submit', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:02:00.000Z'));
-    const codexPanel = { ...terminalPanel, state: { customState: { agentType: 'codex' } } };
+    const codexPanel = { ...terminalPanel, state: { isActive: false, customState: { agentType: 'codex' } } };
     vi.mocked(panelManager.createPanel).mockResolvedValue(codexPanel);
     vi.mocked(panelManager.getPanel).mockReturnValue(codexPanel);
     vi.mocked(terminalPanelManager.getLastOutputAt).mockReturnValue(undefined);
@@ -2789,7 +2835,7 @@ describe('runpane IPC handlers', () => {
 
   it('cancels retry when a staged frame transitions before confirmation', async () => {
     vi.useFakeTimers();
-    const codexPanel = { ...terminalPanel, state: { customState: { agentType: 'codex' } } };
+    const codexPanel = { ...terminalPanel, state: { isActive: false, customState: { agentType: 'codex' } } };
     vi.mocked(panelManager.createPanel).mockResolvedValue(codexPanel);
     vi.mocked(panelManager.getPanel).mockReturnValue(codexPanel);
     vi.mocked(terminalPanelManager.getTerminalSnapshot)
@@ -2828,7 +2874,7 @@ describe('runpane IPC handlers', () => {
   it('returns a bounded blocker after three confirmed staged submit attempts', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:01:59.000Z'));
-    const codexPanel = { ...terminalPanel, state: { customState: { agentType: 'codex' } } };
+    const codexPanel = { ...terminalPanel, state: { isActive: false, customState: { agentType: 'codex' } } };
     vi.mocked(panelManager.createPanel).mockResolvedValue(codexPanel);
     vi.mocked(panelManager.getPanel).mockReturnValue(codexPanel);
     vi.mocked(terminalPanelManager.getOutputGeneration)
@@ -2879,6 +2925,7 @@ describe('runpane IPC handlers', () => {
     const createdPanel: ToolPanel = {
       ...terminalPanel,
       state: {
+        isActive: false,
         customState: {
           agentType: 'codex',
           isCliPanel: true,
@@ -2891,6 +2938,7 @@ describe('runpane IPC handlers', () => {
     vi.mocked(panelManager.createPanel).mockImplementation(async (request) => ({
       ...createdPanel,
       state: {
+        isActive: false,
         customState: {
           ...createdPanel.state.customState,
           ...request.initialState,
@@ -2900,6 +2948,7 @@ describe('runpane IPC handlers', () => {
     vi.mocked(panelManager.getPanel).mockImplementation(() => ({
       ...createdPanel,
       state: {
+        isActive: false,
         customState: {
           ...createdPanel.state.customState,
           initialInputSentAt: '2026-01-01T00:02:00.000Z',
@@ -2943,7 +2992,7 @@ describe('runpane IPC handlers', () => {
 
   it('never retries when the composer clears without activity', async () => {
     vi.useFakeTimers();
-    const codexPanel = { ...terminalPanel, state: { customState: { agentType: 'codex' } } };
+    const codexPanel = { ...terminalPanel, state: { isActive: false, customState: { agentType: 'codex' } } };
     vi.mocked(panelManager.createPanel).mockResolvedValue(codexPanel);
     vi.mocked(panelManager.getPanel).mockReturnValue(codexPanel);
     vi.mocked(terminalPanelManager.getTerminalSnapshot)
@@ -2990,7 +3039,7 @@ describe('runpane IPC handlers', () => {
           let createdPanel: ToolPanel | undefined;
           vi.mocked(panelManager.createPanel).mockImplementation(async (request) => {
             createRequest = request;
-            const initialState = request.initialState ?? {};
+            const initialState = (request.initialState ?? {}) as TerminalPanelState;
             const customState: TerminalPanelState = { ...initialState };
             if (initialState.initialInputMode === 'argument') {
               customState.initialInputSentAt = '2026-01-01T00:02:00.000Z';
@@ -2999,12 +3048,16 @@ describe('runpane IPC handlers', () => {
               id: 'panel-1',
               sessionId: session.id,
               type: 'terminal',
-              title: request.title,
+              title: request.title ?? '',
               state: {
                 isActive: false,
                 customState,
               },
-              metadata: {},
+              metadata: {
+                createdAt: '2026-01-01T00:00:00.000Z',
+                lastActiveAt: '2026-01-01T00:01:00.000Z',
+                position: 0,
+              },
             };
             return createdPanel;
           });
@@ -3027,7 +3080,7 @@ describe('runpane IPC handlers', () => {
             return terminalSnapshot(
               toolKind === 'codex' && inputCase.name === 'slash' ? `› ${inputCase.input}` : 'ready',
               'idle',
-              toolKind,
+              toolKind as 'claude' | 'codex',
             );
           });
           const tool: RunpaneToolSpec = toolKind === 'custom'
@@ -3041,8 +3094,8 @@ describe('runpane IPC handlers', () => {
             panes: [{ name: `${toolKind}-${inputCase.name}`, tool }],
           }]);
           await vi.runAllTimersAsync();
-          const result = await resultPromise;
-          const initialState = createRequest?.initialState;
+          const result = await resultPromise as { items: Array<{ ok?: boolean; initialInput?: unknown }> };
+          const initialState = createRequest?.initialState as TerminalPanelState | undefined;
           const useArgument = toolKind === 'claude'
             || toolKind === 'cursor'
             || (toolKind === 'codex' && inputCase.name !== 'slash');

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -2095,33 +2095,18 @@ function outputToText(output: SessionOutput): string {
 async function panelScrollbackOutput(panel: ToolPanel, limit: number): Promise<{ text: string; hasMore: boolean; timestamp: string } | null> {
   const timestamp = toIsoString(panel.metadata.lastActiveAt) ?? new Date().toISOString();
 
-  // Prefer the live screen emulator. Its rendered buffer applies cursor motions
-  // in place, so callers building agent context never receive the overlapping
-  // fragment corruption (e.g. "Workingorking•rking") that ANSI-stripping the raw
-  // append log produces for in-place repaints (spinners, progress bars, TUIs).
-  // Request one extra line so hasMore reflects truncation.
-  const clean = await terminalPanelManager.getCleanTerminalScrollback(panel.id, limit + 1);
-  if (clean !== null) {
-    const cleanLines = clean.split('\n');
-    const hasMore = cleanLines.length > limit;
-    return { text: cleanLines.slice(-limit).join('\n'), hasMore, timestamp };
+  // Ask for one extra rendered line so hasMore reflects emulator truncation.
+  let text = await terminalPanelManager.getCleanTerminalScrollback(panel.id, limit + 1);
+  if (text === null) {
+    const rawScrollback = getPanelScrollback(panel);
+    if (!rawScrollback) return null;
+    text = sanitizeTerminalOutput(rawScrollback);
   }
+  if (!text) return null;
 
-  const rawScrollback = getPanelScrollback(panel);
-  if (!rawScrollback) {
-    return null;
-  }
-
-  const stripped = sanitizeTerminalOutput(rawScrollback);
-  if (!stripped) {
-    return null;
-  }
-
-  const allLines = stripped.split('\n');
+  const allLines = text.split('\n');
   const hasMore = allLines.length > limit;
-  const text = allLines.slice(-limit).join('\n');
-
-  return { text, hasMore, timestamp };
+  return { text: allLines.slice(-limit).join('\n'), hasMore, timestamp };
 }
 
 function getPanelScrollback(panel: ToolPanel): string | null {

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -720,12 +720,12 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:output', async (request: PaneCommandValue): Promise<RunpanePanelOutputResult> => {
-    return withRunpaneAction(services, 'panels:output', {}, () => {
+  commandRegistry.register('runpane:panels:output', async (request: unknown): Promise<RunpanePanelOutputResult> => {
+    return withRunpaneAction(services, 'panels:output', {}, async () => {
       const normalized = parsePanelOutputRequest(request);
       const panel = resolvePanel(normalized.panelId);
       const limit = normalized.limit ?? DEFAULT_PANEL_OUTPUT_LIMIT;
-      const scrollbackResult = panel.type === 'terminal' ? panelScrollbackOutput(panel, limit) : null;
+      const scrollbackResult = panel.type === 'terminal' ? await panelScrollbackOutput(panel, limit) : null;
 
       if (scrollbackResult) {
         return {
@@ -2092,7 +2092,21 @@ function outputToText(output: SessionOutput): string {
   }
 }
 
-function panelScrollbackOutput(panel: ToolPanel, limit: number): { text: string; hasMore: boolean; timestamp: string } | null {
+async function panelScrollbackOutput(panel: ToolPanel, limit: number): Promise<{ text: string; hasMore: boolean; timestamp: string } | null> {
+  const timestamp = toIsoString(panel.metadata.lastActiveAt) ?? new Date().toISOString();
+
+  // Prefer the live screen emulator. Its rendered buffer applies cursor motions
+  // in place, so callers building agent context never receive the overlapping
+  // fragment corruption (e.g. "Workingorking•rking") that ANSI-stripping the raw
+  // append log produces for in-place repaints (spinners, progress bars, TUIs).
+  // Request one extra line so hasMore reflects truncation.
+  const clean = await terminalPanelManager.getCleanTerminalScrollback(panel.id, limit + 1);
+  if (clean !== null) {
+    const cleanLines = clean.split('\n');
+    const hasMore = cleanLines.length > limit;
+    return { text: cleanLines.slice(-limit).join('\n'), hasMore, timestamp };
+  }
+
   const rawScrollback = getPanelScrollback(panel);
   if (!rawScrollback) {
     return null;
@@ -2106,7 +2120,6 @@ function panelScrollbackOutput(panel: ToolPanel, limit: number): { text: string;
   const allLines = stripped.split('\n');
   const hasMore = allLines.length > limit;
   const text = allLines.slice(-limit).join('\n');
-  const timestamp = toIsoString(panel.metadata.lastActiveAt) ?? new Date().toISOString();
 
   return { text, hasMore, timestamp };
 }

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -720,9 +720,9 @@ export function registerRunpaneHandlers(
     }));
   });
 
-  commandRegistry.register('runpane:panels:output', async (request: unknown): Promise<RunpanePanelOutputResult> => {
+  commandRegistry.register('runpane:panels:output', async (request: PaneCommandValue): Promise<RunpanePanelOutputResult> => {
     return withRunpaneAction(services, 'panels:output', {}, async () => {
-      const normalized = parsePanelOutputRequest(request as PaneCommandValue);
+      const normalized = parsePanelOutputRequest(request);
       const panel = resolvePanel(normalized.panelId);
       const limit = normalized.limit ?? DEFAULT_PANEL_OUTPUT_LIMIT;
       const scrollbackResult = panel.type === 'terminal' ? await panelScrollbackOutput(panel, limit) : null;

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -722,7 +722,7 @@ export function registerRunpaneHandlers(
 
   commandRegistry.register('runpane:panels:output', async (request: unknown): Promise<RunpanePanelOutputResult> => {
     return withRunpaneAction(services, 'panels:output', {}, async () => {
-      const normalized = parsePanelOutputRequest(request);
+      const normalized = parsePanelOutputRequest(request as PaneCommandValue);
       const panel = resolvePanel(normalized.panelId);
       const limit = normalized.limit ?? DEFAULT_PANEL_OUTPUT_LIMIT;
       const scrollbackResult = panel.type === 'terminal' ? await panelScrollbackOutput(panel, limit) : null;

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -2098,27 +2098,15 @@ async function panelScrollbackOutput(panel: ToolPanel, limit: number): Promise<{
   // Ask for one extra rendered line so hasMore reflects emulator truncation.
   let text = await terminalPanelManager.getCleanTerminalScrollback(panel.id, limit + 1);
   if (text === null) {
-    const rawScrollback = getPanelScrollback(panel);
-    if (!rawScrollback) return null;
-    text = sanitizeTerminalOutput(rawScrollback);
+    const persistedScrollback = normalizeScrollbackBuffer(getTerminalCustomState(panel).scrollbackBuffer);
+    if (!persistedScrollback) return null;
+    text = sanitizeTerminalOutput(persistedScrollback);
   }
   if (!text) return null;
 
   const allLines = text.split('\n');
   const hasMore = allLines.length > limit;
   return { text: allLines.slice(-limit).join('\n'), hasMore, timestamp };
-}
-
-function getPanelScrollback(panel: ToolPanel): string | null {
-  const liveScrollback = terminalPanelManager.getTerminalScrollback(panel.id);
-  if (liveScrollback !== null) {
-    return liveScrollback;
-  }
-
-  const persisted = normalizeScrollbackBuffer(getTerminalCustomState(panel).scrollbackBuffer);
-  if (persisted) return persisted;
-
-  return null;
 }
 
 function panelOutputCommand(panelId: string): string {

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -1940,6 +1940,26 @@ export class TerminalPanelManager {
   }
 
   /**
+   * Clean plain-text scrollback for a live terminal, sourced from the screen
+   * emulator rather than the raw append log. The append log accumulates every
+   * repaint frame; stripping its ANSI leaves overlapping fragments (e.g.
+   * "Workingorking•rking") for any output that updates in place via cursor
+   * motion. The emulator applies those motions like a real terminal, so its
+   * rendered buffer is corruption-free. Returns null when the panel has no live
+   * emulator (lazy/inactive terminals) so callers can fall back to persisted
+   * state.
+   */
+  async getCleanTerminalScrollback(panelId: string, maxLines: number): Promise<string | null> {
+    const emulator = this.terminals.get(panelId)?.screenEmulator;
+    if (!emulator) {
+      return null;
+    }
+    await emulator.waitForIdle();
+    const text = emulator.getScrollbackText(maxLines);
+    return text.length > 0 ? text : null;
+  }
+
+  /**
    * Returns the alternate screen buffer state for a terminal panel.
    * Used by the renderer to initialize TUI detection when a panel
    * remounts while a full-screen program is already running.

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -1932,14 +1932,6 @@ export class TerminalPanelManager {
   }
 
   /**
-   * Get scrollback buffer for a specific terminal.
-   * Returns null if terminal not found.
-   */
-  getTerminalScrollback(panelId: string): string | null {
-    return this.terminals.get(panelId)?.scrollbackBuffer ?? null;
-  }
-
-  /**
    * Clean plain-text scrollback from the rendered screen model. Returns null
    * without a live emulator so callers can use persisted state.
    */

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -1940,14 +1940,8 @@ export class TerminalPanelManager {
   }
 
   /**
-   * Clean plain-text scrollback for a live terminal, sourced from the screen
-   * emulator rather than the raw append log. The append log accumulates every
-   * repaint frame; stripping its ANSI leaves overlapping fragments (e.g.
-   * "Workingorking•rking") for any output that updates in place via cursor
-   * motion. The emulator applies those motions like a real terminal, so its
-   * rendered buffer is corruption-free. Returns null when the panel has no live
-   * emulator (lazy/inactive terminals) so callers can fall back to persisted
-   * state.
+   * Clean plain-text scrollback from the rendered screen model. Returns null
+   * without a live emulator so callers can use persisted state.
    */
   async getCleanTerminalScrollback(panelId: string, maxLines: number): Promise<string | null> {
     const emulator = this.terminals.get(panelId)?.screenEmulator;

--- a/main/src/services/terminalStateEmulator.test.ts
+++ b/main/src/services/terminalStateEmulator.test.ts
@@ -143,6 +143,16 @@ describe('TerminalStateEmulator', () => {
     expect(emulator.getScrollbackText()).toContain('line-01');
   });
 
+  it('rejects invalid scrollback line limits', () => {
+    const emulator = new TerminalStateEmulator(40, 3);
+
+    expect(() => emulator.getScrollbackText(-1)).toThrow(RangeError);
+    expect(() => emulator.getScrollbackText(1.5)).toThrow(RangeError);
+    expect(() => emulator.getScrollbackText(Number.POSITIVE_INFINITY)).toThrow(RangeError);
+
+    emulator.dispose();
+  });
+
   it('captures OSC title set via the OSC 0 form', async () => {
     const emulator = new TerminalStateEmulator(20, 5);
     emulator.write('\x1b]0;Action Required · Codex\x07');

--- a/main/src/services/terminalStateEmulator.test.ts
+++ b/main/src/services/terminalStateEmulator.test.ts
@@ -130,6 +130,19 @@ describe('TerminalStateEmulator', () => {
     emulator.dispose();
   });
 
+  it('preserves bounded scrollback reads after disposal', async () => {
+    const emulator = new TerminalStateEmulator(40, 3);
+    for (let i = 1; i <= 10; i++) {
+      emulator.write(`line-${String(i).padStart(2, '0')}\r\n`);
+    }
+    await emulator.waitForIdle();
+
+    emulator.dispose();
+
+    expect(emulator.getScrollbackText(2)).toBe('line-09\nline-10');
+    expect(emulator.getScrollbackText()).toContain('line-01');
+  });
+
   it('captures OSC title set via the OSC 0 form', async () => {
     const emulator = new TerminalStateEmulator(20, 5);
     emulator.write('\x1b]0;Action Required · Codex\x07');

--- a/main/src/services/terminalStateEmulator.test.ts
+++ b/main/src/services/terminalStateEmulator.test.ts
@@ -95,6 +95,41 @@ describe('TerminalStateEmulator', () => {
     expect(emulator.getOscTitle()).toBe('✳ Ready');
   });
 
+  it('renders in-place cursor-motion repaints as clean scrollback text', async () => {
+    const emulator = new TerminalStateEmulator(20, 5);
+
+    // A spinner that repaints its status line in place via cursor-column moves
+    // (not carriage returns). The raw append log of these bytes, once ANSI is
+    // stripped, collapses into overlapping garbage ("Workingorking•rking...").
+    // The emulator applies the motions in place, so the rendered line is clean.
+    emulator.write('Working');
+    emulator.write('\x1b[7D\x1b[KWorking.');
+    emulator.write('\x1b[8D\x1b[KWorking..');
+    emulator.write('\x1b[9D\x1b[KWorking...');
+    await emulator.waitForIdle();
+
+    const text = emulator.getScrollbackText();
+    expect(text).toBe('Working...');
+    expect(text).not.toContain('orking•');
+    emulator.dispose();
+  });
+
+  it('limits scrollback text to the last N rendered lines', async () => {
+    const emulator = new TerminalStateEmulator(40, 3);
+    for (let i = 1; i <= 10; i++) {
+      emulator.write(`line-${String(i).padStart(2, '0')}\r\n`);
+    }
+    await emulator.waitForIdle();
+
+    const lastThree = emulator.getScrollbackText(3);
+    expect(lastThree).toBe('line-08\nline-09\nline-10');
+
+    const all = emulator.getScrollbackText();
+    expect(all).toContain('line-01');
+    expect(all).toContain('line-10');
+    emulator.dispose();
+  });
+
   it('captures OSC title set via the OSC 0 form', async () => {
     const emulator = new TerminalStateEmulator(20, 5);
     emulator.write('\x1b]0;Action Required · Codex\x07');

--- a/main/src/services/terminalStateEmulator.ts
+++ b/main/src/services/terminalStateEmulator.ts
@@ -120,19 +120,12 @@ export class TerminalStateEmulator {
    * cursor moves rather than carriage returns).
    */
   getScrollbackText(maxLines?: number): string {
-    if (this.disposed) {
-      const lines = this.finalScrollbackText === '' ? [] : this.finalScrollbackText.split('\n');
-      return maxLines !== undefined && maxLines >= 0 && maxLines < lines.length
-        ? lines.slice(lines.length - maxLines).join('\n')
-        : this.finalScrollbackText;
-    }
-
-    const buffer = this.terminal.buffer.active;
-    const total = buffer.length;
-    const lines: string[] = [];
-
-    for (let index = 0; index < total; index += 1) {
-      lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+    const lines = this.disposed ? this.finalScrollbackText.split('\n') : [];
+    if (!this.disposed) {
+      const buffer = this.terminal.buffer.active;
+      for (let index = 0; index < buffer.length; index += 1) {
+        lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+      }
     }
 
     // Trim trailing blank rows first so `maxLines` counts real content, not the

--- a/main/src/services/terminalStateEmulator.ts
+++ b/main/src/services/terminalStateEmulator.ts
@@ -18,6 +18,7 @@ export class TerminalStateEmulator {
   private finalIsAlternateScreen = false;
   private finalSerializedBuffer = '';
   private finalScreenText = '';
+  private finalScrollbackText = '';
   private currentTitle = '';
   private currentProgress = '';
 
@@ -119,7 +120,12 @@ export class TerminalStateEmulator {
    * cursor moves rather than carriage returns).
    */
   getScrollbackText(maxLines?: number): string {
-    if (this.disposed) return this.finalScreenText;
+    if (this.disposed) {
+      const lines = this.finalScrollbackText === '' ? [] : this.finalScrollbackText.split('\n');
+      return maxLines !== undefined && maxLines >= 0 && maxLines < lines.length
+        ? lines.slice(lines.length - maxLines).join('\n')
+        : this.finalScrollbackText;
+    }
 
     const buffer = this.terminal.buffer.active;
     const total = buffer.length;
@@ -163,6 +169,7 @@ export class TerminalStateEmulator {
     // viewport-only capture would silently drop the session's history.
     this.finalSerializedBuffer = this.serializeForRestore(true);
     this.finalScreenText = this.getScreenText();
+    this.finalScrollbackText = this.getScrollbackText();
     this.disposed = true;
     this.terminal.dispose();
     const resolvers = this.idleResolvers;

--- a/main/src/services/terminalStateEmulator.ts
+++ b/main/src/services/terminalStateEmulator.ts
@@ -120,6 +120,10 @@ export class TerminalStateEmulator {
    * cursor moves rather than carriage returns).
    */
   getScrollbackText(maxLines?: number): string {
+    if (maxLines !== undefined && (!Number.isSafeInteger(maxLines) || maxLines < 0)) {
+      throw new RangeError('maxLines must be a non-negative safe integer');
+    }
+
     const lines = this.disposed ? this.finalScrollbackText.split('\n') : [];
     if (!this.disposed) {
       const buffer = this.terminal.buffer.active;

--- a/main/src/services/terminalStateEmulator.ts
+++ b/main/src/services/terminalStateEmulator.ts
@@ -123,19 +123,22 @@ export class TerminalStateEmulator {
 
     const buffer = this.terminal.buffer.active;
     const total = buffer.length;
-    const start = maxLines !== undefined && maxLines >= 0 && maxLines < total
-      ? total - maxLines
-      : 0;
     const lines: string[] = [];
 
-    for (let index = start; index < total; index += 1) {
+    for (let index = 0; index < total; index += 1) {
       lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
     }
 
+    // Trim trailing blank rows first so `maxLines` counts real content, not the
+    // empty rows below the cursor.
     while (lines.length > 0 && lines[lines.length - 1] === '') {
       lines.pop();
     }
-    return lines.join('\n');
+
+    const limited = maxLines !== undefined && maxLines >= 0 && maxLines < lines.length
+      ? lines.slice(lines.length - maxLines)
+      : lines;
+    return limited.join('\n');
   }
 
   /** Latest OSC window/icon title, preserved after dispose. */

--- a/main/src/services/terminalStateEmulator.ts
+++ b/main/src/services/terminalStateEmulator.ts
@@ -110,6 +110,34 @@ export class TerminalStateEmulator {
     return lines.join('\n');
   }
 
+  /**
+   * Return plain text for the buffer's scrollback history plus the current
+   * viewport, optionally limited to the last `maxLines` rows. This model
+   * rendered every PTY byte with cursor motions applied in place, so the text
+   * is free of the overlapping-fragment corruption that plagues an ANSI-stripped
+   * raw append log (spinners, progress bars, TUI status lines that repaint via
+   * cursor moves rather than carriage returns).
+   */
+  getScrollbackText(maxLines?: number): string {
+    if (this.disposed) return this.finalScreenText;
+
+    const buffer = this.terminal.buffer.active;
+    const total = buffer.length;
+    const start = maxLines !== undefined && maxLines >= 0 && maxLines < total
+      ? total - maxLines
+      : 0;
+    const lines: string[] = [];
+
+    for (let index = start; index < total; index += 1) {
+      lines.push(buffer.getLine(index)?.translateToString(true) ?? '');
+    }
+
+    while (lines.length > 0 && lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+    return lines.join('\n');
+  }
+
   /** Latest OSC window/icon title, preserved after dispose. */
   getOscTitle(): string {
     return this.currentTitle;


### PR DESCRIPTION
## Description

Fixes #457 — new Claude Code tab receives another panel's mangled screen buffer as its first prompt.

Panel-scrollback readers sourced text from the raw PTY append log (`terminal.scrollbackBuffer`) and merely ANSI-stripped it. The append log accumulates every repaint frame — agents and tools update in place via cursor-motion escapes (`\x1b[nD`, `\x1b[K`, column addressing), not carriage returns. `sanitizeTerminalOutput` only collapses `\r`-based overwrites, so cursor-motion fragments concatenate into the reported garbage ("Workingorking•rking•king•ingngg"). The default 500-line copy preset ≈ the reported 9–12 KB.

The codebase already knew the raw log is unreliable — `getTerminalState` and agent-status detection both use the screen emulator instead. Three consumers shared the defective raw-log path:

1. `runpane panels output` → `getPanelScrollback` (main/src/ipc/runpane.ts) — the context-capture path; its output flows into `--initial-input-file`, prepended to the typed "continue"
2. `terminal:getScrollbackClean` (main/src/ipc/panels.ts) — the UI @-terminal raw-copy feature
3. `terminal:save-scrollback` (main/src/ipc/panels.ts) — the @-terminal embed-copy feature

The fix routes all three through a new `getScrollbackText()` method on the screen emulator, which renders clean plain text from the already-correct rendered buffer.

Changes:
- `TerminalStateEmulator.getScrollbackText(maxLines?)`: clean plain text from the rendered buffer (scrollback history + viewport), trimming trailing blanks before applying the line limit
- `TerminalPanelManager.getCleanTerminalScrollback(panelId, maxLines)`: awaits emulator idle, returns clean text or null (no live emulator → caller falls back to persisted state)
- Routed both `panels.ts` IPC handlers through the emulator, keeping the sanitized persisted-state fallback for lazy/inactive terminals
- Routed `runpane panels output` through the emulator (made `panelScrollbackOutput` async)
- Tests: emulator renders in-place cursor repaints as clean text, line-limit trimming, and a runpane integration test asserting the emulator source wins over the raw log

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [ ] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified

- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [x] State management/IPC events
- [ ] Diff viewer CSS

## Screenshots (if applicable)

N/A — the bug produces no visible UI change; the symptom is in the agent's session JSONL (first `user` message contains another panel's screen dump). The fix changes what text the scrollback readers return internally.

## Additional Notes

- `pnpm run typecheck` passes. OxLint exit 0, ESLint 0 errors in touched files.
- `terminalStateEmulator.test.ts` (9), `runpane.test.ts` (60), `terminalPanelManager.test.ts` — all pass.
- Two non-code failures (Knip's zod/mini resolution; daemonRegistryBindings minimatch CJS/ESM) reproduce identically on the base commit — pre-existing, not from this change.
- Manual end-to-end testing was not performed — the dev Electron app shows "Open Pane from the desktop app" on both this branch and plain main (v2.4.62), a pre-existing Windows dev environment issue unrelated to this  @fix.
- One pre-existing typecheck error on the base commit (`runpane.ts:475 PaneCommandValue`) was fixed as part of the rebase cleanup (cast `request as PaneCommandValue`).

<!-- pr-test-automation-summary:start -->
## Automated QA

Status: passed at `33adc2d7`. An isolated Electron dev app and local RunPane wrapper returned clean `Working...` and `qa-sentinel` text from both `panels screen` and `panels output`, with no repaint fragments. Typecheck, lint, and 116 focused tests pass. No screenshots were needed because this PR changes terminal text plumbing, not layout. Remaining human check: optional raw and embed `@` terminal copy in a packaged app.
<!-- pr-test-automation-summary:end -->