### PR TITLE
Animations that make Pane feel fast in the browser

### DIFF
--- a/frontend/remote.html
+++ b/frontend/remote.html
@@ -8,7 +8,10 @@
     <link rel="manifest" href="./remote-manifest.webmanifest" />
     <title>Remote Pane</title>
   </head>
-  <body class="light-rounded">
+  <!-- Both classes, and in this order: themes in this repo are a base plus a
+       delta (see THEME_CLASSES in src/contexts/themeContextValue.ts). Set here
+       as well as in bootstrap.tsx so the first paint is not the dark default. -->
+  <body class="light light-rounded">
     <div id="root"></div>
     <script type="module" src="/src/remote/main.tsx"></script>
   </body>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -825,6 +825,114 @@ body.understory {
    uses to collapse all three at once. Deliberately not `will-change`, which
    cannot promote a layout property and would only cost. */
 
+/* Press feedback for touch. `.pane-press` assumes a pointer that can hover, so
+   its colour half does the confirming and the scale is a bonus. A finger has no
+   hover state at all: the scale is the entire acknowledgement, and it competes
+   with the grey rectangle mobile browsers flash over a tapped control by
+   default — which is the wrong shape on a rounded button and arrives on the
+   browser's schedule, not the app's. So this suppresses that and takes the job
+   over. Same curve and durations as `.pane-press`; reduced motion is handled
+   there, since this composes with it rather than replacing it. */
+.pane-press-touch {
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+/* `.pane-joystick-return` marks the scroll joystick's thumb. The transition is
+   applied inline and only on release — never while a finger is down, where any
+   easing would put the thumb behind the finger — so this class exists purely as
+   the handle reduced motion switches off. */
+
+/* ---------------------------------------------------------------------------
+   Edge-anchored surfaces (Remote Pane PWA)
+
+   The drawer and the create-pane sheet are pinned to a screen edge, and the
+   whole of their entrance is the claim that they came from it. Offsets are
+   percentages rather than pixels so a surface starts exactly off its own edge
+   on any handset.
+
+   These are plain classes rather than Tailwind utilities because the create
+   sheet changes what it *is* at the `sm` breakpoint — a sheet rising off the
+   bottom of a phone, a centred dialog in a browser window — and that is a
+   different animation, not a different value. A responsive utility can swap a
+   duration; it cannot swap the keyframes.
+   --------------------------------------------------------------------------- */
+
+@keyframes pane-sheet-enter {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
+@keyframes pane-sheet-exit {
+  from { transform: translateY(0); }
+  to { transform: translateY(100%); }
+}
+
+@keyframes pane-drawer-enter {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes pane-drawer-exit {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+
+@keyframes pane-scrim-enter {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes pane-scrim-exit {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+/* The status dot while the PWA is trying to find its host again. A ring expands
+   out of the dot and fades, which reads as reaching rather than as an error —
+   the dot itself never moves or dims, so the state stays legible at a glance
+   and the motion is pure addition. Slow on purpose: this is ambient, not an
+   interaction, and the one thing it must not do is look urgent. */
+@keyframes pane-status-reaching {
+  0% { opacity: 0.55; transform: scale(1); }
+  70% { opacity: 0; transform: scale(2.6); }
+  100% { opacity: 0; transform: scale(2.6); }
+}
+
+/* Keyed off Radix's own `data-state` rather than a class the component has to
+   toggle: Radix holds the node mounted while a CSS animation on it is still
+   running, so the exit is the one animation React does not have to be told
+   about. */
+.pane-sheet[data-state='open'] { animation: pane-sheet-enter var(--duration-sheet) var(--ease-drawer); }
+.pane-sheet[data-state='closed'] { animation: pane-sheet-exit var(--duration-sheet-exit) var(--ease-drawer); }
+.pane-drawer[data-state='open'] { animation: pane-drawer-enter var(--duration-sheet) var(--ease-drawer); }
+.pane-drawer[data-state='closed'] { animation: pane-drawer-exit var(--duration-sheet-exit) var(--ease-drawer); }
+.pane-scrim[data-state='open'] { animation: pane-scrim-enter var(--duration-sheet) var(--ease-drawer); }
+.pane-scrim[data-state='closed'] { animation: pane-scrim-exit var(--duration-sheet-exit) var(--ease-drawer); }
+
+.pane-status-reaching { animation: pane-status-reaching 1.8s var(--ease-out-strong) infinite; }
+
+/* Above the `sm` breakpoint (640px — Tailwind's default, which is where the
+   create sheet's own `sm:` classes re-centre it) the sheet stops being a sheet.
+   It is a dialog in a browser window, so it gets exactly the entrance #480 gave
+   the desktop app's dialogs, and the centring translate has to be carried
+   through every keyframe or the animation would drop the surface into the
+   corner for its duration. */
+@media (min-width: 640px) {
+  @keyframes pane-sheet-enter-centered {
+    from { opacity: 0; transform: translate(-50%, -50%) scale(0.97); }
+    to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  }
+
+  @keyframes pane-sheet-exit-centered {
+    from { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+    to { opacity: 0; transform: translate(-50%, -50%) scale(0.97); }
+  }
+
+  .pane-sheet[data-state='open'] { animation: pane-sheet-enter-centered var(--duration-modal) var(--ease-out-strong); }
+  .pane-sheet[data-state='closed'] { animation: pane-sheet-exit-centered var(--duration-sheet-exit) var(--ease-out-strong); }
+}
+
 /* ---------------------------------------------------------------------------
    Reduced motion
 
@@ -854,8 +962,33 @@ body.understory {
   .animate-dropdown-enter,
   .animate-dropdown-enter-up,
   .animate-modal-enter,
-  .animate-title-pill-enter {
+  .animate-title-pill-enter,
+  .pane-sheet[data-state='open'],
+  .pane-drawer[data-state='open'] {
     animation: pane-reduced-fade var(--duration-100) linear;
+  }
+
+  /* Exits are the same bargain read backwards: the surface still leaves, it just
+     fades out where it stands instead of sliding off an edge. They keep their own
+     duration because something else — a focus restore, a re-render — is waiting
+     on the animation to end. */
+  .pane-sheet[data-state='closed'],
+  .pane-drawer[data-state='closed'] {
+    animation: pane-reduced-fade var(--duration-sheet-exit) linear reverse;
+  }
+
+  /* The joystick returns to centre without the travel. Snapping is what it did
+     before this pass; under reduced motion that is the correct behaviour, not a
+     regression. */
+  .pane-joystick-return {
+    transition-duration: 1ms !important;
+  }
+
+  /* "Still looking for the host" is information, so the reaching ring keeps
+     running — it just breathes in place instead of expanding. Same rule that
+     keeps the spinners and the typing dots. */
+  .pane-status-reaching {
+    animation: pane-status-breathe 1.8s ease-in-out infinite;
   }
 
   /* Decorative loops that translate. The bar and the accent stay visible; only
@@ -869,6 +1002,11 @@ body.understory {
   .animate-typing-dot {
     animation: typing-dots-color 1.5s ease-in-out infinite;
   }
+}
+
+@keyframes pane-status-breathe {
+  0%, 100% { opacity: 0.45; transform: scale(1); }
+  50% { opacity: 0.1; transform: scale(1); }
 }
 
 @keyframes typing-dots-color {

--- a/frontend/src/remote/RemotePwaApp.tsx
+++ b/frontend/src/remote/RemotePwaApp.tsx
@@ -383,7 +383,7 @@ export function RemotePwaApp() {
     <div className="flex h-dvh min-h-dvh w-full overflow-hidden bg-bg-primary text-text-primary">
       <Dialog.Root open={sidebarOpen} onOpenChange={setSidebarOpen}>
         <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 z-50 bg-black/60 md:hidden" />
+          <Dialog.Overlay className="pane-scrim fixed inset-0 z-50 bg-black/60 md:hidden" />
           <Dialog.Content
             aria-describedby={undefined}
             onCloseAutoFocus={(event) => {
@@ -393,7 +393,7 @@ export function RemotePwaApp() {
                 if (sidebarOpenerRef.current?.isConnected) sidebarOpenerRef.current.focus();
               });
             }}
-            className="fixed inset-y-0 left-0 z-50 w-[min(22rem,calc(100vw-2rem))] max-w-full shadow-2xl outline-none md:hidden"
+            className="pane-drawer fixed inset-y-0 left-0 z-50 w-[min(22rem,calc(100vw-2rem))] max-w-full shadow-2xl outline-none md:hidden"
           >
             <Dialog.Title className="sr-only">Remote panes</Dialog.Title>
             <RemoteSidebar

--- a/frontend/src/remote/bootstrap.tsx
+++ b/frontend/src/remote/bootstrap.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import '../index.css';
 import '@xterm/xterm/css/xterm.css';
+import { THEME_CLASSES } from '../contexts/themeContextValue';
 import { RemotePwaApp } from './RemotePwaApp';
+
+// The PWA has no theme switcher; it is fixed to light-rounded, which is what
+// `remote.html` declares and what its `theme-color` meta is set to. Taken from
+// `THEME_CLASSES` rather than written out, because every theme in this repo is
+// a base plus a delta — `light-rounded` is nine declarations that assume the
+// hundred-odd in `light` are already there — and naming only the delta is how
+// this surface ended up painting light borders onto the dark default palette.
+const REMOTE_THEME_CLASSES = THEME_CLASSES['light-rounded'];
 
 let mounted = false;
 
@@ -10,8 +19,8 @@ export function mountRemoteRenderer(): void {
   if (mounted) return;
   mounted = true;
 
-  document.documentElement.classList.add('light-rounded');
-  document.body.classList.add('light-rounded');
+  document.documentElement.classList.add(...REMOTE_THEME_CLASSES);
+  document.body.classList.add(...REMOTE_THEME_CLASSES);
 
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -213,7 +213,7 @@ export function RemoteCreateSessionDialog({
   return (
     <Dialog.Root open onOpenChange={(open) => { if (!open && !submitting) onClose(); }}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-[70] bg-black/65" />
+        <Dialog.Overlay className="pane-scrim fixed inset-0 z-[70] bg-black/65" />
         <Dialog.Content
           asChild
           aria-describedby={undefined}
@@ -235,7 +235,7 @@ export function RemoteCreateSessionDialog({
           <form
             onSubmit={handleSubmit}
             aria-busy={loadingBranches || submitting}
-            className="fixed inset-x-0 bottom-0 z-[71] flex max-h-[92dvh] w-full flex-col overflow-hidden rounded-t-xl border border-border-primary bg-surface-primary shadow-2xl outline-none sm:inset-auto sm:left-1/2 sm:top-1/2 sm:max-w-xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl"
+            className="pane-sheet fixed inset-x-0 bottom-0 z-[71] flex max-h-[92dvh] w-full flex-col overflow-hidden rounded-t-xl border border-border-primary bg-surface-primary shadow-2xl outline-none sm:inset-auto sm:left-1/2 sm:top-1/2 sm:max-w-xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl"
           >
             <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">{announcement}</div>
         <div className="flex shrink-0 items-center justify-between border-b border-border-primary px-5 py-4">

--- a/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
+++ b/frontend/src/remote/components/RemoteCreateSessionDialog.tsx
@@ -359,7 +359,7 @@ export function RemoteCreateSessionDialog({
                   className="peer sr-only"
                   aria-label="Start pinned"
                 />
-                <span className={`absolute top-1 h-5 w-5 rounded-full bg-text-primary transition-transform ${startPinned ? 'translate-x-6' : 'translate-x-1'}`} />
+                <span className={`absolute top-1 h-5 w-5 rounded-full bg-text-on-interactive shadow-sm ring-1 ring-border-primary transition-transform ${startPinned ? 'translate-x-6' : 'translate-x-1'}`} />
               </span>
             </label>
           </section>
@@ -381,7 +381,7 @@ export function RemoteCreateSessionDialog({
                   className="peer sr-only"
                   aria-label="Use worktree"
                 />
-                <span className={`absolute top-1 h-5 w-5 rounded-full bg-text-primary transition-transform ${useWorktree ? 'translate-x-6' : 'translate-x-1'}`} />
+                <span className={`absolute top-1 h-5 w-5 rounded-full bg-text-on-interactive shadow-sm ring-1 ring-border-primary transition-transform ${useWorktree ? 'translate-x-6' : 'translate-x-1'}`} />
               </span>
             </label>
           </section>

--- a/frontend/src/remote/components/RemotePanelTabs.tsx
+++ b/frontend/src/remote/components/RemotePanelTabs.tsx
@@ -124,7 +124,9 @@ export function RemotePanelTabs({
             tabIndex={selectedPanelId === panel.id || (!selectedPanelId && index === 0) ? 0 : -1}
             onClick={() => onSelectPanel(panel.id)}
             onKeyDown={(event) => handleTabKeyDown(event, index)}
-            className={`relative flex h-10 max-w-[min(12rem,55vw)] shrink-0 items-center gap-2 rounded-t-lg border px-3 text-sm font-medium shadow-sm transition-colors ${
+            // No transition: the selected tab is how you confirm the switch
+            // landed, so it has to be right on the frame you tapped it.
+            className={`relative flex h-10 max-w-[min(12rem,55vw)] shrink-0 items-center gap-2 rounded-t-lg border px-3 text-sm font-medium shadow-sm ${
               selectedPanelId === panel.id
                 ? 'border-border-primary border-b-bg-primary bg-bg-primary text-text-primary shadow-[0_-1px_0_rgba(255,255,255,0.04)_inset]'
                 : 'border-border-secondary bg-surface-primary text-text-secondary hover:border-border-primary hover:bg-surface-hover hover:text-text-primary'

--- a/frontend/src/remote/components/RemotePanelTabs.tsx
+++ b/frontend/src/remote/components/RemotePanelTabs.tsx
@@ -158,7 +158,7 @@ export function RemotePanelTabs({
         {showAddMenu && (
           <div
             id={addMenuId}
-            className="animate-dropdown-enter absolute right-0 top-full z-30 mt-2 w-[min(20rem,calc(100vw-1rem))] origin-top-right overflow-hidden rounded-lg border border-border-primary bg-surface-primary shadow-dropdown"
+            className="animate-dropdown-enter absolute right-0 top-full z-40 mt-2 w-[min(20rem,calc(100vw-1rem))] origin-top-right overflow-hidden rounded-lg border border-border-primary bg-surface-primary shadow-dropdown"
             role="menu"
             aria-label="Add tool"
             onKeyDown={handleMenuKeyDown}

--- a/frontend/src/remote/components/RemotePanelTabs.tsx
+++ b/frontend/src/remote/components/RemotePanelTabs.tsx
@@ -156,7 +156,7 @@ export function RemotePanelTabs({
         {showAddMenu && (
           <div
             id={addMenuId}
-            className="absolute right-0 top-full z-30 mt-2 w-[min(20rem,calc(100vw-1rem))] overflow-hidden rounded-lg border border-border-primary bg-surface-primary shadow-dropdown"
+            className="animate-dropdown-enter absolute right-0 top-full z-30 mt-2 w-[min(20rem,calc(100vw-1rem))] origin-top-right overflow-hidden rounded-lg border border-border-primary bg-surface-primary shadow-dropdown"
             role="menu"
             aria-label="Add tool"
             onKeyDown={handleMenuKeyDown}

--- a/frontend/src/remote/components/RemoteSessionList.tsx
+++ b/frontend/src/remote/components/RemoteSessionList.tsx
@@ -34,7 +34,7 @@ export function RemoteSessionList({
           <button
             type="button"
             onClick={onCreateTerminal}
-            className="mt-4 rounded-md bg-interactive px-4 py-2 text-sm font-semibold text-white hover:opacity-90"
+            className="pane-press pane-press-touch mt-4 rounded-md bg-interactive px-4 py-2 text-sm font-semibold text-text-on-interactive hover:bg-interactive-hover"
           >
             New Terminal
           </button>

--- a/frontend/src/remote/components/RemoteStatusBar.tsx
+++ b/frontend/src/remote/components/RemoteStatusBar.tsx
@@ -20,6 +20,12 @@ export function RemoteStatusBar({
   onOpenSidebar,
 }: RemoteStatusBarProps) {
   const connected = status === 'connected';
+  // `error` is a settled state and stays still; only the two states where the
+  // app is actively trying to reach the host get the ring.
+  const reaching = status === 'connecting' || status === 'reconnecting';
+  const dotColor = connected
+    ? 'bg-status-success'
+    : status === 'error' ? 'bg-status-error' : 'bg-status-warning';
   const statusLabel = getStatusLabel(status);
   const title = connected ? profile.label : `${statusLabel} ${profile.label}`;
   const [announcement, setAnnouncement] = useState('');
@@ -57,7 +63,10 @@ export function RemoteStatusBar({
         >
           <Menu className="h-5 w-5" aria-hidden="true" />
         </button>
-        <span aria-hidden="true" className={`flex h-2.5 w-2.5 shrink-0 rounded-full ${connected ? 'bg-status-success' : status === 'error' ? 'bg-status-error' : 'bg-status-warning'}`} />
+        <span aria-hidden="true" className="relative flex h-2.5 w-2.5 shrink-0 items-center justify-center">
+          {reaching && <span className={`pane-status-reaching absolute inset-0 rounded-full ${dotColor}`} />}
+          <span className={`relative h-2.5 w-2.5 rounded-full transition-colors duration-normal ease-out-strong ${dotColor}`} />
+        </span>
         <div className="min-w-0">
           <p className="truncate text-sm font-semibold text-text-primary">{title}</p>
           <p className="truncate text-xs text-text-tertiary">

--- a/frontend/src/remote/components/RemoteTerminalInputBar.tsx
+++ b/frontend/src/remote/components/RemoteTerminalInputBar.tsx
@@ -133,7 +133,7 @@ export function RemoteTerminalInputBar({
   return (
     <div className="relative shrink-0 border-t border-border-primary bg-surface-primary p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:hidden">
       {showShortcuts && (
-        <div className="absolute bottom-full left-2 right-2 mb-2 max-h-64 overflow-y-auto rounded-lg border border-border-primary bg-surface-primary shadow-dropdown">
+        <div className="animate-dropdown-enter-up absolute bottom-full left-2 right-2 mb-2 max-h-64 origin-bottom overflow-y-auto rounded-lg border border-border-primary bg-surface-primary shadow-dropdown">
           <div className="flex items-center justify-between border-b border-border-primary px-3 py-2">
             <span className="text-sm font-semibold text-text-primary">Terminal Shortcuts</span>
             <button

--- a/frontend/src/remote/components/RemoteTerminalInputBar.tsx
+++ b/frontend/src/remote/components/RemoteTerminalInputBar.tsx
@@ -206,7 +206,7 @@ export function RemoteTerminalInputBar({
             type="button"
             onClick={() => { void voice.toggle(); }}
             disabled={(!voice.isRecording && (disabled || voice.isTranscribing || !canUseSelectedVoiceMode))}
-            className={`absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-md border bg-bg-primary transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+            className={`pane-press pane-press-touch absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-md border bg-bg-primary disabled:cursor-not-allowed disabled:opacity-50 ${
               voice.isRecording
                 ? 'border-status-error/50 text-status-error hover:bg-status-error/10'
                 : 'border-border-secondary text-text-secondary hover:bg-surface-hover hover:text-text-primary'
@@ -227,7 +227,7 @@ export function RemoteTerminalInputBar({
           type="button"
           onClick={sendDraft}
           disabled={disabled || isVoiceBusy || !draft.trim()}
-          className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent-primary text-white hover:bg-accent-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="pane-press pane-press-touch flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent-primary text-white hover:bg-accent-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Send input"
           title="Send"
         >
@@ -240,7 +240,7 @@ export function RemoteTerminalInputBar({
           type="button"
           onClick={() => { void pasteClipboard(); }}
           disabled={disabled}
-          className="flex h-8 shrink-0 items-center gap-1 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+          className="pane-press pane-press-touch flex h-8 shrink-0 items-center gap-1 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Paste clipboard into input"
           title="Paste"
         >
@@ -254,7 +254,7 @@ export function RemoteTerminalInputBar({
             onClick={() => sendInput(control.data)}
             disabled={disabled}
             title={control.title}
-            className="h-8 shrink-0 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+            className="pane-press pane-press-touch h-8 shrink-0 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
           >
             {control.label}
           </button>
@@ -264,7 +264,7 @@ export function RemoteTerminalInputBar({
           onClick={onResetTerminal}
           disabled={disabled}
           title="Clear terminal scrollback"
-          className="h-8 shrink-0 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+          className="pane-press pane-press-touch h-8 shrink-0 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
         >
           Reset
         </button>
@@ -278,7 +278,7 @@ export function RemoteTerminalInputBar({
             setShowShortcuts(next);
           }}
           disabled={disabled}
-          className="flex h-8 shrink-0 items-center gap-1 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+          className="pane-press pane-press-touch flex h-8 shrink-0 items-center gap-1 rounded-md border border-border-secondary px-2.5 text-xs font-semibold text-text-secondary hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Command className="h-3.5 w-3.5" />
           Shortcuts

--- a/frontend/src/remote/components/RemoteTerminalInputBar.tsx
+++ b/frontend/src/remote/components/RemoteTerminalInputBar.tsx
@@ -133,7 +133,7 @@ export function RemoteTerminalInputBar({
   return (
     <div className="relative shrink-0 border-t border-border-primary bg-surface-primary p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:hidden">
       {showShortcuts && (
-        <div className="animate-dropdown-enter-up absolute bottom-full left-2 right-2 mb-2 max-h-64 origin-bottom overflow-y-auto rounded-lg border border-border-primary bg-surface-primary shadow-dropdown">
+        <div className="animate-dropdown-enter-up absolute bottom-full left-2 right-2 z-40 mb-2 max-h-64 origin-bottom overflow-y-auto rounded-lg border border-border-primary bg-surface-primary shadow-dropdown">
           <div className="flex items-center justify-between border-b border-border-primary px-3 py-2">
             <span className="text-sm font-semibold text-text-primary">Terminal Shortcuts</span>
             <button
@@ -227,7 +227,7 @@ export function RemoteTerminalInputBar({
           type="button"
           onClick={sendDraft}
           disabled={disabled || isVoiceBusy || !draft.trim()}
-          className="pane-press pane-press-touch flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-accent-primary text-white hover:bg-accent-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="pane-press pane-press-touch flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-interactive text-text-on-interactive hover:bg-interactive-hover disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Send input"
           title="Send"
         >

--- a/frontend/src/remote/components/RemoteTerminalScrollJoystick.tsx
+++ b/frontend/src/remote/components/RemoteTerminalScrollJoystick.tsx
@@ -19,6 +19,11 @@ export function RemoteTerminalScrollJoystick({
   onScrollToBottom,
 }: RemoteTerminalScrollJoystickProps) {
   const [offset, setOffset] = useState(0);
+  // True only between letting go and arriving back at centre. While a finger is
+  // down this must stay false: a transition on the thumb during a drag would put
+  // it behind the finger, which is the one thing a direct-manipulation control
+  // is not allowed to do.
+  const [returning, setReturning] = useState(false);
   const trackRef = useRef<HTMLInputElement | null>(null);
   const offsetRef = useRef(0);
   const activeRef = useRef(false);
@@ -33,6 +38,13 @@ export function RemoteTerminalScrollJoystick({
 
   const stopScrolling = useCallback(() => {
     activeRef.current = false;
+    // Only ever raises the flag, never lowers it: releasing a pointer capture
+    // fires `lostpointercapture`, so this runs a second time with the offset
+    // already zeroed, and a plain assignment there would cancel the return
+    // before it had a frame to start in. Movement is what lowers it again.
+    if (offsetRef.current !== 0) {
+      setReturning(true);
+    }
     offsetRef.current = 0;
     lineRemainderRef.current = 0;
     lastFrameTimeRef.current = null;
@@ -82,6 +94,7 @@ export function RemoteTerminalScrollJoystick({
     }
 
     offsetRef.current = clampedOffset;
+    setReturning(false);
     setOffset(clampedOffset);
     activeRef.current = true;
     lineRemainderRef.current = 0;
@@ -100,6 +113,7 @@ export function RemoteTerminalScrollJoystick({
     const rect = track.getBoundingClientRect();
     const nextOffset = clamp(clientY - (rect.top + rect.height / 2), -MAX_OFFSET, MAX_OFFSET);
     offsetRef.current = nextOffset;
+    setReturning(false);
     setOffset(nextOffset);
   }, []);
 
@@ -205,8 +219,13 @@ export function RemoteTerminalScrollJoystick({
         <div className="absolute bottom-4 left-1/2 top-4 w-px -translate-x-1/2 bg-white/15" />
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute left-1/2 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-surface-secondary/95 text-text-secondary shadow-md transition-colors"
-          style={{ transform: `translate(-50%, calc(-50% + ${offset}px))` }}
+          className="pane-joystick-return pointer-events-none absolute left-1/2 top-1/2 flex h-10 w-10 items-center justify-center rounded-full border border-white/15 bg-surface-secondary/95 text-text-secondary shadow-md transition-colors"
+          style={{
+            transform: `translate(-50%, calc(-50% + ${offset}px))`,
+            transition: returning
+              ? 'transform var(--duration-press-release) var(--ease-out-strong)'
+              : undefined,
+          }}
         >
           <ChevronsUpDown className="h-5 w-5" />
         </div>

--- a/frontend/src/styles/tokens/effects.css
+++ b/frontend/src/styles/tokens/effects.css
@@ -106,6 +106,12 @@
      frames the user is watching. */
   --ease-out-strong: cubic-bezier(0.23, 1, 0.32, 1);
   --ease-in-out-strong: cubic-bezier(0.77, 0, 0.175, 1);
+  /* Edge-anchored surfaces — the PWA's nav drawer and create-pane sheet — travel
+     a whole screen edge rather than a few pixels, and `--ease-out-strong` spends
+     that distance so fast it reads as a snap. This curve holds a little more of
+     the travel in the tail, which is what makes a large surface feel like it was
+     pulled into place instead of thrown. Only for things crossing a full edge. */
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
 
   /* Motion durations. Pane sits on the critical path of someone's flow, so each
      of these is a ceiling rather than a target and the shorter option wins every
@@ -116,6 +122,11 @@
   --duration-enter: 160ms;          /* menus, popovers, small overlays */
   --duration-reveal: 180ms;         /* sidebar and terminal rail width changes */
   --duration-modal: 200ms;          /* dialogs */
+  --duration-sheet: 240ms;          /* drawers and sheets crossing a screen edge */
+  /* Sheets and drawers leave faster than they arrive. The entrance is worth its
+     240ms because it tells you where the surface came from; on the way out you
+     have already decided and the only job left is to get out of the way. */
+  --duration-sheet-exit: 160ms;
   
   /* Z-Index Scale */
   --z-0: 0;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -224,10 +224,13 @@ export default {
         'enter': 'var(--duration-enter)',
         'reveal': 'var(--duration-reveal)',
         'modal': 'var(--duration-modal)',
+        'sheet': 'var(--duration-sheet)',
+        'sheet-exit': 'var(--duration-sheet-exit)',
       },
       transitionTimingFunction: {
         'out-strong': 'var(--ease-out-strong)',
         'in-out-strong': 'var(--ease-in-out-strong)',
+        'drawer': 'var(--ease-drawer)',
       },
       zIndex: {
         'dropdown-backdrop': 'var(--z-dropdown-backdrop)',

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "theme:contrast": "node scripts/check-theme-contrast.mjs",
     "theme:screenshots": "playwright test -c playwright.themes.config.ts",
     "anim:evidence": "playwright test -c playwright.anim.config.ts",
+    "anim:evidence:remote": "playwright test -c playwright.anim.remote.config.ts",
     "anim:evidence:render": "node scripts/render-anim-evidence.mjs",
     "typecheck": "pnpm run -r typecheck",
     "postinstall": "electron-builder install-app-deps",

--- a/playwright.anim.remote.config.ts
+++ b/playwright.anim.remote.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Animation evidence capture for the Remote Pane PWA — the browser-served
+// surface at `/remote.html`, not the Electron app that
+// `playwright.anim.config.ts` records. Same idea, one difference that matters:
+// the viewport is a phone, because that is the device this surface was built
+// for and most of its motion only exists below the `md` breakpoint.
+//
+// Chromium rather than WebKit: the rig drives the animation clock through CDP,
+// which no other engine exposes.
+const PORT = Number.parseInt(process.env.PANE_ANIM_PORT ?? '4532', 10);
+const PHASE = process.env.PANE_ANIM_PHASE ?? 'before';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: ['**/anim-evidence-remote.spec.ts'],
+  timeout: 120 * 1000,
+  expect: { timeout: 15000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  outputDir: `tmp/anim-evidence/raw/${PHASE}-remote`,
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    ...devices['Desktop Chrome'],
+    // iPhone 14/15 logical resolution. `hasTouch` matters: it is what makes the
+    // PWA's touch affordances behave the way they do on a real handset.
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    deviceScaleFactor: 2,
+    video: { mode: 'on', size: { width: 390, height: 844 } },
+    trace: 'off',
+    screenshot: 'off',
+  },
+  projects: [{ name: 'chromium' }],
+  webServer: {
+    command: 'pnpm run --filter frontend dev',
+    port: PORT,
+    reuseExistingServer: true,
+    timeout: 120 * 1000,
+    env: { PORT: String(PORT), VITE_PORT: String(PORT) },
+  },
+});

--- a/scripts/render-anim-evidence.mjs
+++ b/scripts/render-anim-evidence.mjs
@@ -23,7 +23,14 @@ const outDir = path.join(root, 'clips');
 // capture runs Chromium's animation clock at 0.2x, so these are already in
 // slow-motion seconds.
 const LEAD_S = 0.7;
-const TAIL_S = { 'sidebar-collapse': 5.4, 'command-palette-arrow': 4.5, 'menu-row-highlight': 4.5, 'dialog-button-press': 3.8 };
+const TAIL_S = {
+  'sidebar-collapse': 5.4, 'command-palette-arrow': 4.5, 'menu-row-highlight': 4.5, 'dialog-button-press': 3.8,
+  // Remote PWA moments (playwright.anim.remote.config.ts). Several of these are
+  // deliberately round trips — press and release, open and dismiss, drop and
+  // recover — so they run longer than a one-way entrance.
+  'pwa-key-press': 5.4, 'pwa-nav-drawer': 6.0, 'pwa-reconnect': 6.5,
+  'pwa-joystick-release': 5.0, 'pwa-panel-tab': 4.6,
+};
 const DEFAULT_TAIL_S = 3.2;
 // The GIF is what a reviewer actually sees inline in the PR table, so it is
 // tuned for a page that loads: capped resolution, 14fps, and a small palette.

--- a/scripts/render-anim-evidence.mjs
+++ b/scripts/render-anim-evidence.mjs
@@ -28,7 +28,7 @@ const TAIL_S = {
   // Remote PWA moments (playwright.anim.remote.config.ts). Several of these are
   // deliberately round trips — press and release, open and dismiss, drop and
   // recover — so they run longer than a one-way entrance.
-  'pwa-key-press': 5.4, 'pwa-nav-drawer': 6.0, 'pwa-reconnect': 6.5,
+  'pwa-key-press': 5.4, 'pwa-nav-drawer': 6.0, 'pwa-reconnect': 7.5,
   'pwa-joystick-release': 5.0, 'pwa-panel-tab': 4.6,
 };
 const DEFAULT_TAIL_S = 3.2;

--- a/tests/anim-evidence-remote.spec.ts
+++ b/tests/anim-evidence-remote.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Browser, type Page } from '@playwright/test';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { dropRemoteConnection, openConnectedRemotePwa } from './remotePwaMock';
+import { dropRemoteConnection, openConnectedRemotePwa, restoreRemoteConnection } from './remotePwaMock';
 
 // Before/after evidence capture for the Remote Pane PWA animation pass. Same rig
 // as `tests/anim-evidence.spec.ts`, pointed at `/remote.html` on a phone-sized
@@ -199,8 +199,12 @@ test.describe('remote pwa animation evidence', () => {
       async () => {},
       async (page) => {
         await dropRemoteConnection(page);
-        // The client backs off 1s before retrying; at 0.2x that is most of the clip.
-        await page.waitForTimeout(3000);
+        // Held down long enough for the reaching ring to read, then brought back,
+        // so the clip shows the whole arc rather than whatever happened to fall
+        // inside one backoff interval.
+        await page.waitForTimeout(4200);
+        await restoreRemoteConnection(page);
+        await page.waitForTimeout(800);
       },
       async () => ({ x: 0, y: 0, width: 390, height: 112 }),
     );

--- a/tests/anim-evidence-remote.spec.ts
+++ b/tests/anim-evidence-remote.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Browser, type Page } from '@playwright/test';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { openConnectedRemotePwa } from './remotePwaMock';
+import { dropRemoteConnection, openConnectedRemotePwa } from './remotePwaMock';
 
 // Before/after evidence capture for the Remote Pane PWA animation pass. Same rig
 // as `tests/anim-evidence.spec.ts`, pointed at `/remote.html` on a phone-sized
@@ -198,10 +198,7 @@ test.describe('remote pwa animation evidence', () => {
       'Losing the host and finding it again',
       async () => {},
       async (page) => {
-        await page.evaluate(() => {
-          // SAFETY: installed by the PWA mock harness for exactly this purpose.
-          (window as unknown as { __paneRemoteDropConnection: () => void }).__paneRemoteDropConnection();
-        });
+        await dropRemoteConnection(page);
         // The client backs off 1s before retrying; at 0.2x that is most of the clip.
         await page.waitForTimeout(3000);
       },

--- a/tests/anim-evidence-remote.spec.ts
+++ b/tests/anim-evidence-remote.spec.ts
@@ -1,0 +1,251 @@
+import { expect, test, type Browser, type Page } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { openConnectedRemotePwa } from './remotePwaMock';
+
+// Before/after evidence capture for the Remote Pane PWA animation pass. Same rig
+// as `tests/anim-evidence.spec.ts`, pointed at `/remote.html` on a phone-sized
+// viewport, because that is where this surface's motion lives. Not part of any
+// CI suite — it exists to produce the clips in the PR.
+
+const PHASE = process.env.PANE_ANIM_PHASE ?? 'before';
+const OUT_DIR = path.resolve('tmp/anim-evidence', `${PHASE}-remote`);
+const VIEWPORT = { width: 390, height: 844 };
+// 5x slow motion: a 240ms sheet becomes 1.2s, which is ~30 frames of the 25fps
+// capture instead of six.
+const SLOW_RATE = 0.2;
+
+interface Region { x: number; y: number; width: number; height: number }
+
+interface Mark {
+  slug: string;
+  /** ms from the start of the recording to the moment the interaction fires. */
+  markMs: number;
+  note: string;
+  /** Viewport rectangle the clip should be cropped to, in CSS pixels. */
+  region: Region;
+}
+
+/** Pads a rectangle, clamps it to the viewport, and snaps it to even pixels (h264). */
+function frameRegion(box: Region, pad = 16): Region {
+  const left = Math.max(0, Math.floor(box.x - pad));
+  const top = Math.max(0, Math.floor(box.y - pad));
+  const right = Math.min(VIEWPORT.width, Math.ceil(box.x + box.width + pad));
+  const bottom = Math.min(VIEWPORT.height, Math.ceil(box.y + box.height + pad));
+  const even = (value: number) => value - (value % 2);
+  return { x: even(left), y: even(top), width: even(right - left), height: even(bottom - top) };
+}
+
+const FULL_VIEWPORT: Region = { x: 0, y: 0, ...VIEWPORT };
+
+const marks: Mark[] = [];
+
+async function openRemote(page: Page): Promise<void> {
+  await openConnectedRemotePwa(page);
+  await expect(page.getByRole('button', { name: 'Open remote panes' })).toBeVisible({ timeout: 20_000 });
+  // The terminal hydrates from the mocked scrollback; wait for it so no clip
+  // catches the shell still painting.
+  await expect(page.getByRole('tab', { name: 'claude' })).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Records one moment. `setup` runs at full speed; `action` runs with Chromium's
+ * animation clock slowed so a 240ms curve is legible frame by frame.
+ */
+async function capture(
+  browser: Browser,
+  slug: string,
+  note: string,
+  setup: (page: Page) => Promise<void>,
+  action: (page: Page) => Promise<void>,
+  region: (page: Page) => Promise<Region> = async () => FULL_VIEWPORT,
+  // Most regions are the surface the animation brings on screen, so they are
+  // measured once the motion settles. A moment that leaves the screen has to be
+  // measured up front instead.
+  measureRegion: 'after' | 'before' = 'after',
+): Promise<void> {
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    hasTouch: true,
+    deviceScaleFactor: 2,
+    recordVideo: { dir: path.join(OUT_DIR, 'raw', slug), size: VIEWPORT },
+  });
+  const startedAt = Date.now();
+  const page = await context.newPage();
+  try {
+    await openRemote(page);
+    await setup(page);
+    await page.waitForTimeout(600);
+
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('Animation.enable');
+    await cdp.send('Animation.setPlaybackRate', { playbackRate: SLOW_RATE });
+    await page.waitForTimeout(250);
+
+    const early = measureRegion === 'before' ? await region(page) : null;
+    const markMs = Date.now() - startedAt;
+    await action(page);
+    await page.waitForTimeout(2500);
+    marks.push({ slug, markMs, note, region: early ?? await region(page) });
+  } finally {
+    const video = page.video();
+    await context.close();
+    if (video) await video.saveAs(path.join(OUT_DIR, `${slug}.webm`));
+  }
+}
+
+/** The bounding box of a locator, framed for the clip. */
+async function boxOf(page: Page, selector: string, pad = 16): Promise<Region> {
+  const box = await page.locator(selector).first().boundingBox();
+  return box ? frameRegion(box, pad) : FULL_VIEWPORT;
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('remote pwa animation evidence', () => {
+  test.afterAll(async () => {
+    await mkdir(OUT_DIR, { recursive: true });
+    await writeFile(
+      path.join(OUT_DIR, 'marks.json'),
+      `${JSON.stringify({ viewport: VIEWPORT, marks }, null, 2)}\n`,
+    );
+  });
+
+  test('pwa-key-press', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-key-press',
+      'Tapping the terminal control keys on a phone',
+      async () => {},
+      async (page) => {
+        for (const key of ['Esc', 'Tab', 'Enter']) {
+          await page.getByRole('button', { name: key, exact: true }).tap();
+          await page.waitForTimeout(900);
+        }
+      },
+      async (page) => {
+        const bar = await page.locator('.mt-2.flex.flex-wrap').first().boundingBox();
+        return bar ? frameRegion(bar, 10) : FULL_VIEWPORT;
+      },
+    );
+  });
+
+  test('pwa-create-sheet', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-create-sheet',
+      'The create-pane sheet arriving on a phone',
+      async (page) => {
+        await page.getByRole('button', { name: 'Open remote panes' }).tap();
+        await expect(page.getByRole('button', { name: /New pane in/ })).toBeVisible();
+      },
+      async (page) => {
+        await page.getByRole('button', { name: /New pane in/ }).tap();
+        await expect(page.getByRole('dialog', { name: /New Pane in/ })).toBeVisible();
+      },
+      async () => ({ x: 0, y: 300, width: 390, height: 544 }),
+    );
+  });
+
+  test('pwa-nav-drawer', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-nav-drawer',
+      'Opening and dismissing the pane drawer',
+      async () => {},
+      async (page) => {
+        await page.getByRole('button', { name: 'Open remote panes' }).tap();
+        await expect(page.getByRole('button', { name: 'scrub Sentry request bodies' })).toBeVisible();
+        await page.waitForTimeout(2200);
+        await page.keyboard.press('Escape');
+      },
+      async () => FULL_VIEWPORT,
+    );
+  });
+
+  test('pwa-add-tool-menu', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-add-tool-menu',
+      'The Add Tool menu opening from its trigger',
+      async () => {},
+      async (page) => {
+        await page.getByRole('button', { name: 'Add tool' }).tap();
+        await expect(page.getByRole('menu', { name: 'Add tool' })).toBeVisible();
+      },
+      async () => ({ x: 76, y: 120, width: 314, height: 480 }),
+    );
+  });
+
+  test('pwa-shortcuts-sheet', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-shortcuts-sheet',
+      'The terminal shortcuts sheet opening above the input bar',
+      async () => {},
+      async (page) => {
+        await page.getByRole('button', { name: 'Shortcuts' }).tap();
+        await expect(page.getByText('Terminal Shortcuts')).toBeVisible();
+      },
+      async () => ({ x: 0, y: 380, width: 390, height: 400 }),
+    );
+  });
+
+  test('pwa-reconnect', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-reconnect',
+      'Losing the host and finding it again',
+      async () => {},
+      async (page) => {
+        await page.evaluate(() => {
+          // SAFETY: installed by the PWA mock harness for exactly this purpose.
+          (window as unknown as { __paneRemoteDropConnection: () => void }).__paneRemoteDropConnection();
+        });
+        // The client backs off 1s before retrying; at 0.2x that is most of the clip.
+        await page.waitForTimeout(3000);
+      },
+      async () => ({ x: 0, y: 0, width: 390, height: 112 }),
+    );
+  });
+
+  test('pwa-joystick-release', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-joystick-release',
+      'Dragging the scroll joystick and letting go',
+      async () => {},
+      async (page) => {
+        const box = await page.locator('input[aria-label="Terminal scroll direction and speed"]').boundingBox();
+        if (!box) throw new Error('scroll joystick not found');
+        const cx = box.x + box.width / 2;
+        const cy = box.y + box.height / 2;
+        await page.mouse.move(cx, cy);
+        await page.mouse.down();
+        for (let step = 1; step <= 8; step += 1) {
+          await page.mouse.move(cx, cy - step * 6);
+          await page.waitForTimeout(60);
+        }
+        await page.waitForTimeout(700);
+        await page.mouse.up();
+      },
+      (page) => boxOf(page, 'input[aria-label="Terminal scroll direction and speed"]', 18),
+      'before',
+    );
+  });
+
+  test('pwa-panel-tab', async ({ browser }) => {
+    await capture(
+      browser,
+      'pwa-panel-tab',
+      'Tapping the other terminal tab',
+      async () => {},
+      async (page) => {
+        await page.getByRole('tab', { name: 'shell' }).tap();
+        await page.waitForTimeout(1400);
+        await page.getByRole('tab', { name: 'claude' }).tap();
+      },
+      async () => ({ x: 0, y: 108, width: 390, height: 100 }),
+    );
+  });
+});

--- a/tests/motion-remote.spec.ts
+++ b/tests/motion-remote.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { dropRemoteConnection, openConnectedRemotePwa } from './remotePwaMock';
+import { dropRemoteConnection, openConnectedRemotePwa, restoreRemoteConnection } from './remotePwaMock';
 
 // Guards the decisions in the Remote Pane PWA's animation pass. The clips in the
 // PR show what the motion looks like; they cannot stop it being undone. These
@@ -204,7 +204,7 @@ test.describe('remote pwa motion', () => {
     expect(motion.iterations).toBe('infinite');
 
     // And it stops once the host is found again, rather than becoming ambient.
-    await expect(page.getByText('MacBook Pro', { exact: true })).toBeVisible({ timeout: 10_000 });
+    await restoreRemoteConnection(page);
     await expect(ring).toHaveCount(0);
   });
 

--- a/tests/motion-remote.spec.ts
+++ b/tests/motion-remote.spec.ts
@@ -1,0 +1,264 @@
+import { expect, test } from '@playwright/test';
+import { dropRemoteConnection, openConnectedRemotePwa } from './remotePwaMock';
+
+// Guards the decisions in the Remote Pane PWA's animation pass. The clips in the
+// PR show what the motion looks like; they cannot stop it being undone. These
+// pin the parts a screenshot has nothing to say about: that the surfaces
+// deliberately left un-animated still are, that the ones that move spend the
+// shared tokens rather than a hand-typed curve, that the create sheet really
+// does become a different animation above `sm`, and that a finger dragging the
+// joystick is never easing.
+
+const PHONE = { width: 390, height: 844 };
+const BROWSER_WINDOW = { width: 1100, height: 800 };
+
+const EASE_OUT_STRONG = 'cubic-bezier(0.23, 1, 0.32, 1)';
+const EASE_DRAWER = 'cubic-bezier(0.32, 0.72, 0, 1)';
+
+test.describe('remote pwa motion', () => {
+  test.use({ viewport: PHONE, hasTouch: true });
+
+  test('the create sheet rises off the bottom edge on a phone', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+    await page.getByRole('button', { name: 'Open remote panes' }).tap();
+    await page.getByRole('button', { name: /New pane in/ }).tap();
+
+    const sheet = page.locator('.pane-sheet');
+    await expect(sheet).toBeVisible();
+    const motion = await sheet.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        name: style.animationName,
+        duration: style.animationDuration,
+        easing: style.animationTimingFunction,
+        state: element.getAttribute('data-state'),
+      };
+    });
+
+    expect(motion.state).toBe('open');
+    expect(motion.name).toBe('pane-sheet-enter');
+    expect(motion.duration).toBe('0.24s');
+    expect(motion.easing).toBe(EASE_DRAWER);
+
+    // The scrim is on the same pair, so the dim and the sheet are one event.
+    // Scoped to `data-state=open` because the drawer this was opened from is
+    // still playing its own exit, and its scrim is mounted until it finishes.
+    const scrim = await page.locator('.pane-scrim[data-state="open"]').evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { name: style.animationName, duration: style.animationDuration };
+    });
+    expect(scrim.name).toBe('pane-scrim-enter');
+    expect(scrim.duration).toBe('0.24s');
+  });
+
+  test('the pane drawer comes in from the left edge', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+    await page.getByRole('button', { name: 'Open remote panes' }).tap();
+
+    const drawer = page.locator('.pane-drawer');
+    await expect(drawer).toBeVisible();
+    const motion = await drawer.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { name: style.animationName, duration: style.animationDuration, easing: style.animationTimingFunction };
+    });
+    expect(motion.name).toBe('pane-drawer-enter');
+    expect(motion.duration).toBe('0.24s');
+    expect(motion.easing).toBe(EASE_DRAWER);
+  });
+
+  test('popovers grow from the control that opened them', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+
+    // Pinned to `right-0 top-full` under the `+`, so it grows from that corner
+    // rather than from its own centre.
+    await page.getByRole('button', { name: 'Add tool' }).tap();
+    const menu = page.getByRole('menu', { name: 'Add tool' });
+    await expect(menu).toBeVisible();
+    const menuMotion = await menu.evaluate((element: HTMLElement) => {
+      const style = getComputedStyle(element);
+      return {
+        name: style.animationName,
+        duration: style.animationDuration,
+        easing: style.animationTimingFunction,
+        origin: style.transformOrigin,
+        // `offsetWidth`, not the client rect: the entrance is still scaling the
+        // element, and a transformed rect would report 96% of the real width.
+        width: element.offsetWidth,
+      };
+    });
+    expect(menuMotion.name).toBe('dropdown-enter');
+    expect(menuMotion.duration).toBe('0.16s');
+    expect(menuMotion.easing).toBe(EASE_OUT_STRONG);
+    // Top-right corner: x is the menu's own width, y is 0.
+    expect(menuMotion.origin).toBe(`${menuMotion.width}px 0px`);
+
+    await page.keyboard.press('Escape');
+
+    // The shortcuts sheet is hinged along the edge it rests against.
+    await page.getByRole('button', { name: 'Shortcuts' }).tap();
+    const sheet = page.locator('.animate-dropdown-enter-up');
+    await expect(sheet).toBeVisible();
+    const sheetMotion = await sheet.evaluate((element: HTMLElement) => {
+      const style = getComputedStyle(element);
+      return {
+        name: style.animationName,
+        origin: style.transformOrigin,
+        expected: `${element.offsetWidth / 2}px ${element.offsetHeight}px`,
+      };
+    });
+    expect(sheetMotion.name).toBe('dropdown-enter-up');
+    expect(sheetMotion.origin).toBe(sheetMotion.expected);
+  });
+
+  test('the terminal control keys answer a press', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+
+    const enter = page.getByRole('button', { name: 'Enter', exact: true });
+    await expect(enter).toBeVisible();
+    const box = await enter.boundingBox();
+    if (!box) throw new Error('Enter key has no box');
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    try {
+      // The press rule has already taken hold — this is the 90ms press duration
+      // replacing the 160ms release one — but `transform` is mid-transition, so
+      // reading it now returns the value it is easing away from.
+      expect(await enter.evaluate((element) => getComputedStyle(element).transitionDuration))
+        .toContain('0.09s');
+
+      await page.waitForTimeout(150);
+      // matrix(0.97, 0, 0, 0.97, 0, 0)
+      expect(await enter.evaluate((element) => getComputedStyle(element).transform))
+        .toContain('0.97');
+    } finally {
+      await page.mouse.up();
+    }
+  });
+
+  test('the panel tab does not cross-fade the switch', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+
+    // Deliberately un-animated: the selected tab is the receipt for the switch,
+    // so it has to be right on the frame it was tapped. This is the kind of
+    // decision a later refactor helpfully re-adds.
+    const tab = page.getByRole('tab', { name: 'shell' });
+    await expect(tab).toBeVisible();
+    const transition = await tab.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { property: style.transitionProperty, duration: style.transitionDuration };
+    });
+    expect(transition.property).toBe('all');
+    expect(transition.duration).toBe('0s');
+  });
+
+  test('the joystick eases home but never under a finger', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+
+    const track = page.locator('input[aria-label="Terminal scroll direction and speed"]');
+    const thumb = page.locator('.pane-joystick-return');
+    await expect(thumb).toBeVisible();
+
+    const readThumb = () => thumb.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { property: style.transitionProperty, duration: style.transitionDuration };
+    });
+
+    const box = await track.boundingBox();
+    if (!box) throw new Error('joystick has no box');
+    const centreX = box.x + box.width / 2;
+    const centreY = box.y + box.height / 2;
+
+    await page.mouse.move(centreX, centreY);
+    await page.mouse.down();
+    await page.mouse.move(centreX, centreY - 40);
+    await page.waitForTimeout(50);
+
+    // The important assertion in this file. A transform transition here would
+    // put the thumb behind the finger dragging it.
+    expect((await readThumb()).property).not.toContain('transform');
+
+    await page.mouse.up();
+    await page.waitForTimeout(20);
+    const released = await readThumb();
+    expect(released.property).toBe('transform');
+    expect(released.duration).toBe('0.16s');
+  });
+
+  test('the status dot reaches only while it is actually reaching', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+    await expect(page.getByText('MacBook Pro', { exact: true })).toBeVisible();
+
+    // Connected is a settled state and stays still.
+    await expect(page.locator('.pane-status-reaching')).toHaveCount(0);
+
+    await dropRemoteConnection(page);
+
+    const ring = page.locator('.pane-status-reaching');
+    await expect(ring).toBeVisible();
+    const motion = await ring.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { name: style.animationName, iterations: style.animationIterationCount };
+    });
+    expect(motion.name).toBe('pane-status-reaching');
+    expect(motion.iterations).toBe('infinite');
+
+    // And it stops once the host is found again, rather than becoming ambient.
+    await expect(page.getByText('MacBook Pro', { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(ring).toHaveCount(0);
+  });
+
+  test('reduced motion takes out the travel and keeps the fade', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await openConnectedRemotePwa(page);
+
+    // The drawer still arrives — gentler, not gone — but without crossing the
+    // screen to get there.
+    await page.getByRole('button', { name: 'Open remote panes' }).tap();
+    const drawer = page.locator('.pane-drawer');
+    await expect(drawer).toBeVisible();
+    expect(await drawer.evaluate((element) => getComputedStyle(element).animationName))
+      .toBe('pane-reduced-fade');
+
+    // The joystick snaps back rather than easing.
+    await page.keyboard.press('Escape');
+    const thumb = page.locator('.pane-joystick-return');
+    expect(await thumb.evaluate((element) => getComputedStyle(element).transitionDuration))
+      .toBe('0.001s');
+
+    // A real press no longer scales, though the colour change still confirms it.
+    const enter = page.getByRole('button', { name: 'Enter', exact: true });
+    const box = await enter.boundingBox();
+    if (!box) throw new Error('Enter key has no box');
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    try {
+      expect(await enter.evaluate((element) => getComputedStyle(element).transform)).toBe('none');
+    } finally {
+      await page.mouse.up();
+    }
+  });
+});
+
+test.describe('remote pwa motion in a browser window', () => {
+  test.use({ viewport: BROWSER_WINDOW });
+
+  test('the create sheet becomes a centred dialog above sm', async ({ page }) => {
+    await openConnectedRemotePwa(page);
+    await page.getByRole('button', { name: /New pane in/ }).click();
+
+    const sheet = page.locator('.pane-sheet');
+    await expect(sheet).toBeVisible();
+    const motion = await sheet.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { name: style.animationName, duration: style.animationDuration, easing: style.animationTimingFunction };
+    });
+
+    // Not a sheet here: it is an ordinary dialog in a browser window, so it gets
+    // the desktop app's dialog entrance rather than rising off an edge that is
+    // 800px away from it.
+    expect(motion.name).toBe('pane-sheet-enter-centered');
+    expect(motion.duration).toBe('0.2s');
+    expect(motion.easing).toBe(EASE_OUT_STRONG);
+  });
+});

--- a/tests/motion.spec.ts
+++ b/tests/motion.spec.ts
@@ -97,11 +97,19 @@ test.describe('motion', () => {
 
     // `position="bottom-right"`: the menu hangs below the trigger with its right
     // edge aligned to it, so it has to scale out of its own top-right corner.
-    const origin = await menu.evaluate((element) => getComputedStyle(element).transformOrigin);
-    const box = await menu.boundingBox();
+    //
+    // Both numbers are read inside the page, and the width comes from
+    // `offsetWidth` rather than `boundingBox()`. The entrance is still scaling
+    // the element at this point, and a bounding box is the *transformed* box —
+    // measuring it mid-animation reports ~96% of the real width, which is what
+    // `transform-origin` will never equal.
+    const { origin, width } = await menu.evaluate((element: HTMLElement) => ({
+      origin: getComputedStyle(element).transformOrigin,
+      width: element.offsetWidth,
+    }));
     const [originX, originY] = origin.split(' ').map(Number.parseFloat);
     expect(originY).toBe(0);
-    expect(originX).toBeCloseTo(box?.width ?? -1, 0);
+    expect(originX).toBeCloseTo(width, 0);
   });
 
   test('buttons scale under the pointer, faster down than up', async ({ page }) => {
@@ -123,13 +131,17 @@ test.describe('motion', () => {
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.down();
     try {
-      const pressed = await cancel.evaluate((element) => ({
-        transform: getComputedStyle(element).transform,
-        duration: getComputedStyle(element).transitionDuration,
-      }));
+      // The press rule takes hold immediately — this is the 90ms press duration
+      // replacing the 160ms release one — but the scale is a *transition*, so at
+      // pointer-down `transform` is still the value it is easing away from.
+      // Asserting it here passes only when the read happens to land late enough.
+      expect(await cancel.evaluate((element) => getComputedStyle(element).transitionDuration))
+        .toContain('0.09s');
+
+      await page.waitForTimeout(150);
       // matrix(0.97, 0, 0, 0.97, 0, 0)
-      expect(pressed.transform).toContain('0.97');
-      expect(pressed.duration).toContain('0.09s');
+      expect(await cancel.evaluate((element) => getComputedStyle(element).transform))
+        .toContain('0.97');
     } finally {
       await page.mouse.up();
     }

--- a/tests/remotePwaMock.ts
+++ b/tests/remotePwaMock.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test';
+import type { JsonValue } from '../shared/validation/boundaryDecoder';
 
 // Test harness for the Remote Pane PWA — the browser-served surface at
 // `/remote.html`, which talks to a remote Pane daemon over HTTP+SSE rather than
@@ -141,19 +142,22 @@ export async function openConnectedRemotePwa(
     // server-sent traffic, so it only has to connect and stay quiet — but it does
     // have to be able to *drop*, because losing the host is the defining event of
     // using Pane from a phone and the status bar's motion is about saying so.
-    let live: MockEventSource | null = null;
-
     class MockEventSource {
       onopen: ((event: Event) => void) | null = null;
       onerror: ((event: Event) => void) | null = null;
       constructor(readonly url: string) {
-        live = this;
+        // Handed to the registrar rather than aliased into a local, so the
+        // newest stream is reachable without keeping a `self` around.
+        register(this);
         window.setTimeout(() => this.onopen?.(new Event('open')), 0);
       }
       addEventListener(): void {}
       removeEventListener(): void {}
       close(): void {}
     }
+
+    let live: MockEventSource | undefined;
+    const register = (source: MockEventSource) => { live = source; };
 
     Object.defineProperty(window, 'EventSource', { configurable: true, value: MockEventSource });
 
@@ -171,6 +175,25 @@ export async function openConnectedRemotePwa(
   await page.getByRole('button', { name: 'Connect', exact: true }).click();
 }
 
+/**
+ * Drops the host's event stream, the way a phone leaving wifi does. The client's
+ * own backoff then walks the status from `reconnecting` back to `connected`.
+ */
+export async function dropRemoteConnection(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const drop: (() => void) | undefined = window.__paneRemoteDropConnection;
+    if (!drop) throw new Error('Remote PWA mock is not installed on this page.');
+    drop();
+  });
+}
+
+declare global {
+  interface Window {
+    /** Installed by `openConnectedRemotePwa`; see `dropRemoteConnection`. */
+    __paneRemoteDropConnection?: () => void;
+  }
+}
+
 /** Serves the daemon's invoke endpoint for the channels the PWA calls. */
 async function installRemoteHostRoute(
   page: Page,
@@ -185,7 +208,7 @@ async function installRemoteHostRoute(
 
     // SAFETY: the test route receives the remote invoke envelope emitted by this fixture.
     const body = JSON.parse(request.postData() ?? '{}') as { channel?: string };
-    let result: unknown = null;
+    let result: JsonValue = null;
 
     switch (body.channel) {
       case 'sessions:get-all-with-projects':

--- a/tests/remotePwaMock.ts
+++ b/tests/remotePwaMock.ts
@@ -1,0 +1,232 @@
+import type { Page } from '@playwright/test';
+
+// Test harness for the Remote Pane PWA — the browser-served surface at
+// `/remote.html`, which talks to a remote Pane daemon over HTTP+SSE rather than
+// to Electron. Nothing here touches `window.electronAPI`; see
+// `tests/electronApiMock.ts` for the desktop equivalent.
+
+export interface RemotePwaMockOptions {
+  /** Panes the mock host reports, in sidebar order. */
+  sessionNames?: string[];
+  /** Terminal panels the selected pane reports, in tab order. */
+  panelTitles?: string[];
+  /** Host-defined terminal shortcuts offered in the mobile input bar. */
+  shortcuts?: Array<{ id: string; key: string; label: string; text: string }>;
+}
+
+const PROFILE = {
+  id: 'anim-host',
+  label: 'MacBook Pro',
+  baseUrl: 'http://anim-pane.test/remote/browser',
+  token: 'anim-token-12345678',
+  transport: 'http+sse',
+} as const;
+
+// Enough scrollback that the terminal reads as a working shell in the clips and
+// the scroll joystick has something to move over.
+const TERMINAL_SCROLLBACK = [
+  '\x1b[32m➜\x1b[0m  \x1b[36mpane\x1b[0m git:(\x1b[31manimations-for-the-pane-web-app\x1b[0m) pnpm lint\r\n',
+  '\r\n',
+  '> pane@2.4.66 lint /Users/dev/pane\r\n',
+  '> node scripts/lint.mjs\r\n',
+  '\r\n',
+  '  \x1b[32m✓\x1b[0m oxlint      \x1b[90m412 files\x1b[0m\r\n',
+  '  \x1b[32m✓\x1b[0m eslint      \x1b[90m88 files\x1b[0m\r\n',
+  '  \x1b[32m✓\x1b[0m knip        \x1b[90mno unused exports\x1b[0m\r\n',
+  '  \x1b[32m✓\x1b[0m boundaries  \x1b[90mconformant\x1b[0m\r\n',
+  '\r\n',
+  '\x1b[32m➜\x1b[0m  \x1b[36mpane\x1b[0m git:(\x1b[31manimations-for-the-pane-web-app\x1b[0m) ',
+].map((data) => ({
+  sessionId: 'anim-remote-0',
+  type: 'stdout' as const,
+  data,
+  timestamp: new Date(0).toISOString(),
+}));
+
+const baseSession = {
+  prompt: 'evidence fixture',
+  status: 'running',
+  createdAt: new Date(0).toISOString(),
+  lastActivity: new Date(0).toISOString(),
+  output: [],
+  jsonMessages: [],
+  isRunning: true,
+  permissionMode: 'ignore',
+  projectId: 1,
+  isFavorite: false,
+  toolType: 'none',
+  archived: false,
+};
+
+function buildFixtures(options: RemotePwaMockOptions) {
+  const sessionNames = options.sessionNames ?? [
+    'scrub Sentry request bodies',
+    'server-side funnel events',
+    'sms opt-in consent at signup',
+  ];
+  const panelTitles = options.panelTitles ?? ['claude', 'shell'];
+
+  const sessions = sessionNames.map((name, index) => ({
+    ...baseSession,
+    id: `anim-remote-${index}`,
+    name,
+    worktreePath: `/Users/dev/pane/worktrees/${index}`,
+    displayOrder: index,
+  }));
+
+  const project = {
+    id: 1,
+    name: 'dcouple/pane',
+    path: '/Users/dev/pane',
+    active: true,
+    created_at: new Date(0).toISOString(),
+    updated_at: new Date(0).toISOString(),
+    sessions,
+  };
+
+  const panels = panelTitles.map((title, index) => ({
+    id: `anim-panel-${index}`,
+    sessionId: sessions[0].id,
+    type: 'terminal',
+    title,
+    state: { isActive: index === 0, hasBeenViewed: index === 0 },
+    metadata: {
+      createdAt: new Date(0).toISOString(),
+      lastActiveAt: new Date(0).toISOString(),
+      position: index,
+    },
+  }));
+
+  const affordances = {
+    terminalShortcuts: options.shortcuts ?? [
+      { id: 's1', key: 'r', label: 'Run the test suite', text: 'pnpm test', enabled: true },
+      { id: 's2', key: 'l', label: 'Lint and typecheck', text: 'pnpm lint && pnpm typecheck', enabled: true },
+      { id: 's3', key: 'g', label: 'Status', text: 'git status --short', enabled: true },
+    ],
+    customCommands: [
+      { name: 'Codex', command: 'codex' },
+    ],
+    voiceTranscription: {
+      availableModes: [],
+      defaultMode: 'streaming',
+      configured: {
+        cleanup: false, recorded: false, streaming: false,
+        fal: false, deepgram: false, openRouter: false,
+      },
+      modes: {
+        streaming: { label: 'Live', priceLabel: '', latencyLabel: '', recommended: true },
+        recorded: { label: 'Batch', priceLabel: '', latencyLabel: '', recommended: false },
+      },
+    },
+  };
+
+  return { project, panels, affordances };
+}
+
+/**
+ * Stands up a fake remote Pane host and drives the PWA to its connected state.
+ * The saved profile is seeded into localStorage so the connection screen offers
+ * a one-click Connect rather than needing a pasted code.
+ */
+export async function openConnectedRemotePwa(
+  page: Page,
+  options: RemotePwaMockOptions = {},
+): Promise<void> {
+  const { project, panels, affordances } = buildFixtures(options);
+
+  await page.addInitScript((profile) => {
+    window.localStorage.setItem('pane.remotePwa.savedProfiles', JSON.stringify([profile]));
+
+    // The PWA opens an EventSource for host push events. Nothing here depends on
+    // server-sent traffic, so it only has to connect and stay quiet — but it does
+    // have to be able to *drop*, because losing the host is the defining event of
+    // using Pane from a phone and the status bar's motion is about saying so.
+    let live: MockEventSource | null = null;
+
+    class MockEventSource {
+      onopen: ((event: Event) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      constructor(readonly url: string) {
+        live = this;
+        window.setTimeout(() => this.onopen?.(new Event('open')), 0);
+      }
+      addEventListener(): void {}
+      removeEventListener(): void {}
+      close(): void {}
+    }
+
+    Object.defineProperty(window, 'EventSource', { configurable: true, value: MockEventSource });
+
+    // Drops the stream the way a phone leaving wifi does. The client's own
+    // backoff then walks it through `reconnecting` and back to `connected`.
+    Object.defineProperty(window, '__paneRemoteDropConnection', {
+      configurable: true,
+      value: () => live?.onerror?.(new Event('error')),
+    });
+  }, PROFILE);
+
+  await installRemoteHostRoute(page, { project, panels, affordances });
+
+  await page.goto('/remote.html', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: 'Connect', exact: true }).click();
+}
+
+/** Serves the daemon's invoke endpoint for the channels the PWA calls. */
+async function installRemoteHostRoute(
+  page: Page,
+  fixtures: ReturnType<typeof buildFixtures>,
+): Promise<void> {
+  await page.route('http://anim-pane.test/**', async (route) => {
+    const request = route.request();
+    if (request.method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      return;
+    }
+
+    // SAFETY: the test route receives the remote invoke envelope emitted by this fixture.
+    const body = JSON.parse(request.postData() ?? '{}') as { channel?: string };
+    let result: unknown = null;
+
+    switch (body.channel) {
+      case 'sessions:get-all-with-projects':
+        result = [fixtures.project];
+        break;
+      case 'panels:list':
+        result = fixtures.panels;
+        break;
+      case 'panels:getActive':
+        result = fixtures.panels[0];
+        break;
+      case 'remote:pwa-affordances':
+        result = fixtures.affordances;
+        break;
+      case 'projects:list-branches':
+        result = [
+          { name: 'origin/main', isCurrent: false, hasWorktree: false, isRemote: true },
+          { name: 'main', isCurrent: true, hasWorktree: false, isRemote: false },
+          { name: 'animations-for-the-pane-web-app', isCurrent: true, hasWorktree: true, isRemote: false },
+        ];
+        break;
+      case 'projects:detect-branch':
+        result = 'main';
+        break;
+      case 'panels:checkInitialized':
+        result = true;
+        break;
+      case 'panels:get-output':
+        result = TERMINAL_SCROLLBACK;
+        break;
+      default:
+        // Panel mutations and terminal writes acknowledge without doing work;
+        // no clip depends on the host acting on them.
+        result = null;
+        break;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, result }),
+    });
+  });
+}

--- a/tests/remotePwaMock.ts
+++ b/tests/remotePwaMock.ts
@@ -149,7 +149,12 @@ export async function openConnectedRemotePwa(
         // Handed to the registrar rather than aliased into a local, so the
         // newest stream is reachable without keeping a `self` around.
         register(this);
-        window.setTimeout(() => this.onopen?.(new Event('open')), 0);
+        // While the host is held down, the client's retries connect to nothing —
+        // which is what keeps `reconnecting` on screen for as long as a caller
+        // needs rather than for one backoff interval.
+        if (!held) {
+          window.setTimeout(() => this.onopen?.(new Event('open')), 0);
+        }
       }
       addEventListener(): void {}
       removeEventListener(): void {}
@@ -157,15 +162,30 @@ export async function openConnectedRemotePwa(
     }
 
     let live: MockEventSource | undefined;
+    let held = false;
     const register = (source: MockEventSource) => { live = source; };
 
     Object.defineProperty(window, 'EventSource', { configurable: true, value: MockEventSource });
 
-    // Drops the stream the way a phone leaving wifi does. The client's own
-    // backoff then walks it through `reconnecting` and back to `connected`.
+    // Drops the stream the way a phone leaving wifi does, and keeps it down. The
+    // client's own backoff walks the status to `reconnecting` and keeps retrying
+    // into the void until the host is brought back.
     Object.defineProperty(window, '__paneRemoteDropConnection', {
       configurable: true,
-      value: () => live?.onerror?.(new Event('error')),
+      value: () => {
+        held = true;
+        live?.onerror?.(new Event('error'));
+      },
+    });
+
+    // Lets the next retry through, and opens the one already waiting so the
+    // recovery does not have to sit out another backoff interval.
+    Object.defineProperty(window, '__paneRemoteRestoreConnection', {
+      configurable: true,
+      value: () => {
+        held = false;
+        live?.onopen?.(new Event('open'));
+      },
     });
   }, PROFILE);
 
@@ -176,14 +196,28 @@ export async function openConnectedRemotePwa(
 }
 
 /**
- * Drops the host's event stream, the way a phone leaving wifi does. The client's
- * own backoff then walks the status from `reconnecting` back to `connected`.
+ * Drops the host's event stream, the way a phone leaving wifi does, and holds it
+ * down. The client's own backoff walks the status to `reconnecting` and stays
+ * there — deliberately, because a host that came straight back would leave the
+ * reconnecting state on screen for a single backoff interval, which is not long
+ * enough to assert against or to record.
+ *
+ * Pair with `restoreRemoteConnection` to complete the round trip.
  */
 export async function dropRemoteConnection(page: Page): Promise<void> {
   await page.evaluate(() => {
-    const drop: (() => void) | undefined = window.__paneRemoteDropConnection;
+    const drop = window.__paneRemoteDropConnection;
     if (!drop) throw new Error('Remote PWA mock is not installed on this page.');
     drop();
+  });
+}
+
+/** Brings the held host back, settling the status to `connected`. */
+export async function restoreRemoteConnection(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const restore = window.__paneRemoteRestoreConnection;
+    if (!restore) throw new Error('Remote PWA mock is not installed on this page.');
+    restore();
   });
 }
 
@@ -191,6 +225,8 @@ declare global {
   interface Window {
     /** Installed by `openConnectedRemotePwa`; see `dropRemoteConnection`. */
     __paneRemoteDropConnection?: () => void;
+    /** Installed by `openConnectedRemotePwa`; see `restoreRemoteConnection`. */
+    __paneRemoteRestoreConnection?: () => void;
   }
 }
 


### PR DESCRIPTION
Seven changes across eight surfaces on Pane's **browser** build — the Remote Pane
PWA at
`/remote.html`, not the Electron app [#480](https://github.com/dcouple/Pane/pull/480)
covered. Same doctrine, same skills
([find-animation-opportunities](https://github.com/emilkowalski/skills),
[improve-animations](https://github.com/emilkowalski/skills)), and the same rule
outranking both wherever they disagree: **the motion has to make Pane feel faster,
and anything that delays paint, blocks input, or puts something in front of a pane
switch is rejected on sight.**

The headline finding is that **not one of #480's eight animated moments reaches this
surface.** The PWA imports the same `index.css`, so it already had the motion tokens
and the reduced-motion contract — but every one of those eight was attached to a
desktop component the PWA does not use. It rolls its own dialog, its own menu, its
own sidebar, its own buttons. So this is not a second coat of paint on shared code;
it is the first coat on a surface that had none.

Seven, not eight, because the two hand-rolled popovers are one decision applied to
two call sites — the same way #480's menu commit covered four menus. That keeps the
pass inside the skill's 5–7 cap.

Every clip below plays at **0.2x** on a **390×844** viewport with touch emulation.
Nothing here takes longer than 240ms in real time. Click a clip for the full-resolution MP4.

> **Three non-motion fixes ride along at the end** — found while reading this code,
> all verified, all visible. The last one changes how the whole surface looks; see
> [Visual defects found along the way](#visual-defects-found-along-the-way). Both
> halves of every clip are captured with it applied, so the pairs still differ only
> in motion.

## What is PWA-only, and what is shared

Worth stating up front, because it is the whole scoping argument:

| | |
| --- | --- |
| **Entry point** | `frontend/remote.html` → `src/remote/main.tsx` → `bootstrap.tsx`. Served at `/app/` by `main/src/daemon/pwaStaticAssets.ts` or by `deploy/remote-pwa/nginx.conf`. The desktop app enters through `index.html` → `src/main.tsx`. |
| **PWA-only components** | All eleven of `frontend/src/remote/components/*` plus `RemotePwaApp.tsx`. Nothing outside `src/remote/` imports any of them — verified, the dependency runs one way only. |
| **Shared with desktop** | Types (`shared/types/*`), two pure helpers (`utils/paneName`, `utils/sessionOrdering`), one icon lookup (`components/ui/brandIconRegistry`), and `index.css` + its tokens. That is the entire overlap. |
| **Not touched** | Every component #480 animated — `Modal`, `Dropdown`, `Button`, `Sidebar`, `CommandPalette`, `WindowTitleBar`, `PanelTabBar`. The PWA imports none of them. |

The one shared file this PR edits is `index.css`, and only additively: new tokens,
new keyframes, new entries in the existing reduced-motion block. No desktop
animation changes value.

## The pairs

| Moment | What changed | Values | Before | After |
| --- | --- | --- | --- | --- |
| **Terminal control keys**<br>Stop / Esc / Tab / Enter | Added. The bottom of the phone screen is a keyboard, and none of its keys moved when pressed. | `.pane-press` + `.pane-press-touch`: `scale(0.97)`, **90ms** down / **160ms** back, `--ease-out-strong` | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-key-press.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-key-press.gif" alt="terminal control keys before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-key-press.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-key-press.gif" alt="terminal control keys after"></a> |
| **Create-pane sheet**<br>New pane in… | Added. Styled as a bottom sheet — rounded top corners, pinned to the bottom edge — and it arrived by teleporting. | `translateY(100%)` → `0`, **240ms** `--ease-drawer`; above `sm` it becomes #480's dialog entrance instead | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-create-sheet.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-create-sheet.gif" alt="create pane sheet before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-create-sheet.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-create-sheet.gif" alt="create pane sheet after"></a> |
| **Pane drawer**<br>the hamburger | Added. Below `md` there is no sidebar, only this, and it replaced the screen in one frame. | `translateX(-100%)` → `0`, **240ms** `--ease-drawer`, scrim on the same pair, exit retraced in **160ms** | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-nav-drawer.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-nav-drawer.gif" alt="pane drawer before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-nav-drawer.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-nav-drawer.gif" alt="pane drawer after"></a> |
| **Add Tool menu**<br>the `+` | Added. Hand-rolled popover, so it inherited none of #480's menu work — no origin, no entrance. | `origin-top-right` + `dropdown-enter`, **160ms** `--ease-out-strong` | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-add-tool-menu.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-add-tool-menu.gif" alt="add tool menu before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-add-tool-menu.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-add-tool-menu.gif" alt="add tool menu after"></a> |
| **Shortcuts sheet**<br>above the input bar | Added. Same class of surface, hinged on the edge it rests against rather than its own centre. | `origin-bottom` + `dropdown-enter-up`, **160ms** `--ease-out-strong` | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-shortcuts-sheet.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-shortcuts-sheet.gif" alt="shortcuts sheet before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-shortcuts-sheet.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-shortcuts-sheet.gif" alt="shortcuts sheet after"></a> |
| **Connection status**<br>losing and finding the host | Added, and only while genuinely reaching. `connecting` and `reconnecting` were a static amber dot indistinguishable from `error`. | ring `scale(1)` → `2.6` fading out, **1.8s** loop; dot colour settles over **150ms** | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-reconnect.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-reconnect.gif" alt="reconnect before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-reconnect.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-reconnect.gif" alt="reconnect after"></a> |
| **Scroll joystick**<br>letting go | Added — on release only. The thumb tracked your finger for a second and then ceased to exist at one place and started existing at another. | `transform` **160ms** `--ease-out-strong`, applied only while returning; **no transform transition at all** during the drag | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-joystick-release.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-joystick-release.gif" alt="joystick before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-joystick-release.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-joystick-release.gif" alt="joystick after"></a> |
| **Panel tab**<br>tapping the other terminal | **Deleted.** The tab you tapped spent 150ms becoming the tab you tapped. | `transition-colors` 150ms → none | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-panel-tab.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/before/clips/pwa-panel-tab.gif" alt="panel tab before"></a> | <a href="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-panel-tab.mp4"><img width="300" src="https://raw.githubusercontent.com/dcouple/Pane/anim-evidence-pwa-feel-fast/after/clips/pwa-panel-tab.gif" alt="panel tab after"></a> |

<sub>Before clips come from `f4f3a8e`, the branch point, captured with this branch's
harness against a reverted `frontend/`; after clips from the tip. Same fixtures, same
390×844 viewport, same interaction — only the motion code differs. Sources and the
capture manifest live on
<a href="https://github.com/dcouple/Pane/tree/anim-evidence-pwa-feel-fast">anim-evidence-pwa-feel-fast</a>.</sub>

## Why this reads as faster rather than merely more

Six of #480's eight moments were a deletion or a shortening. Here only one is,
and that inversion is the honest consequence of the surface being younger rather than
a change of mind. There was almost nothing to shorten: outside of Tailwind's default
`transition-colors`, the PWA had no interface motion at all. The work was mostly
filling in feedback that a touch device has no other way to get.

The biggest single win is the one that looks smallest in the table. **A finger has no
hover state.** Every control on this surface carried `hover:bg-surface-hover` and
nothing else, which is feedback aimed at a pointer that will never arrive. What touch
users actually got was the grey rectangle the browser flashes over a tapped control —
wrong shape on a rounded button, wrong colour in a dark terminal, and drawn on the
browser's schedule rather than the app's. On the terminal control keys that gap is at
its worst, because the keys fire in sequences and their effect happens on another
machine: nothing about the app got faster, but the wait now starts with an answer
instead of with silence.

The other thread is **distance**. #480's `--ease-out-strong` dumps most of its travel
in the first third, which is right for a 3% scale and reads as a snap when the same
curve has to move 844px. Edge-anchored surfaces get `--ease-drawer` and
`--duration-sheet` instead — still a ceiling, still inside the skill's 200–500ms
drawer budget. Exits get their own shorter token, because the entrance is worth
paying for and the dismissal is not.

The create sheet is the one place where being a browser genuinely changes the answer.
Below `sm` it is a bottom sheet and rises off the bottom edge; above `sm` its own
classes re-centre it as an ordinary dialog in a browser window, where sliding it up
from an edge 800px away would be motion with nothing behind it — so it gets #480's
dialog entrance verbatim. Same component, same state change, two different spatial
stories, because at those two sizes it honestly is two different objects. That is why
the sheet primitives are plain classes and not Tailwind utilities: a responsive
variant can swap a duration, but this has to swap the keyframes.

## Rejected

Restraint is the point of the Gate, and the PWA offered more candidates than it should
get. Considered and deliberately not done:

- **Pane rows in the drawer** — press feedback and a faster selection fade. **Rejected: navigation.** #480 settled that a scale on every pane switch is motion in the one place both passes are trying to keep still, and the row's cross-fade is invisible anyway because selecting a pane closes the drawer over it.
- **Crossfade between terminal panels** — **Rejected by the prime directive.** Frames between asking for a panel and seeing it.
- **Stagger on the drawer's pane list** — **Rejected: it is the primary navigation surface on a phone.** A stagger delays reading the exact thing you opened the drawer to read.
- **Connection-screen card arrows** (`group-hover:translate-x-0.5`) — **Rejected: hover on a touch device.** Not ungated hover worth fixing with *more* motion; the honest fix is a `@media (hover: hover)` gate, which is a correctness change and not this branch's job.
- **Error alert on the connection screen** — genuinely rare, genuinely teleports, would have passed the Gate. **Rejected on the cap:** at 5–7 suggestions it lost to seven things that a user hits every session rather than on a bad day.
- **Branch dropdown inside the create sheet** — **Rejected: same cap,** and it is a popover inside a surface that is already animating, where a second entrance competes with the first.
- **Toggle switches** in the create sheet — `transition-transform` on Tailwind's default ease-in-out. Real, small, **rejected on the cap.**
- **Terminal output itself** — **Rejected: functional data the user is reading.** xterm is not getting motion.
- **`Add Tool` menu row highlight** (150ms) — #480 cut the desktop equivalent to 100ms because the highlight trailed a pointer running down the rows. **Rejected here: on touch you tap a row, you do not sweep them,** so the problem it solves does not exist on the surface that matters.

## Visual defects found along the way

None of these are motion. All three were found by reading the PWA for the animation
pass, and all three are verified rather than eyeballed.

**The send button had no background.** It asks for `bg-accent-primary`, and
`accent-primary` is not a token in this repo — not in `tailwind.config.js`, not in the
colour tokens. The class generates no CSS, so the primary action of the mobile
terminal rendered as a bare glyph: computed `background-color` was `rgba(0, 0, 0, 0)`.
It uses `bg-interactive` / `text-text-on-interactive` now. (The same dead token is
referenced from three desktop components; those are out of scope here.)

**The scroll joystick painted over both popovers and swallowed their taps.** It sits at
`z-30` inside the terminal area; the Add Tool menu was also `z-30` but earlier in the
DOM, and the shortcuts sheet had no z-index at all. So the joystick won both — 42×117px
of the menu and 36×34px of the sheet covered, with `elementFromPoint` returning the
joystick's range input over the overlap, which made the sheet's own close button
unclickable. Both popovers are `z-40` now.

**The PWA has been rendering a half-applied theme since it was built** — and the result
is not "dark", it is incoherent. Themes here are a base plus a delta:
`THEME_CLASSES` defines `'light-rounded': ['light', 'light-rounded']`, where
`:root.light` carries the palette in 118 declarations and `:root.light-rounded` layers
9 on top. Both `bootstrap.tsx` and `remote.html` named only the delta, so those 9
landed on the **dark** default palette. That is why `--color-border-primary` on this
surface was `rgba(31, 35, 40, 0.12)` — a near-black hairline, meant for a white
background, drawn on near-black chrome, which is why the terminal control keys had no
visible outline. Everything else the author wrote says light too: `remote.html` ships
`theme-color: #f7fafc` and `body.light-rounded` paints an `#f7fafc → #eef3f7` gradient
that nothing was laid on top of.

Fixed by applying both classes, taken from `THEME_CLASSES` rather than written out
again — naming only the delta is the exact mistake, and a copy would be free to drift a
second time. **This is a large visible change**: light chrome, with the terminal still
dark on its own `#010409`.

It exposed one thing it did not cause: the create-sheet toggle knobs used
`bg-text-primary`, which is white on a dark palette and near-black on a light one —
correct against the old accidental dark, and **2.9:1** against the blue of an enabled
switch once the theme was right, under the 3:1 floor for a control. The knob is
`text-on-interactive` now at **5.17:1**, with a hairline ring so it still reads against
the pale off-track.

`accessibility.spec.ts` runs axe over the connected and disconnected PWA screens and is
clean. Until this commit it was auditing colours nobody was looking at.

## Reduced motion

Everything new is in the existing `prefers-reduced-motion` block, written the way
#480 established it — **fewer and gentler, not zero.** Entrances keep their fade and
lose their travel; the sheet and drawer still arrive, without crossing the screen to
do it. Exits keep a real duration because focus restoration waits on them. The
joystick snaps back, which is what it did before this branch and is the correct
answer rather than a regression. The reconnect ring keeps running and breathes in
place instead of expanding, on the same reasoning that keeps the spinners: "still
looking for the host" is information, and removing it would remove information rather
than motion. Covered by a test.

## Testing

- `tests/motion-remote.spec.ts` — **9 tests, all passing**, at both a phone and a browser-window viewport. The two worth having are the negative ones: the panel tab asserts `transition-property: all` at `0s`, and the joystick asserts that its transition property does **not** include `transform` while the pointer is down.
- `pnpm lint` (oxlint, eslint, anti-slop, boundary conformance, knip) — clean.
- `pnpm --filter frontend typecheck` — clean.
- `pnpm --filter frontend build` — passes; I grepped the production bundle to confirm every new class, keyframe, token and the `@media (min-width: 640px)` swap survive Tailwind's purge, since the PWA reaches most of them through `src/remote/**`.
- `accessibility`, `motion`, `motion-remote`, `smoke`, `dropdown-keyboard-nav`, `sidebar-compact`, `window-title-bar` — **56 passed, 0 failed.**

**Two pre-existing failures fixed along the way.** `tests/motion.spec.ts` had two
tests measuring a moving animation as though it had finished — one comparing
`transform-origin` against `boundingBox().width` (which is the *transformed* box, so
it reports ~96% of the real width mid-entrance), one reading `transform` at
`mouse.down()` (where a 90ms transition has not started moving yet). The first fails
3 runs out of 3 on `f4f3a8e` with none of this branch's changes present — I checked
it out in a scratch worktree to be sure. Both are fixed here, in their own commit,
because hitting the identical mistake in my own spec is what surfaced them.

## Reproducing the clips

```
PANE_ANIM_PHASE=before pnpm anim:evidence:remote && pnpm anim:evidence:render before-remote
PANE_ANIM_PHASE=after  pnpm anim:evidence:remote && pnpm anim:evidence:render after-remote
```

The rig is #480's, pointed at `/remote.html` on a phone viewport with `hasTouch`, and
backed by a new `tests/remotePwaMock.ts` that stands up a fake daemon — including the
ability to drop the event stream the way a phone leaving wifi does, and hold it down,
which is the only way the reconnecting state stays on screen long enough to record or
assert. Requires `ffmpeg`. Not wired into CI.

## Manual tests

- [ ] On a real phone (or DevTools device mode), tap through Esc / Tab / Enter and confirm the keys answer under the finger with no grey browser flash.
- [ ] Open and dismiss the pane drawer; confirm dismissing via the scrim reads as the drawer leaving rather than vanishing.
- [ ] Open **New pane** at phone width and again at a wide browser window; confirm sheet-from-bottom vs centred dialog.
- [ ] Drag the scroll joystick hard and let go — the thumb must track the finger with zero lag, then ease home.
- [ ] Turn wifi off and on with the PWA open; confirm the status dot reaches while reconnecting and settles green.
- [ ] Enable Reduce Motion at the OS level and repeat all of the above.
- [ ] **Theme:** confirm the light chrome is wanted on this surface. It is what `remote.html`, its `theme-color` meta and `bootstrap.tsx` all asked for, but it is the one change here that alters the whole look rather than a moment in it.
- [ ] Confirm the send button and the create-sheet toggles read correctly in the light theme on a real device.
