### PR TITLE
feat(updater): add a quit action so the macOS manual install can be completed

### DIFF
--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -82,6 +82,12 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     isMacPlatform: isMac(),
     hasUpdate: versionInfo?.hasUpdate === true,
   });
+  const manualInstallQuitInstruction = offerQuit
+    ? 'use Quit Pane below before dragging Pane.app into Applications'
+    : 'quit Pane before dragging Pane.app into Applications';
+  const manualInstallSteps = offerQuit
+    ? 'use Quit Pane below, then drag Pane.app into Applications and choose Replace'
+    : 'quit Pane, drag Pane.app into Applications, and choose Replace';
 
   const startDownloadUpdate = useCallback(async () => {
     if (!window.electronAPI?.updater) {
@@ -224,9 +230,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
         userStartedUpdateRef.current = false;
         if (response.success) {
           setUpdateState('idle');
-          setMessage(offerQuit
-            ? 'Terminal opened and the update command was copied. Paste it and press Return to open the latest installer. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.'
-            : 'Terminal opened and the update command was copied. Paste it and press Return to open the latest installer. Once the installer opens, quit Pane before dragging Pane.app into Applications.');
+          setMessage(`Terminal opened and the update command was copied. Paste it and press Return to open the latest installer. Once the installer opens, ${manualInstallQuitInstruction}.`);
         } else {
           setError(response.error || 'Failed to open Terminal');
           setUpdateState('error');
@@ -281,9 +285,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       const response = await window.electronAPI.updater.openTerminalWithCommand();
       if (response.success) {
         setError(null);
-        setMessage(offerQuit
-          ? 'Terminal opened and the update command was copied. Paste it and press Return. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.'
-          : 'Terminal opened and the update command was copied. Paste it and press Return. Once the installer opens, quit Pane before dragging Pane.app into Applications.');
+        setMessage(`Terminal opened and the update command was copied. Paste it and press Return. Once the installer opens, ${manualInstallQuitInstruction}.`);
       } else {
         setMessage(null);
         setError(response.error || 'Failed to open Terminal');
@@ -414,9 +416,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
           Paste it, press Return, and the latest Pane installer will download and open.
         </p>
         <p className="text-text-secondary">
-          {offerQuit
-            ? 'After the DMG opens: use Quit Pane below, then drag Pane.app into Applications and choose Replace.'
-            : 'After the DMG opens: quit Pane, drag Pane.app into Applications, and choose Replace.'}
+          After the DMG opens: {manualInstallSteps}.
           {' '}Your settings and sessions are preserved.
         </p>
         <code className="block bg-surface-primary border border-border-primary rounded px-3 py-2 text-xs text-text-primary font-mono break-all">
@@ -629,10 +629,8 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                       <div className="space-y-3">
                         {isMac() ? (
                           <p className="text-sm text-text-secondary">
-                            Use the update command above, or download the DMG directly. After the DMG opens,
-                            {offerQuit
-                              ? ' use Quit Pane below, then drag Pane.app into Applications and choose Replace.'
-                              : ' quit Pane, drag Pane.app into Applications, and choose Replace.'}
+                            Use the update command above, or download the DMG directly. After the DMG opens,{' '}
+                            {manualInstallSteps}.
                           </p>
                         ) : (
                           <>

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { AlertCircle, CheckCircle, Clipboard, Download, ExternalLink, Loader2, Power, Terminal } from 'lucide-react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
@@ -37,6 +37,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   const [message, setMessage] = useState<string | null>(null);
   const [isPackaged, setIsPackaged] = useState(false);
   const [quitRequested, setQuitRequested] = useState(false);
+  const quitHintId = useId();
   const userStartedUpdateRef = useRef(false);
   const downloadStartedRef = useRef(false);
   const installStartedRef = useRef(false);
@@ -202,6 +203,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   }, [clearInstallTimeout, installDownloadedUpdate, isOpen, startDownloadUpdate]);
 
   const handleStartUpdate = async () => {
+    setQuitRequested(false);
     if (!window.electronAPI?.updater) {
       setError('Update functionality not available');
       return;
@@ -222,7 +224,9 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
         userStartedUpdateRef.current = false;
         if (response.success) {
           setUpdateState('idle');
-          setMessage('Terminal opened and the update command was copied. Paste it and press Return to open the latest installer. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.');
+          setMessage(offerQuit
+            ? 'Terminal opened and the update command was copied. Paste it and press Return to open the latest installer. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.'
+            : 'Terminal opened and the update command was copied. Paste it and press Return to open the latest installer. Once the installer opens, quit Pane before dragging Pane.app into Applications.');
         } else {
           setError(response.error || 'Failed to open Terminal');
           setUpdateState('error');
@@ -243,6 +247,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   };
 
   const handleCopyUpdateCommand = async () => {
+    setQuitRequested(false);
     if (!window.electronAPI?.updater) {
       setError('Update functionality not available');
       return;
@@ -266,6 +271,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   };
 
   const handleOpenTerminalWithCommand = async () => {
+    setQuitRequested(false);
     if (!window.electronAPI?.updater) {
       setError('Update functionality not available');
       return;
@@ -733,7 +739,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                 the downloaded and error states, so the ordinary macOS path — which
                 returns to 'idle' with a message — would otherwise offer no way out. */}
             {offerQuit && quitRequested && (
-              <span id="quit-confirm-hint" role="alert" className="text-sm text-text-secondary">
+              <span id={quitHintId} role="alert" className="text-sm text-text-secondary">
                 Quitting stops running agents.
                 <span className="sr-only"> Choose Quit now to confirm.</span>
               </span>
@@ -743,7 +749,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                 onClick={handleQuitForManualInstall}
                 variant={quitRequested ? 'danger' : 'secondary'}
                 disabled={isUpdateBusy}
-                aria-describedby={quitRequested ? 'quit-confirm-hint' : undefined}
+                aria-describedby={quitRequested ? quitHintId : undefined}
                 icon={<Power className="w-4 h-4" />}
               >
                 {quitRequested ? 'Quit now' : 'Quit Pane'}

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -23,9 +23,6 @@ interface UpdateDialogProps {
 
 type UpdateState = 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'installing' | 'error';
 
-const QUIT_CONFIRM_ANNOUNCEMENT =
-  'Quitting stops running agents and closes Pane so the new version can replace it. Choose Quit now to confirm.';
-
 interface DownloadProgress {
   bytesPerSecond: number;
   percent: number;
@@ -78,6 +75,12 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       });
     }
   }, []);
+
+  const offerQuit = shouldOfferQuitForManualInstall({
+    isPackaged,
+    isMacPlatform: isMac(),
+    hasUpdate: versionInfo?.hasUpdate === true,
+  });
 
   const startDownloadUpdate = useCallback(async () => {
     if (!window.electronAPI?.updater) {
@@ -272,7 +275,9 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       const response = await window.electronAPI.updater.openTerminalWithCommand();
       if (response.success) {
         setError(null);
-        setMessage('Terminal opened and the update command was copied. Paste it and press Return. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.');
+        setMessage(offerQuit
+          ? 'Terminal opened and the update command was copied. Paste it and press Return. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.'
+          : 'Terminal opened and the update command was copied. Paste it and press Return. Once the installer opens, quit Pane before dragging Pane.app into Applications.');
       } else {
         setMessage(null);
         setError(response.error || 'Failed to open Terminal');
@@ -340,11 +345,6 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   };
   const isUpdateBusy = updateState === 'checking' || updateState === 'available' || updateState === 'downloading' || updateState === 'installing';
   const progressMilestone = downloadProgress ? Math.floor(downloadProgress.percent / 10) * 10 : 0;
-  const offerQuit = shouldOfferQuitForManualInstall({
-    isPackaged,
-    isMacPlatform: isMac(),
-    hasUpdate: versionInfo?.hasUpdate === true,
-  });
   const statusAnnouncement = message ?? ({
     idle: '',
     checking: 'Checking for updates',
@@ -427,7 +427,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       closeOnEscape={!isUpdateBusy}
       closeOnOverlayClick={!isUpdateBusy}
     >
-      <LiveRegion>{quitRequested ? QUIT_CONFIRM_ANNOUNCEMENT : statusAnnouncement}</LiveRegion>
+      <LiveRegion>{statusAnnouncement}</LiveRegion>
       <ModalHeader
         title="Software Update"
         icon={<Download className="w-6 h-6 text-interactive" />}
@@ -733,8 +733,9 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                 the downloaded and error states, so the ordinary macOS path — which
                 returns to 'idle' with a message — would otherwise offer no way out. */}
             {offerQuit && quitRequested && (
-              <span className="text-sm text-text-secondary text-right">
+              <span id="quit-confirm-hint" role="alert" className="text-sm text-text-secondary">
                 Quitting stops running agents.
+                <span className="sr-only"> Choose Quit now to confirm.</span>
               </span>
             )}
             {offerQuit && (
@@ -742,6 +743,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                 onClick={handleQuitForManualInstall}
                 variant={quitRequested ? 'danger' : 'secondary'}
                 disabled={isUpdateBusy}
+                aria-describedby={quitRequested ? 'quit-confirm-hint' : undefined}
                 icon={<Power className="w-4 h-4" />}
               >
                 {quitRequested ? 'Quit now' : 'Quit Pane'}

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertCircle, CheckCircle, Clipboard, Download, ExternalLink, Loader2, Terminal } from 'lucide-react';
+import { AlertCircle, CheckCircle, Clipboard, Download, ExternalLink, Loader2, Power, Terminal } from 'lucide-react';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { isMac } from '../utils/platformUtils';
 import { LiveRegion } from './ui/LiveRegion';
+import { shouldOfferQuitForManualInstall } from './updateDialogQuit';
 
 interface UpdateDialogProps {
   isOpen: boolean;
@@ -22,6 +23,9 @@ interface UpdateDialogProps {
 
 type UpdateState = 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'installing' | 'error';
 
+const QUIT_CONFIRM_ANNOUNCEMENT =
+  'Quitting stops running agents and closes Pane so the new version can replace it. Choose Quit now to confirm.';
+
 interface DownloadProgress {
   bytesPerSecond: number;
   percent: number;
@@ -35,6 +39,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [isPackaged, setIsPackaged] = useState(false);
+  const [quitRequested, setQuitRequested] = useState(false);
   const userStartedUpdateRef = useRef(false);
   const downloadStartedRef = useRef(false);
   const installStartedRef = useRef(false);
@@ -55,6 +60,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       setDownloadProgress(null);
       setError(null);
       setMessage(null);
+      setQuitRequested(false);
       userStartedUpdateRef.current = false;
       downloadStartedRef.current = false;
       installStartedRef.current = false;
@@ -213,7 +219,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
         userStartedUpdateRef.current = false;
         if (response.success) {
           setUpdateState('idle');
-          setMessage('Terminal opened and the update command was copied. Paste it and press Return to open the latest installer.');
+          setMessage('Terminal opened and the update command was copied. Paste it and press Return to open the latest installer. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.');
         } else {
           setError(response.error || 'Failed to open Terminal');
           setUpdateState('error');
@@ -266,7 +272,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       const response = await window.electronAPI.updater.openTerminalWithCommand();
       if (response.success) {
         setError(null);
-        setMessage('Terminal opened and the update command was copied. Paste it and press Return.');
+        setMessage('Terminal opened and the update command was copied. Paste it and press Return. Once the installer opens, use Quit Pane below before dragging Pane.app into Applications.');
       } else {
         setMessage(null);
         setError(response.error || 'Failed to open Terminal');
@@ -275,6 +281,42 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     } catch (err: unknown) {
       setMessage(null);
       setError(err instanceof Error ? err.message : 'Failed to open Terminal');
+      setUpdateState('error');
+    }
+  };
+
+  const handleQuitForManualInstall = async () => {
+    if (!window.electronAPI?.updater) {
+      setMessage(null);
+      setError('Update functionality not available');
+      setUpdateState('error');
+      return;
+    }
+
+    // Arm on the first press. Quitting interrupts every running agent, and this
+    // button sits next to Close.
+    if (!quitRequested) {
+      setQuitRequested(true);
+      return;
+    }
+
+    try {
+      const response = await window.electronAPI.updater.quitForManualInstall();
+      if (!response.success) {
+        setQuitRequested(false);
+        setMessage(null);
+        setError(response.error || 'Failed to quit Pane');
+        setUpdateState('error');
+      }
+      // A successful reply means the quit was requested, not that Pane is gone:
+      // the shutdown asks about in-flight archive tasks and is abandoned if the
+      // user chooses to wait. So nothing here disables the dialog or latches a
+      // "quitting" state — a user who waits keeps a working dialog and can press
+      // Quit again.
+    } catch (err: unknown) {
+      setQuitRequested(false);
+      setMessage(null);
+      setError(err instanceof Error ? err.message : 'Failed to quit Pane');
       setUpdateState('error');
     }
   };
@@ -298,6 +340,11 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   };
   const isUpdateBusy = updateState === 'checking' || updateState === 'available' || updateState === 'downloading' || updateState === 'installing';
   const progressMilestone = downloadProgress ? Math.floor(downloadProgress.percent / 10) * 10 : 0;
+  const offerQuit = shouldOfferQuitForManualInstall({
+    isPackaged,
+    isMacPlatform: isMac(),
+    hasUpdate: versionInfo?.hasUpdate === true,
+  });
   const statusAnnouncement = message ?? ({
     idle: '',
     checking: 'Checking for updates',
@@ -357,8 +404,10 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
           Paste it, press Return, and the latest Pane installer will download and open.
         </p>
         <p className="text-text-secondary">
-          After the DMG opens: close Pane, drag Pane.app into Applications, and choose Replace.
-          Your settings and sessions are preserved.
+          {offerQuit
+            ? 'After the DMG opens: use Quit Pane below, then drag Pane.app into Applications and choose Replace.'
+            : 'After the DMG opens: quit Pane, drag Pane.app into Applications, and choose Replace.'}
+          {' '}Your settings and sessions are preserved.
         </p>
         <code className="block bg-surface-primary border border-border-primary rounded px-3 py-2 text-xs text-text-primary font-mono break-all">
           curl -fsSL https://runpane.com/install.sh | sh
@@ -378,7 +427,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       closeOnEscape={!isUpdateBusy}
       closeOnOverlayClick={!isUpdateBusy}
     >
-      <LiveRegion>{statusAnnouncement}</LiveRegion>
+      <LiveRegion>{quitRequested ? QUIT_CONFIRM_ANNOUNCEMENT : statusAnnouncement}</LiveRegion>
       <ModalHeader
         title="Software Update"
         icon={<Download className="w-6 h-6 text-interactive" />}
@@ -568,7 +617,9 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                         {isMac() ? (
                           <p className="text-sm text-text-secondary">
                             Use the update command above, or download the DMG directly. After the DMG opens,
-                            close Pane, drag Pane.app into Applications, and choose Replace.
+                            {offerQuit
+                              ? ' use Quit Pane below, then drag Pane.app into Applications and choose Replace.'
+                              : ' quit Pane, drag Pane.app into Applications, and choose Replace.'}
                           </p>
                         ) : (
                           <>
@@ -666,7 +717,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       </ModalBody>
 
       <ModalFooter>
-        <div className="flex justify-between items-center w-full">
+        <div className="flex justify-between items-center w-full gap-4">
           <div className="text-sm text-text-tertiary">
             {versionInfo?.releaseUrl && (
               <button
@@ -677,13 +728,33 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
               </button>
             )}
           </div>
-          <Button
-            onClick={onClose}
-            variant="secondary"
-            disabled={isUpdateBusy}
-          >
-            Close
-          </Button>
+          <div className="flex items-center gap-3">
+            {/* In the footer, not renderMacUpdateActions(): that panel only renders in
+                the downloaded and error states, so the ordinary macOS path — which
+                returns to 'idle' with a message — would otherwise offer no way out. */}
+            {offerQuit && quitRequested && (
+              <span className="text-sm text-text-secondary text-right">
+                Quitting stops running agents.
+              </span>
+            )}
+            {offerQuit && (
+              <Button
+                onClick={handleQuitForManualInstall}
+                variant={quitRequested ? 'danger' : 'secondary'}
+                disabled={isUpdateBusy}
+                icon={<Power className="w-4 h-4" />}
+              >
+                {quitRequested ? 'Quit now' : 'Quit Pane'}
+              </Button>
+            )}
+            <Button
+              onClick={onClose}
+              variant="secondary"
+              disabled={isUpdateBusy}
+            >
+              Close
+            </Button>
+          </div>
         </div>
       </ModalFooter>
     </Modal>

--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -333,6 +333,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   };
 
   const openDmgDownload = () => {
+    setQuitRequested(false);
     if (versionInfo?.downloadUrl) {
       window.electronAPI.openExternal(versionInfo.downloadUrl);
     }
@@ -393,7 +394,10 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
           </Button>
           {versionInfo?.releaseUrl && (
             <Button
-              onClick={() => window.electronAPI.openExternal(versionInfo.releaseUrl!)}
+              onClick={() => {
+                setQuitRequested(false);
+                window.electronAPI.openExternal(versionInfo.releaseUrl!);
+              }}
               variant="secondary"
               size="sm"
               icon={<ExternalLink className="w-4 h-4" />}
@@ -485,7 +489,10 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                   </Button>
                 ) : (
                   <Button
-                    onClick={() => versionInfo.releaseUrl && window.electronAPI.openExternal(versionInfo.releaseUrl)}
+                    onClick={() => {
+                      setQuitRequested(false);
+                      if (versionInfo.releaseUrl) window.electronAPI.openExternal(versionInfo.releaseUrl);
+                    }}
                     variant="primary"
                   >
                     View Release
@@ -653,7 +660,10 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                       </div>
                       {versionInfo?.releaseUrl && (
                         <button
-                          onClick={() => window.electronAPI.openExternal(versionInfo.releaseUrl!)}
+                          onClick={() => {
+                            setQuitRequested(false);
+                            window.electronAPI.openExternal(versionInfo.releaseUrl!);
+                          }}
                           className="mt-3 text-sm text-interactive hover:text-interactive-hover underline"
                         >
                           View Release on GitHub
@@ -702,7 +712,13 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                         </blockquote>
                       ),
                       a: ({ href, children }) => (
-                        <a href={href} className="text-interactive hover:text-interactive-hover underline" target="_blank" rel="noopener noreferrer">
+                        <a
+                          href={href}
+                          className="text-interactive hover:text-interactive-hover underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => setQuitRequested(false)}
+                        >
                           {children}
                         </a>
                       ),
@@ -727,7 +743,10 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
           <div className="text-sm text-text-tertiary">
             {versionInfo?.releaseUrl && (
               <button
-                onClick={() => window.electronAPI.openExternal(versionInfo.releaseUrl!)}
+                onClick={() => {
+                  setQuitRequested(false);
+                  window.electronAPI.openExternal(versionInfo.releaseUrl!);
+                }}
                 className="hover:text-text-secondary underline transition-colors"
               >
                 View on GitHub

--- a/frontend/src/components/updateDialogQuit.test.ts
+++ b/frontend/src/components/updateDialogQuit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { shouldOfferQuitForManualInstall, type ManualQuitGate } from './updateDialogQuit';
+
+const macWithUpdate: ManualQuitGate = {
+  isPackaged: true,
+  isMacPlatform: true,
+  hasUpdate: true,
+};
+
+describe('shouldOfferQuitForManualInstall', () => {
+  it('offers the quit affordance on the packaged macOS manual-install path', () => {
+    expect(shouldOfferQuitForManualInstall(macWithUpdate)).toBe(true);
+  });
+
+  it('stays off where the installer replaces Pane in place', () => {
+    // Windows auto-updates through quitAndInstall(), so nothing needs the user
+    // to free the bundle by hand.
+    expect(shouldOfferQuitForManualInstall({ ...macWithUpdate, isMacPlatform: false })).toBe(false);
+  });
+
+  it('stays off in an unpackaged build, which has no bundle to replace', () => {
+    expect(shouldOfferQuitForManualInstall({ ...macWithUpdate, isPackaged: false })).toBe(false);
+  });
+
+  it('stays off when there is no update to install', () => {
+    expect(shouldOfferQuitForManualInstall({ ...macWithUpdate, hasUpdate: false })).toBe(false);
+  });
+});

--- a/frontend/src/components/updateDialogQuit.ts
+++ b/frontend/src/components/updateDialogQuit.ts
@@ -1,0 +1,24 @@
+/**
+ * Gate for the Software Update dialog's quit affordance.
+ *
+ * Extracted so it can be unit tested without a DOM: Modal renders through a
+ * Radix portal, so renderToStaticMarkup produces nothing for the dialog body.
+ */
+
+export interface ManualQuitGate {
+  isPackaged: boolean;
+  isMacPlatform: boolean;
+  hasUpdate: boolean;
+}
+
+/**
+ * Whether to offer quitting Pane from the update dialog.
+ *
+ * Only the macOS manual-install path needs it. There the DMG mounts while Pane
+ * is still running, so the drag into /Applications fails until Pane exits.
+ * Windows replaces the app in place through quitAndInstall(), and an unpackaged
+ * dev build has no installer to make room for.
+ */
+export function shouldOfferQuitForManualInstall(gate: ManualQuitGate): boolean {
+  return gate.isPackaged && gate.isMacPlatform && gate.hasUpdate;
+}

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -104,6 +104,7 @@ interface ElectronAPI {
     installUpdate: () => Promise<IPCResponse>;
     copyUpdateCommand: () => Promise<IPCResponse<{ command: string }>>;
     openTerminalWithCommand: () => Promise<IPCResponse<{ command: string }>>;
+    quitForManualInstall: () => Promise<IPCResponse>;
   };
 
   // System utilities

--- a/main/src/ipc/updater.test.ts
+++ b/main/src/ipc/updater.test.ts
@@ -10,6 +10,13 @@ interface IpcMainStub {
   handle(channel: string, listener: IpcHandler): void;
 }
 
+interface AppStub {
+  getVersion: () => string;
+  getName: () => string;
+  isPackaged: boolean;
+  quit: ReturnType<typeof vi.fn>;
+}
+
 function createIpcMainStub(): IpcMainStub {
   const handlers = new Map<string, IpcHandler>();
 
@@ -24,15 +31,15 @@ function createIpcMainStub(): IpcMainStub {
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
 
 describe('updater:quit-for-manual-install', () => {
-  let quit: ReturnType<typeof vi.fn>;
+  let app: AppStub;
   let ipcMain: IpcMainStub;
 
   beforeEach(() => {
-    quit = vi.fn();
+    app = { getVersion: () => '2.4.70', getName: () => 'Pane', isPackaged: true, quit: vi.fn() };
     ipcMain = createIpcMainStub();
     // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
     registerUpdaterHandlers(ipcMain, {
-      app: { getVersion: () => '2.4.70', getName: () => 'Pane', isPackaged: true, quit },
+      app,
       versionChecker: { checkForUpdates: vi.fn() },
     } as never);
   });
@@ -56,9 +63,9 @@ describe('updater:quit-for-manual-install', () => {
 
     // app.quit() is deferred a tick so the reply reaches the renderer before
     // index.ts's before-quit shutdown starts tearing the app down.
-    expect(quit).not.toHaveBeenCalled();
+    expect(app.quit).not.toHaveBeenCalled();
     await new Promise<void>(resolve => setImmediate(resolve));
-    expect(quit).toHaveBeenCalledTimes(1);
+    expect(app.quit).toHaveBeenCalledTimes(1);
   });
 
   it('refuses off macOS, where the installer replaces Pane in place', async () => {
@@ -66,10 +73,23 @@ describe('updater:quit-for-manual-install', () => {
 
     expect(await invokeQuit()).toEqual({
       success: false,
-      error: 'Quitting for a manual install is only available on macOS',
+      error: 'Quitting for a manual install is only available in packaged macOS builds',
     });
 
     await new Promise<void>(resolve => setImmediate(resolve));
-    expect(quit).not.toHaveBeenCalled();
+    expect(app.quit).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unpackaged macOS renderer outside the manual-install path', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    app.isPackaged = false;
+
+    expect(await invokeQuit()).toEqual({
+      success: false,
+      error: 'Quitting for a manual install is only available in packaged macOS builds',
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(app.quit).not.toHaveBeenCalled();
   });
 });

--- a/main/src/ipc/updater.test.ts
+++ b/main/src/ipc/updater.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerUpdaterHandlers } from './updater';
+import type { PaneCommandValue } from '../daemon/commandRegistry';
+
+type TestIpcEvent = { readonly sender?: { readonly id?: number } };
+type IpcHandler = (_event: TestIpcEvent, ...args: PaneCommandValue[]) => PaneCommandValue | Promise<PaneCommandValue>;
+
+interface IpcMainStub {
+  handlers: Map<string, IpcHandler>;
+  handle(channel: string, listener: IpcHandler): void;
+}
+
+function createIpcMainStub(): IpcMainStub {
+  const handlers = new Map<string, IpcHandler>();
+
+  return {
+    handlers,
+    handle(channel, listener) {
+      handlers.set(channel, listener);
+    },
+  };
+}
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+
+describe('updater:quit-for-manual-install', () => {
+  let quit: ReturnType<typeof vi.fn>;
+  let ipcMain: IpcMainStub;
+
+  beforeEach(() => {
+    quit = vi.fn();
+    ipcMain = createIpcMainStub();
+    // SAFETY: This test fixture intentionally supplies the minimal structural substitute exercised by the unit.
+    registerUpdaterHandlers(ipcMain, {
+      app: { getVersion: () => '2.4.70', getName: () => 'Pane', isPackaged: true, quit },
+      versionChecker: { checkForUpdates: vi.fn() },
+    } as never);
+  });
+
+  afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    }
+  });
+
+  function invokeQuit() {
+    const handler = ipcMain.handlers.get('updater:quit-for-manual-install');
+    if (!handler) throw new Error('updater:quit-for-manual-install was never registered');
+    return handler({});
+  }
+
+  it('quits the app so the mounted DMG can replace the running bundle', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    expect(await invokeQuit()).toEqual({ success: true });
+
+    // app.quit() is deferred a tick so the reply reaches the renderer before
+    // index.ts's before-quit shutdown starts tearing the app down.
+    expect(quit).not.toHaveBeenCalled();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(quit).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses off macOS, where the installer replaces Pane in place', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    expect(await invokeQuit()).toEqual({
+      success: false,
+      error: 'Quitting for a manual install is only available on macOS',
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(quit).not.toHaveBeenCalled();
+  });
+});

--- a/main/src/ipc/updater.ts
+++ b/main/src/ipc/updater.ts
@@ -191,6 +191,29 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
   });
 
   /**
+   * Completes the macOS manual-install path: the DMG mounts while Pane is still
+   * running, so dragging Pane.app into /Applications fails until Pane exits.
+   *
+   * `app.quit()` is what releases the bundle. It runs index.ts's `before-quit`
+   * shutdown, whose `destroyAllTerminals()` kills the PTY processes holding
+   * `pty.node` inside Pane.app. A window close would not do this — on darwin
+   * `window-all-closed` deliberately keeps the app alive.
+   *
+   * Deferred by one tick so this reply reaches the renderer before teardown
+   * begins. Success means "quit requested", not "Pane is gone": the shutdown
+   * still asks the user about in-flight archive tasks and is abandoned if they
+   * choose to wait, so the renderer must stay usable after this resolves.
+   */
+  ipcMain.handle('updater:quit-for-manual-install', () => {
+    if (process.platform !== 'darwin') {
+      return { success: false, error: 'Quitting for a manual install is only available on macOS' };
+    }
+
+    setImmediate(() => app.quit());
+    return { success: true };
+  });
+
+  /**
    * Temporary workaround pending Apple code signing:
    * `quitAndInstall()` does not work on unsigned macOS builds because Gatekeeper
    * quarantines the downloaded update, preventing it from replacing the running app.

--- a/main/src/ipc/updater.ts
+++ b/main/src/ipc/updater.ts
@@ -205,8 +205,8 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
    * choose to wait, so the renderer must stay usable after this resolves.
    */
   ipcMain.handle('updater:quit-for-manual-install', () => {
-    if (process.platform !== 'darwin') {
-      return { success: false, error: 'Quitting for a manual install is only available on macOS' };
+    if (!app.isPackaged || process.platform !== 'darwin') {
+      return { success: false, error: 'Quitting for a manual install is only available in packaged macOS builds' };
     }
 
     setImmediate(() => app.quit());

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -447,6 +447,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     installUpdate: (): Promise<IPCResponse> => invokeIpc('updater:install-update'),
     copyUpdateCommand: (): Promise<IPCResponse> => invokeIpc('updater:copy-update-command'),
     openTerminalWithCommand: (): Promise<IPCResponse> => invokeIpc('updater:open-terminal-with-command'),
+    quitForManualInstall: (): Promise<IPCResponse> => invokeIpc('updater:quit-for-manual-install'),
   },
 
   // System utilities

--- a/playwright.ci.minimal.config.ts
+++ b/playwright.ci.minimal.config.ts
@@ -5,8 +5,16 @@ const devServerPort = getPlaywrightPort();
 
 export default defineConfig({
   testDir: './tests',
-  // Keep the fast startup checks and the maintained accessibility journeys in CI.
-  testMatch: ['smoke.spec.ts', 'health-check.spec.ts', 'accessibility.spec.ts'],
+  // Keep the fast startup checks and the maintained accessibility journeys in CI,
+  // plus the update-dialog quit spec: it is the only check that fails if the macOS
+  // manual-install quit affordance is removed, and it pins navigator.platform itself
+  // so it asserts the same thing on CI's Linux host as it does on a Mac.
+  testMatch: [
+    'smoke.spec.ts',
+    'health-check.spec.ts',
+    'accessibility.spec.ts',
+    'update-dialog-quit.spec.ts',
+  ],
   // Allow enough time for cold CI startup while keeping failures bounded.
   timeout: 30 * 1000,
   expect: {

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -55,12 +55,32 @@ type ElectronApiMockOptions = {
   activeProjectId?: number | null;
   paneChatAgentChangeDelayMs?: number;
   feedbackOutcome?: 'success' | 'failure';
+  /** Whether main reports a packaged build; several update affordances gate on it. */
+  isPackaged?: boolean;
+  /**
+   * Overrides `navigator.platform`, which is what `isMac()` reads. Without this a
+   * macOS-only assertion would pass on a Mac and silently vanish on CI's Linux.
+   */
+  navigatorPlatform?: string;
+  updateCheckResult?: {
+    current: string;
+    latest: string;
+    hasUpdate: boolean;
+    releaseUrl?: string;
+    downloadUrl?: string;
+  };
 };
 
 export async function installElectronApiMock(page: Page, options: ElectronApiMockOptions = {}) {
   await page.addInitScript((mockOptions: ElectronApiMockOptions) => {
     if (mockOptions.notificationsSupported === false) {
       Reflect.deleteProperty(window, 'Notification');
+    }
+    if (mockOptions.navigatorPlatform !== undefined) {
+      Object.defineProperty(navigator, 'platform', {
+        configurable: true,
+        value: mockOptions.navigatorPlatform,
+      });
     }
     function success(): Promise<{ success: true; data: null }>;
     function success<Value>(data: Value): Promise<{ success: true; data: Value }>;
@@ -233,6 +253,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     const sessionDeleteCalls: string[] = [];
     const sessionFavoriteToggleCalls: string[] = [];
     let sessionsGetCount = 0;
+    let quitForManualInstallCalls = 0;
 
     const subscribe = (channel: string, callback: MockEventCallback) => {
       const callbacks = listeners.get(channel) ?? new Set<MockEventCallback>();
@@ -348,8 +369,15 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         latest: 'test',
         hasUpdate: false,
       }),
-      isPackaged: () => Promise.resolve(false),
-      checkForUpdates: () => success({ hasUpdate: false }),
+      isPackaged: () => Promise.resolve(mockOptions.isPackaged === true),
+      checkForUpdates: () => success(mockOptions.updateCheckResult ?? { hasUpdate: false }),
+      updater: namespace({
+        quitForManualInstall: () => {
+          quitForManualInstallCalls += 1;
+          // The real handler quits Pane; a test only needs to see that it was asked.
+          return success();
+        },
+      }),
       openExternal: (url: string) => {
         openedExternalUrls.push(url);
         // Matches preload's Promise<IPCResponse> contract; callers await this result.
@@ -882,6 +910,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         getSessionFavoriteToggleCalls() {
           return clone(sessionFavoriteToggleCalls);
+        },
+        getQuitForManualInstallCalls() {
+          return quitForManualInstallCalls;
         },
       },
     });

--- a/tests/update-dialog-quit.spec.ts
+++ b/tests/update-dialog-quit.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test, type Page } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+type UpdateQuitMock = {
+  getQuitForManualInstallCalls: () => number;
+};
+
+const UPDATE_AVAILABLE = {
+  current: '2.4.70',
+  latest: '2.4.71',
+  hasUpdate: true,
+  releaseUrl: 'https://github.com/dcouple/Pane/releases/tag/v2.4.71',
+  downloadUrl: 'https://github.com/dcouple/Pane/releases/download/v2.4.71/Pane.dmg',
+};
+
+function readQuitCalls(page: Page) {
+  // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+  return page.evaluate(() => (
+    window as typeof window & { __paneTestElectronMock: UpdateQuitMock }
+  ).__paneTestElectronMock.getQuitForManualInstallCalls());
+}
+
+/**
+ * Reaches the Software Update dialog the way a user does: the sidebar version
+ * opens About, and a check that finds an update hands off to the update dialog.
+ *
+ * `navigatorPlatform` is not optional decoration — `isMac()` reads
+ * `navigator.platform`, so without pinning it these assertions would pass on a
+ * macOS workstation and silently stop testing anything anywhere else.
+ */
+async function openUpdateDialog(page: Page, navigatorPlatform: string) {
+  await installElectronApiMock(page, {
+    isPackaged: true,
+    navigatorPlatform,
+    updateCheckResult: UPDATE_AVAILABLE,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await expect(page.locator('[data-testid="sidebar"]').first()).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole('button', { name: /^About Pane version/ }).click();
+  await page.getByRole('button', { name: 'Check for updates' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Software Update' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test.describe('Software Update dialog quit affordance', () => {
+  test('lets a macOS user quit Pane so the mounted DMG can replace it', async ({ page }) => {
+    const dialog = await openUpdateDialog(page, 'MacIntel');
+
+    const quit = dialog.getByRole('button', { name: /Quit Pane/ });
+    await expect(quit).toBeVisible();
+    // Close must survive: a user who is not ready to quit still needs a way out.
+    await expect(dialog.getByRole('button', { name: 'Close', exact: true })).toBeEnabled();
+
+    // First press only arms the confirmation — quitting interrupts running agents.
+    await quit.click();
+    expect(await readQuitCalls(page)).toBe(0);
+
+    const confirm = dialog.getByRole('button', { name: /Quit now/ });
+    await expect(confirm).toBeVisible();
+    await confirm.click();
+    await expect.poll(() => readQuitCalls(page)).toBe(1);
+
+    // The quit can still be abandoned by the archive-tasks prompt in the main
+    // process, so the dialog must stay usable rather than latch a dead state.
+    await expect(dialog.getByRole('button', { name: 'Close', exact: true })).toBeEnabled();
+  });
+
+  test('offers no quit where the installer replaces Pane in place', async ({ page }) => {
+    const dialog = await openUpdateDialog(page, 'Win32');
+
+    await expect(dialog.getByRole('button', { name: /Quit Pane/ })).toHaveCount(0);
+    await expect(dialog.getByRole('button', { name: 'Close', exact: true })).toBeEnabled();
+  });
+});

--- a/tests/update-dialog-quit.spec.ts
+++ b/tests/update-dialog-quit.spec.ts
@@ -58,6 +58,13 @@ test.describe('Software Update dialog quit affordance', () => {
     await quit.click();
     expect(await readQuitCalls(page)).toBe(0);
 
+    // Any other action cancels the destructive confirmation. Following the
+    // release link must not leave the dialog one click away from quitting.
+    await dialog.getByRole('button', { name: 'View on GitHub' }).click();
+    await expect(dialog.getByRole('button', { name: /Quit Pane/ })).toBeVisible();
+    expect(await readQuitCalls(page)).toBe(0);
+
+    await dialog.getByRole('button', { name: /Quit Pane/ }).click();
     const confirm = dialog.getByRole('button', { name: /Quit now/ });
     await expect(confirm).toBeVisible();
     await confirm.click();


### PR DESCRIPTION
## Summary

On macOS the update path is manual, because unsigned builds cannot use electron-updater's `quitAndInstall()`: Gatekeeper quarantines the downloaded replacement. The dialog sends the user to `curl -fsSL https://runpane.com/install.sh | sh`, which downloads the DMG and opens it, then tells them to drag Pane.app into Applications and choose Replace. That drag cannot succeed while Pane is running, and the dialog offered only a Close button. Its own instructions named a step it gave no way to perform.

`app.quit()` is what frees the bundle. It runs the `before-quit` shutdown in `main/src/index.ts:1283`, whose `destroyAllTerminals()` (`:1431`) kills the PTY processes holding `pty.node` inside `Pane.app`. A window close would not do it, because `window-all-closed` deliberately keeps the app alive on darwin (`:1277`).

- New `updater:quit-for-manual-install` handler, guarded to darwin, deferred one tick with `setImmediate` so the reply reaches the renderer before teardown begins.
- Quit button in the dialog footer beside Close, which is unchanged. Gated to packaged macOS builds with an update available.
- Footer rather than `renderMacUpdateActions()`: that panel renders only in the `downloaded` and `error` states, while the ordinary macOS path returns to `idle` with a message and would otherwise still dead-end.
- First press arms a confirmation, second press quits, since quitting interrupts every running agent and the button sits next to Close. Any other action in the dialog disarms it.
- A successful reply means the quit was requested, not that Pane is gone: the shutdown prompts about in-flight archive tasks and is abandoned if the user chooses to wait, so nothing latches the dialog into a quitting state.
- The instruction copy branches on whether the button is actually rendered, so an unpackaged dev build in the error state never names a button that is not there.

Scoped channel name rather than a generic `app:quit`, to avoid handing the renderer an unconditional kill switch. `updater:` is absent from both daemon-owned channel lists in `main/src/preload.ts`, so this always quits the local machine and never routes to a remote daemon.

## Screenshots

**1. macOS, update available.** Dialog as first opened, with `Quit Pane` and `Close` in the footer.

<p align="center">
  <img width="672" height="410" alt="1-mac-update-available" src="https://github.com/user-attachments/assets/9974fb55-658d-4c9d-9a00-8c4759b565ff" />
</p>

**2. After `Update Pane`.** The state that previously dead-ended. Terminal has been opened, the message points at the button, and the footer now offers a way out.

<p align="center">
  <img width="672" height="512" alt="2-mac-after-update-pane" src="https://github.com/user-attachments/assets/bcb8434b-fd66-456c-b9e2-cd9781c167c5" />
</p>

**3. Confirmation armed.** Red `Quit now` with "Quitting stops running agents.", and `Close` still enabled.

<p align="center">
  <img width="672" height="512" alt="3-mac-quit-armed" src="https://github.com/user-attachments/assets/0ad6a4cf-3690-47c3-9688-7091a22f2f8f" />
</p>

**4. Non-macOS.** No quit affordance, `Close` only.

<p align="center">
  <img width="672" height="410" alt="4-windows-no-quit" src="https://github.com/user-attachments/assets/def28798-a2ec-44a0-92d5-0a85818d8f82" />
</p>

All four states are also asserted by the new Playwright spec.

## Test plan

- [x] `pnpm typecheck` clean across all four projects
- [x] `pnpm lint` exit 0: oxlint including the 15 blocking anti-slop rules, eslint, advisory 0 findings, boundary conformance, knip
- [x] `main` vitest: 68 files, 625 tests (after `pnpm rebuild better-sqlite3-multiple-ciphers`, per the Node/Electron ABI split)
- [x] frontend vitest: 27 files, 270 tests
- [x] `pnpm test:ci:minimal` run locally: 29 passed, including the new spec
- [x] New `main/src/ipc/updater.test.ts`: darwin quits, non-darwin refuses, and the quit is deferred rather than synchronous
- [x] New `tests/update-dialog-quit.spec.ts`: full click-through, arm then confirm, plus a non-macOS case asserting the button is absent
- [x] End to end on a real packaged build: built at 2.4.69 so the live 2.4.70 release is genuinely newer, launched with an isolated `PANE_DIR`. The real version check fired (`[Version Checker] Update available on startup: 2.4.70`) and the shutdown log confirms the quit path ran: `before-quit fired` then `Destroying all terminal panel processes` then `Calling app.exit(0)`, with the process gone afterwards

The new spec is added to `playwright.ci.minimal.config.ts`. It is the only check that fails if the footer button is deleted: the two vitest suites cover the IPC handler and the gate predicate, and both still pass without the button. It pins `navigator.platform` itself through a new opt-in `navigatorPlatform` option in `tests/electronApiMock.ts`, because `isMac()` reads that property. Without pinning it, the macOS assertions would pass on a Mac and silently assert nothing on CI's Linux host.

## Not addressed

The root cause of the manual path is that macOS builds are unsigned. This makes the documented workaround completable. Signing would remove this path entirely, including the dialog copy and this button.

Two deliberate open questions, both flagged during review:

- The button appears in every macOS state with an update available, including before the user has obtained the installer. Gating it on evidence the manual path had started would re-create a dead-end for anyone who ran the install command in their own terminal, so I left it visible.
- The armed confirmation has no explicit Cancel. Taking any other action disarms it, and Close remains available, so it is not a trap.



<!-- pr-test-automation-summary:start -->
## Automated QA update (head `06490222`)

Status: local verification passed. Packaged macOS, confirmation/disarm behavior, main-process eligibility, and non-macOS absence are covered with mocked Electron APIs.

- Typecheck and lint passed; advisory anti-slop findings: 0.
- Frontend Vitest: 27 files, 270 tests passed.
- Main Vitest: 68 files, 626 tests passed.
- Playwright updater dialog: 2 tests passed.
- Screenshots: [update available](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-491-06490222-7252e56269f1-update-available.png), [quit confirmation](https://github.com/dcouple/Pane/releases/download/pr-assets/pr-491-06490222-146aae1e12fb-quit-confirmation.png).

Remaining for human review: all GitHub Actions checks passed. Optionally repeat the final quit against a packaged macOS build. Merge remains with parsa.
<!-- pr-test-automation-summary:end -->
