### PR TITLE
Fix the main-process crash when streaming kitty graphics: bound the PTY command scrape

### DIFF
--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -250,12 +250,12 @@ function createConfigManagerStub(): ConfigManager {
 
 type TerminalOutputEvent = { sessionId: string; panelId: string; output: string };
 
-type DataDrivenPty = TerminalUnderTest['pty'] & {
-  onData(listener: (data: string) => void): { dispose(): void };
-  onExit(listener: (exit: { exitCode: number; signal?: number }) => void): { dispose(): void };
+type DataDrivenTerminal = TerminalUnderTest & {
+  pty: TerminalUnderTest['pty'] & {
+    onData(listener: (data: string) => void): { dispose(): void };
+    onExit(listener: (exit: { exitCode: number; signal?: number }) => void): { dispose(): void };
+  };
 };
-
-type DataDrivenTerminal = TerminalUnderTest & { pty: DataDrivenPty };
 
 type TerminalDataHandlerAccess = {
   setupTerminalHandlers(terminal: DataDrivenTerminal): void;

--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -248,6 +248,46 @@ function createConfigManagerStub(): ConfigManager {
   });
 }
 
+type TerminalOutputEvent = { sessionId: string; panelId: string; output: string };
+
+type DataDrivenPty = TerminalUnderTest['pty'] & {
+  onData(listener: (data: string) => void): { dispose(): void };
+  onExit(listener: (exit: { exitCode: number; signal?: number }) => void): { dispose(): void };
+};
+
+type DataDrivenTerminal = TerminalUnderTest & { pty: DataDrivenPty };
+
+type TerminalDataHandlerAccess = {
+  setupTerminalHandlers(terminal: DataDrivenTerminal): void;
+};
+
+/**
+ * Wires a terminal through the real `setupTerminalHandlers` and hands back the
+ * `emit` seam, so tests can drive the production `pty.onData` listener directly
+ * instead of reimplementing its accounting.
+ */
+function createDataDrivenTerminal(overrides: Partial<TerminalUnderTest> = {}) {
+  const base = createTerminal({ outputBuffer: '', ...overrides });
+  let listener: ((data: string) => void) | undefined;
+  const terminal: DataDrivenTerminal = {
+    ...base,
+    pty: {
+      ...base.pty,
+      onData: vi.fn((next: (data: string) => void) => {
+        listener = next;
+        return { dispose: vi.fn() };
+      }),
+      onExit: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+  };
+  return {
+    terminal,
+    emit(data: string) {
+      listener?.(data);
+    },
+  };
+}
+
 async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -1003,5 +1043,130 @@ describe('TerminalPanelManager agent session capture', () => {
       }),
     });
     disposeFlowControlRecord(terminal.flowControl);
+  });
+});
+
+describe('TerminalPanelManager command scrape bounds', () => {
+  // `currentCommand` reconstructs the typed command line by scraping echoed PTY
+  // output, so it sees every byte a program prints. Kitty graphics frames are
+  // base64 (an alphabet with no CR or LF) inside APC sequences, and a full-screen
+  // TUI positions its cursor with CSI rather than newlines — so a game streamed
+  // through terminal-browser never reaches the reset branch. Uncapped, the
+  // accumulator grew past V8's max string length and `+=` threw
+  // `RangeError: Invalid string length`, taking down the main process.
+  const KITTY_FRAME = `\x1b_Gf=100,a=T,m=0;${'QUJD'.repeat(16_384)}\x1b\\`;
+
+  function useStubRuntime() {
+    const combinedSink = { send: vi.fn() };
+    setPaneRuntime({
+      eventSink: combinedSink,
+      daemonEventSink: { send: vi.fn() },
+      getConfigManager: () => createConfigManagerStub(),
+      getPtyHostRuntime: () => null,
+      getWebviewContextMap: () => new Map(),
+    });
+    return combinedSink;
+  }
+
+  function cleanup(terminal: DataDrivenTerminal) {
+    if (terminal.idleTimer) clearTimeout(terminal.idleTimer);
+    if (terminal.outputFlushTimer) clearTimeout(terminal.outputFlushTimer);
+    disposeFlowControlRecord(terminal.flowControl);
+  }
+
+  afterEach(() => {
+    resetPaneRuntimeForTests();
+    vi.mocked(panelManager.emitPanelEvent).mockReset();
+    vi.mocked(panelManager.getPanel).mockReset();
+    vi.mocked(panelManager.updatePanel).mockReset();
+    vi.useRealTimers();
+  });
+
+  it('holds the command scrape at its cap no matter how much newline-free output streams', () => {
+    vi.useFakeTimers();
+    useStubRuntime();
+    const manager = testAccess<TerminalDataHandlerAccess>(new TerminalPanelManager());
+    const { terminal, emit } = createDataDrivenTerminal();
+    manager.setupTerminalHandlers(terminal);
+
+    // The premise of the crash: a graphics frame carries no CR/LF at all.
+    expect(KITTY_FRAME).not.toMatch(/[\r\n]/);
+
+    for (let i = 0; i < 100; i += 1) emit(KITTY_FRAME);
+    const afterFirstBurst = terminal.currentCommand.length;
+
+    for (let i = 0; i < 100; i += 1) emit(KITTY_FRAME);
+    const afterSecondBurst = terminal.currentCommand.length;
+
+    // ~13MB streamed. Before the cap this grew 1:1 with the stream; the bound has
+    // to be independent of volume, which is what stops it reaching 512M chars.
+    expect(afterFirstBurst).toBeLessThanOrEqual(8192);
+    expect(afterSecondBurst).toBe(afterFirstBurst);
+
+    cleanup(terminal);
+  });
+
+  it('still streams every graphics frame to the renderer while the scrape is capped', () => {
+    vi.useFakeTimers();
+    const combinedSink = useStubRuntime();
+    const manager = testAccess<TerminalDataHandlerAccess>(new TerminalPanelManager());
+    const { terminal, emit } = createDataDrivenTerminal();
+    manager.setupTerminalHandlers(terminal);
+
+    for (let i = 0; i < 20; i += 1) emit(KITTY_FRAME);
+    vi.runOnlyPendingTimers();
+
+    // The cap lives on the scrape heuristic, not the render path: the frames a
+    // game emits must still reach xterm byte for byte.
+    // SAFETY: `terminal:output` is emitted from exactly one call site
+    // (`flushOutputBuffer`), which always sends `{ sessionId, panelId, output }`.
+    const streamed = combinedSink.send.mock.calls
+      .filter(([channel]) => channel === 'terminal:output')
+      .map(([, payload]) => (payload as TerminalOutputEvent).output)
+      .join('');
+    expect(streamed).toBe(KITTY_FRAME.repeat(20));
+
+    cleanup(terminal);
+  });
+
+  it('keeps the most recently typed bytes when it trims the scrape', () => {
+    vi.useFakeTimers();
+    useStubRuntime();
+    const manager = testAccess<TerminalDataHandlerAccess>(new TerminalPanelManager());
+    const { terminal, emit } = createDataDrivenTerminal();
+    manager.setupTerminalHandlers(terminal);
+
+    for (let i = 0; i < 10; i += 1) emit(KITTY_FRAME);
+    emit('whoami');
+
+    // Trimming from the front is what preserves the command: what the user typed
+    // is always the newest bytes before Enter.
+    expect(terminal.currentCommand.endsWith('whoami')).toBe(true);
+
+    cleanup(terminal);
+  });
+
+  it('records typed commands and stops history growing without bound', () => {
+    vi.useFakeTimers();
+    useStubRuntime();
+    const manager = testAccess<TerminalDataHandlerAccess>(new TerminalPanelManager());
+    const { terminal, emit } = createDataDrivenTerminal();
+    manager.setupTerminalHandlers(terminal);
+
+    emit('ls -la');
+    emit('\r\n');
+    expect(terminal.commandHistory).toEqual(['ls -la']);
+
+    for (let i = 0; i < 150; i += 1) {
+      emit(`echo ${i}`);
+      emit('\r\n');
+    }
+
+    // A long-lived panel keeps a bounded window, not every command it ever ran.
+    expect(terminal.commandHistory).toHaveLength(100);
+    expect(terminal.commandHistory.at(-1)).toBe('echo 149');
+    expect(terminal.commandHistory.at(0)).toBe('echo 50');
+
+    cleanup(terminal);
   });
 });

--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -3,7 +3,7 @@ import type { ConfigManager } from './configManager';
 import { resetPaneRuntimeForTests, setPaneRuntime } from '../core/runtime';
 import { createFlowControlRecord, disposeFlowControlRecord, type FlowControlRecord } from '../ptyHost/flowControl';
 import { TerminalStateEmulator } from './terminalStateEmulator';
-import type { TerminalPanelState } from '../../../shared/types/panels';
+import type { TerminalPanelOutputEvent, TerminalPanelState } from '../../../shared/types/panels';
 
 import { TerminalPanelManager } from './terminalPanelManager';
 import { panelManager } from '../test/setup';
@@ -247,8 +247,6 @@ function createConfigManagerStub(): ConfigManager {
     getUsePtyHost: () => false,
   });
 }
-
-type TerminalOutputEvent = { sessionId: string; panelId: string; output: string };
 
 type DataDrivenTerminal = TerminalUnderTest & {
   pty: TerminalUnderTest['pty'] & {
@@ -1068,7 +1066,7 @@ describe('TerminalPanelManager command scrape bounds', () => {
     return combinedSink;
   }
 
-  function cleanup(terminal: DataDrivenTerminal) {
+  function cleanup(terminal: TerminalUnderTest) {
     if (terminal.idleTimer) clearTimeout(terminal.idleTimer);
     if (terminal.outputFlushTimer) clearTimeout(terminal.outputFlushTimer);
     disposeFlowControlRecord(terminal.flowControl);
@@ -1122,7 +1120,7 @@ describe('TerminalPanelManager command scrape bounds', () => {
     // (`flushOutputBuffer`), which always sends `{ sessionId, panelId, output }`.
     const streamed = combinedSink.send.mock.calls
       .filter(([channel]) => channel === 'terminal:output')
-      .map(([, payload]) => (payload as TerminalOutputEvent).output)
+      .map(([, payload]) => (payload as TerminalPanelOutputEvent).output)
       .join('');
     expect(streamed).toBe(KITTY_FRAME.repeat(20));
 
@@ -1166,6 +1164,22 @@ describe('TerminalPanelManager command scrape bounds', () => {
     expect(terminal.commandHistory).toHaveLength(100);
     expect(terminal.commandHistory.at(-1)).toBe('echo 149');
     expect(terminal.commandHistory.at(0)).toBe('echo 50');
+
+    cleanup(terminal);
+  });
+
+  it('bounds and copies command history at state-read boundaries', async () => {
+    const manager = testAccess<SnapshotAccess>(new TerminalPanelManager());
+    const commandHistory = Array.from({ length: 151 }, (_, index) => `echo ${index}`);
+    const terminal = createTerminal({ commandHistory });
+    manager.terminals.set(terminal.panelId, terminal);
+
+    const state = await manager.getTerminalState(terminal.panelId);
+
+    expect(state?.commandHistory).toHaveLength(100);
+    expect(state?.commandHistory?.at(0)).toBe('echo 51');
+    expect(state?.commandHistory?.at(-1)).toBe('echo 150');
+    expect(state?.commandHistory).not.toBe(commandHistory);
 
     cleanup(terminal);
   });

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -64,6 +64,10 @@ function isValidUuid(value: string | undefined): value is string {
   return value !== undefined && UUID_PATTERN.test(value);
 }
 
+function boundedCommandHistory(history: string[] | undefined): string[] {
+  return history?.slice(-MAX_COMMAND_HISTORY) ?? [];
+}
+
 function terminalCustomState(state: ToolPanel['state']): TerminalPanelState {
   // SAFETY: TerminalPanelManager owns terminal panels and persists this exact
   // custom-state contract; non-terminal panel states never enter these paths.
@@ -1511,7 +1515,7 @@ export class TerminalPanelManager {
       scrollbackBuffer: savedScrollback,
       alternateScreenBuffer: terminal.alternateScreenBuffer,
       isAlternateScreen: savedIsAlternateScreen,
-      commandHistory: terminal.commandHistory.slice(-100), // Keep last 100 commands
+      commandHistory: boundedCommandHistory(terminal.commandHistory),
       lastActivityTime: terminal.lastActivity.toISOString(),
       lastActiveCommand: terminal.currentCommand,
       serializedBuffer: terminal.screenEmulator?.isAlternateScreen
@@ -1561,7 +1565,7 @@ export class TerminalPanelManager {
       terminal.scrollbackBuffer = state.scrollbackBuffer;
     }
     terminal.alternateScreenBuffer = state.alternateScreenBuffer || '';
-    terminal.commandHistory = state.commandHistory || [];
+    terminal.commandHistory = boundedCommandHistory(state.commandHistory);
     
     // Send restoration indicator to terminal
     const restorationMsg = `\r\n[Session Restored from ${state.lastActivityTime || 'previous session'}]\r\n`;
@@ -1610,7 +1614,7 @@ export class TerminalPanelManager {
       scrollbackBuffer: cappedScrollback,
       alternateScreenBuffer: terminal.alternateScreenBuffer,
       isAlternateScreen,
-      commandHistory: terminal.commandHistory,
+      commandHistory: boundedCommandHistory(terminal.commandHistory),
       lastActivityTime: terminal.lastActivity.toISOString(),
       lastActiveCommand: terminal.currentCommand,
       // An active alternate screen cannot be reconstructed from normal shell

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -1248,9 +1248,10 @@ export class TerminalPanelManager {
       if (data.includes('\r') || data.includes('\n')) {
         if (terminal.currentCommand.trim()) {
           terminal.commandHistory.push(terminal.currentCommand);
-          if (terminal.commandHistory.length > MAX_COMMAND_HISTORY) {
-            terminal.commandHistory.splice(0, terminal.commandHistory.length - MAX_COMMAND_HISTORY);
-          }
+          terminal.commandHistory.splice(
+            0,
+            Math.max(0, terminal.commandHistory.length - MAX_COMMAND_HISTORY),
+          );
 
           // Emit command executed event
           panelManager.emitPanelEvent(

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -33,6 +33,15 @@ const MAX_CONCURRENT_SPAWNS = 3;
 const AGENT_STATUS_POLL_MS = 500; // cadence for re-deriving blocked/working/done from the live screen
 const MAX_SCROLLBACK_BUFFER_SIZE = 500_000; // 500KB of normal shell history
 const MAX_ALTERNATE_SCREEN_BUFFER_SIZE = 100_000; // 100KB of recent TUI redraw state
+// The command scrape reads echoed PTY output, so it sees every byte a program
+// prints — not just what the user typed — and only resets on CR/LF. Kitty graphics
+// frames carry neither (base64 inside APC sequences), so a tool streaming them
+// grew this past V8's max string length until `+=` threw `RangeError: Invalid
+// string length` and took down the main process.
+const MAX_CURRENT_COMMAND_SIZE = 8192; // 8KB — a typed command line, not a data stream
+// Matches the slice(-100) already applied on save, so a long-lived panel stops
+// growing an array that `getTerminalState` returns in full.
+const MAX_COMMAND_HISTORY = 100;
 const MIN_PTY_COLS = 20;
 const MIN_PTY_ROWS = 5;
 const FORCED_REDRAW_TRANSITION_MS = 50;
@@ -1239,6 +1248,9 @@ export class TerminalPanelManager {
       if (data.includes('\r') || data.includes('\n')) {
         if (terminal.currentCommand.trim()) {
           terminal.commandHistory.push(terminal.currentCommand);
+          if (terminal.commandHistory.length > MAX_COMMAND_HISTORY) {
+            terminal.commandHistory.splice(0, terminal.commandHistory.length - MAX_COMMAND_HISTORY);
+          }
 
           // Emit command executed event
           panelManager.emitPanelEvent(
@@ -1265,8 +1277,9 @@ export class TerminalPanelManager {
           terminal.currentCommand = '';
         }
       } else {
-        // Accumulate command input
-        terminal.currentCommand += data;
+        // Accumulate command input, keeping only the tail: what the user typed is
+        // always the newest bytes before Enter, so trimming the front preserves it.
+        terminal.currentCommand = (terminal.currentCommand + data).slice(-MAX_CURRENT_COMMAND_SIZE);
       }
 
       // Buffer output for batching instead of sending immediately


### PR DESCRIPTION
## Description

Bounds a string on the PTY data path that could grow until V8 refused to extend it, killing the main process. One-line production fix; the rest is the evidence for it.

Pane died with an unrecoverable main-process crash while a game was streaming through `terminal-browser`:

```
RangeError: Invalid string length
  at terminalPanelManager.js:1099:44
  at EventEmitter2.fire (node-pty-darwin-arm64/lib/eventEmitter2.js:41:22)
  at ReadStream.<anonymous> (node-pty-darwin-arm64/lib/terminal.js:92:61)
```

Building `main/` with the repo's own `tsc` config puts an exact line and column match on that frame:

```
main/dist/main/src/services/terminalPanelManager.js
1099:                terminal.currentCommand += data;
                                               ^ column 44
```

### Root cause

`terminal.currentCommand` reconstructs the command line the user typed by scraping *echoed PTY output*, so it sees every byte a program prints. It resets only when a chunk contains CR or LF, and nothing capped it:

```ts
if (data.includes('\r') || data.includes('\n')) {
  if (terminal.currentCommand.trim()) { /* ...push, reset... */ }
} else {
  terminal.currentCommand += data;   // unbounded
}
```

Kitty graphics frames contain neither character. The payload is base64 — an alphabet with no CR or LF — wrapped in APC sequences, and a full-screen TUI positions its cursor with CSI rather than newlines. So a game streaming frames appended every one of them to the accumulator and never once reached the reset branch, until the string crossed V8's ~512M-character ceiling and `+=` threw. A game is the worst case here: it re-renders continuously, so it gets there in minutes where a static page might never.

Worth being precise about two things:

- **This is not an out-of-memory.** `RangeError: Invalid string length` is V8 refusing to build a string past a hard per-string ceiling. It fires with gigabytes of RAM still free, so "use less memory" would not have fixed it.
- **It is not one oversized chunk.** node-pty reads through a ~64KB stream buffer, so a single `data` can never be 512MB. The defect is unbounded *accumulation across* chunks, which is why the fix is a cap rather than chunking.

Every other accumulator on this path was already bounded — `outputBuffer` flushes each chunk, and `scrollbackBuffer`, `alternateScreenBuffer` and `agentSessionScrapeBuffer` all run through `trimAnsiSafe` every call. `currentCommand` was the only one without a ceiling.

### The fix

Cap the accumulator at 8KB, keeping the **tail**, because what the user typed is always the newest bytes before Enter:

```ts
terminal.currentCommand = (terminal.currentCommand + data).slice(-MAX_CURRENT_COMMAND_SIZE);
```

8KB is chosen to be far past any real command line while far below anything that
threatens a string limit. `ARG_MAX` on macOS is 1MB, but that bounds an executed
argv, not a line someone types at a prompt.

If it looks like this truncates short commands, it does not: `String.slice(-N)`
clamps to 0 and returns the whole string when it is shorter than `N`, so the
common path is a plain append. V8 returns the receiver for a full-range slice, so
there is no extra copy either.

Also bound `commandHistory` in memory to the 100 entries already applied when panel state is saved — `getTerminalState` returns that array in full, so a long-lived panel was growing it without limit.

The production change is 12 lines.

### Inline images still render

The cap sits on the scrape heuristic, which nothing draws. Image data reaches xterm through `outputBuffer` on a path this PR does not touch, so kitty, sixel and iTerm2 frames render exactly as they did before. There is a test asserting the streamed bytes arrive at the renderer intact.

### Relationship to #486

`terminalPanelManager.ts` was last modified in #438, so the inline-image work did not introduce this. What #486 changed is *reachability*: it enabled the kitty protocol that image-streaming tools need, which is what put a newline-free multi-hundred-megabyte stream through this handler in the first place. The bug is older than the PR that exposed it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — no documented behavior changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [ ] I have tested the Electron app locally with `pnpm electron-dev` — see Testing notes

## Critical Areas Modified
- [x] **Session output handling (requires explicit permission)** — this change is on the `pty.onData` path. Deliberate and necessary: the crash is on this path. The only behavior change is that a string that previously grew without limit now stops at 8KB; no bytes are added, dropped or reordered on the render path.
- [x] State management/IPC events — `currentCommand` feeds `lastActiveCommand` in persisted panel state and `getTerminalSnapshot`, so both are now bounded too. That was a real secondary problem: before this, a long graphics session was writing a multi-hundred-megabyte string into panel state and across IPC.

## Testing notes

Four regression tests in `main/src/services/terminalPanelManager.test.ts` drive the real `pty.onData` listener through `setupTerminalHandlers`:

1. **Bounded under a newline-free flood** — streams ~13MB of kitty-shaped APC frames and asserts the scrape stays at its cap, measured after two separate bursts so the bound is proven independent of volume. That independence is the property that stops it reaching 512M chars.
2. **Frames still reach the renderer** — asserts the streamed bytes arrive at the event sink identical to what was emitted.
3. **Tail preservation** — after a flood, typed input is still the suffix of the accumulator.
4. **History stays bounded** — typed commands are recorded, and a 151-command panel keeps the last 100.

Verified as genuine regression tests: reverting the fix and re-running fails tests 1 and 4. Tests 2 and 3 pass either way by design — they are guarantees that the fix did not break streaming, not detectors of the original bug.

I did not add the "write a >256MB string to a PTY" test that would reproduce the crash end to end. It needs ~512MB to actually fire, which makes it minutes-long, memory-hungry and flaky, and it would be by far the slowest thing in the suite. The invariant that matters — the accumulator is bounded regardless of input volume — is provable in milliseconds and does fail on the unfixed code. Happy to add the heavyweight version behind an opt-in env guard if reviewers want it.

**Manual test:** run `terminal-browser` in a pane, load something that repaints continuously, and confirm images still render and the app survives. I have not run this — it needs a real interactive Electron session, and the crash it exercises takes minutes of streaming to reproduce.

```
pnpm --filter main test    →  627 passed (67 files)
pnpm typecheck             →  clean
pnpm lint                  →  clean (0 advisory findings)
pnpm build:main            →  pass
pnpm build:frontend        →  pass
```

## Additional Notes

**Known limitation, deliberately not fixed here.** The design underneath is weak: `currentCommand` infers user input from program *output*, so anything that prints without newlines pollutes it. After this PR a graphics-streaming session will still eventually push ~8KB of base64 into `commandHistory` and fire a bogus `terminal:command_executed` event when a newline finally arrives. That behavior exists today at 500MB scale — this PR bounds it rather than redesigning it. The real fix is to derive commands from the PTY **write** path, i.e. what the user actually types, instead of scraping the read path. That belongs in its own change, not smuggled into a crash fix.
