### PR TITLE
Window Controls Overlay on Windows and Linux, so the title bar carries the pane name

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import type { CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import { CreateSessionDialog } from './CreateSessionDialog';
 import { ProjectSessionList, ArchivedSessions } from './ProjectSessionList';
@@ -7,7 +6,6 @@ import { ArchiveProgress } from './ArchiveProgress';
 import { Archive, ArrowUpDown, ChevronDown, ChevronRight, Cpu, FolderGit2, Home, Monitor, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Pin, Settings as SettingsIcon, Plus, RefreshCw, MessageSquare, SquareTerminal } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { usePaneLogo } from '../hooks/usePaneLogo';
-import { isMac } from '../utils/platformUtils';
 import { IconButton } from './ui/Button';
 import { Tooltip } from './ui/Tooltip';
 import { Kbd } from './ui/Kbd';
@@ -21,9 +19,6 @@ import { SessionStatusBadge } from './SessionStatusBadge';
 import { AgentActivityDot, AgentStatusDot } from './ui/AgentStatusDot';
 import { useSessionAgentDisplayStatus } from '../hooks/useAgentStatus';
 import { PANE_CHAT_SESSION_ID } from '../../../shared/types/paneChat';
-
-// SAFETY: Electron supports WebkitAppRegion although React's CSSProperties omits the vendor property.
-const dragRegionStyle = { WebkitAppRegion: 'drag' } as CSSProperties;
 import { API } from '../utils/api';
 import type { Project } from '../types/project';
 import type { Session } from '../types/session';
@@ -491,10 +486,6 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
           className="pane-sidebar-shell pane-sidebar-shell-collapsed bg-surface-primary text-text-primary h-full flex flex-col flex-shrink-0"
           style={{ width: '48px' }}
         >
-          {/* Drag handle for window (not needed on macOS — handled by App-level spacer) */}
-          {!isMac() && (
-            <div className="h-3 flex-shrink-0" style={dragRegionStyle} />
-          )}
           {/* Logo */}
           <div className="flex shrink-0 items-center justify-center border-b border-border-primary px-1 py-2">
             <img src={paneLogo} alt="Pane" className="h-6 w-6" />
@@ -783,10 +774,6 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
         className="pane-sidebar-shell bg-surface-primary text-text-primary h-full flex flex-col relative flex-shrink-0"
         style={{ width: `${width}px` }}
       >
-        {/* Drag handle for window (not needed on macOS — handled by App-level spacer) */}
-        {!isMac() && (
-          <div className="h-3 flex-shrink-0" style={dragRegionStyle} />
-        )}
         {/* Resize handle */}
         <div
           className="absolute top-0 right-0 w-1 h-full cursor-col-resize group z-10"

--- a/frontend/src/components/WindowTitleBar.tsx
+++ b/frontend/src/components/WindowTitleBar.tsx
@@ -5,10 +5,36 @@ import { useSessionStore } from '../stores/sessionStore';
 import type { Project } from '../types/project';
 import { APP_WINDOW_TITLE, formatPaneTitle, resolvePaneStatusPills, resolvePaneTitle } from '../utils/paneTitle';
 import { isMac } from '../utils/platformUtils';
+import { isWindowControlsOverlayEnabled } from '../utils/titleBarOverlay';
 import { Badge } from './ui/Badge';
 
 // SAFETY: Electron supports WebkitAppRegion although React's CSSProperties omits the vendor property.
 const TITLE_BAR_STYLE = { height: 38, WebkitAppRegion: 'drag' } as CSSProperties;
+// Breathing room between the window controls and the title, on both sides.
+const GUTTER_PX = 8;
+// Traffic lights sit at x=10 with ~70px of width (see `trafficLightPosition` in
+// main/src/index.ts); padding both sides equally keeps the title centered on the
+// window while clearing them.
+const MAC_INSET_STYLE: CSSProperties = { paddingLeft: 88, paddingRight: 88 };
+// Windows and Linux put the controls on the right, and on the left under an RTL
+// system layout, so the inset cannot be symmetric or hardcoded. `titlebar-area-x`
+// is where the page's share of the strip starts and `titlebar-area-width` how far
+// it runs, both in CSS pixels, so the leftover on the far side is everything the
+// two do not cover. Chromium recomputes them on DPI, RTL and maximise changes,
+// which is why the numbers never appear here.
+//
+// The `100%` resolves against this element's containing block — the full-width
+// `pane-app-shell` column in App.tsx — which is the same coordinate space the
+// env() values are reported in.
+//
+// With the env() fallbacks — the shape a window that somehow lost the overlay
+// would compute — this collapses to a symmetric gutter rather than to nothing.
+// `max()` keeps a mis-reported rect from producing a negative padding, which CSS
+// would drop on the floor.
+const OVERLAY_INSET_STYLE: CSSProperties = {
+  paddingLeft: `calc(env(titlebar-area-x, 0px) + ${GUTTER_PX}px)`,
+  paddingRight: `max(${GUTTER_PX}px, calc(100% - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100%) + ${GUTTER_PX}px))`,
+};
 // An rtl line box overflows at its left edge, so the ellipsis lands on the head
 // and the end of a long pane name ("… (TM-622)") survives. The inner ltr embed
 // keeps the name itself a single left-to-right run — without it, trailing
@@ -21,14 +47,15 @@ interface WindowTitleBarProps {
 }
 
 /**
- * The macOS title bar strip above the tool tabs: a window drag region that also
- * names the pane you are looking at. Passive text only — no pointer handlers, so
- * the whole strip keeps dragging and double-click-to-zoom.
+ * The title bar strip above the tool tabs: a window drag region that also names
+ * the pane you are looking at. Passive text only — no pointer handlers, so the
+ * whole strip keeps dragging and double-click-to-zoom.
  *
- * Windows and Linux keep their native frame, so there is no strip to fill there —
- * but they still get the name, because this also owns `document.title`. That is
- * what their native title bar reads, and what every platform's task switcher and
- * taskbar show, so the window is identifiable off-screen as well as on it.
+ * It renders wherever the app owns the title bar: macOS via `hiddenInset`, and
+ * Windows and Linux via the Window Controls Overlay. A Linux desktop that failed
+ * the overlay gate in main keeps its native frame and gets no strip — there it
+ * is `document.title`, which this also owns, that carries the pane name. That is
+ * true on every platform for the taskbar and task switcher.
  */
 export function WindowTitleBar({ projects }: WindowTitleBarProps) {
   const activeView = useNavigationStore(state => state.activeView);
@@ -45,7 +72,7 @@ export function WindowTitleBar({ projects }: WindowTitleBarProps) {
   const windowTitle = formatPaneTitle(title);
 
   // Runs before the platform gate below: naming the window is the part of this
-  // that Windows and Linux can use.
+  // that a native-framed Windows or Linux window still uses.
   useEffect(() => {
     document.title = windowTitle;
     return () => {
@@ -53,17 +80,20 @@ export function WindowTitleBar({ projects }: WindowTitleBarProps) {
     };
   }, [windowTitle]);
 
-  if (!isMac()) return null;
+  // macOS owns the strip through `hiddenInset`; Windows and Linux own it when
+  // main enabled the overlay. Deliberately not gated on
+  // `navigator.windowControlsOverlay.visible`: that reads false in plenty of
+  // contexts the API is merely present in, and this element carries the window's
+  // only drag region once the native title bar is gone. It stays put in
+  // fullscreen for the same reason the macOS strip always has.
+  if (!isMac() && !isWindowControlsOverlayEnabled()) return null;
 
   const pills = title ? resolvePaneStatusPills(activeSession) : [];
 
   return (
     <div
-      // Traffic lights sit at x=10 with ~70px of width (see `trafficLightPosition`
-      // in main/src/index.ts); padding both sides equally keeps the title centered
-      // on the window while clearing them.
-      className="flex-shrink-0 flex items-center justify-center overflow-hidden bg-bg-primary px-[88px] select-none"
-      style={TITLE_BAR_STYLE}
+      className="flex-shrink-0 flex items-center justify-center overflow-hidden bg-bg-primary select-none"
+      style={{ ...TITLE_BAR_STYLE, ...(isMac() ? MAC_INSET_STYLE : OVERLAY_INSET_STYLE) }}
       data-testid="window-title-bar"
     >
       {title && (

--- a/frontend/src/contexts/ThemeProvider.tsx
+++ b/frontend/src/contexts/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useConfigStore } from '../stores/configStore';
+import { isWindowControlsOverlayEnabled, readTitleBarOverlayColors } from '../utils/titleBarOverlay';
 import { THEME_CLASSES, ThemeContext, type Theme } from './themeContextValue';
 
 const VALID_THEMES = new Set<string>(Object.keys(THEME_CLASSES));
@@ -60,6 +61,25 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
     localStorage.setItem('theme', theme);
 
+  }, [theme, highContrast]);
+
+  // Window Controls Overlay: the OS draws the caption buttons, so they only
+  // follow the theme if we tell them to. This is the single choke point every
+  // theme and high-contrast change passes through, which is why the bridge lives
+  // here rather than in the title bar — the strip may be absent (Pane Chat, the
+  // Linux native-frame fallback) while the buttons are still on screen.
+  //
+  // Passive, and declared after the layout effect above, so the classes are
+  // already stamped when the tokens are read.
+  useEffect(() => {
+    if (!isWindowControlsOverlayEnabled()) return;
+
+    const colors = readTitleBarOverlayColors();
+    if (!colors) return;
+
+    void window.electronAPI?.setTitleBarOverlay(colors).catch((error) => {
+      console.error('Failed to apply title bar overlay colors:', error);
+    });
   }, [theme, highContrast]);
 
   const updateTheme = (nextTheme: Theme) => {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -87,6 +87,12 @@ interface ElectronAPI {
   getPlatform: () => Promise<string>;
   isPackaged: () => Promise<boolean>;
 
+  // Window Controls Overlay (Windows/Linux). `windowControlsOverlayEnabled` is a
+  // plain boolean, not a promise: it is resolved in the preload from argv so the
+  // first render already knows whether the page owns the title bar.
+  windowControlsOverlayEnabled: boolean;
+  setTitleBarOverlay: (colors: { color: string; symbolColor: string }) => Promise<IPCResponse>;
+
   // Version checking
   checkForUpdates: () => Promise<IPCResponse<VersionInfo>>;
   getVersionInfo: () => Promise<IPCResponse>;

--- a/frontend/src/utils/titleBarOverlay.test.ts
+++ b/frontend/src/utils/titleBarOverlay.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { toOverlayHex } from './titleBarOverlay';
+
+describe('toOverlayHex', () => {
+  it('normalises the legacy rgb() serialization the CSSOM returns', () => {
+    expect(toOverlayHex('rgb(13, 17, 23)')).toBe('#0d1117');
+    expect(toOverlayHex('rgb(200, 208, 217)')).toBe('#c8d0d9');
+    expect(toOverlayHex('rgb(255, 255, 255)')).toBe('#ffffff');
+  });
+
+  it('drops alpha, because the overlay plate is opaque', () => {
+    expect(toOverlayHex('rgba(13, 17, 23, 0.5)')).toBe('#0d1117');
+    expect(toOverlayHex('rgb(13 17 23 / 50%)')).toBe('#0d1117');
+    expect(toOverlayHex('#0d1117ff')).toBe('#0d1117');
+    expect(toOverlayHex('#abcd')).toBe('#aabbcc');
+  });
+
+  it('accepts the hex and space-separated forms themes author tokens in', () => {
+    expect(toOverlayHex('#0D1117')).toBe('#0d1117');
+    expect(toOverlayHex('#abc')).toBe('#aabbcc');
+    expect(toOverlayHex('rgb(13 17 23)')).toBe('#0d1117');
+    expect(toOverlayHex('  rgb(13,17,23)  ')).toBe('#0d1117');
+  });
+
+  it('handles percentage channels', () => {
+    expect(toOverlayHex('rgb(100%, 0%, 50%)')).toBe('#ff0080');
+  });
+
+  it('clamps out-of-range channels instead of emitting a malformed hex', () => {
+    expect(toOverlayHex('rgb(300, -20, 23)')).toBe('#ff0017');
+  });
+
+  it('returns null for notations Electron would reject, so the bridge stays silent', () => {
+    for (const value of ['', '   ', 'transparent', 'oklch(0.2 0.03 260)', 'color(srgb 0 0 0)', 'rgb(1, 2)', 'nonsense']) {
+      expect(toOverlayHex(value)).toBeNull();
+    }
+  });
+});

--- a/frontend/src/utils/titleBarOverlay.ts
+++ b/frontend/src/utils/titleBarOverlay.ts
@@ -1,0 +1,121 @@
+/**
+ * Theme -> Window Controls Overlay colour bridge.
+ *
+ * On Windows and Linux the minimise/maximise/close buttons are drawn by the OS,
+ * outside the page, so no CSS reaches them. Electron takes their plate and glyph
+ * colours as strings, which means every theme switch has to resolve the active
+ * theme's tokens and hand the pair back to the main process.
+ *
+ * The colours are read from the live cascade rather than a per-theme table, so
+ * all 27 themes — and any future one — are covered by whatever
+ * `--color-bg-primary` and `--color-text-secondary` resolve to.
+ */
+
+/** Plate colour: the title bar strip's own background (`bg-bg-primary`). */
+const OVERLAY_COLOR_TOKEN = '--color-bg-primary';
+/** Glyph colour: the same token the strip's pane name uses. */
+const OVERLAY_SYMBOL_COLOR_TOKEN = '--color-text-secondary';
+
+export interface TitleBarOverlayColors {
+  color: string;
+  symbolColor: string;
+}
+
+/**
+ * True when the main process handed this window's title bar to the page. Comes
+ * from the preload (argv), so it is available synchronously on first render.
+ * False in the browser-served Remote PWA, which has no Electron bridge at all.
+ */
+export function isWindowControlsOverlayEnabled(): boolean {
+  return window.electronAPI?.windowControlsOverlayEnabled === true;
+}
+
+const HEX_SHORT = /^#([0-9a-f])([0-9a-f])([0-9a-f])([0-9a-f])?$/i;
+const HEX_LONG = /^#([0-9a-f]{6})([0-9a-f]{2})?$/i;
+const FUNCTIONAL = /^rgba?\(([^)]+)\)$/i;
+
+const toHexByte = (channel: number): string =>
+  Math.max(0, Math.min(255, Math.round(channel))).toString(16).padStart(2, '0');
+
+/**
+ * Narrows a CSS colour to the `#rrggbb` form Electron's overlay accepts.
+ *
+ * Chromium's colour parser behind `titleBarOverlay` is not the full CSS grammar:
+ * it takes hex and comma-separated `rgb()`/`rgba()` and nothing else. Normalising
+ * here keeps the main process from having to guess, and keeps a theme that
+ * happens to author a token in some other notation from silently killing the
+ * bridge. Alpha is dropped — the overlay plate is always opaque.
+ */
+export function toOverlayHex(cssColor: string): string | null {
+  const value = cssColor.trim();
+  if (!value) return null;
+
+  const short = HEX_SHORT.exec(value);
+  if (short) {
+    return `#${short[1]}${short[1]}${short[2]}${short[2]}${short[3]}${short[3]}`.toLowerCase();
+  }
+
+  const long = HEX_LONG.exec(value);
+  if (long) {
+    return `#${long[1]}`.toLowerCase();
+  }
+
+  const functional = FUNCTIONAL.exec(value);
+  if (!functional) return null;
+
+  // Accepts both the legacy `rgb(r, g, b)` serialization the CSSOM returns and
+  // the modern `rgb(r g b / a)` an author may have written.
+  const channels = functional[1]
+    .replace(/\//g, ' ')
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((channel) => (channel.endsWith('%') ? (parseFloat(channel) * 255) / 100 : parseFloat(channel)));
+
+  if (channels.length !== 3 || channels.some((channel) => !Number.isFinite(channel))) return null;
+
+  return `#${channels.map(toHexByte).join('')}`;
+}
+
+/**
+ * Resolves the overlay colours from the theme classes currently stamped on the
+ * document.
+ *
+ * The tokens are read off a probe element rather than via
+ * `getComputedStyle(root).getPropertyValue('--color-bg-primary')`: a custom
+ * property's computed value is only var()-substituted, so it comes back in
+ * whatever notation the theme author used (`#0d1117`, `rgb(13 17 23)`, a
+ * `var()` chain). Resolving them as real `background-color`/`color` declarations
+ * makes the CSSOM serialize both as `rgb(r, g, b)`, one shape to parse.
+ */
+export function readTitleBarOverlayColors(doc: Document = document): TitleBarOverlayColors | null {
+  const probe = doc.createElement('div');
+  probe.setAttribute('aria-hidden', 'true');
+  probe.style.cssText = [
+    'position:absolute',
+    'width:0',
+    'height:0',
+    'overflow:hidden',
+    'pointer-events:none',
+    `background-color:var(${OVERLAY_COLOR_TOKEN})`,
+    `color:var(${OVERLAY_SYMBOL_COLOR_TOKEN})`,
+  ].join(';');
+
+  doc.body.appendChild(probe);
+  try {
+    const computed = getComputedStyle(probe);
+
+    // A missing token makes `var()` invalid at computed-value time, which lands
+    // on the initial `transparent` rather than on an error. Reporting that would
+    // weld a black plate to the strip, so leave the overlay as it is instead.
+    if (/^rgba\(.*,\s*0\)$/.test(computed.backgroundColor) || computed.backgroundColor === 'transparent') {
+      return null;
+    }
+
+    const color = toOverlayHex(computed.backgroundColor);
+    const symbolColor = toOverlayHex(computed.color);
+    return color && symbolColor ? { color, symbolColor } : null;
+  } finally {
+    probe.remove();
+  }
+}

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -67,6 +67,14 @@ import type { SessionManager } from './services/sessionManager';
 import { isCliAgentType, resolveAgentTypeFromCommand } from './services/agents/agentIdentity';
 import type { ConfigManager } from './services/configManager';
 import { areKeyboardShortcutsEnabled, shouldForwardCommandPaletteShortcut } from './utils/keyboardShortcuts';
+import {
+  parseStoredOverlayColors,
+  shouldEnableWindowControlsOverlay,
+  WINDOW_CONTROLS_OVERLAY_ARG,
+  WINDOW_CONTROLS_OVERLAY_COLORS_KEY,
+  WINDOW_CONTROLS_OVERLAY_HEIGHT,
+  type WindowControlsOverlayColors,
+} from './utils/windowControlsOverlay';
 import type { WorktreeManager } from './services/worktreeManager';
 import type { GitStatusManager } from './services/gitStatusManager';
 import type { DatabaseService } from './database/database';
@@ -269,6 +277,22 @@ if (isDevelopment) {
   // Devtron can be installed manually in DevTools console with: require('devtron').install()
 }
 
+/**
+ * Last overlay colours the renderer derived from the active theme. Read at
+ * window creation, which happens before any renderer code runs, so a returning
+ * user never sees the system-default plate flash before their theme applies.
+ */
+function readStoredOverlayColors(): WindowControlsOverlayColors | null {
+  try {
+    return parseStoredOverlayColors(
+      databaseService?.getUserPreference(WINDOW_CONTROLS_OVERLAY_COLORS_KEY) ?? null
+    );
+  } catch (error) {
+    console.error('Failed to read stored window controls overlay colors:', error);
+    return null;
+  }
+}
+
 async function createWindow() {
   // Strip iframe-blocking headers for localhost URLs (enables embedded browser panel)
   session.defaultSession.webRequest.onHeadersReceived(
@@ -301,6 +325,8 @@ async function createWindow() {
     Menu.setApplicationMenu(null);
   }
 
+  const windowControlsOverlay = shouldEnableWindowControlsOverlay(process.platform, process.env);
+
   const mainWindowOptions: BrowserWindowConstructorOptions = {
     width: 1400,
     height: 900,
@@ -309,12 +335,25 @@ async function createWindow() {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      webviewTag: true
+      webviewTag: true,
+      // The renderer has to know whether it owns the title bar before its first
+      // paint, so this travels in argv rather than over async IPC.
+      additionalArguments: windowControlsOverlay ? [WINDOW_CONTROLS_OVERLAY_ARG] : [],
     },
   };
   if (process.platform === 'darwin') {
     mainWindowOptions.titleBarStyle = 'hiddenInset';
     mainWindowOptions.trafficLightPosition = { x: 10, y: 10 };
+  } else if (windowControlsOverlay) {
+    // The OS keeps the buttons (and Windows keeps Snap Layouts with them); the
+    // rest of the strip becomes WindowTitleBar. Colours are seeded from the last
+    // theme the renderer reported so the plate is not a grey block until the
+    // first paint lands — see the theme bridge in ThemeProvider.
+    const storedColors = readStoredOverlayColors();
+    mainWindowOptions.titleBarStyle = 'hidden';
+    mainWindowOptions.titleBarOverlay = storedColors
+      ? { ...storedColors, height: WINDOW_CONTROLS_OVERLAY_HEIGHT }
+      : { height: WINDOW_CONTROLS_OVERLAY_HEIGHT };
   }
   mainWindow = new BrowserWindow(mainWindowOptions);
 

--- a/main/src/ipc/app.ts
+++ b/main/src/ipc/app.ts
@@ -2,6 +2,14 @@ import { IpcMain, shell } from 'electron';
 import { execFile } from 'child_process';
 import type { AppServices } from './types';
 import { revealInFileManager } from '../utils/revealInFileManager';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
+import { decodeBoundary } from '../../../shared/validation/boundaryDecoder';
+import {
+  overlayColorsSchema,
+  WINDOW_CONTROLS_OVERLAY_COLORS_KEY,
+  WINDOW_CONTROLS_OVERLAY_HEIGHT,
+  type WindowControlsOverlayColors,
+} from '../utils/windowControlsOverlay';
 
 export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): void {
   const { app } = services;
@@ -17,6 +25,46 @@ export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): vo
 
   ipcMain.handle('is-packaged', () => {
     return app.isPackaged;
+  });
+
+  // The Window Controls Overlay buttons are drawn by the OS, so they cannot pick
+  // up our CSS. The renderer resolves the active theme's tokens to hex and posts
+  // them here on every theme switch; we also persist the pair so the next window
+  // is created already wearing them instead of the system default.
+  ipcMain.handle('window:set-title-bar-overlay', (_event, colors: PaneCommandValue) => {
+    let normalized: WindowControlsOverlayColors;
+    try {
+      normalized = decodeBoundary(colors, overlayColorsSchema);
+    } catch {
+      return { success: false, error: 'Invalid overlay colors' };
+    }
+
+    try {
+      services.databaseService.setUserPreference(
+        WINDOW_CONTROLS_OVERLAY_COLORS_KEY,
+        JSON.stringify(normalized)
+      );
+    } catch (error) {
+      // Losing the cache only costs a themed plate on the next cold start.
+      console.error('Failed to persist window controls overlay colors:', error);
+    }
+
+    const window = services.getMainWindow();
+    if (!window || window.isDestroyed()) {
+      return { success: false, error: 'No window' };
+    }
+
+    try {
+      // Throws on platforms without an overlay (macOS, or a Linux desktop that
+      // failed the gate), so the renderer can call this unconditionally.
+      window.setTitleBarOverlay({ ...normalized, height: WINDOW_CONTROLS_OVERLAY_HEIGHT });
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to set title bar overlay',
+      };
+    }
   });
 
   // System utilities

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -1,4 +1,8 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import {
+  WINDOW_CONTROLS_OVERLAY_ARG,
+  type WindowControlsOverlayColors,
+} from './utils/windowControlsOverlay';
 import type { CreateSessionRequest, Session } from './types/session';
 import type { AppConfig, UpdateConfigRequest } from './types/config';
 import type { CreateProjectRequest, UpdateProjectRequest, Project } from '../../frontend/src/types/project';
@@ -423,6 +427,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAppVersion: () => invokeIpc('get-app-version'),
   getPlatform: () => invokeIpc('get-platform'),
   isPackaged: () => invokeIpc('is-packaged'),
+
+  // Window Controls Overlay: whether this window handed its title bar to the
+  // page. Main decides (see shouldEnableWindowControlsOverlay) and passes the
+  // answer through additionalArguments, so the renderer can branch on it during
+  // its first render instead of awaiting IPC and flashing the wrong layout.
+  windowControlsOverlayEnabled: process.argv.includes(WINDOW_CONTROLS_OVERLAY_ARG),
+  setTitleBarOverlay: (colors: WindowControlsOverlayColors): Promise<IPCResponse> =>
+    invokeIpc('window:set-title-bar-overlay', colors),
 
   // Version checking
   checkForUpdates: (): Promise<IPCResponse> => invokeIpc('version:check-for-updates'),

--- a/main/src/utils/windowControlsOverlay.test.ts
+++ b/main/src/utils/windowControlsOverlay.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decodeBoundary,
+  decodeOptionalBoundary,
+  type JsonValue,
+} from '../../../shared/validation/boundaryDecoder';
+import {
+  overlayColorsSchema,
+  parseStoredOverlayColors,
+  shouldEnableWindowControlsOverlay,
+} from './windowControlsOverlay';
+
+const decodeColors = (value: JsonValue) => decodeOptionalBoundary(value, overlayColorsSchema) ?? null;
+
+describe('shouldEnableWindowControlsOverlay', () => {
+  it('leaves macOS on hiddenInset', () => {
+    expect(shouldEnableWindowControlsOverlay('darwin', {})).toBe(false);
+    expect(shouldEnableWindowControlsOverlay('darwin', { XDG_CURRENT_DESKTOP: 'GNOME' })).toBe(false);
+  });
+
+  it('is always on for Windows', () => {
+    expect(shouldEnableWindowControlsOverlay('win32', {})).toBe(true);
+  });
+
+  it('enables Linux desktops that draw client-side decorations', () => {
+    for (const desktop of ['GNOME', 'ubuntu:GNOME', 'KDE', 'X-Cinnamon', 'XFCE', 'Pantheon', 'COSMIC']) {
+      expect(shouldEnableWindowControlsOverlay('linux', { XDG_CURRENT_DESKTOP: desktop })).toBe(true);
+    }
+  });
+
+  it('falls back to the native frame on unrecognised or unset Linux desktops', () => {
+    expect(shouldEnableWindowControlsOverlay('linux', {})).toBe(false);
+    expect(shouldEnableWindowControlsOverlay('linux', { XDG_CURRENT_DESKTOP: '' })).toBe(false);
+    expect(shouldEnableWindowControlsOverlay('linux', { XDG_CURRENT_DESKTOP: 'i3' })).toBe(false);
+    expect(shouldEnableWindowControlsOverlay('linux', { XDG_CURRENT_DESKTOP: 'sway:wlroots' })).toBe(false);
+  });
+
+  it('reads the session fallbacks when XDG_CURRENT_DESKTOP is missing', () => {
+    expect(shouldEnableWindowControlsOverlay('linux', { XDG_SESSION_DESKTOP: 'plasma' })).toBe(true);
+    expect(shouldEnableWindowControlsOverlay('linux', { DESKTOP_SESSION: 'cinnamon' })).toBe(true);
+  });
+
+  it('lets PANE_WINDOW_CONTROLS_OVERLAY win in both directions, but never on macOS', () => {
+    expect(shouldEnableWindowControlsOverlay('linux', { PANE_WINDOW_CONTROLS_OVERLAY: '1' })).toBe(true);
+    expect(shouldEnableWindowControlsOverlay('darwin', { PANE_WINDOW_CONTROLS_OVERLAY: 'true' })).toBe(false);
+    expect(
+      shouldEnableWindowControlsOverlay('win32', { PANE_WINDOW_CONTROLS_OVERLAY: '0' })
+    ).toBe(false);
+    expect(
+      shouldEnableWindowControlsOverlay('linux', {
+        PANE_WINDOW_CONTROLS_OVERLAY: 'false',
+        XDG_CURRENT_DESKTOP: 'GNOME',
+      })
+    ).toBe(false);
+  });
+});
+
+describe('overlayColorsSchema', () => {
+  it('accepts six-digit hex and lowercases it', () => {
+    expect(decodeColors({ color: '#0D1117', symbolColor: '  #FFFFFF  ' })).toEqual({
+      color: '#0d1117',
+      symbolColor: '#ffffff',
+    });
+  });
+
+  it('rejects notations Chromium may not parse', () => {
+    for (const value of ['rgb(13 17 23)', 'oklch(0.2 0.03 260)', '#fff', '#0d1117ff', 'red', '', null, 42]) {
+      expect(decodeColors({ color: value, symbolColor: '#ffffff' })).toBeNull();
+      expect(decodeColors({ color: '#ffffff', symbolColor: value })).toBeNull();
+    }
+  });
+
+  it('rejects a payload that is not a colour pair', () => {
+    expect(decodeColors({ color: '#0d1117' })).toBeNull();
+    expect(decodeColors(null)).toBeNull();
+    expect(decodeColors('#0d1117')).toBeNull();
+  });
+
+  it('reports where the payload failed, so a bad bridge is debuggable', () => {
+    expect(() => decodeBoundary({ color: '#0d1117', symbolColor: 'red' }, overlayColorsSchema)).toThrow(
+      /input\.symbolColor/
+    );
+  });
+});
+
+describe('parseStoredOverlayColors', () => {
+  it('round-trips a stored pair', () => {
+    const stored = JSON.stringify({ color: '#0d1117', symbolColor: '#c8d0d9' });
+    expect(parseStoredOverlayColors(stored)).toEqual({ color: '#0d1117', symbolColor: '#c8d0d9' });
+  });
+
+  it('returns null for absent or corrupt preferences instead of throwing', () => {
+    expect(parseStoredOverlayColors(null)).toBeNull();
+    expect(parseStoredOverlayColors('')).toBeNull();
+    expect(parseStoredOverlayColors('not json')).toBeNull();
+    expect(parseStoredOverlayColors('{"color":"blue"}')).toBeNull();
+  });
+});

--- a/main/src/utils/windowControlsOverlay.ts
+++ b/main/src/utils/windowControlsOverlay.ts
@@ -1,0 +1,147 @@
+import {
+  boundary,
+  decodeOptionalBoundary,
+  type BoundarySchema,
+} from '../../../shared/validation/boundaryDecoder';
+
+/**
+ * Window Controls Overlay (WCO) support for Windows and Linux.
+ *
+ * With `titleBarStyle: 'hidden'` + `titleBarOverlay`, the OS keeps drawing the
+ * minimise/maximise/close buttons in the corner — so Windows keeps Snap Layouts
+ * on maximise hover — and the rest of the title bar becomes page content. That
+ * is the direct analogue of macOS `hiddenInset`, which is why `WindowTitleBar`
+ * can render the same strip on all three platforms.
+ *
+ * The buttons stay OS-drawn, so their plate does not inherit our CSS. It has to
+ * be told the theme's colours via `titleBarOverlay.color` / `symbolColor` at
+ * window creation and re-told on every theme switch through
+ * `win.setTitleBarOverlay()`.
+ */
+
+/**
+ * Overlay height in DIPs. Matches `TITLE_BAR_STYLE.height` in
+ * `frontend/src/components/WindowTitleBar.tsx` so the strip is the same size on
+ * every platform; the system default is ~32px on Windows.
+ */
+export const WINDOW_CONTROLS_OVERLAY_HEIGHT = 38;
+
+/** Preference key holding the last colours the renderer derived from the theme. */
+export const WINDOW_CONTROLS_OVERLAY_COLORS_KEY = 'windowControlsOverlayColors';
+
+/**
+ * Passed to the renderer through `webPreferences.additionalArguments` so the
+ * preload can answer "is the overlay on?" synchronously, before first paint.
+ * The renderer must not re-derive the gate below: if it disagreed with the main
+ * process on Linux we would ship either a frameless window with no drag region
+ * or a doubled title bar.
+ */
+export const WINDOW_CONTROLS_OVERLAY_ARG = '--pane-window-controls-overlay';
+
+/** Explicit user override, checked before any platform detection. */
+const OVERRIDE_ENV_VAR = 'PANE_WINDOW_CONTROLS_OVERLAY';
+
+/**
+ * Desktop environments that draw client-side decorations, so a window without a
+ * server-side title bar still gets resize borders, shadows and snapping.
+ * Anything not on this list — bare window managers, tiling WMs, kiosk and
+ * remote sessions, or an unset `XDG_CURRENT_DESKTOP` — keeps the native frame.
+ */
+const CSD_DESKTOPS = new Set([
+  'gnome',
+  'gnome-classic',
+  'gnome-flashback',
+  'ubuntu',
+  'unity',
+  'kde',
+  'plasma',
+  'cinnamon',
+  'x-cinnamon',
+  'xfce',
+  'mate',
+  'pantheon',
+  'budgie',
+  'budgie-desktop',
+  'deepin',
+  'dde',
+  'lxqt',
+  'cosmic',
+]);
+
+/**
+ * `XDG_CURRENT_DESKTOP` is a colon-separated preference list ("ubuntu:GNOME"),
+ * so any token matching is enough. The two session variables are checked as
+ * fallbacks because some display managers only set one of the three.
+ */
+function detectsCsdDesktop(env: NodeJS.ProcessEnv): boolean {
+  const sources = [env.XDG_CURRENT_DESKTOP, env.XDG_SESSION_DESKTOP, env.DESKTOP_SESSION];
+
+  return sources.some((source) =>
+    (source ?? '')
+      .split(':')
+      .map((token) => token.trim().toLowerCase())
+      .some((token) => token.length > 0 && CSD_DESKTOPS.has(token))
+  );
+}
+
+/**
+ * Whether this process should hand the title bar to the page.
+ *
+ * macOS is excluded because it already has `hiddenInset`. Windows is always on.
+ * Linux is opt-out by desktop environment rather than opt-in by guesswork: WCO
+ * behaviour there is a property of the window manager, and the fallback (native
+ * frame plus `document.title`) is the behaviour that shipped in #475, so an
+ * unrecognised desktop loses nothing.
+ */
+export function shouldEnableWindowControlsOverlay(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv
+): boolean {
+  // Not an override the escape hatch below can reach: `hiddenInset` and the
+  // overlay are mutually exclusive, and macOS has no overlay to colour.
+  if (platform !== 'win32' && platform !== 'linux') return false;
+
+  const override = env[OVERRIDE_ENV_VAR];
+  if (override === '1' || override === 'true') return true;
+  if (override === '0' || override === 'false') return false;
+
+  return platform === 'win32' || detectsCsdDesktop(env);
+}
+
+export interface WindowControlsOverlayColors {
+  /** Plate behind the OS-drawn buttons. */
+  color: string;
+  /** The glyphs on those buttons. */
+  symbolColor: string;
+}
+
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+
+/**
+ * Electron hands these straight to Chromium's CSS colour parser, which accepts a
+ * narrower grammar than CSS itself (no space-separated `rgb()`, no `oklch()`).
+ * The renderer already normalises to `#rrggbb`; anything else is refused here
+ * rather than passed on to native code.
+ */
+const overlayHexColor: BoundarySchema<string> = {
+  decode(current) {
+    const value = boundary.string.decode(current).trim();
+    return HEX_COLOR.test(value) ? value.toLowerCase() : current.fail('expected #rrggbb color');
+  },
+};
+
+/** Decodes the overlay colour pair from an untrusted IPC or preference payload. */
+export const overlayColorsSchema = boundary.object({
+  color: overlayHexColor,
+  symbolColor: overlayHexColor,
+});
+
+/** Parses the persisted preference written by the theme bridge. */
+export function parseStoredOverlayColors(raw: string | null): WindowControlsOverlayColors | null {
+  if (!raw) return null;
+  try {
+    return decodeOptionalBoundary(JSON.parse(raw), overlayColorsSchema) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -26,6 +26,8 @@ type ElectronApiMockOptions = {
   initialConfig?: JsonObject;
   initialPreferences?: Record<string, string>;
   platform?: 'darwin' | 'linux' | 'win32';
+  /** Whether main handed the title bar to the page (Window Controls Overlay). */
+  windowControlsOverlayEnabled?: boolean;
   availableShells?: Array<Record<string, string>>;
   configReadDelayMs?: number;
   configGetFailures?: number;
@@ -338,6 +340,8 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         isFocused: () => Promise.resolve(true),
       },
       getPlatform: () => Promise.resolve(mockOptions.platform ?? 'linux'),
+      windowControlsOverlayEnabled: mockOptions.windowControlsOverlayEnabled === true,
+      setTitleBarOverlay: () => success(),
       getVersionInfo: () => success({
         version: 'test',
         current: 'test',

--- a/tests/window-title-bar.spec.ts
+++ b/tests/window-title-bar.spec.ts
@@ -47,14 +47,17 @@ const titleBarLabel = (page: Page) => page.getByTestId('window-title-bar-label')
 async function openDesktop(
   page: Page,
   platform: 'darwin' | 'win32' = 'darwin',
+  windowControlsOverlay = false,
 ): Promise<void> {
-  // The strip only exists on macOS (isMac reads navigator.platform), so pin the
-  // platform here instead of skipping the test everywhere else.
+  // macOS is detected from navigator.platform (isMac), so pin it here instead of
+  // skipping the test everywhere else. Windows and Linux instead ask the preload
+  // whether main gave the page the title bar, which is the flag below.
   await page.addInitScript((navigatorPlatform) => {
     Object.defineProperty(window.navigator, 'platform', { get: () => navigatorPlatform });
   }, platform === 'darwin' ? 'MacIntel' : 'Win32');
   await installElectronApiMock(page, {
     platform,
+    windowControlsOverlayEnabled: windowControlsOverlay,
     initialProjects: [project],
     initialSessions: [worktreeSession, mainRepoSession],
     initialUiState: { expandedProjects: [project.id] },
@@ -142,9 +145,9 @@ test.describe('window title bar', () => {
   });
 
   test('names the window itself, on platforms with no strip too', async ({ page }) => {
-    // Windows and Linux keep their native title bar, so document.title is the
-    // only place the pane name can reach them — plus every platform's taskbar
-    // and task switcher.
+    // A Linux desktop that fails the Window Controls Overlay gate keeps its
+    // native title bar, so document.title is the only place the pane name can
+    // reach it — plus every platform's taskbar and task switcher.
     await openDesktop(page, 'win32');
 
     await expect(page.getByTestId('window-title-bar')).toHaveCount(0);
@@ -160,6 +163,45 @@ test.describe('window title bar', () => {
     // Leaving the pane for Pane Chat releases the name again.
     await page.getByRole('button', { name: 'Pane Chat' }).first().click();
     await expect.poll(() => page.title()).toBe('Pane');
+  });
+
+  test('takes over the strip when the window controls overlay is on', async ({ page }) => {
+    await openDesktop(page, 'win32', true);
+
+    await expect(page.getByTestId('window-title-bar')).toBeVisible();
+    await page.getByRole('button', { name: worktreeSession.name, exact: true }).click();
+    await expect(titleBarLabel(page)).toHaveText(
+      `${project.name}·${worktreeSession.name}`,
+    );
+
+    const insets = await titleBarLabel(page).evaluate((label) => {
+      const bar = label.closest('[data-testid="window-title-bar"]');
+      if (!(bar instanceof HTMLElement)) return null;
+      const computed = getComputedStyle(bar);
+      return {
+        specifiedLeft: bar.style.paddingLeft,
+        specifiedRight: bar.style.paddingRight,
+        computedLeft: computed.paddingLeft,
+        computedRight: computed.paddingRight,
+        region: computed.getPropertyValue('-webkit-app-region'),
+      };
+    });
+
+    // The insets are driven by the overlay's own geometry, so the controls are
+    // cleared wherever the OS puts them — on the right, or on the left under an
+    // RTL system layout — at whatever width the current DPI makes them.
+    expect(insets?.specifiedLeft).toContain('titlebar-area-x');
+    expect(insets?.specifiedRight).toContain('titlebar-area-width');
+    // Never the macOS traffic-light inset, which is the wrong side here.
+    expect(insets?.computedLeft).not.toBe('88px');
+    expect(insets?.computedRight).not.toBe('88px');
+    // A browser reports no titlebar-area, which is the shape a window that lost
+    // the overlay would compute: the fallbacks have to leave a usable symmetric
+    // strip rather than collapse it.
+    expect(insets?.computedLeft).toBe('8px');
+    expect(insets?.computedRight).toBe('8px');
+    // With the sidebar's drag strips retired, this is the only drag surface left.
+    expect(insets?.region).toBe('drag');
   });
 
   test('keeps the whole strip draggable', async ({ page }) => {


### PR DESCRIPTION
## Description

Closes #476.

#472 gave macOS the centered `<project> · <pane name>` strip using the empty
`hiddenInset` title bar. Windows and Linux had no such strip — #475 gave them the
name through `document.title`, but the in-window title with its status pills was
still macOS-only, and the native frame sat above the themed app as a chunk of
unthemed OS chrome.

This adopts the Window Controls Overlay on Windows and Linux: `titleBarStyle:
'hidden'` plus `titleBarOverlay`. The OS keeps drawing the caption buttons — so
Windows keeps Snap Layouts on maximise hover, which `frame: false` would have
cost us — and the rest of the strip becomes `WindowTitleBar`, the same component
macOS already renders.

### Theme → overlay colour bridge (the bulk of it)

The overlay buttons are drawn outside the page, so no CSS reaches them. Electron
takes their plate and glyph colours as strings, which has to be re-supplied on
every theme switch.

Rather than 27 hand-maintained entries, the bridge reads the live cascade.
`ThemeProvider` is the single choke point every theme *and* high-contrast change
passes through, so one passive effect there — declared after the layout effect
that stamps the theme classes — resolves `--color-bg-primary` (the strip's own
background) and `--color-text-secondary` (the token the pane name uses) and posts
them to `win.setTitleBarOverlay()`. Any future theme is covered for free.

The tokens are read off a throwaway probe element rather than via
`getComputedStyle(root).getPropertyValue('--color-bg-primary')`. A custom
property's computed value is only `var()`-substituted, so it comes back in
whatever notation the theme authored (`#0d1117`, `rgb(13 17 23)`, a `var()`
chain); resolving them as real `background-color`/`color` declarations makes the
CSSOM serialize both as `rgb(r, g, b)`, one shape to parse. That matters because
Chromium's colour parser behind `titleBarOverlay` is narrower than CSS itself —
it takes hex and comma-separated `rgb()` and nothing else — so the renderer
normalises to `#rrggbb` and the main process refuses anything that isn't.

The pair is persisted as a user preference and read back at window creation, so a
returning user's window is *created* wearing their theme instead of flashing the
system-default grey plate until first paint.

### Side-aware insets

`WindowTitleBar` loses the `isMac()` gate. macOS keeps its 88px symmetric inset
(traffic lights). Windows and Linux drive theirs from the overlay's own geometry:

```
padding-left:  calc(env(titlebar-area-x, 0px) + 8px)
padding-right: max(8px, calc(100% - env(titlebar-area-x, 0px)
                            - env(titlebar-area-width, 100%) + 8px))
```

`titlebar-area-x` is where the page's share of the strip starts and
`titlebar-area-width` how far it runs, so the leftover on the far side is
everything the two do not cover. That clears the controls on the **right** under
LTR and on the **left** under an RTL system layout, at whatever width the current
DPI makes them, with no pixel constants anywhere. Chromium recomputes the env
values on DPI, RTL and maximise changes, and they live in the same CSS-pixel
space as the `100%` (which resolves against the full-width `pane-app-shell`
column) — including under the app's `uiScale` zoom, where both shrink together.

Deliberately **not** gated on `navigator.windowControlsOverlay.visible`: Chrome
exposes that API in ordinary contexts with `visible: false` (verified in the
Playwright run below), and this element carries the window's only drag region
once the native title bar is gone. It stays put in fullscreen for the same reason
the macOS strip always has.

### Linux gate — how it decides

WCO behaviour on Linux is a property of the window manager, so `main` decides and
the renderer never re-derives it (a disagreement would ship either a frameless
window with no drag region or a doubled title bar). The decision travels to the
renderer through `webPreferences.additionalArguments`, so it is available
synchronously in the preload before first paint rather than over async IPC.

`shouldEnableWindowControlsOverlay(platform, env)`:

1. **macOS** — always off; `hiddenInset` and the overlay are mutually exclusive.
2. **`PANE_WINDOW_CONTROLS_OVERLAY=1|true` / `0|false`** — explicit escape hatch,
   wins over everything below.
3. **Windows** — always on.
4. **Linux** — on only when a desktop environment known to draw client-side
   decorations appears in `XDG_CURRENT_DESKTOP`, `XDG_SESSION_DESKTOP` or
   `DESKTOP_SESSION` (GNOME and its variants, Ubuntu, Unity, KDE/Plasma,
   Cinnamon, XFCE, MATE, Pantheon, Budgie, Deepin, LXQt, COSMIC).
   `XDG_CURRENT_DESKTOP` is a colon-separated preference list (`ubuntu:GNOME`),
   so any token matching is enough.
5. **Anything else** — bare and tiling window managers, kiosk and remote
   sessions, an unset `XDG_CURRENT_DESKTOP` — falls back to the native frame plus
   `document.title`, which is exactly the behaviour #475 shipped. An unrecognised
   desktop loses nothing.

### Also

- Overlay height pinned to 38 to match the macOS strip, instead of the ~32px
  system default.
- The two non-mac drag strips in `Sidebar.tsx` retire, since the real strip now
  exists. On a Linux desktop that takes the native-frame fallback this removes a
  12px drag affordance, but the native title bar there is still draggable.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally

## Critical Areas Modified

- [x] State management/IPC events — new `window:set-title-bar-overlay` channel

## Testing

**⚠️ Needs manual test on Windows + two Linux desktops.** This was written on
macOS, where win32/linux runtime behaviour cannot be exercised at all. Everything
below is types, Electron 41.10.3 docs, and renderer-level tests; none of it
proves the overlay itself renders.

Automated, all passing locally:

- `main/src/utils/windowControlsOverlay.test.ts` (12 tests) — the Linux gate
  across GNOME/`ubuntu:GNOME`/KDE/X-Cinnamon/XFCE/Pantheon/COSMIC, the fallbacks
  for `i3`/`sway:wlroots`/unset, the session-variable fallbacks, the env override
  in both directions, and the colour-pair decoder.
- `frontend/src/utils/titleBarOverlay.test.ts` (6 tests) — `toOverlayHex` over
  the legacy `rgb(r, g, b)` the CSSOM returns, hex, space-separated and
  percentage forms, alpha dropping, channel clamping, and rejection of
  `oklch()`/`color(srgb …)` which Electron would refuse.
- `tests/window-title-bar.spec.ts` — new case with the overlay on, asserting the
  strip renders on a non-mac platform, that the insets reference
  `titlebar-area-x`/`titlebar-area-width` rather than the macOS 88px, that the
  env fallbacks leave a usable symmetric strip, and that `-webkit-app-region` is
  still `drag`. Existing cases (rename tracking, main-repo pane, non-shifting
  pills, `document.title` on the native-frame fallback, whole-strip drag) all
  still pass.
- `pnpm typecheck`, `pnpm lint` (oxlint + anti-slop + knip + boundary
  conformance), `pnpm --filter frontend build`, `pnpm --filter main build`,
  `main run bundle:preload` (sandboxed-preload verification).
- Full Playwright suite: 112 passed, 1 pre-existing unrelated failure
  (`settings.spec.ts` remote host setup — fails identically on a clean tree).
  All 27 theme-screenshot cases pass.
- Frontend Vitest 266/266. Main Vitest matches the clean tree exactly (the 5
  failures there are the known `better-sqlite3` `NODE_MODULE_VERSION` mismatch,
  unrelated).

What a human still has to check, since nothing above can:

**Windows**
1. The strip renders, the caption buttons sit at the right end of it, and the
   pane name is clear of them.
2. Drag the strip to move the window; double-click it to maximise.
3. Hover maximise — Snap Layouts still appears.
4. Switch through several themes, light and dark, and confirm the button plate
   and glyphs follow immediately, with no grey block.
5. Restart with a non-default theme — the window should come up already themed.
6. Change display scaling to 150%/200% and confirm the title stays clear of the
   buttons.
7. Windows set to an RTL display language: the buttons move left and the inset
   must follow.
8. Toggle high contrast in Settings and confirm the plate follows that too.
9. Fullscreen and back.

**Linux — at least two desktops, ideally one allowlisted (GNOME/KDE) and one not
(a tiling WM)**
1. On the allowlisted desktop: strip renders, buttons drawn, drag and
   double-click work, resize borders still work, theme switching drives the
   plate.
2. On the non-allowlisted one: native title bar is intact and `document.title`
   still carries the pane name — i.e. unchanged from today.
3. `PANE_WINDOW_CONTROLS_OVERLAY=1` forces the overlay on the second desktop, and
   `=0` forces the native frame on the first.

**macOS** — regression check only; the mac path is unchanged apart from the 88px
inset moving from a Tailwind class to an inline style.

## Additional Notes

Not in scope, per the issue: `document.title` from #475 stays on every platform —
it is what names the window in the task switcher and taskbar, including on macOS
where the native strip is hidden.
