### PR TITLE
Animations that make Pane feel fast

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -838,7 +838,7 @@ function App() {
         <div className="pane-main-layout flex flex-1 min-h-0">
         <MainProcessLogger />
         <div
-          className="pane-sidebar-slot flex-shrink-0 overflow-hidden transition-[width] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]"
+          className="pane-sidebar-slot pane-reveal flex-shrink-0 overflow-hidden transition-[width] duration-reveal ease-out-strong"
           style={{ width: sidebarCollapsed ? '48px' : `${sidebarWidth}px` }}
         >
           <Sidebar

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -93,6 +93,10 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
       onClose={onClose}
       initialFocusRef={inputRef}
       size="md"
+      // Cmd+Shift+P is a hundred-times-a-day reflex. Anything between the
+      // keystroke and a focused input reads as the app being slow, not as
+      // polish, so the palette does not animate in.
+      instant
       showCloseButton={false}
       className="!max-h-[min(500px,80vh)]"
     >
@@ -159,7 +163,10 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                 aria-disabled={item.disabled}
                 tabIndex={-1}
                 className={cn(
-                  'w-full flex items-center justify-between px-4 py-2 text-sm transition-colors',
+                  // No transition on the row highlight either: it moves on every
+                  // arrow key, and a 150ms cross-fade means the selection is
+                  // always trailing the key you already pressed.
+                  'w-full flex items-center justify-between px-4 py-2 text-sm',
                   item.disabled
                     ? 'text-text-tertiary opacity-60 cursor-not-allowed'
                     : 'cursor-pointer',

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1772,7 +1772,7 @@ export const SessionView = memo(() => {
 
               {/* Right column: terminal at full height — outer wrapper clips, inner stays fixed width so xterm doesn't reflow */}
               <div
-                className={`pane-terminal-rail flex-shrink-0 overflow-hidden transition-[width] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] ${immersiveMode ? '' : 'border-l border-border-primary'}`}
+                className={`pane-terminal-rail pane-reveal flex-shrink-0 overflow-hidden transition-[width] duration-reveal ease-out-strong ${immersiveMode ? '' : 'border-l border-border-primary'}`}
                 style={{ width: immersiveMode ? '0px' : `${rightTerminalWidth}px` }}
               >
                 <div
@@ -1826,7 +1826,7 @@ export const SessionView = memo(() => {
                 {/* Bottom: persistent terminal (collapsible) */}
                 {defaultTerminalPanel && (
                   <div
-                    className="pane-terminal-dock flex-shrink-0 border-t border-border-primary transition-[height] duration-200"
+                    className="pane-terminal-dock pane-reveal flex-shrink-0 border-t border-border-primary transition-[height] duration-reveal ease-out-strong"
                     style={{ height: isTerminalCollapsed ? '32px' : `${terminalHeight}px` }}
                   >
                     {/* Terminal tab header with collapse toggle and pill shortcuts */}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -294,6 +294,8 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
         top: rect.bottom + 8,
         left: Math.min(left, maxLeft),
         zIndex: 10000,
+        // Hangs below the trigger; grow out of that corner.
+        transformOrigin: 'top left',
       });
     };
 

--- a/frontend/src/components/WindowTitleBar.tsx
+++ b/frontend/src/components/WindowTitleBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type CSSProperties } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 
 import { useNavigationStore } from '../stores/navigationStore';
 import { useSessionStore } from '../stores/sessionStore';
@@ -42,6 +42,38 @@ const OVERLAY_INSET_STYLE: CSSProperties = {
 const HEAD_ELLIPSIS_STYLE: CSSProperties = { direction: 'rtl' };
 const LTR_RUN_STYLE: CSSProperties = { direction: 'ltr', unicodeBidi: 'embed' };
 
+/**
+ * Which of `keys` appeared just now, as opposed to being here all along.
+ *
+ * The distinction is the whole point of animating these at all. A pill that
+ * arrives while you are watching the pane — the PR opened, the branch became
+ * mergeable — is a state change, and motion is how a state change stops being a
+ * thing you have to notice. A pill that is simply present because you switched
+ * to a pane that already had one is not news, and animating it would put motion
+ * on pane switching, which is the one thing this must not do.
+ *
+ * Keyed by `scope` (the pane): when that changes, everything counts as
+ * pre-existing.
+ */
+function useArrivedKeys(scope: string | null, keys: string[]): Set<string> {
+  const signature = keys.join('\u0000');
+  const [seen, setSeen] = useState({ scope, signature, arrived: new Set<string>() });
+
+  if (seen.scope !== scope || seen.signature !== signature) {
+    // Render-phase update: React re-renders immediately with the value below,
+    // so the commit that first paints a new pill already carries its class.
+    setSeen({
+      scope,
+      signature,
+      arrived: seen.scope === scope
+        ? new Set(keys.filter(key => !seen.signature.split('\u0000').includes(key)))
+        : new Set(),
+    });
+  }
+
+  return seen.scope === scope && seen.signature === signature ? seen.arrived : new Set();
+}
+
 interface WindowTitleBarProps {
   projects: Project[];
 }
@@ -80,6 +112,9 @@ export function WindowTitleBar({ projects }: WindowTitleBarProps) {
     };
   }, [windowTitle]);
 
+  const pills = title ? resolvePaneStatusPills(activeSession) : [];
+  const arrived = useArrivedKeys(activeSession?.id ?? null, pills.map(pill => pill.key));
+
   // macOS owns the strip through `hiddenInset`; Windows and Linux own it when
   // main enabled the overlay. Deliberately not gated on
   // `navigator.windowControlsOverlay.visible`: that reads false in plenty of
@@ -87,8 +122,6 @@ export function WindowTitleBar({ projects }: WindowTitleBarProps) {
   // only drag region once the native title bar is gone. It stays put in
   // fullscreen for the same reason the macOS strip always has.
   if (!isMac() && !isWindowControlsOverlayEnabled()) return null;
-
-  const pills = title ? resolvePaneStatusPills(activeSession) : [];
 
   return (
     <div
@@ -128,7 +161,9 @@ export function WindowTitleBar({ projects }: WindowTitleBarProps) {
                   key={pill.key}
                   variant={pill.variant}
                   size="sm"
-                  className="whitespace-nowrap px-1.5 py-0 text-[10px] leading-4"
+                  className={`whitespace-nowrap px-1.5 py-0 text-[10px] leading-4${
+                    arrived.has(pill.key) ? ' origin-left animate-title-pill-enter' : ''
+                  }`}
                   title={pill.tooltip}
                 >
                   {pill.label}

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -184,6 +184,9 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
         zIndex: 10000,
         width,
         maxWidth: `calc(100vw - ${ADD_TOOL_MENU_VIEWPORT_MARGIN * 2}px)`,
+        // Pinned under the button's left edge, so that corner is where the menu
+        // should look like it grew from.
+        transformOrigin: 'top left',
       });
     };
 

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -25,7 +25,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     children,
     ...props 
   }, ref) => {
-    const baseStyles = 'inline-flex items-center justify-center font-medium transition-all duration-normal focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-primary disabled:cursor-not-allowed disabled:opacity-50';
+    // `pane-press` carries the transition and the :active scale — see index.css.
+    // It also replaces the `transition-all` that used to live here, which
+    // animated layout properties off the compositor on every colour change.
+    const baseStyles = 'pane-press inline-flex items-center justify-center font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-primary disabled:cursor-not-allowed disabled:opacity-50';
     
     const variants = {
       primary: 'bg-interactive text-text-on-interactive hover:bg-interactive-hover focus:ring-interactive shadow-button hover:shadow-button-hover',
@@ -104,7 +107,7 @@ export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
     icon,
     ...props 
   }, ref) => {
-    const baseStyles = 'inline-flex items-center justify-center transition-all duration-normal focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-primary disabled:cursor-not-allowed disabled:opacity-50';
+    const baseStyles = 'pane-press inline-flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-bg-primary disabled:cursor-not-allowed disabled:opacity-50';
     
     const variants = {
       primary: 'bg-interactive text-text-on-interactive hover:bg-interactive-hover focus:ring-interactive',

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -349,6 +349,12 @@ export function Dropdown({
           )}
           style={{
             ...fixedStyle,
+            // Grow out of the trigger rather than out of thin air. The menu is
+            // anchored by whichever pair of edges `computePosition` pinned it
+            // with, so those edges are exactly where the trigger is — scaling
+            // from that corner is what makes the menu look like it came from the
+            // button you pressed instead of appearing over it.
+            transformOrigin: `${fixedStyle.bottom !== undefined ? 'bottom' : 'top'} ${fixedStyle.right !== undefined ? 'right' : 'left'}`,
             boxShadow: 'var(--shadow-dropdown-elevated), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
           }}
         >

--- a/frontend/src/components/ui/Dropdown.tsx
+++ b/frontend/src/components/ui/Dropdown.tsx
@@ -386,7 +386,13 @@ export function Dropdown({
                       disabled={item.disabled}
                       className={cn(
                         'w-full text-left px-3 py-2.5 rounded-sm',
-                        'transition-all duration-200 ease-out flex items-center gap-3',
+                        // Colours only, and fast. A menu row is highlighted by
+                        // running the pointer down the list, so anything slower
+                        // than about 100ms leaves the highlight visibly trailing
+                        // the cursor. `transition-all` also animated layout and
+                        // shadow properties off the compositor on every row the
+                        // pointer crossed.
+                        'transition-[color,background-color,border-color,box-shadow] duration-100 ease-out flex items-center gap-3',
                         'focus:outline-none focus:ring-2 focus:ring-focus-ring-subtle',
                         'min-h-[2.5rem] group relative',
                         item.disabled && 'opacity-50 cursor-not-allowed',
@@ -398,7 +404,7 @@ export function Dropdown({
                       {Icon && (
                         <div className="flex items-center justify-center w-5 h-5 flex-shrink-0">
                           <Icon className={cn(
-                            'w-4 h-4 transition-colors duration-200 ease-out',
+                            'w-4 h-4 transition-colors duration-100 ease-out',
                             'stroke-[1.5]',
                             item.iconColor || 'text-current'
                           )} />
@@ -408,13 +414,13 @@ export function Dropdown({
                       <div className="flex-1 min-w-0 py-0.5">
                         <div className={cn(
                           'text-sm font-medium leading-tight',
-                          'transition-colors duration-200 ease-out',
+                          'transition-colors duration-100 ease-out',
                           'group-hover:text-inherit'
                         )}>
                           {item.label}
                         </div>
                         {item.description && (
-                          <div className="text-xs text-text-tertiary mt-1 leading-tight transition-colors duration-200 ease-out">
+                          <div className="text-xs text-text-tertiary mt-1 leading-tight transition-colors duration-100 ease-out">
                             {item.description}
                           </div>
                         )}
@@ -475,7 +481,7 @@ export function DropdownMenuItem({
       className={cn(
         'w-full text-left px-3 py-2.5 rounded-sm',
         'text-text-secondary hover:bg-interactive/10 hover:text-text-primary hover:shadow-[inset_0_1px_2px_rgba(0,0,0,0.05)]',
-        'transition-all duration-200 ease-out flex items-center gap-3',
+        'transition-[color,background-color,box-shadow] duration-100 ease-out flex items-center gap-3',
         'focus:outline-none focus:ring-2 focus:ring-focus-ring-subtle',
         'min-h-[2.5rem] group', // Better touch target and consistent height
         className
@@ -484,10 +490,10 @@ export function DropdownMenuItem({
     >
       {Icon && (
         <div className="flex items-center justify-center w-5 h-5 flex-shrink-0">
-          <Icon className="w-4 h-4 text-text-tertiary group-hover:text-current stroke-[1.5] transition-colors duration-200 ease-out" />
+          <Icon className="w-4 h-4 text-text-tertiary group-hover:text-current stroke-[1.5] transition-colors duration-100 ease-out" />
         </div>
       )}
-      <span className="text-sm font-medium group-hover:text-inherit transition-colors duration-200 ease-out">{label}</span>
+      <span className="text-sm font-medium group-hover:text-inherit transition-colors duration-100 ease-out">{label}</span>
     </button>
   );
 }

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -18,6 +18,14 @@ export interface ModalProps {
   ariaLabel?: string;
   initialFocusRef?: React.RefObject<HTMLElement | null>;
   restoreFocusOnClose?: boolean;
+  /**
+   * Opens with no entrance animation at all. Set it on a surface reached by
+   * keyboard dozens or hundreds of times a day — the command palette — where an
+   * entrance is not polish, it is the gap between pressing the shortcut and
+   * being able to type. Raycast's palette has no open animation for exactly
+   * this reason.
+   */
+  instant?: boolean;
 }
 
 function canReceiveFocus(element: HTMLElement | null): element is HTMLElement {
@@ -38,6 +46,7 @@ export const Modal: React.FC<ModalProps> = ({
   ariaLabel,
   initialFocusRef,
   restoreFocusOnClose = true,
+  instant = false,
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
   const openerRef = useRef<HTMLElement | null>(null);
@@ -78,7 +87,12 @@ export const Modal: React.FC<ModalProps> = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-modal-backdrop bg-modal-overlay backdrop-blur-sm animate-modal-overlay-enter" />
+        <Dialog.Overlay
+          className={cn(
+            'fixed inset-0 z-modal-backdrop bg-modal-overlay backdrop-blur-sm',
+            !instant && 'animate-modal-overlay-enter',
+          )}
+        />
         <Dialog.Content
           ref={contentRef}
           aria-modal="true"
@@ -110,7 +124,7 @@ export const Modal: React.FC<ModalProps> = ({
             <div
               className={cn(
                 'relative bg-bg-primary rounded-modal shadow-modal w-full max-h-[calc(100vh-2rem)] overflow-hidden flex flex-col',
-                'animate-modal-enter',
+                !instant && 'animate-modal-enter',
                 className,
               )}
             >

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -78,7 +78,7 @@ export const Modal: React.FC<ModalProps> = ({
   return (
     <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-modal-backdrop bg-modal-overlay backdrop-blur-sm" />
+        <Dialog.Overlay className="fixed inset-0 z-modal-backdrop bg-modal-overlay backdrop-blur-sm animate-modal-overlay-enter" />
         <Dialog.Content
           ref={contentRef}
           aria-modal="true"
@@ -109,7 +109,8 @@ export const Modal: React.FC<ModalProps> = ({
           <PortalContainerProvider value={portalContainer}>
             <div
               className={cn(
-                'relative bg-bg-primary rounded-modal shadow-modal w-full max-h-[calc(100vh-2rem)] overflow-hidden flex flex-col animate-fadeIn',
+                'relative bg-bg-primary rounded-modal shadow-modal w-full max-h-[calc(100vh-2rem)] overflow-hidden flex flex-col',
+                'animate-modal-enter',
                 className,
               )}
             >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -819,11 +819,11 @@ body.understory {
   transition-duration: var(--duration-press);
 }
 
-/* Marks a width/height reveal — the sidebar, the terminal rail — so reduced
-   motion can collapse it to its end state without hunting for the utilities. */
-.pane-reveal {
-  will-change: width, height;
-}
+/* `.pane-reveal` marks a width/height reveal — the sidebar slot, the terminal
+   rail, the terminal dock. It carries no styles of its own: the transition lives
+   on the element as Tailwind utilities, and this is the handle reduced motion
+   uses to collapse all three at once. Deliberately not `will-change`, which
+   cannot promote a layout property and would only cost. */
 
 /* ---------------------------------------------------------------------------
    Reduced motion

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -798,6 +798,85 @@ body.understory {
   background-color: transparent;
 }
 
+/* ---------------------------------------------------------------------------
+   Motion primitives
+   --------------------------------------------------------------------------- */
+
+/* Press feedback. The interface confirming it heard the pointer, before any
+   actual work has happened, is the cheapest way for an app to feel fast. The
+   press is quicker than the release on purpose: the acknowledgement lands under
+   the finger, and the settle back is allowed to be the leisurely half.
+   This also replaces `transition: all`, which animated layout properties off the
+   compositor every time a button changed colour. */
+.pane-press {
+  transition-property: background-color, border-color, color, box-shadow, opacity, transform;
+  transition-duration: var(--duration-press-release);
+  transition-timing-function: var(--ease-out-strong);
+}
+
+.pane-press:active:not(:disabled):not([aria-disabled='true']) {
+  transform: scale(0.97);
+  transition-duration: var(--duration-press);
+}
+
+/* Marks a width/height reveal — the sidebar, the terminal rail — so reduced
+   motion can collapse it to its end state without hunting for the utilities. */
+.pane-reveal {
+  will-change: width, height;
+}
+
+/* ---------------------------------------------------------------------------
+   Reduced motion
+
+   Fewer and gentler, not none. Opacity and colour still carry meaning and cost
+   nothing vestibular, so they stay; movement — translate, scale, the layout
+   reveals — collapses. Spinners and pulses stay too: they are how the app says
+   "busy", and removing them would remove information rather than motion.
+   --------------------------------------------------------------------------- */
+
+@keyframes pane-reduced-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* No scale under the pointer; the colour change still confirms the press. */
+  .pane-press:active:not(:disabled):not([aria-disabled='true']) {
+    transform: none;
+  }
+
+  /* Reveals jump to their end state instead of sweeping the layout across. */
+  .pane-reveal {
+    transition-duration: 1ms !important;
+  }
+
+  /* Entrances keep their fade and drop the travel. */
+  .animate-dropdown-enter,
+  .animate-dropdown-enter-up,
+  .animate-modal-enter,
+  .animate-title-pill-enter {
+    animation: pane-reduced-fade var(--duration-100) linear;
+  }
+
+  /* Decorative loops that translate. The bar and the accent stay visible; only
+     the sweep stops. */
+  .animate-slide-progress,
+  .animate-status-working {
+    animation: none;
+  }
+
+  /* The typing indicator keeps its colour cycle and loses the scale pulse. */
+  .animate-typing-dot {
+    animation: typing-dots-color 1.5s ease-in-out infinite;
+  }
+}
+
+@keyframes typing-dots-color {
+  0%, 20% { color: rgb(96 165 250); }
+  50% { color: rgb(167 139 250); }
+  100% { color: rgb(96 165 250); }
+}
+
 /* Custom animations for the working indicator */
 @keyframes slide-progress {
   0% {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -987,21 +987,6 @@ body.understory {
 }
 
 /* Custom animations for UX improvements */
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-.animate-fadeIn {
-  animation: fadeIn 0.3s ease-out;
-}
-
 @keyframes slideDown {
   0% {
     opacity: 0;

--- a/frontend/src/styles/tokens/effects.css
+++ b/frontend/src/styles/tokens/effects.css
@@ -97,6 +97,25 @@
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-back-out: cubic-bezier(0.175, 0.885, 0.32, 1.275);
   --ease-dropdown: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+  /* Interface motion curves. The built-in easings above are too weak to read as
+     deliberate at the durations Pane can afford, so anything that enters, leaves
+     or reveals uses these: they dump most of their distance in the first third,
+     which is what makes a short animation feel like a fast response rather than
+     a slow one. Ease-in is deliberately absent from this set — it delays the
+     frames the user is watching. */
+  --ease-out-strong: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
+
+  /* Motion durations. Pane sits on the critical path of someone's flow, so each
+     of these is a ceiling rather than a target and the shorter option wins every
+     tie. Surfaces reached by keyboard hundreds of times a day get none of them:
+     they do not animate at all. */
+  --duration-press: 90ms;           /* pointer down — has to feel instant */
+  --duration-press-release: 160ms;  /* and settle back on release */
+  --duration-enter: 160ms;          /* menus, popovers, small overlays */
+  --duration-reveal: 180ms;         /* sidebar and terminal rail width changes */
+  --duration-modal: 200ms;          /* dialogs */
   
   /* Z-Index Scale */
   --z-0: 0;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -219,6 +219,15 @@ export default {
         'fast': 'var(--duration-75)',
         'normal': 'var(--duration-150)',
         'slow': 'var(--duration-300)',
+        'press': 'var(--duration-press)',
+        'press-release': 'var(--duration-press-release)',
+        'enter': 'var(--duration-enter)',
+        'reveal': 'var(--duration-reveal)',
+        'modal': 'var(--duration-modal)',
+      },
+      transitionTimingFunction: {
+        'out-strong': 'var(--ease-out-strong)',
+        'in-out-strong': 'var(--ease-in-out-strong)',
       },
       zIndex: {
         'dropdown-backdrop': 'var(--z-dropdown-backdrop)',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -254,6 +254,8 @@ export default {
         'zoom-in-95': 'zoom-in-95 0.2s ease-out',
         'dropdown-enter': 'dropdown-enter 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
         'dropdown-enter-up': 'dropdown-enter-up 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+        'modal-enter': 'modal-enter var(--duration-modal) var(--ease-out-strong)',
+        'modal-overlay-enter': 'fade-in var(--duration-modal) var(--ease-out-strong)',
       },
       keyframes: {
         shimmer: {
@@ -276,6 +278,10 @@ export default {
         'zoom-in-95': {
           '0%': { transform: 'scale(0.95)' },
           '100%': { transform: 'scale(1)' },
+        },
+        'modal-enter': {
+          '0%': { opacity: 0, transform: 'scale(0.97)' },
+          '100%': { opacity: 1, transform: 'scale(1)' },
         },
         'dropdown-enter': {
           '0%': { 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -255,6 +255,7 @@ export default {
         'dropdown-enter': 'dropdown-enter var(--duration-enter) var(--ease-out-strong)',
         'dropdown-enter-up': 'dropdown-enter-up var(--duration-enter) var(--ease-out-strong)',
         'modal-enter': 'modal-enter var(--duration-modal) var(--ease-out-strong)',
+        'title-pill-enter': 'title-pill-enter var(--duration-150) var(--ease-out-strong)',
         'modal-overlay-enter': 'fade-in var(--duration-modal) var(--ease-out-strong)',
       },
       keyframes: {
@@ -282,6 +283,13 @@ export default {
         'modal-enter': {
           '0%': { opacity: 0, transform: 'scale(0.97)' },
           '100%': { opacity: 1, transform: 'scale(1)' },
+        },
+        // Grows out of the end of the pane name it hangs off (the element sets
+        // `transform-origin: left center`), so the pill reads as something the
+        // title gained rather than something dropped next to it.
+        'title-pill-enter': {
+          '0%': { opacity: 0, transform: 'translateX(-4px) scale(0.9)' },
+          '100%': { opacity: 1, transform: 'translateX(0) scale(1)' },
         },
         // Paired with `transform-origin` at the trigger (see Dropdown.tsx), so
         // the scale does most of the spatial work and the translate is only the

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -252,8 +252,8 @@ export default {
         'in': 'in 0.2s ease-out',
         'fade-in': 'fade-in 0.2s ease-out',
         'zoom-in-95': 'zoom-in-95 0.2s ease-out',
-        'dropdown-enter': 'dropdown-enter 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-        'dropdown-enter-up': 'dropdown-enter-up 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+        'dropdown-enter': 'dropdown-enter var(--duration-enter) var(--ease-out-strong)',
+        'dropdown-enter-up': 'dropdown-enter-up var(--duration-enter) var(--ease-out-strong)',
         'modal-enter': 'modal-enter var(--duration-modal) var(--ease-out-strong)',
         'modal-overlay-enter': 'fade-in var(--duration-modal) var(--ease-out-strong)',
       },
@@ -283,25 +283,16 @@ export default {
           '0%': { opacity: 0, transform: 'scale(0.97)' },
           '100%': { opacity: 1, transform: 'scale(1)' },
         },
+        // Paired with `transform-origin` at the trigger (see Dropdown.tsx), so
+        // the scale does most of the spatial work and the translate is only the
+        // small nudge that gives the entrance a direction.
         'dropdown-enter': {
-          '0%': { 
-            opacity: 0, 
-            transform: 'translateY(-8px) scale(0.96)' 
-          },
-          '100%': { 
-            opacity: 1, 
-            transform: 'translateY(0) scale(1)' 
-          },
+          '0%': { opacity: 0, transform: 'translateY(-4px) scale(0.96)' },
+          '100%': { opacity: 1, transform: 'translateY(0) scale(1)' },
         },
         'dropdown-enter-up': {
-          '0%': { 
-            opacity: 0, 
-            transform: 'translateY(8px) scale(0.96)' 
-          },
-          '100%': { 
-            opacity: 1, 
-            transform: 'translateY(0) scale(1)' 
-          },
+          '0%': { opacity: 0, transform: 'translateY(4px) scale(0.96)' },
+          '100%': { opacity: 1, transform: 'translateY(0) scale(1)' },
         },
       },
       ringColor: {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "a11y:scan": "playwright test tests/accessibility.spec.ts",
     "theme:contrast": "node scripts/check-theme-contrast.mjs",
     "theme:screenshots": "playwright test -c playwright.themes.config.ts",
+    "anim:evidence": "playwright test -c playwright.anim.config.ts",
+    "anim:evidence:render": "node scripts/render-anim-evidence.mjs",
     "typecheck": "pnpm run -r typecheck",
     "postinstall": "electron-builder install-app-deps",
     "electron:rebuild": "pnpm exec electron-rebuild -f -w better-sqlite3-multiple-ciphers -m ./main",

--- a/playwright.anim.config.ts
+++ b/playwright.anim.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Animation evidence capture. Records one video per animated moment against the
+// Vite dev server with the Electron API mocked, so the before/after clips in the
+// PR are the same viewport, same fixtures, same interaction — only the motion
+// code differs. Run it once on the pre-change commit and once after.
+//
+// Only the renderer is needed here, so this config starts Vite directly instead
+// of `pnpm electron-dev`, and on its own port so it never fights another
+// worktree's dev server.
+const PORT = Number.parseInt(process.env.PANE_ANIM_PORT ?? '4531', 10);
+const PHASE = process.env.PANE_ANIM_PHASE ?? 'before';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: ['**/anim-evidence.spec.ts'],
+  timeout: 90 * 1000,
+  expect: { timeout: 15000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  outputDir: `tmp/anim-evidence/raw/${PHASE}`,
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    viewport: { width: 1280, height: 800 },
+    video: { mode: 'on', size: { width: 1280, height: 800 } },
+    trace: 'off',
+    screenshot: 'off',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'pnpm run --filter frontend dev',
+    port: PORT,
+    reuseExistingServer: true,
+    timeout: 120 * 1000,
+    env: { PORT: String(PORT), VITE_PORT: String(PORT) },
+  },
+});

--- a/scripts/render-anim-evidence.mjs
+++ b/scripts/render-anim-evidence.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Turns the raw Playwright recordings from `tests/anim-evidence.spec.ts` into the
+// before/after clips the animation PR embeds: each one trimmed to its moment,
+// cropped to the surface that moves, and written as both an inline GIF and an
+// MP4. Run it after each capture phase:
+//
+//   PANE_ANIM_PHASE=before pnpm exec playwright test -c playwright.anim.config.ts
+//   node scripts/render-anim-evidence.mjs before
+//
+// Requires ffmpeg on PATH.
+import { execFile } from 'node:child_process';
+import { readFile, mkdir, readdir, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+
+const phase = process.argv[2] ?? 'before';
+const root = path.resolve('tmp/anim-evidence', phase);
+const outDir = path.join(root, 'clips');
+
+// Lead-in before the interaction, and how much of the aftermath to keep. The
+// capture runs Chromium's animation clock at 0.2x, so these are already in
+// slow-motion seconds.
+const LEAD_S = 0.7;
+const TAIL_S = { 'sidebar-collapse': 6.5, 'command-palette-arrow': 4.5, 'menu-row-highlight': 4.5, 'dialog-button-press': 3.8 };
+const DEFAULT_TAIL_S = 3.2;
+// Cap the GIF's long edge so the PR table stays readable and the files stay small.
+const GIF_MAX_EDGE = 640;
+const GIF_MIN_EDGE = 460;
+const MP4_MAX_EDGE = 1100;
+
+async function main() {
+  const { marks } = JSON.parse(await readFile(path.join(root, 'marks.json'), 'utf8'));
+  await mkdir(outDir, { recursive: true });
+
+  for (const mark of marks) {
+    const source = path.join(root, `${mark.slug}.webm`);
+    const start = Math.max(0, mark.markMs / 1000 - LEAD_S);
+    const duration = TAIL_S[mark.slug] ?? DEFAULT_TAIL_S;
+    const { x, y, width, height } = mark.region;
+    const crop = `crop=${width}:${height}:${x}:${y}`;
+    // Clips are captured at CSS-pixel resolution, so a tightly cropped menu comes
+    // out small. Clamp the long edge into a band that reads in a PR table without
+    // blowing the file up.
+    const longEdge = Math.max(width, height);
+    const sizeFilter = (edge) => (width >= height
+      ? `scale=${edge}:-2:flags=lanczos`
+      : `scale=-2:${edge}:flags=lanczos`);
+    const gifScale = sizeFilter(Math.min(GIF_MAX_EDGE, Math.max(GIF_MIN_EDGE, longEdge)));
+    const mp4Scale = sizeFilter(Math.min(MP4_MAX_EDGE, Math.max(GIF_MIN_EDGE, longEdge)));
+
+    const mp4 = path.join(outDir, `${mark.slug}.mp4`);
+    await run('ffmpeg', [
+      '-v', 'error', '-y', '-ss', String(start), '-i', source, '-t', String(duration),
+      '-vf', `${crop},${mp4Scale},format=yuv420p`,
+      '-c:v', 'libx264', '-preset', 'slow', '-crf', '26', '-movflags', '+faststart', mp4,
+    ]);
+
+    const palette = path.join(outDir, `${mark.slug}.palette.png`);
+    const gifFilters = `${crop},fps=20,${gifScale}`;
+    await run('ffmpeg', [
+      '-v', 'error', '-y', '-ss', String(start), '-i', source, '-t', String(duration),
+      '-vf', `${gifFilters},palettegen=max_colors=96:stats_mode=diff`, palette,
+    ]);
+    await run('ffmpeg', [
+      '-v', 'error', '-y', '-ss', String(start), '-i', source, '-t', String(duration),
+      '-i', palette,
+      '-lavfi', `${gifFilters}[v];[v][1:v]paletteuse=dither=bayer:bayer_scale=4:diff_mode=rectangle`,
+      path.join(outDir, `${mark.slug}.gif`),
+    ]);
+    await unlink(palette);
+    console.log(`rendered ${mark.slug} (${start.toFixed(2)}s +${duration}s, ${width}x${height})`);
+  }
+
+  const rendered = (await readdir(outDir)).filter((name) => name.endsWith('.gif'));
+  console.log(`\n${rendered.length} clips in ${outDir}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/render-anim-evidence.mjs
+++ b/scripts/render-anim-evidence.mjs
@@ -23,11 +23,15 @@ const outDir = path.join(root, 'clips');
 // capture runs Chromium's animation clock at 0.2x, so these are already in
 // slow-motion seconds.
 const LEAD_S = 0.7;
-const TAIL_S = { 'sidebar-collapse': 6.5, 'command-palette-arrow': 4.5, 'menu-row-highlight': 4.5, 'dialog-button-press': 3.8 };
+const TAIL_S = { 'sidebar-collapse': 5.4, 'command-palette-arrow': 4.5, 'menu-row-highlight': 4.5, 'dialog-button-press': 3.8 };
 const DEFAULT_TAIL_S = 3.2;
-// Cap the GIF's long edge so the PR table stays readable and the files stay small.
-const GIF_MAX_EDGE = 640;
-const GIF_MIN_EDGE = 460;
+// The GIF is what a reviewer actually sees inline in the PR table, so it is
+// tuned for a page that loads: capped resolution, 14fps, and a small palette.
+// The MP4 beside it is the full-quality version for anyone who wants to scrub.
+const GIF_MAX_EDGE = 520;
+const GIF_MIN_EDGE = 420;
+const GIF_FPS = 14;
+const GIF_COLORS = 64;
 const MP4_MAX_EDGE = 1100;
 
 async function main() {
@@ -58,15 +62,15 @@ async function main() {
     ]);
 
     const palette = path.join(outDir, `${mark.slug}.palette.png`);
-    const gifFilters = `${crop},fps=20,${gifScale}`;
+    const gifFilters = `${crop},fps=${GIF_FPS},${gifScale}`;
     await run('ffmpeg', [
       '-v', 'error', '-y', '-ss', String(start), '-i', source, '-t', String(duration),
-      '-vf', `${gifFilters},palettegen=max_colors=96:stats_mode=diff`, palette,
+      '-vf', `${gifFilters},palettegen=max_colors=${GIF_COLORS}:stats_mode=diff`, palette,
     ]);
     await run('ffmpeg', [
       '-v', 'error', '-y', '-ss', String(start), '-i', source, '-t', String(duration),
       '-i', palette,
-      '-lavfi', `${gifFilters}[v];[v][1:v]paletteuse=dither=bayer:bayer_scale=4:diff_mode=rectangle`,
+      '-lavfi', `${gifFilters}[v];[v][1:v]paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle`,
       path.join(outDir, `${mark.slug}.gif`),
     ]);
     await unlink(palette);

--- a/tests/anim-evidence.spec.ts
+++ b/tests/anim-evidence.spec.ts
@@ -1,0 +1,320 @@
+import { expect, test, type Browser, type Page } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { installElectronApiMock } from './electronApiMock';
+
+// Before/after evidence capture for the animation pass. Each moment gets its own
+// browser context so the video starts at a known instant, and each records the
+// offset at which the interaction begins so the clips can be trimmed to the
+// motion itself. Not part of any CI suite — driven by scripts/capture-anim-evidence.mjs.
+
+const PHASE = process.env.PANE_ANIM_PHASE ?? 'before';
+const OUT_DIR = path.resolve('tmp/anim-evidence', PHASE);
+const VIEWPORT = { width: 1280, height: 800 };
+// 5x slow motion: a 180ms transition becomes 900ms, which is ~22 frames of the
+// 25fps capture instead of 4.
+const SLOW_RATE = 0.2;
+
+const project = {
+  id: 1,
+  name: 'dcouple/pane',
+  path: '/tmp/pane',
+  active: true,
+  created_at: new Date(0).toISOString(),
+  updated_at: new Date(0).toISOString(),
+};
+
+const baseSession = {
+  prompt: 'evidence fixture',
+  status: 'stopped',
+  createdAt: new Date(0).toISOString(),
+  lastActivity: new Date(0).toISOString(),
+  output: [],
+  jsonMessages: [],
+  isRunning: false,
+  permissionMode: 'ignore',
+  projectId: project.id,
+  isFavorite: false,
+  toolType: 'none',
+  archived: false,
+};
+
+const sessions = [
+  { ...baseSession, id: 'anim-pane-a', name: 'scrub Sentry request bodies (TM-622)', worktreePath: '/tmp/pane/wt/a', displayOrder: 0 },
+  { ...baseSession, id: 'anim-pane-b', name: 'sidebar compact menu', worktreePath: '/tmp/pane/wt/b', displayOrder: 1 },
+  { ...baseSession, id: 'anim-pane-c', name: 'title bar overlay insets', worktreePath: '/tmp/pane/wt/c', displayOrder: 2 },
+  { ...baseSession, id: 'anim-pane-main', name: 'pane', worktreePath: '/tmp/pane', isMainRepo: true, displayOrder: 3 },
+];
+
+interface Region { x: number; y: number; width: number; height: number }
+
+interface Mark {
+  slug: string;
+  /** ms from the start of the recording to the moment the interaction fires. */
+  markMs: number;
+  note: string;
+  /** Viewport rectangle the clip should be cropped to, in CSS pixels. */
+  region: Region;
+}
+
+/** Pads a rectangle, clamps it to the viewport, and snaps it to even pixels (h264). */
+function frameRegion(box: Region, pad = 24): Region {
+  const left = Math.max(0, Math.floor(box.x - pad));
+  const top = Math.max(0, Math.floor(box.y - pad));
+  const right = Math.min(VIEWPORT.width, Math.ceil(box.x + box.width + pad));
+  const bottom = Math.min(VIEWPORT.height, Math.ceil(box.y + box.height + pad));
+  const even = (value: number) => value - (value % 2);
+  return { x: even(left), y: even(top), width: even(right - left), height: even(bottom - top) };
+}
+
+const FULL_VIEWPORT: Region = { x: 0, y: 0, ...VIEWPORT };
+
+const marks: Mark[] = [];
+
+async function openDesktop(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(window.navigator, 'platform', { get: () => 'MacIntel' });
+  });
+  await installElectronApiMock(page, {
+    platform: 'darwin',
+    analyticsConsentShown: true,
+    initialProjects: [project],
+    initialSessions: sessions,
+    initialUiState: { expandedProjects: [project.id] },
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await expect(page.locator('[data-testid="sidebar"]').first()).toBeVisible({ timeout: 20_000 });
+}
+
+/**
+ * Records one moment. `setup` runs at full speed; `action` runs with Chromium's
+ * animation clock slowed so a 200ms curve is legible frame by frame.
+ */
+async function capture(
+  browser: Browser,
+  slug: string,
+  note: string,
+  setup: (page: Page) => Promise<void>,
+  action: (page: Page) => Promise<void>,
+  region: (page: Page) => Promise<Region> = async () => FULL_VIEWPORT,
+  // Most regions are the surface the animation brings on screen, so they are
+  // measured once the motion settles. A moment that leaves the screen — a press
+  // that dismisses its own dialog — has to be measured up front instead.
+  measureRegion: 'after' | 'before' = 'after',
+): Promise<void> {
+  // The recording size has to match the viewport: Playwright pads a larger
+  // canvas rather than scaling the page into it, which would offset every crop.
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    recordVideo: { dir: path.join(OUT_DIR, 'raw', slug), size: VIEWPORT },
+  });
+  const startedAt = Date.now();
+  const page = await context.newPage();
+  try {
+    await openDesktop(page);
+    await setup(page);
+    await page.waitForTimeout(600);
+
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('Animation.enable');
+    await cdp.send('Animation.setPlaybackRate', { playbackRate: SLOW_RATE });
+    await page.waitForTimeout(250);
+
+    const early = measureRegion === 'before' ? await region(page) : null;
+    const markMs = Date.now() - startedAt;
+    await action(page);
+    await page.waitForTimeout(2500);
+    marks.push({ slug, markMs, note, region: early ?? await region(page) });
+  } finally {
+    const video = page.video();
+    await context.close();
+    if (video) await video.saveAs(path.join(OUT_DIR, `${slug}.webm`));
+  }
+}
+
+/** The bounding box of a locator, framed for the clip. */
+async function boxOf(page: Page, selector: string, pad = 24): Promise<Region> {
+  const box = await page.locator(selector).first().boundingBox();
+  return box ? frameRegion(box, pad) : FULL_VIEWPORT;
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('animation evidence', () => {
+  test.afterAll(async () => {
+    await mkdir(OUT_DIR, { recursive: true });
+    await writeFile(
+      path.join(OUT_DIR, 'marks.json'),
+      `${JSON.stringify({ viewport: VIEWPORT, marks }, null, 2)}\n`,
+    );
+  });
+
+  test('command-palette-open', async ({ browser }) => {
+    await capture(
+      browser,
+      'command-palette-open',
+      'Cmd+Shift+P opens the command palette',
+      async () => {},
+      async (page) => {
+        await page.keyboard.press('Meta+Shift+P');
+        await expect(page.getByPlaceholder('Search commands...')).toBeVisible();
+      },
+      (page) => boxOf(page, '[role="dialog"]', 48),
+    );
+  });
+
+  test('command-palette-arrow', async ({ browser }) => {
+    await capture(
+      browser,
+      'command-palette-arrow',
+      'Arrow keys move the selection through the command list',
+      async (page) => {
+        await page.keyboard.press('Meta+Shift+P');
+        await expect(page.getByPlaceholder('Search commands...')).toBeVisible();
+      },
+      async (page) => {
+        for (let i = 0; i < 6; i += 1) {
+          await page.keyboard.press('ArrowDown');
+          await page.waitForTimeout(220);
+        }
+      },
+      (page) => boxOf(page, '[role="listbox"]', 12),
+    );
+  });
+
+  test('sidebar-collapse', async ({ browser }) => {
+    await capture(
+      browser,
+      'sidebar-collapse',
+      'Collapsing and re-expanding the sidebar',
+      async () => {},
+      async (page) => {
+        await page.getByRole('button', { name: 'Collapse sidebar' }).click();
+        await page.waitForTimeout(2600);
+        await page.getByRole('button', { name: 'Expand sidebar' }).click();
+      },
+      async () => ({ x: 0, y: 0, width: 760, height: 800 }),
+    );
+  });
+
+  test('sidebar-menu-open', async ({ browser }) => {
+    await capture(
+      browser,
+      'sidebar-menu-open',
+      'The sidebar overflow menu opening from its trigger',
+      async () => {},
+      async (page) => {
+        await page.getByRole('button', { name: 'Sidebar menu' }).click();
+        await expect(page.getByRole('menu')).toBeVisible();
+      },
+      (page) => boxOf(page, '[role="menu"]', 52),
+    );
+  });
+
+  test('menu-row-highlight', async ({ browser }) => {
+    await capture(
+      browser,
+      'menu-row-highlight',
+      'Running the pointer down the menu rows',
+      async (page) => {
+        await page.getByRole('button', { name: 'Sidebar menu' }).click();
+        await expect(page.getByRole('menu')).toBeVisible();
+      },
+      async (page) => {
+        const items = page.getByRole('menu').getByRole('menuitem');
+        const count = await items.count();
+        for (let i = 0; i < count; i += 1) {
+          const box = await items.nth(i).boundingBox();
+          if (!box) continue;
+          await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+          await page.waitForTimeout(260);
+        }
+      },
+      (page) => boxOf(page, '[role="menu"]', 12),
+    );
+  });
+
+  test('new-pane-dialog', async ({ browser }) => {
+    await capture(
+      browser,
+      'new-pane-dialog',
+      'Opening the New Pane dialog',
+      async () => {},
+      async (page) => {
+        await page.getByRole('button', { name: `New pane in ${project.name}` }).click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+      },
+      (page) => boxOf(page, '[role="dialog"]', 48),
+    );
+  });
+
+  test('dialog-button-press', async ({ browser }) => {
+    await capture(
+      browser,
+      'dialog-button-press',
+      'Pressing and releasing the dialog’s primary button',
+      async (page) => {
+        await page.getByRole('button', { name: `New pane in ${project.name}` }).click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+      },
+      async (page) => {
+        const cancel = page.getByRole('dialog').getByRole('button', { name: 'Cancel' });
+        const box = await cancel.boundingBox();
+        if (!box) throw new Error('Cancel button has no box');
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.waitForTimeout(400);
+        await page.mouse.down();
+        await page.waitForTimeout(1400);
+        await page.mouse.up();
+      },
+      async (page) => {
+        const footer = await page.getByRole('dialog').getByRole('button', { name: 'Cancel' }).boundingBox();
+        return footer ? frameRegion({ ...footer, width: footer.width + 220 }, 44) : FULL_VIEWPORT;
+      },
+      'before',
+    );
+  });
+
+  test('title-bar-pill', async ({ browser }) => {
+    await capture(
+      browser,
+      'title-bar-pill',
+      'A pull-request pill arriving in the title bar',
+      async (page) => {
+        await page.getByRole('button', { name: sessions[0].name, exact: true }).click();
+        await expect(page.getByTestId('window-title-bar-label')).toBeVisible();
+      },
+      async (page) => {
+        await page.evaluate((update) => (
+          // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+          window as typeof window & {
+            __paneTestElectronMock: {
+              emitGitStatusUpdated: (sessionId: string, gitStatus: typeof update.gitStatus) => void;
+            };
+          }
+        ).__paneTestElectronMock.emitGitStatusUpdated(update.id, update.gitStatus),
+        {
+          id: sessions[0].id,
+          gitStatus: {
+            state: 'ahead',
+            ahead: 3,
+            isReadyToMerge: true,
+            prNumber: 481,
+            prState: 'OPEN',
+            prTitle: 'Animations that make Pane feel fast',
+          },
+        });
+        await expect(page.getByTestId('window-title-bar-pills')).toBeVisible();
+      },
+      // The strip runs the full window width; frame the name and the pills that
+      // land beside it rather than 1280px of empty drag region.
+      async (page) => {
+        const label = await page.getByTestId('window-title-bar-label').boundingBox();
+        return label
+          ? frameRegion({ x: label.x, y: 0, width: label.width + 210, height: 38 }, 12)
+          : FULL_VIEWPORT;
+      },
+    );
+  });
+});

--- a/tests/motion.spec.ts
+++ b/tests/motion.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test, type Page } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+// Guards the decisions in the animation pass that a screenshot cannot: that the
+// surfaces which must not animate still do not, that the ones which do use the
+// motion tokens rather than a hand-typed curve, and that reduced motion actually
+// takes the movement out.
+
+const project = {
+  id: 1,
+  name: 'dcouple/pane',
+  path: '/tmp/pane',
+  active: true,
+  created_at: new Date(0).toISOString(),
+  updated_at: new Date(0).toISOString(),
+};
+
+const session = {
+  id: 'motion-pane',
+  name: 'motion fixture',
+  prompt: 'motion fixture',
+  status: 'stopped',
+  createdAt: new Date(0).toISOString(),
+  lastActivity: new Date(0).toISOString(),
+  output: [],
+  jsonMessages: [],
+  isRunning: false,
+  permissionMode: 'ignore',
+  projectId: project.id,
+  isFavorite: false,
+  toolType: 'none',
+  archived: false,
+  worktreePath: '/tmp/pane/wt/a',
+  displayOrder: 0,
+};
+
+async function openDesktop(page: Page): Promise<void> {
+  await installElectronApiMock(page, {
+    analyticsConsentShown: true,
+    initialProjects: [project],
+    initialSessions: [session],
+    initialUiState: { expandedProjects: [project.id] },
+    activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await expect(page.locator('[data-testid="sidebar"]').first()).toBeVisible({ timeout: 20_000 });
+}
+
+test.describe('motion', () => {
+  test('the command palette opens with no entrance animation', async ({ page }) => {
+    await openDesktop(page);
+
+    await page.keyboard.press('ControlOrMeta+Shift+P');
+    const input = page.getByPlaceholder('Search commands...');
+    await expect(input).toBeVisible();
+
+    // A hundred-times-a-day keyboard surface: any entrance reads as lag, so the
+    // panel and its backdrop both have to come up on the frame the key fires.
+    const panelAnimation = await page.evaluate(() => {
+      const panel = document.querySelector('[aria-modal="true"] .rounded-modal');
+      return panel ? getComputedStyle(panel).animationName : null;
+    });
+    expect(panelAnimation).toBe('none');
+
+    // ...and the selected row is wherever the arrow keys put it, with no
+    // cross-fade trailing the keystroke.
+    const rowDuration = await page.evaluate(() => {
+      const row = document.querySelector('[role="option"]');
+      return row ? getComputedStyle(row).transitionDuration : null;
+    });
+    expect(rowDuration).toBe('0s');
+  });
+
+  test('a dialog opens on the shared motion tokens', async ({ page }) => {
+    await openDesktop(page);
+
+    await page.getByRole('button', { name: `New pane in ${project.name}` }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    const panel = await page.evaluate(() => {
+      const element = document.querySelector('[aria-modal="true"] .rounded-modal');
+      if (!element) return null;
+      const style = getComputedStyle(element);
+      return { name: style.animationName, duration: style.animationDuration, easing: style.animationTimingFunction };
+    });
+    expect(panel?.name).toBe('modal-enter');
+    expect(panel?.duration).toBe('0.2s');
+    expect(panel?.easing).toBe('cubic-bezier(0.23, 1, 0.32, 1)');
+  });
+
+  test('a menu grows from the corner it is pinned to', async ({ page }) => {
+    await openDesktop(page);
+
+    await page.getByRole('button', { name: 'Sidebar menu' }).click();
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+
+    // `position="bottom-right"`: the menu hangs below the trigger with its right
+    // edge aligned to it, so it has to scale out of its own top-right corner.
+    const origin = await menu.evaluate((element) => getComputedStyle(element).transformOrigin);
+    const box = await menu.boundingBox();
+    const [originX, originY] = origin.split(' ').map(Number.parseFloat);
+    expect(originY).toBe(0);
+    expect(originX).toBeCloseTo(box?.width ?? -1, 0);
+  });
+
+  test('buttons scale under the pointer, faster down than up', async ({ page }) => {
+    await openDesktop(page);
+
+    await page.getByRole('button', { name: `New pane in ${project.name}` }).click();
+    const cancel = page.getByRole('dialog').getByRole('button', { name: 'Cancel' });
+    await expect(cancel).toBeVisible();
+
+    const resting = await cancel.evaluate((element) => ({
+      transform: getComputedStyle(element).transform,
+      duration: getComputedStyle(element).transitionDuration,
+    }));
+    expect(resting.transform).toBe('none');
+    expect(resting.duration).toContain('0.16s');
+
+    const box = await cancel.boundingBox();
+    if (!box) throw new Error('Cancel button has no box');
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    try {
+      const pressed = await cancel.evaluate((element) => ({
+        transform: getComputedStyle(element).transform,
+        duration: getComputedStyle(element).transitionDuration,
+      }));
+      // matrix(0.97, 0, 0, 0.97, 0, 0)
+      expect(pressed.transform).toContain('0.97');
+      expect(pressed.duration).toContain('0.09s');
+    } finally {
+      await page.mouse.up();
+    }
+  });
+
+  test('reduced motion takes out the movement and keeps the fade', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await openDesktop(page);
+
+    // The sidebar reveal collapses to its end state instead of sweeping the
+    // whole window layout across.
+    const reveal = await page.locator('.pane-sidebar-slot').evaluate(
+      (element) => getComputedStyle(element).transitionDuration,
+    );
+    expect(reveal).toBe('0.001s');
+
+    // The menu still fades — reduced motion means gentler, not gone — but the
+    // travel and the scale are out.
+    await page.getByRole('button', { name: 'Sidebar menu' }).click();
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+    expect(await menu.evaluate((element) => getComputedStyle(element).animationName))
+      .toBe('pane-reduced-fade');
+
+    // And a real press no longer scales, though the colour change still
+    // confirms it.
+    await page.keyboard.press('Escape');
+    await page.getByRole('button', { name: `New pane in ${project.name}` }).click();
+    const cancel = page.getByRole('dialog').getByRole('button', { name: 'Cancel' });
+    await expect(cancel).toBeVisible();
+    const box = await cancel.boundingBox();
+    if (!box) throw new Error('Cancel button has no box');
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    try {
+      expect(await cancel.evaluate((element) => getComputedStyle(element).transform)).toBe('none');
+    } finally {
+      await page.mouse.up();
+    }
+  });
+});


### PR DESCRIPTION
Eight animated moments across Pane's daily-driver surfaces, worked through Emil
Kowalski's [find-animation-opportunities](https://github.com/emilkowalski/skills)
and [improve-animations](https://github.com/emilkowalski/skills) as doctrine, under
one rule that outranks the doctrine wherever they disagree: **the motion has to make
Pane feel faster, and anything that delays paint, blocks input, or puts something in
front of a pane switch is rejected on sight.**

Six of the eight are a deletion or a shortening; only two add motion that was not
there. That ratio is the point rather than an accident — on a tool you are inside all
day, the best animation is usually a shorter one, and sometimes it is none.

Every clip below plays at **0.2x**. Nothing in this branch takes longer than 200ms in
real time; at real speed a still frame of any of it shows nothing. Click a clip for the
full-resolution MP4.

## The pairs

| Moment | What changed | Values | Before | After |
| --- | --- | --- | --- | --- |
| **Command palette**<br>`Cmd+Shift+P` | Deleted. The palette inherited the dialog entrance and its rows cross-faded the selection on every arrow key. | `animation: none` on the panel and the backdrop; `transition: 0s` on the row highlight | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/command-palette-open.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/command-palette-open.gif" alt="command-palette-open before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/command-palette-open.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/command-palette-open.gif" alt="command-palette-open after"></a> |
| **Command palette**<br>arrowing the list | Deleted. The highlight now lands on the row you selected instead of easing towards it. | was `transition-colors` 150ms → none | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/command-palette-arrow.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/command-palette-arrow.gif" alt="command-palette-arrow before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/command-palette-arrow.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/command-palette-arrow.gif" alt="command-palette-arrow after"></a> |
| **Sidebar collapse**<br>and re-expand | Halved, and the curve turned around: it was an ease-in-out, so the slowest part was the beginning — the part you are watching for a response. | `transition-[width]` 300ms `cubic-bezier(0.4,0,0.2,1)` → **180ms** `cubic-bezier(0.23,1,0.32,1)` | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/sidebar-collapse.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/sidebar-collapse.gif" alt="sidebar-collapse before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/sidebar-collapse.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/sidebar-collapse.gif" alt="sidebar-collapse after"></a> |
| **Menu entrance**<br>sidebar overflow menu | Now grows out of the corner it is pinned to instead of its own centre, and finishes sooner. | `transform-origin` from the computed anchor; 200ms `cubic-bezier(0.25,0.46,0.45,0.94)` → **160ms** `cubic-bezier(0.23,1,0.32,1)`; travel 8px → 4px | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/sidebar-menu-open.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/sidebar-menu-open.gif" alt="sidebar-menu-open before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/sidebar-menu-open.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/sidebar-menu-open.gif" alt="sidebar-menu-open after"></a> |
| **Menu row highlight**<br>pointer down the rows | Halved and narrowed. At 200ms the highlight was visibly trailing the cursor by the third row. | `transition-all` 200ms → `transition-[color,background-color,border-color,box-shadow]` **100ms** | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/menu-row-highlight.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/menu-row-highlight.gif" alt="menu-row-highlight before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/menu-row-highlight.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/menu-row-highlight.gif" alt="menu-row-highlight after"></a> |
| **Dialog entrance**<br>New Pane | Shortened, and the backdrop now arrives with the panel instead of snapping on a frame ahead of it. | `scale(0.95)` 300ms `ease-out` → `scale(0.97)` **200ms** `cubic-bezier(0.23,1,0.32,1)`, backdrop on the same pair | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/new-pane-dialog.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/new-pane-dialog.gif" alt="new-pane-dialog before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/new-pane-dialog.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/new-pane-dialog.gif" alt="new-pane-dialog after"></a> |
| **Button press**<br>any `Button` / `IconButton` | Added. There was no `:active` state at all — press a button and the interface said nothing until the work finished. | `scale(0.97)`, **90ms** down / **160ms** back, `cubic-bezier(0.23,1,0.32,1)` | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/dialog-button-press.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/dialog-button-press.gif" alt="dialog-button-press before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/dialog-button-press.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/dialog-button-press.gif" alt="dialog-button-press after"></a> |
| **Title-bar status pill**<br>PR opens / becomes mergeable | Added, and only when the pill *arrives* — switching to a pane that already has one does not animate. | opacity + `translateX(-4px) scale(0.9)`, **150ms** `cubic-bezier(0.23,1,0.32,1)`, `transform-origin: left` | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/title-bar-pill.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/before/clips/title-bar-pill.gif" alt="title-bar-pill before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/title-bar-pill.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-feel-fast/after/clips/title-bar-pill.gif" alt="title-bar-pill after"></a> |

<sub>Before clips come from `b2cd4f9`, the branch point; after clips from the tip.
Same fixtures, same 1280x800 viewport, same interaction — only the motion code differs.
Sources and the capture manifest live on
[`anim-evidence-feel-fast`](https://github.com/dcouple/Pane/tree/anim-evidence-feel-fast).</sub>

## What is behind the numbers

Pane had eight easing tokens and none of them were usable for interface motion: the
`--ease-out` in `effects.css` is Tailwind's `cubic-bezier(0, 0, 0.2, 1)`, too weak to
read as deliberate at the durations this app can afford, so components that wanted
something stronger hand-typed their own — `cubic-bezier(0.16, 1, 0.3, 1)` in
`InterceptorToast`, `cubic-bezier(0.25, 0.46, 0.45, 0.94)` in the dropdown keyframes.
The first commit adds `--ease-out-strong` / `--ease-in-out-strong` and a duration scale
named for the moment rather than the number — `press`, `press-release`, `enter`,
`reveal`, `modal` — with the ceiling written into the comment. Everything after that
spends those tokens; there are no new hand-typed curves in the branch.

`--ease-out-strong` is the reason the shortenings read as *faster* rather than merely
shorter. It dumps most of its distance in the first third, so by 60ms of the sidebar's
180ms the layout has visibly committed to its new shape and the rest is the tail
settling. The old ease-in-out spent its slowest frames at the start, which is exactly
where the user is looking for a response.

## Rejected

Restraint is part of this. Considered and deliberately not done:

- **Sliding indicator under the panel tabs** — Rejected: reached by `Cmd+1..9`, keyboard-initiated, 100+/day. That tier gets no animation, ever.
- **Crossfade on pane switching** — Rejected by the prime directive: motion in front of the work. It would put frames between asking for a pane and seeing it.
- **Animating the title-bar name across a pane switch** — Rejected: same. The name is how you confirm the switch landed; it should be correct on the first frame, not on the tenth.
- **Tooltip entrance fade** — Rejected: a tooltip already costs a 400ms delay, and Pane has no group-instant-follow, so every tooltip in a toolbar would pay the animation again. A fade here makes text later to read, not nicer. (Noted in passing: `Tooltip`'s `transition-opacity duration-150` is dead — the tooltip is positioned in a layout effect and never paints at opacity 0. Left alone; deleting dead CSS is not this branch's job.)
- **Stagger on the sidebar session list** — Rejected: it is the primary navigation surface and it is on screen constantly. A stagger delays reading the thing you opened the window to read.
- **Press feedback on sidebar rows and panel tabs** — Rejected: pressable, but they are navigation at high frequency, and a scale on every pane switch is motion in the one place this branch is trying to keep still.
- **`highlight-prompt`'s 2s flash** — Rejected: a documented, deliberate locate-flash on a rare action. Not re-litigating a settled decision.

## Reduced motion

The frontend had no `prefers-reduced-motion` handling anywhere before this — one match
in the whole package, in a scroll utility. The branch adds it, written the way the
setting is meant to work: **fewer and gentler, not zero.** Opacity and colour survive
because they carry meaning at no vestibular cost; the movement collapses — presses stop
scaling, the width reveals jump to their end state, entrances keep their fade and lose
their travel. Spinners and pulses stay, because they are how the app says "busy" and
removing them would remove information rather than motion. It is covered by a test.

## Testing

- `tests/motion.spec.ts` — five tests, all passing. The ones worth having are the negative ones: the palette's panel asserts `animation-name: none` and its rows a `0s` transition, because "we deliberately did not animate this" is what a later refactor helpfully re-adds. The rest pin values to the tokens rather than to numbers typed twice, and the last drives a real press and a real menu under `prefers-reduced-motion: reduce`.
- `pnpm lint` (oxlint, eslint, advisory, boundary conformance, knip) — clean.
- `pnpm --filter frontend typecheck` — clean.
- `window-title-bar`, `dropdown-keyboard-nav`, `sidebar-compact`, `smoke`, `settings` — 53 passed, 1 failed: `settings.spec.ts` › *discards remote subview drafts and rebaselines a completed host setup*. **Pre-existing** — it fails identically with `frontend/` checked out at `b2cd4f9`, so it is not from this branch.

## Reproducing the clips

```
PANE_ANIM_PHASE=before pnpm anim:evidence && pnpm anim:evidence:render before
PANE_ANIM_PHASE=after  pnpm anim:evidence && pnpm anim:evidence:render after
```

The rig drops Chromium's animation clock to 0.2x through CDP immediately before each
interaction — and only then, so setup still runs at full speed — and records the
viewport rectangle each surface occupies once the motion settles, so the renderer can
crop to the thing that moved. Not wired into CI; it exists to produce this table.
Requires `ffmpeg`.

https://claude.ai/code/session_01WL3PtNCSp37SzLJQJ5QZk3
