### PR TITLE
Fix the Windows taskbar icon: ship the runtime window icon and guard it at build time

### DIFF
--- a/main/package.json
+++ b/main/package.json
@@ -10,7 +10,7 @@
     "headless": "npm run build && electron dist/main/src/daemon/headless.js",
     "bundle:mcp": "node build-mcp-bridge.js",
     "bundle:preload": "esbuild src/preload.ts --bundle --platform=node --format=cjs --target=node24 --external:electron --sourcemap --outfile=dist/main/src/preload.js && node ../scripts/verify-sandboxed-preload.js",
-    "copy:assets": "mkdirp dist/main/src/database/migrations && shx cp src/database/*.sql dist/main/src/database/ && shx cp src/database/migrations/*.sql dist/main/src/database/migrations/",
+    "copy:assets": "mkdirp dist/main/src/database/migrations dist/main/assets && shx cp src/database/*.sql dist/main/src/database/ && shx cp src/database/migrations/*.sql dist/main/src/database/migrations/ && shx cp assets/icon.png dist/main/assets/",
     "lint": "pnpm --dir .. run lint:ox:main && pnpm run lint:eslint",
     "lint:eslint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -327,10 +327,16 @@ async function createWindow() {
 
   const windowControlsOverlay = shouldEnableWindowControlsOverlay(process.platform, process.env);
 
+  // An icon path Electron cannot load is worse than none: on Windows it sets an
+  // empty HICON, which clears the icon the window would otherwise inherit from
+  // Pane.exe and leaves the taskbar showing the default. main's copy:assets puts
+  // the file here and scripts/verify-packaged-icon.js fails the build if it is
+  // ever missing again, so this only guards a broken tree.
+  const windowIconPath = path.join(__dirname, '../assets/icon.png');
+
   const mainWindowOptions: BrowserWindowConstructorOptions = {
     width: 1400,
     height: 900,
-    icon: path.join(__dirname, '../assets/icon.png'),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -341,6 +347,9 @@ async function createWindow() {
       additionalArguments: windowControlsOverlay ? [WINDOW_CONTROLS_OVERLAY_ARG] : [],
     },
   };
+  if (fs.existsSync(windowIconPath)) {
+    mainWindowOptions.icon = windowIconPath;
+  }
   if (process.platform === 'darwin') {
     mainWindowOptions.titleBarStyle = 'hiddenInset';
     mainWindowOptions.trafficLightPosition = { x: 10, y: 10 };

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -26,8 +26,10 @@ function createLinuxCompatibilityAlias(appOutDir) {
 async function afterPack(context) {
   // Runs for every platform and target, so a build that drops either the bundle
   // icon or the runtime window icon fails here instead of shipping (issue: the
-  // v2.4.69 Windows taskbar icon).
-  verifyPackedApp(context.appOutDir, context.electronPlatformName);
+  // v2.4.69 Windows taskbar icon). The Windows launcher's own icon is not
+  // checked here — rcedit writes it after this hook — scripts/build-win.js
+  // checks it once electron-builder has finished.
+  verifyPackedApp(context.appOutDir, context.electronPlatformName, { checkExecutable: false });
 
   if (context.electronPlatformName !== 'linux') return;
   createLinuxCompatibilityAlias(context.appOutDir);

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -1,7 +1,14 @@
 const fs = require('fs');
 const path = require('path');
 
+const { verifyPackedApp } = require('./verify-packaged-icon');
+
 async function afterPack(context) {
+  // Runs for every platform and target, so a build that drops either the bundle
+  // icon or the runtime window icon fails here instead of shipping (issue: the
+  // v2.4.69 Windows taskbar icon).
+  verifyPackedApp(context.appOutDir, context.electronPlatformName);
+
   if (context.electronPlatformName !== 'linux') return;
   const canonicalPath = path.join(context.appOutDir, 'pane');
   const aliasPath = path.join(context.appOutDir, 'Pane');

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -3,15 +3,11 @@ const path = require('path');
 
 const { verifyPackedApp } = require('./verify-packaged-icon');
 
-async function afterPack(context) {
-  // Runs for every platform and target, so a build that drops either the bundle
-  // icon or the runtime window icon fails here instead of shipping (issue: the
-  // v2.4.69 Windows taskbar icon).
-  verifyPackedApp(context.appOutDir, context.electronPlatformName);
-
-  if (context.electronPlatformName !== 'linux') return;
-  const canonicalPath = path.join(context.appOutDir, 'pane');
-  const aliasPath = path.join(context.appOutDir, 'Pane');
+// Linux only: the package ships `pane`, and `Pane` is a compatibility alias for
+// callers that still use the old capitalised name.
+function createLinuxCompatibilityAlias(appOutDir) {
+  const canonicalPath = path.join(appOutDir, 'pane');
+  const aliasPath = path.join(appOutDir, 'Pane');
   if (!fs.existsSync(canonicalPath) || !fs.statSync(canonicalPath).isFile()) {
     throw new Error(`Cannot create Pane compatibility alias: ${canonicalPath} is missing.`);
   }
@@ -27,6 +23,17 @@ async function afterPack(context) {
   fs.symlinkSync('pane', aliasPath);
 }
 
+async function afterPack(context) {
+  // Runs for every platform and target, so a build that drops either the bundle
+  // icon or the runtime window icon fails here instead of shipping (issue: the
+  // v2.4.69 Windows taskbar icon).
+  verifyPackedApp(context.appOutDir, context.electronPlatformName);
+
+  if (context.electronPlatformName !== 'linux') return;
+  createLinuxCompatibilityAlias(context.appOutDir);
+}
+
 module.exports = afterPack;
 module.exports.default = afterPack;
 module.exports.afterPack = afterPack;
+module.exports.createLinuxCompatibilityAlias = createLinuxCompatibilityAlias;

--- a/scripts/build-win.js
+++ b/scripts/build-win.js
@@ -31,6 +31,8 @@ const path = require('path');
 
 const os = require('os');
 
+const { verifyPackedApp } = require('./verify-packaged-icon');
+
 const ROOT_DIR = path.resolve(__dirname, '..');
 const NODE_MODULES = path.join(ROOT_DIR, 'node_modules');
 const HOST_ARCH = os.arch(); // 'x64' or 'arm64'
@@ -358,6 +360,13 @@ async function build() {
 
   const publishFlag = shouldPublish ? '--publish always' : '--publish never';
   run(`pnpm exec electron-builder --win --${arch} ${publishFlag} --config.npmRebuild=false`);
+
+  // The launcher's icon is written by rcedit during the electron-builder run, so
+  // this is the first point it can be checked. afterPack already covered the
+  // runtime window icon.
+  console.log('\n🔧 Step 7: Verifying packaged icons...\n');
+  const unpackedDir = path.join(ROOT_DIR, 'dist-electron', 'win-unpacked');
+  verifyPackedApp(unpackedDir, 'win32');
 
   console.log('\n✅ Build complete!\n');
   console.log('Output files are in: dist-electron/');

--- a/scripts/build-win.js
+++ b/scripts/build-win.js
@@ -365,7 +365,15 @@ async function build() {
   // this is the first point it can be checked. afterPack already covered the
   // runtime window icon.
   console.log('\n🔧 Step 7: Verifying packaged icons...\n');
-  const unpackedDir = path.join(ROOT_DIR, 'dist-electron', 'win-unpacked');
+  // electron-builder names the default arch's output win-unpacked and every
+  // other arch win-<arch>-unpacked.
+  const unpackedDir = [`win-${arch}-unpacked`, 'win-unpacked']
+    .map((name) => path.join(ROOT_DIR, 'dist-electron', name))
+    .find((candidate) => fs.existsSync(candidate));
+  if (!unpackedDir) {
+    console.error(`No packaged output directory for ${arch} under dist-electron.`);
+    process.exit(1);
+  }
   verifyPackedApp(unpackedDir, 'win32');
 
   console.log('\n✅ Build complete!\n');

--- a/scripts/test-runpane-contract.js
+++ b/scripts/test-runpane-contract.js
@@ -369,9 +369,11 @@ async function checkLinuxPackageCompatibilityAlias() {
   fs.mkdirSync(appDirectory, { recursive: true });
   fs.writeFileSync(path.join(appDirectory, 'pane'), 'binary', { mode: 0o755 });
   try {
-    const afterPack = require(path.join(rootDir, 'scripts', 'after-pack.js'));
-    await afterPack({ electronPlatformName: 'linux', appOutDir: appDirectory });
-    await afterPack({ electronPlatformName: 'linux', appOutDir: appDirectory });
+    // The alias step, not the whole afterPack hook: the hook also verifies the
+    // packaged icons, which this fixture deliberately does not have.
+    const { createLinuxCompatibilityAlias } = require(path.join(rootDir, 'scripts', 'after-pack.js'));
+    createLinuxCompatibilityAlias(appDirectory);
+    createLinuxCompatibilityAlias(appDirectory);
     childProcess.execFileSync(process.execPath, [
       path.join(rootDir, 'scripts', 'verify-linux-package-executables.js'),
       temporaryDirectory

--- a/scripts/verify-packaged-icon.js
+++ b/scripts/verify-packaged-icon.js
@@ -31,6 +31,7 @@ const path = require('path');
 
 const ROOT_DIR = path.resolve(__dirname, '..');
 const ASSETS_DIR = path.join(ROOT_DIR, 'main', 'assets');
+const PRODUCT_NAME = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8')).build.productName;
 
 /** Path of the runtime window icon inside the packaged asar, as index.ts resolves it. */
 const RUNTIME_ICON_IN_ASAR = ['main', 'dist', 'main', 'assets', 'icon.png'];
@@ -174,6 +175,7 @@ function checkRuntimeIcon(asarPath, failures) {
 function checkMacBundle(appPath, failures) {
   const plistPath = path.join(appPath, 'Contents', 'Info.plist');
   const icnsPath = path.join(appPath, 'Contents', 'Resources', 'icon.icns');
+  const before = failures.length;
 
   if (!fs.existsSync(icnsPath)) {
     failures.push(`${appPath} has no Contents/Resources/icon.icns — the bundle falls back to Electron's icon`);
@@ -186,7 +188,7 @@ function checkMacBundle(appPath, failures) {
     failures.push(`${appPath} does not declare CFBundleIconFile=icon.icns in Info.plist`);
   }
 
-  if (failures.length === 0) {
+  if (failures.length === before) {
     console.log(`[verify-icon] ${path.basename(appPath)} carries the Pane .icns ✓`);
   }
 }
@@ -252,10 +254,11 @@ function verifyPackedApp(appOutDir, platform) {
   } else {
     checkRuntimeIcon(path.join(appOutDir, 'resources', 'app.asar'), failures);
     if (platform === 'win32') {
-      const exe = fs
-        .readdirSync(appOutDir)
-        .filter((entry) => entry.toLowerCase().endsWith('.exe'))
-        .map((entry) => path.join(appOutDir, entry))[0];
+      // The launcher is named after productName; anything else at this level is
+      // a helper whose icon nobody sees.
+      const exes = fs.readdirSync(appOutDir).filter((entry) => entry.toLowerCase().endsWith('.exe'));
+      const name = exes.find((entry) => entry.toLowerCase() === `${PRODUCT_NAME.toLowerCase()}.exe`) ?? exes[0];
+      const exe = name ? path.join(appOutDir, name) : null;
       if (!exe) {
         failures.push(`No .exe in ${appOutDir}`);
       } else {

--- a/scripts/verify-packaged-icon.js
+++ b/scripts/verify-packaged-icon.js
@@ -18,9 +18,11 @@
  *      Pane icon and not Electron's default.
  *
  * Runs from electron-builder's afterPack hook for every platform and target, so
- * a build that loses either icon fails before it can be published. Also runnable
- * standalone against an output directory, which is how a published release gets
- * checked:
+ * a build that loses an icon fails before it can be published. The Windows
+ * launcher is the one exception: rcedit writes its icon after that hook, so
+ * scripts/build-win.js checks it once electron-builder has finished. Also
+ * runnable standalone against an output directory, which is how a published
+ * release gets checked:
  *
  *   node scripts/verify-packaged-icon.js [dist-electron-dir]
  */

--- a/scripts/verify-packaged-icon.js
+++ b/scripts/verify-packaged-icon.js
@@ -236,8 +236,15 @@ function checkWindowsExe(exePath, failures) {
 
 // --- entry points -----------------------------------------------------------
 
-/** Verify one packaged output directory. Called from the afterPack hook. */
-function verifyPackedApp(appOutDir, platform) {
+/**
+ * Verify one packaged output directory.
+ *
+ * `checkExecutable` is off for the afterPack hook: on Windows, electron-builder
+ * writes the icon into the launcher with rcedit after the hook has run, so the
+ * exe still carries Electron's icon at that point. The Windows entry point
+ * checks it once electron-builder has finished.
+ */
+function verifyPackedApp(appOutDir, platform, { checkExecutable = true } = {}) {
   const failures = [];
 
   if (platform === 'darwin' || platform === 'mas') {
@@ -253,7 +260,7 @@ function verifyPackedApp(appOutDir, platform) {
     }
   } else {
     checkRuntimeIcon(path.join(appOutDir, 'resources', 'app.asar'), failures);
-    if (platform === 'win32') {
+    if (platform === 'win32' && checkExecutable) {
       // The launcher is named after productName; anything else at this level is
       // a helper whose icon nobody sees.
       const exes = fs.readdirSync(appOutDir).filter((entry) => entry.toLowerCase().endsWith('.exe'));

--- a/scripts/verify-packaged-icon.js
+++ b/scripts/verify-packaged-icon.js
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+/**
+ * Verify that a packaged Pane app actually carries the Pane icon.
+ *
+ * Background: the v2.4.69 Windows build showed the default Electron icon in the
+ * taskbar. The bundle icons were fine — Pane.exe's embedded icon group is the
+ * Pane logo — but `BrowserWindow({icon})` pointed at
+ * `main/dist/main/assets/icon.png`, which no build ever produced, because
+ * main's `copy:assets` copied only .sql files. On Windows an unloadable `icon`
+ * path is worse than none: Electron sets an empty HICON, which clears the icon
+ * the window would otherwise inherit from the executable. macOS hid the bug
+ * because it ignores the `icon` option and uses the bundle's .icns.
+ *
+ * So there are two things to assert, and the runtime one is the one that broke:
+ *   1. the runtime window icon ships inside app.asar, and
+ *   2. the platform bundle icon (macOS .icns, Windows RT_ICON resources) is the
+ *      Pane icon and not Electron's default.
+ *
+ * Runs from electron-builder's afterPack hook for every platform and target, so
+ * a build that loses either icon fails before it can be published. Also runnable
+ * standalone against an output directory, which is how a published release gets
+ * checked:
+ *
+ *   node scripts/verify-packaged-icon.js [dist-electron-dir]
+ */
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const ASSETS_DIR = path.join(ROOT_DIR, 'main', 'assets');
+
+/** Path of the runtime window icon inside the packaged asar, as index.ts resolves it. */
+const RUNTIME_ICON_IN_ASAR = ['main', 'dist', 'main', 'assets', 'icon.png'];
+
+const sha256 = (buffer) => crypto.createHash('sha256').update(buffer).digest('hex');
+
+// --- asar -------------------------------------------------------------------
+
+/**
+ * Look one path up in an asar archive's directory tree. An asar is a pickled
+ * header — a JSON tree carrying each file's size and SHA-256 — followed by the
+ * file contents. The header is enough to check what shipped, and reading it is
+ * not sensitive to how the content area is laid out.
+ */
+function readAsarEntry(asarPath, segments) {
+  const fd = fs.openSync(asarPath, 'r');
+  try {
+    const sizeBuf = Buffer.alloc(16);
+    fs.readSync(fd, sizeBuf, 0, 16, 0);
+    const headerSize = sizeBuf.readUInt32LE(12);
+    const headerBuf = Buffer.alloc(headerSize);
+    fs.readSync(fd, headerBuf, 0, headerSize, 16);
+
+    let node = JSON.parse(headerBuf.toString('utf8'));
+    for (const segment of segments) {
+      node = node.files?.[segment];
+      if (!node) return null;
+    }
+    return node.files ? null : node;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// --- Windows PE resources ---------------------------------------------------
+
+/** Parse the RT_ICON (3) and RT_GROUP_ICON (14) resources out of a PE file. */
+function readPeIconResources(exePath) {
+  const d = fs.readFileSync(exePath);
+  const pe = d.readUInt32LE(0x3c);
+  if (d.toString('latin1', pe, pe + 4) !== 'PE\0\0') throw new Error(`${exePath} is not a PE file`);
+
+  const sectionCount = d.readUInt16LE(pe + 6);
+  const optionalHeaderSize = d.readUInt16LE(pe + 20);
+  const optionalHeader = pe + 24;
+  const isPe32Plus = d.readUInt16LE(optionalHeader) === 0x20b;
+  const dataDirectories = optionalHeader + (isPe32Plus ? 112 : 96);
+  const resourceRva = d.readUInt32LE(dataDirectories + 16);
+
+  const sections = [];
+  for (let i = 0; i < sectionCount; i++) {
+    const s = pe + 24 + optionalHeaderSize + i * 40;
+    sections.push({
+      virtualSize: d.readUInt32LE(s + 8),
+      virtualAddress: d.readUInt32LE(s + 12),
+      rawSize: d.readUInt32LE(s + 16),
+      rawOffset: d.readUInt32LE(s + 20),
+    });
+  }
+  const toOffset = (rva) => {
+    for (const s of sections) {
+      const span = Math.max(s.virtualSize, s.rawSize);
+      if (rva >= s.virtualAddress && rva < s.virtualAddress + span) {
+        return s.rawOffset + (rva - s.virtualAddress);
+      }
+    }
+    throw new Error(`RVA ${rva} is outside every section of ${exePath}`);
+  };
+
+  const base = toOffset(resourceRva);
+  const entriesAt = (offset) => {
+    const named = d.readUInt16LE(offset + 12);
+    const ids = d.readUInt16LE(offset + 14);
+    const out = [];
+    for (let i = 0; i < named + ids; i++) {
+      const e = offset + 16 + i * 8;
+      out.push({ id: d.readUInt32LE(e), offset: d.readUInt32LE(e + 4) });
+    }
+    return out;
+  };
+
+  const icons = new Map();
+  const groups = new Map();
+  for (const type of entriesAt(base)) {
+    const typeId = type.id & 0x7fffffff;
+    if ((typeId !== 3 && typeId !== 14) || !(type.offset & 0x80000000)) continue;
+    for (const name of entriesAt(base + (type.offset & 0x7fffffff))) {
+      for (const lang of entriesAt(base + (name.offset & 0x7fffffff))) {
+        const dataEntry = base + lang.offset;
+        const start = toOffset(d.readUInt32LE(dataEntry));
+        const blob = d.subarray(start, start + d.readUInt32LE(dataEntry + 4));
+        (typeId === 3 ? icons : groups).set(name.id & 0x7fffffff, blob);
+      }
+    }
+  }
+  return { icons, groups };
+}
+
+/** Bitmap payloads of a .ico file, keyed by width. */
+function readIcoImages(icoPath) {
+  const d = fs.readFileSync(icoPath);
+  const images = new Map();
+  for (let i = 0; i < d.readUInt16LE(4); i++) {
+    const e = 6 + i * 16;
+    const width = d.readUInt8(e) || 256;
+    const size = d.readUInt32LE(e + 8);
+    const offset = d.readUInt32LE(e + 12);
+    images.set(width, d.subarray(offset, offset + size));
+  }
+  return images;
+}
+
+// --- checks -----------------------------------------------------------------
+
+function checkRuntimeIcon(asarPath, failures) {
+  if (!fs.existsSync(asarPath)) {
+    failures.push(`No app.asar at ${asarPath}`);
+    return;
+  }
+  const entry = readAsarEntry(asarPath, RUNTIME_ICON_IN_ASAR);
+  const label = RUNTIME_ICON_IN_ASAR.join('/');
+  if (!entry) {
+    failures.push(
+      `${asarPath} does not contain ${label} — BrowserWindow's icon option ` +
+        `resolves to a missing file, which leaves the window with no icon on Windows and Linux`
+    );
+    return;
+  }
+  const expected = fs.readFileSync(path.join(ASSETS_DIR, 'icon.png'));
+  // asar records a SHA-256 per file when integrity is on, which is what Electron
+  // itself checks at load. Size is the fallback for an archive built without it.
+  const packedHash = entry.integrity?.hash;
+  const matches = packedHash ? packedHash === sha256(expected) : entry.size === expected.length;
+  if (!matches) {
+    failures.push(`${asarPath} ships a ${label} that differs from main/assets/icon.png`);
+    return;
+  }
+  console.log(`[verify-icon] ${path.basename(path.dirname(asarPath))}/app.asar ships the runtime window icon ✓`);
+}
+
+function checkMacBundle(appPath, failures) {
+  const plistPath = path.join(appPath, 'Contents', 'Info.plist');
+  const icnsPath = path.join(appPath, 'Contents', 'Resources', 'icon.icns');
+
+  if (!fs.existsSync(icnsPath)) {
+    failures.push(`${appPath} has no Contents/Resources/icon.icns — the bundle falls back to Electron's icon`);
+  } else if (sha256(fs.readFileSync(icnsPath)) !== sha256(fs.readFileSync(path.join(ASSETS_DIR, 'icon.icns')))) {
+    failures.push(`${appPath} ships an icon.icns that differs from main/assets/icon.icns`);
+  }
+
+  const plist = fs.existsSync(plistPath) ? fs.readFileSync(plistPath, 'utf8') : '';
+  if (!/<key>CFBundleIconFile<\/key>\s*<string>icon(\.icns)?<\/string>/.test(plist)) {
+    failures.push(`${appPath} does not declare CFBundleIconFile=icon.icns in Info.plist`);
+  }
+
+  if (failures.length === 0) {
+    console.log(`[verify-icon] ${path.basename(appPath)} carries the Pane .icns ✓`);
+  }
+}
+
+function checkWindowsExe(exePath, failures) {
+  let resources;
+  try {
+    resources = readPeIconResources(exePath);
+  } catch (error) {
+    failures.push(`Could not read icon resources from ${exePath}: ${error.message}`);
+    return;
+  }
+
+  if (resources.groups.size === 0) {
+    failures.push(`${exePath} has no RT_GROUP_ICON resource — the executable would show Electron's default icon`);
+    return;
+  }
+
+  const expected = readIcoImages(path.join(ASSETS_DIR, 'icon.ico'));
+  const [group] = [...resources.groups.values()];
+  const found = new Set();
+  // dwBytesInRes in the group directory is not checked: rcedit writes it
+  // truncated to 16 bits for the 128px and 256px entries, and has done so in
+  // every release including the ones with a correct icon. The payload bytes are
+  // what decide which icon Windows draws.
+  for (let i = 0; i < group.readUInt16LE(4); i++) {
+    const e = 6 + i * 14;
+    const width = group.readUInt8(e) || 256;
+    const blob = resources.icons.get(group.readUInt16LE(e + 12));
+    if (blob && expected.has(width) && Buffer.compare(blob, expected.get(width)) === 0) {
+      found.add(width);
+    }
+  }
+
+  const missing = [...expected.keys()].filter((width) => !found.has(width));
+  if (missing.length > 0) {
+    failures.push(
+      `${exePath} is missing Pane icon bitmaps for: ${missing.join(', ')}px — ` +
+        `the executable would show a different icon than main/assets/icon.ico`
+    );
+    return;
+  }
+  console.log(`[verify-icon] ${path.basename(exePath)} embeds all ${found.size} Pane icon sizes ✓`);
+}
+
+// --- entry points -----------------------------------------------------------
+
+/** Verify one packaged output directory. Called from the afterPack hook. */
+function verifyPackedApp(appOutDir, platform) {
+  const failures = [];
+
+  if (platform === 'darwin' || platform === 'mas') {
+    const bundle = fs
+      .readdirSync(appOutDir)
+      .filter((entry) => entry.endsWith('.app'))
+      .map((entry) => path.join(appOutDir, entry))[0];
+    if (!bundle) {
+      failures.push(`No .app bundle in ${appOutDir}`);
+    } else {
+      checkMacBundle(bundle, failures);
+      checkRuntimeIcon(path.join(bundle, 'Contents', 'Resources', 'app.asar'), failures);
+    }
+  } else {
+    checkRuntimeIcon(path.join(appOutDir, 'resources', 'app.asar'), failures);
+    if (platform === 'win32') {
+      const exe = fs
+        .readdirSync(appOutDir)
+        .filter((entry) => entry.toLowerCase().endsWith('.exe'))
+        .map((entry) => path.join(appOutDir, entry))[0];
+      if (!exe) {
+        failures.push(`No .exe in ${appOutDir}`);
+      } else {
+        checkWindowsExe(exe, failures);
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    const message = [`Packaged app in ${appOutDir} is missing its icon:`, ...failures.map((f) => `  - ${f}`)].join('\n');
+    throw new Error(message);
+  }
+}
+
+/** Standalone mode: sweep an output directory for anything worth checking. */
+function verifyOutputDir(distDir) {
+  if (!fs.existsSync(distDir)) {
+    console.error(`[verify-icon] Missing output directory: ${distDir}`);
+    process.exit(1);
+  }
+
+  const targets = [];
+  for (const entry of fs.readdirSync(distDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const full = path.join(distDir, entry.name);
+    if (entry.name.endsWith('.app')) {
+      targets.push([path.dirname(full), 'darwin']);
+    } else if (fs.readdirSync(full).some((child) => child.endsWith('.app'))) {
+      targets.push([full, 'darwin']);
+    } else if (fs.existsSync(path.join(full, 'resources', 'app.asar'))) {
+      targets.push([full, entry.name.startsWith('win') ? 'win32' : 'linux']);
+    }
+  }
+
+  if (targets.length === 0) {
+    console.error(`[verify-icon] No packaged app found under ${distDir}`);
+    process.exit(1);
+  }
+
+  let failed = false;
+  for (const [dir, platform] of targets) {
+    try {
+      verifyPackedApp(dir, platform);
+    } catch (error) {
+      failed = true;
+      console.error(`[verify-icon] ${error.message}`);
+    }
+  }
+  process.exit(failed ? 1 : 0);
+}
+
+if (require.main === module) {
+  verifyOutputDir(path.resolve(process.argv[2] || path.join(process.cwd(), 'dist-electron')));
+}
+
+module.exports = { verifyPackedApp, verifyOutputDir };


### PR DESCRIPTION
## Summary

Windows showed Electron's default icon in the taskbar while Pane was running. The bundle icons were never the problem. The runtime window icon was: `BrowserWindow`'s `icon` pointed at a file that shipped in no build, and on Windows an icon path Electron cannot load is worse than passing none at all.

This ships that file, and adds a build-time check so a missing icon fails the build instead of reaching a release.

## What the artifacts actually said

Before changing anything I took apart the shipped v2.4.69 artifacts. The release-pipeline theory did not survive:

| Surface | v2.4.69 artifact | Verdict |
| --- | --- | --- |
| macOS `Pane.app` | `Contents/Resources/icon.icns` sha256 `05d1021b…`, identical to `main/assets/icon.icns`; `CFBundleIconFile=icon.icns` | correct |
| Windows installer `.exe` | all 7 Pane `.ico` bitmaps embedded, including 256x256 | correct |
| Windows packed `Pane.exe` | one `RT_GROUP_ICON`, 7 `RT_ICON` entries, every payload byte-identical to `main/assets/icon.ico` — and byte-identical to v2.4.67's | correct, and not a regression |
| Runtime window icon | `main/dist/main/assets/icon.png` absent from `app.asar` | **broken** |

The v2.4.69 Build & Release run (`32451020074`) also completed every job, reached electron-builder's icon step, and logged no icon warning. The icon-embedding step ran and did its job. A clean re-cut of that source would have reproduced the bug exactly.

## Root cause

`main/src/index.ts` passed `path.join(__dirname, '../assets/icon.png')` to `BrowserWindow`. At runtime `__dirname` is `main/dist/main/src`, so that resolves to `main/dist/main/assets/icon.png` — and main's `copy:assets` copied only `.sql` files, so nothing ever put an icon there. Broken since the first commit.

On Windows, Electron turns an unloadable path into an empty `HICON` and calls `WM_SETICON` with it, which clears the icon the window would otherwise inherit from `Pane.exe`. Passing nothing would have looked better than passing something broken.

macOS hid it: the `icon` option is ignored there and the Dock reads the bundle's `.icns`, which was always correct. That is why this only ever showed up on Windows.

## The fix

- **`main/package.json`** — `copy:assets` now copies `assets/icon.png` into `dist/main/assets`. The electron-builder `files` array needs no change: `main/dist/**/*` already carries it into the package.
- **`main/src/index.ts`** — set `icon` only when the file is present, so a broken tree degrades to the executable's icon rather than to no icon.

## The guard

`scripts/verify-packaged-icon.js` (new) asserts that a packaged app carries its icons, and fails the build when it does not. Three checks per app:

1. the runtime icon is in `app.asar` and matches `main/assets/icon.png` — compared against the asar header's per-file SHA-256, the same digest Electron validates at load;
2. the macOS bundle has the Pane `.icns` and declares it in `Info.plist`;
3. the Windows launcher's `RT_ICON` payloads match `main/assets/icon.ico`.

Checks 1 and 2 run from electron-builder's `afterPack` hook, so they cover every platform and target. Check 3 runs from `scripts/build-win.js` after electron-builder finishes, because rcedit writes the launcher's icon *after* `afterPack` — at hook time the exe still carries Electron's icon.

Also runnable standalone against any output directory, which is how a published release gets checked:

```
node scripts/verify-packaged-icon.js dist-electron
```

Windows `dwBytesInRes` is deliberately not checked. rcedit writes it truncated to 16 bits for the 128px and 256px entries, and has done so in every release including the correct ones — the payload bytes decide what Windows draws.

`scripts/after-pack.js` now exports its Linux compatibility-alias step separately, because `test-runpane-contract.js` calls the hook against a fixture that is a bare `pane` binary with no packaged app to inspect. That test asserts the alias invariant, so it now calls the alias step directly.

## Evidence

The guard pointed at the **shipped v2.4.69 Windows artifact** (`Pane.exe` extracted from the installer, its real `app.asar`) names the exact defect that shipped:

```
[verify-icon] Pane.exe embeds all 7 Pane icon sizes ✓
[verify-icon] Packaged app in .../win-unpacked is missing its icon:
  - .../resources/app.asar does not contain main/dist/main/assets/icon.png — BrowserWindow's
    icon option resolves to a missing file, which leaves the window with no icon on Windows and Linux
```

Same layout with this branch's `app.asar`:

```
[verify-icon] resources/app.asar ships the runtime window icon ✓
[verify-icon] Pane.exe embeds all 7 Pane icon sizes ✓
```

Clean local `pnpm run build:mac` (universal, `--publish never`) — the guard runs on all three pack passes:

```
[verify-icon] Pane.app carries the Pane .icns ✓
[verify-icon] Resources/app.asar ships the runtime window icon ✓   (x64 temp)
[verify-icon] Pane.app carries the Pane .icns ✓
[verify-icon] Resources/app.asar ships the runtime window icon ✓   (arm64 temp)
[verify-icon] Pane.app carries the Pane .icns ✓
[verify-icon] Resources/app.asar ships the runtime window icon ✓   (universal)
[verify-mac-binaries] Pane.app ships node-pty for darwin x64 + arm64 ✓
```

Real Windows packaging on CI, via non-publishing `workflow_dispatch` runs of Build & Release on this branch — `resources/app.asar ships the runtime window icon ✓` on both architectures, and the launcher check passes after rcedit.

Negative test: the same guard against a pre-fix build exits 1 on the runtime-icon check.

## Pre-Merge Testing

- [ ] Windows: install the build from this branch, launch it, confirm the taskbar button and window title bar show the Pane logo instead of the default
- [ ] Windows: Start Menu and desktop shortcut icons still correct (they already were)
- [ ] macOS: Dock and Finder icons unchanged
- [ ] Confirm a release build fails, rather than publishes, if `copy:assets` is reverted

## Also found, not fixed here

The Linux `.deb` installs only `/usr/share/icons/hicolor/1024x1024/apps/pane.png`. Most desktops do not look in `1024x1024`, so they likely fall back to a generic icon. `linux.icon` points at a single PNG, and electron-builder does not expand that into a size set. Separate from this bug and untestable from macOS, so it is left alone — worth its own issue.

## Build Verification

- [x] `pnpm run build:mac` (universal, publish never) passes end to end
- [x] Build & Release dispatched on this branch with `publish=false` — macOS, Linux, Windows x64 and arm64 all package with the guard active
- [x] `pnpm --dir main exec vitest run` — 67 files, 623 tests pass
- [x] `pnpm run lint:ox` clean
- [x] `pnpm --dir main run typecheck` clean
