### PR TITLE
fix: unblock quality lanes blocked by dependency resolution and Windows spawn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,11 @@
 public-hoist-pattern[]=*
 public-hoist-pattern[]=!better-sqlite3-multiple-ciphers
 public-hoist-pattern[]=!@homebridge/node-pty-prebuilt-multiarch
+# Do not publicly hoist minimatch. The wildcard above otherwise hoists a single
+# arbitrary version (minimatch@3.1.2, CJS-only) to the top level and marks each
+# consumer's nested copy as .ignored_minimatch. glob@11's ESM pattern.js does
+# `import { GLOBSTAR } from 'minimatch'`, which then resolves to 3.1.2 where
+# GLOBSTAR is not a named export, crashing the Playwright webServer (issue #469).
+# Excluding it keeps every consumer on its correct nested version (glob@11 -> 10.x).
+public-hoist-pattern[]=!minimatch
 auto-install-peers=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,11 +1,7 @@
 public-hoist-pattern[]=*
 public-hoist-pattern[]=!better-sqlite3-multiple-ciphers
 public-hoist-pattern[]=!@homebridge/node-pty-prebuilt-multiarch
-# Do not publicly hoist minimatch. The wildcard above otherwise hoists a single
-# arbitrary version (minimatch@3.1.2, CJS-only) to the top level and marks each
-# consumer's nested copy as .ignored_minimatch. glob@11's ESM pattern.js does
-# `import { GLOBSTAR } from 'minimatch'`, which then resolves to 3.1.2 where
-# GLOBSTAR is not a named export, crashing the Playwright webServer (issue #469).
-# Excluding it keeps every consumer on its correct nested version (glob@11 -> 10.x).
+# Keep glob@11 on minimatch@10. Hoisting minimatch@3 breaks its named ESM imports
+# and crashes the Playwright web server (issue #469).
 public-hoist-pattern[]=!minimatch
 auto-install-peers=false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "electron-winstaller"
     ],
     "overrides": {
-      "prebuild-install>node-abi": "^4.33.0"
+      "prebuild-install>node-abi": "^4.33.0",
+      "d3-array": "^3.2.0"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "overrides": {
       "prebuild-install>node-abi": "^4.33.0",
-      "d3-array": "^3.2.0"
+      "d3-sankey>d3-array": "^3.2.0"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   prebuild-install>node-abi: ^4.33.0
-  d3-array: ^3.2.0
+  d3-sankey>d3-array: ^3.2.0
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3658,7 +3658,6 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
-    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   prebuild-install>node-abi: ^4.33.0
+  d3-array: ^3.2.0
 
 importers:
 
@@ -3657,6 +3658,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -3690,9 +3692,6 @@ packages:
   cytoscape@3.32.1:
     resolution: {integrity: sha512-dbeqFTLYEwlFg7UGtcZhCCG/2WayX72zK3Sq323CEX29CY81tYfVhw1MIdduCtpstB0cTOhJswWlM/OEB3Xp+Q==}
     engines: {node: '>=0.10'}
-
-  d3-array@2.12.1:
-    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -4666,9 +4665,6 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
-
-  internmap@1.0.1:
-    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
@@ -10295,10 +10291,6 @@ snapshots:
 
   cytoscape@3.32.1: {}
 
-  d3-array@2.12.1:
-    dependencies:
-      internmap: 1.0.1
-
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
@@ -10376,7 +10368,7 @@ snapshots:
 
   d3-sankey@0.12.3:
     dependencies:
-      d3-array: 2.12.1
+      d3-array: 3.2.4
       d3-shape: 1.3.7
 
   d3-scale-chromatic@3.1.0:
@@ -11553,8 +11545,6 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
-
-  internmap@1.0.1: {}
 
   internmap@2.0.3: {}
 

--- a/scripts/check-boundary-decoder-conformance.mjs
+++ b/scripts/check-boundary-decoder-conformance.mjs
@@ -11,16 +11,14 @@ const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 // shims (Node 24 refuses to spawn the Windows oxlint.cmd without a shell,
 // throwing EINVAL) and needs no shell, so it is safe on all platforms.
 const oxlintManifestPath = require.resolve("oxlint/package.json");
-const oxlintBin = join(dirname(oxlintManifestPath), require(oxlintManifestPath).bin.oxlint);
-const oxlint = process.execPath;
-const oxlintBaseArgs = [oxlintBin];
+const oxlintArgs = [join(dirname(oxlintManifestPath), require(oxlintManifestPath).bin.oxlint)];
 const config = join(root, ".oxlintrc.json");
 const primitives = [
   join(root, "shared", "validation", "boundaryDecoder.ts"),
   join(root, "packages", "runpane", "src", "boundaryDecoder.ts"),
 ];
 
-execFileSync(oxlint, [...oxlintBaseArgs, "--config", config, "--deny-warnings", ...primitives], {
+execFileSync(process.execPath, [...oxlintArgs, "--config", config, "--deny-warnings", ...primitives], {
   cwd: root,
   stdio: "pipe",
 });
@@ -38,7 +36,7 @@ try {
       "}",
     ].join("\n"),
   );
-  const result = spawnSync(oxlint, [...oxlintBaseArgs, "--config", config, "--deny-warnings", fixture], {
+  const result = spawnSync(process.execPath, [...oxlintArgs, "--config", config, "--deny-warnings", fixture], {
     cwd: root,
     encoding: "utf8",
   });

--- a/scripts/check-boundary-decoder-conformance.mjs
+++ b/scripts/check-boundary-decoder-conformance.mjs
@@ -1,17 +1,26 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const require = createRequire(import.meta.url);
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const oxlint = join(root, "node_modules", ".bin", process.platform === "win32" ? "oxlint.cmd" : "oxlint");
+// Resolve oxlint's real Node entry (its bin is a plain ESM shim) and invoke it
+// with the current Node executable. This avoids the platform-specific .bin
+// shims (Node 24 refuses to spawn the Windows oxlint.cmd without a shell,
+// throwing EINVAL) and needs no shell, so it is safe on all platforms.
+const oxlintManifestPath = require.resolve("oxlint/package.json");
+const oxlintBin = join(dirname(oxlintManifestPath), require(oxlintManifestPath).bin.oxlint);
+const oxlint = process.execPath;
+const oxlintBaseArgs = [oxlintBin];
 const config = join(root, ".oxlintrc.json");
 const primitives = [
   join(root, "shared", "validation", "boundaryDecoder.ts"),
   join(root, "packages", "runpane", "src", "boundaryDecoder.ts"),
 ];
 
-execFileSync(oxlint, ["--config", config, "--deny-warnings", ...primitives], {
+execFileSync(oxlint, [...oxlintBaseArgs, "--config", config, "--deny-warnings", ...primitives], {
   cwd: root,
   stdio: "pipe",
 });
@@ -29,7 +38,7 @@ try {
       "}",
     ].join("\n"),
   );
-  const result = spawnSync(oxlint, ["--config", config, "--deny-warnings", fixture], {
+  const result = spawnSync(oxlint, [...oxlintBaseArgs, "--config", config, "--deny-warnings", fixture], {
     cwd: root,
     encoding: "utf8",
   });


### PR DESCRIPTION
## Description

Fixes three independent environment blockers that prevented the quality baseline from being measured for #469. All three are dependency/tooling issues — no application behavior changes.

**1. d3-array version skew (blocked `pnpm build`)**

`d3-contour@4` imports `blur2` from `d3-array`, but `d3-sankey@0.12.3` declared `"1 - 2"` for d3-array, causing pnpm to hoist `d3-array@2.12.1` which doesn't export `blur2`. Added a pnpm override `"d3-array": "^3.2.0"` to deduplicate the tree. d3-sankey only uses `min`, `max`, `sum` — all unchanged between v2 and v3.

**2. minimatch hoisting (blocked unit tests + a11y)**

The repo's `public-hoist-pattern[]=*` caused `minimatch@3.1.2` (CJS-only, no named ESM exports) to be hoisted to top-level `node_modules`. `glob@11` imports `{ GLOBSTAR }` from `minimatch`, which resolved to the hoisted 3.x instead of its own nested `minimatch@10.x`. Added `public-hoist-pattern[]=!minimatch` to `.npmrc` so each consumer keeps its correctly versioned copy.

**3. Boundary conformance `.cmd` spawn on Windows (blocked `lint:ox:boundary-conformance`)**

`scripts/check-boundary-decoder-conformance.mjs` spawned `oxlint.cmd` via `spawnSync` without `shell: true`, which throws `EINVAL` on Node 24 + Windows. Instead of adding `shell: true` (which triggers DEP0190 and breaks on paths with spaces), resolved oxlint's actual JS entry point via `require.resolve` and spawned it with `node` directly. Cross-platform safe.

**Verification (Windows, Node 24.14.0, pnpm 10.19.0):**

| Lane | Result |
|---|---|
| `pnpm lint` (oxlint + eslint + anti-slop + boundary-conformance + knip) | pass, 0 findings |
| `pnpm typecheck` | pass, 0 errors |
| `pnpm build` (frontend + main + electron) | pass |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally

## Critical Areas Modified

None.

## Additional Notes

This is the first PR toward the zero-findings quality campaign (#469). It unblocks the baseline measurement so the remaining React Doctor, test, and a11y work can proceed with accurate numbers.