### PR TITLE
Fix hung release build: package @xterm/addon-unicode11, bound the headless check

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -35,6 +35,7 @@
         "@lydell/node-pty",
         "@modelcontextprotocol/sdk",
         "@xterm/addon-serialize",
+        "@xterm/addon-unicode11",
         "@xterm/headless",
         "better-sqlite3-multiple-ciphers",
         "bull",

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -1077,8 +1077,14 @@ async function initializeServices() {
 }
 
 if (launchRemoteSetup) {
+  // A rejection here used to go unhandled, which left the process alive with no
+  // output instead of failing: remote setup is a print-and-exit path, so a throw
+  // that never reaches app.exit() reads as a hang.
   void runRemoteSetupCli(process.argv).then((exitCode) => {
     app.exit(exitCode);
+  }).catch((error) => {
+    console.error('[Main] Remote setup failed:', error instanceof Error ? (error.stack ?? error.message) : error);
+    app.exit(1);
   });
 } else if (launchHeadlessDaemon) {
   startHeadlessPaneProcess();

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@lydell/node-pty": "1.2.0-beta.3",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/addon-unicode11": "0.9.0",
     "@xterm/headless": "^6.0.0",
     "better-sqlite3-multiple-ciphers": "12.11.1",
     "bull": "^4.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@xterm/addon-serialize':
         specifier: ^0.14.0
         version: 0.14.0
+      '@xterm/addon-unicode11':
+        specifier: 0.9.0
+        version: 0.9.0
       '@xterm/headless':
         specifier: ^6.0.0
         version: 6.0.0

--- a/scripts/test-packaged-headless-remote-setup.sh
+++ b/scripts/test-packaged-headless-remote-setup.sh
@@ -22,8 +22,15 @@ trap 'rm -rf "$pane_dir" "$output_file" "$extract_dir"' EXIT
   test "$(readlink squashfs-root/Pane)" = pane
 )
 
+# Bounded: remote setup is a print-and-exit path that takes seconds. Without a
+# limit a packaged app that never exits hangs the release job until the runner
+# times out, with the app's own output still trapped in $output_file and never
+# printed, which leaves nothing to debug from.
+timeout_seconds="${PANE_HEADLESS_SETUP_TIMEOUT:-180}"
+
 set +e
-env -u DISPLAY \
+timeout --kill-after=15s "$timeout_seconds" \
+  env -u DISPLAY \
   "$appimage" \
   --appimage-extract-and-run \
   --no-sandbox \
@@ -36,7 +43,15 @@ env -u DISPLAY \
 exit_code=$?
 set -e
 
+echo "--- packaged Pane remote setup output (exit $exit_code) ---"
 cat "$output_file"
+echo "--- end output ---"
+
+if [[ $exit_code -eq 124 || $exit_code -eq 137 ]]; then
+  echo "Packaged Pane remote setup did not exit within ${timeout_seconds}s." >&2
+  echo "Setup is a print-and-exit path, so this means it blocked or threw without exiting." >&2
+  exit 1
+fi
 
 if [[ $exit_code -ne 0 ]]; then
   echo "Packaged Pane remote setup exited with code $exit_code." >&2


### PR DESCRIPTION
The v2.4.68 release build hung for over two hours and published nothing. This fixes the cause and the two things that let a small mistake become a silent multi-hour outage.

## The bug

The packaged Linux app died on startup:

```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: Cannot find module '@xterm/addon-unicode11'
```

Electron renders an uncaught main-process exception as a GUI dialog. On a headless runner nothing exists to dismiss it, so the process never exited. The release job sat there until it was cancelled.

`electron-builder` resolves the asar's production dependencies from the **root** `package.json` graph, and `main/` is a workspace package rather than a root dependency. A dependency declared only in `main/package.json` is therefore pruned from the package. That is exactly why the root already duplicates `@xterm/addon-serialize` and `@xterm/headless`. #486 added `@xterm/addon-unicode11` to `main` alone and missed the convention.

Nothing local catches this: the module resolves fine from `node_modules` in dev, and the failure only exists in a packaged build, and only hangs where there is no display.

## Why it took two hours to see

**The verify script had no time limit.** `scripts/test-packaged-headless-remote-setup.sh` launched the packaged AppImage and waited forever, and only `cat`ed the app's output *after* a successful exit. So the one artifact that explained the failure sat unread in a temp file while the job burned. Now bounded at 180s, output printed either way, with a message saying that a print-and-exit path which did not exit either blocked or threw. This is what produced the stack trace above.

**Remote setup swallowed its own errors.** `runRemoteSetupCli().then(app.exit)` had no `.catch()`, so a rejection became an unhandled rejection and `app.exit()` never ran, turning any setup error into a hang rather than a failure. Now caught, logged with its stack, exits non-zero. (It was not the mechanism here, since this failure was a module-load throw at import, but the shape of the bug was the same.)

## Verification

| check | before | after |
| --- | --- | --- |
| `Verify packaged headless remote setup` | hung, cancelled at 2h16m, zero output | **success in 6s** |

For reference the same step took 5s on v2.4.68's predecessor, so this is back to baseline. The bounded failure run is [32449204158](https://github.com/dcouple/Pane/actions/runs/32449204158), which is where the stack trace came from; the passing run is [32449743681](https://github.com/dcouple/Pane/actions/runs/32449743681).

## Follow-up worth considering

Nothing enforces the root/`main` dependency mirroring, so the next runtime dependency added to `main` can reproduce this exactly. A check comparing `main/package.json` runtime deps against the root would make it a lint failure instead of a release outage.

https://claude.ai/code/session_013K68GYVstL5bwgQpGLjUtj
