### PR TITLE
Add HTML file previews to Explorer

### DIFF
--- a/frontend/src/components/panels/browser/BrowserPanel.test.ts
+++ b/frontend/src/components/panels/browser/BrowserPanel.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeUrl } from './browserUrl';
+
+describe('normalizeUrl', () => {
+  it('preserves file URLs for local HTML previews', () => {
+    expect(normalizeUrl('file:///tmp/Pane%20Preview/index.html')).toBe(
+      'file:///tmp/Pane%20Preview/index.html',
+    );
+  });
+
+  it('keeps existing web URL behavior', () => {
+    expect(normalizeUrl('localhost:4173')).toBe('http://localhost:4173');
+    expect(normalizeUrl('example.com')).toBe('https://example.com');
+  });
+});

--- a/frontend/src/components/panels/browser/BrowserPanel.tsx
+++ b/frontend/src/components/panels/browser/BrowserPanel.tsx
@@ -6,20 +6,11 @@ import { panelApi } from '../../../services/panelApi';
 import { usePanelStore } from '../../../stores/panelStore';
 import { useSessionStore } from '../../../stores/sessionStore';
 import { useResizable } from '../../../hooks/useResizable';
+import { normalizeUrl } from './browserUrl';
 
 interface BrowserPanelProps {
   panel: ToolPanel;
   isActive: boolean;
-}
-
-function normalizeUrl(input: string): string {
-  let url = input.trim();
-  if (!/^https?:\/\//i.test(url)) {
-    // Local hosts default to http, everything else to https
-    const isLocalHost = url.startsWith('localhost') || url.startsWith('127.0.0.1') || url.startsWith('[::1]');
-    url = (isLocalHost ? 'http://' : 'https://') + url;
-  }
-  return url;
 }
 
 const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
@@ -108,8 +99,8 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
     } catch {
       parsed = null;
     }
-    if (!parsed || (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')) {
-      setUrlError('Enter a valid http or https URL');
+    if (!parsed || !['http:', 'https:', 'file:'].includes(parsed.protocol)) {
+      setUrlError('Enter a valid http, https, or file URL');
       return;
     }
     setUrlError('');
@@ -295,7 +286,11 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
       const customEvent = e as CustomEvent<{ url: string; sessionId: string }>;
       if (customEvent.detail.sessionId === panel.sessionId) {
         e.stopImmediatePropagation();
-        navigateTo(customEvent.detail.url);
+        if (customEvent.detail.url === url) {
+          webviewRef.current?.reload();
+        } else {
+          navigateTo(customEvent.detail.url);
+        }
         // Auto-focus this browser panel
         setActivePanelInStore(panel.sessionId, panel.id);
         panelApi.setActivePanel(panel.sessionId, panel.id).catch(() => {});
@@ -303,8 +298,7 @@ const BrowserPanel: React.FC<BrowserPanelProps> = ({ panel, isActive }) => {
     };
     window.addEventListener('browser-panel:navigate', handler);
     return () => window.removeEventListener('browser-panel:navigate', handler);
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- navigateTo reads from refs; re-registering on sessionId change is sufficient
-  }, [panel.sessionId, panel.id, setActivePanelInStore]);
+  }, [panel.sessionId, panel.id, setActivePanelInStore, navigateTo, url]);
 
   // Hide/show DevTools overlay when switching between panel tabs.
   // Close the WebContentsView when inactive so it doesn't cover other panels,

--- a/frontend/src/components/panels/browser/browserUrl.ts
+++ b/frontend/src/components/panels/browser/browserUrl.ts
@@ -1,0 +1,10 @@
+export function normalizeUrl(input: string): string {
+  let url = input.trim();
+  if (!/^(?:https?|file):\/\//i.test(url)) {
+    const isLocalHost = url.startsWith('localhost')
+      || url.startsWith('127.0.0.1')
+      || url.startsWith('[::1]');
+    url = `${isLocalHost ? 'http' : 'https'}://${url}`;
+  }
+  return url;
+}

--- a/frontend/src/components/panels/editor/FileEditor.test.ts
+++ b/frontend/src/components/panels/editor/FileEditor.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { isHtmlFile } from './htmlFile';
+
+describe('isHtmlFile', () => {
+  it.each(['index.html', 'archive/page.htm', 'REPORT.HTML', 'page.HTM'])(
+    'recognizes %s as HTML',
+    (filePath) => expect(isHtmlFile(filePath)).toBe(true),
+  );
+
+  it.each(['index.ts', 'html', 'page.html.txt', 'page.xhtml'])(
+    'does not recognize %s as HTML',
+    (filePath) => expect(isHtmlFile(filePath)).toBe(false),
+  );
+});

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -20,6 +20,10 @@ import { TerminalPopover, PopoverButton } from '../../terminal/TerminalPopover';
 import { areKeyboardShortcutsEnabled, useConfigStore } from '../../../stores/configStore';
 import { LiveRegion } from '../../ui/LiveRegion';
 import { boundary, decodeBoundary } from '../../../../../shared/validation/boundaryDecoder';
+import type { BrowserPanelState, ToolPanel } from '../../../../../shared/types/panels';
+import { panelApi } from '../../../services/panelApi';
+import { usePanelStore } from '../../../stores/panelStore';
+import { isHtmlFile } from './htmlFile';
 interface LanguageByExtension {
   [extension: string]: string;
 }
@@ -37,6 +41,12 @@ const MAX_FILE_SIZE = 15 * 1024 * 1024; // 15MB
 const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'ico', 'bmp']);
 const PDF_EXTENSIONS = new Set(['pdf']);
 
+const filePathResponseSchema = boundary.object({
+  success: boundary.boolean,
+  url: boundary.optional(boundary.string),
+  error: boundary.optional(boundary.string),
+});
+
 function containsEventTarget(container: Node, target: EventTarget | null): boolean {
   return target instanceof Node && container.contains(target);
 }
@@ -50,6 +60,7 @@ interface HeadlessFileTreeProps {
   initialSearchQuery?: string;
   initialShowSearch?: boolean;
   onTreeStateChange?: (state: { expandedDirs: string[]; searchQuery: string; showSearch: boolean }) => void;
+  onHtmlPreview: (filePath: string) => void;
 }
 
 function HeadlessFileTree({
@@ -61,6 +72,7 @@ function HeadlessFileTree({
   initialSearchQuery,
   initialShowSearch,
   onTreeStateChange,
+  onHtmlPreview,
 }: HeadlessFileTreeProps) {
   // Cache stores loaded directory contents. Key = dirPath, Value = FileItem[].
   const filesCacheRef = useRef(new Map<string, FileItem[]>());
@@ -878,33 +890,47 @@ function HeadlessFileTree({
       {searchQuery && (
         <div className="flex-1 overflow-auto">
           {getFilteredFiles().map(file => (
-            <button
-              type="button"
+            <div
               key={file.path}
-              disabled={file.isDirectory}
-              className={`flex w-full items-center px-2 py-1 text-left hover:bg-surface-hover group disabled:cursor-default ${
+              className={`flex w-full items-center hover:bg-surface-hover group ${
                 selectedPath === file.path ? 'bg-interactive' : ''
               }`}
-              style={{ paddingLeft: '8px' }}
-              onClick={() => onFileSelect(file)}
               onContextMenu={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
                 setContextMenu({ x: e.clientX, y: e.clientY, file });
               }}
             >
-              {file.isDirectory ? (
-                <Folder className="w-4 h-4 mr-2 text-interactive flex-shrink-0" />
-              ) : (
-                <File className="w-4 h-4 mr-2 text-text-tertiary flex-shrink-0" />
+              <button
+                type="button"
+                disabled={file.isDirectory}
+                className="flex min-w-0 flex-1 items-center px-2 py-1 text-left disabled:cursor-default"
+                onClick={() => onFileSelect(file)}
+              >
+                {file.isDirectory ? (
+                  <Folder className="w-4 h-4 mr-2 text-interactive flex-shrink-0" />
+                ) : (
+                  <File className="w-4 h-4 mr-2 text-text-tertiary flex-shrink-0" />
+                )}
+                <span className="flex-1 text-sm truncate text-text-primary">
+                  {highlightText(file.name, searchQuery)}
+                </span>
+                <span className="text-xs text-text-tertiary ml-2 truncate max-w-[120px]">
+                  {file.path}
+                </span>
+              </button>
+              {!file.isDirectory && isHtmlFile(file.path) && (
+                <button
+                  type="button"
+                  onClick={() => onHtmlPreview(file.path)}
+                  className="p-1 mr-1 hover:bg-surface-hover rounded text-text-tertiary hover:text-text-primary"
+                  title={`Preview ${file.name}`}
+                  aria-label={`Preview ${file.name}`}
+                >
+                  <Eye className="w-3 h-3" />
+                </button>
               )}
-              <span className="flex-1 text-sm truncate text-text-primary">
-                {highlightText(file.name, searchQuery)}
-              </span>
-              <span className="text-xs text-text-tertiary ml-2 truncate max-w-[120px]">
-                {file.path}
-              </span>
-            </button>
+            </div>
           ))}
           {getFilteredFiles().length === 0 && (
             <div className="p-4 text-text-secondary text-sm">No matching files</div>
@@ -1070,6 +1096,20 @@ function HeadlessFileTree({
                   <RefreshCw className="w-3 h-3" />
                 </button>
               )}
+              {!isFolder && isHtmlFile(data.path) && renamingPath !== data.path && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onHtmlPreview(data.path);
+                  }}
+                  className="opacity-0 group-hover:opacity-100 focus:opacity-100 p-1 hover:bg-surface-hover rounded text-text-tertiary hover:text-text-primary"
+                  title={`Preview ${data.name}`}
+                  aria-label={`Preview ${data.name}`}
+                >
+                  <Eye className="w-3 h-3" />
+                </button>
+              )}
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -1222,6 +1262,9 @@ export function FileEditor({
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<typeof monaco | null>(null);
   const pendingEditorFocusPathRef = useRef<string | null>(null);
+  const addPanel = usePanelStore((state) => state.addPanel);
+  const setActivePanel = usePanelStore((state) => state.setActivePanel);
+  const updatePanelState = usePanelStore((state) => state.updatePanelState);
 
   // Keep ref in sync and clean up blob URLs to prevent memory leaks
   useEffect(() => {
@@ -1279,6 +1322,57 @@ export function FileEditor({
   }, [selectedFile]);
 
   const isBinaryPreview = isImageFile || isPdfFile;
+
+  const previewHtmlFile = useCallback(async (filePath: string) => {
+    setError(null);
+    try {
+      const result = decodeBoundary(
+        await window.electronAPI.invoke('file:getPath', { sessionId, filePath }),
+        filePathResponseSchema,
+      );
+      if (!result.success || !result.url) {
+        throw new Error(result.error || 'Failed to resolve HTML preview URL');
+      }
+
+      const panels = usePanelStore.getState().getSessionPanels(sessionId);
+      const existingPanel = panels.find((candidate) => candidate.type === 'browser');
+      let browserPanel: ToolPanel;
+
+      if (existingPanel) {
+        // SAFETY: The browser panel type discriminator establishes BrowserPanelState.
+        const existingCustomState = (existingPanel.state.customState ?? {}) as BrowserPanelState;
+        browserPanel = {
+          ...existingPanel,
+          title: filePath.split('/').pop() || 'Browser',
+          state: {
+            ...existingPanel.state,
+            customState: { ...existingCustomState, currentUrl: result.url },
+          },
+        };
+        await panelApi.updatePanel(browserPanel.id, {
+          title: browserPanel.title,
+          state: browserPanel.state,
+        });
+        updatePanelState(browserPanel);
+      } else {
+        browserPanel = await panelApi.createPanel({
+          sessionId,
+          type: 'browser',
+          title: filePath.split('/').pop() || 'Browser',
+          initialState: { customState: { currentUrl: result.url } },
+        });
+        addPanel(browserPanel);
+      }
+
+      setActivePanel(sessionId, browserPanel.id);
+      await panelApi.setActivePanel(sessionId, browserPanel.id);
+      window.dispatchEvent(new CustomEvent('browser-panel:navigate', {
+        detail: { url: result.url, sessionId },
+      }));
+    } catch (previewError) {
+      setError(previewError instanceof Error ? previewError.message : 'Failed to preview HTML file');
+    }
+  }, [sessionId, addPanel, setActivePanel, updatePanelState]);
 
   const loadFile = useCallback(async (file: FileItem | null) => {
     if (!file || file.isDirectory) return;
@@ -1626,6 +1720,7 @@ export function FileEditor({
           initialSearchQuery={initialState?.searchQuery}
           initialShowSearch={initialState?.showSearch}
           onTreeStateChange={handleTreeStateChange}
+          onHtmlPreview={previewHtmlFile}
         />
         
         {/* Resize handle */}
@@ -1642,6 +1737,18 @@ export function FileEditor({
           <>
             <div className="flex items-center justify-between px-4 py-2 bg-surface-secondary border-b border-border-primary">
               <div className="flex min-w-0 items-center gap-2">
+                {isHtmlFile(selectedFile.path) && (
+                  <button
+                    type="button"
+                    onClick={() => previewHtmlFile(selectedFile.path)}
+                    className="flex flex-shrink-0 items-center gap-1 rounded-lg border border-border-primary bg-surface-tertiary px-2 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+                    title="Preview file as HTML"
+                    aria-label="Preview file as HTML"
+                  >
+                    <Eye className="w-3 h-3" />
+                    Preview as HTML
+                  </button>
+                )}
                 <File className="w-4 h-4 text-text-tertiary" />
                 <span className="min-w-0 truncate text-sm text-text-primary">
                   {selectedFile.path}

--- a/frontend/src/components/panels/editor/htmlFile.ts
+++ b/frontend/src/components/panels/editor/htmlFile.ts
@@ -1,0 +1,3 @@
+export function isHtmlFile(filePath: string): boolean {
+  return /\.html?$/i.test(filePath);
+}

--- a/main/src/ipc/daemonRegistryBindings.test.ts
+++ b/main/src/ipc/daemonRegistryBindings.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
 import { PaneCommandRegistry } from '../daemon/commandRegistry';
 import { remotePaneClientController } from '../daemon/client/remotePaneClient';
 import { registerFileHandlers } from './file';
@@ -384,6 +386,35 @@ describe('daemon registry IPC bindings', () => {
       [...FILE_CHANNELS].sort(),
     );
     expect(registry.has('file:showInFolder')).toBe(false);
+  });
+
+  it('returns a file URL for a path inside the session worktree', async () => {
+    const registry = new PaneCommandRegistry();
+    const ipcMain = createIpcMainStub();
+    const worktreePath = path.join(process.cwd(), 'Pane Preview');
+    const filePath = path.join(worktreePath, 'index.html');
+
+    // SAFETY: This test fixture supplies the session and path resolver used by file:getPath.
+    registerFileHandlers(ipcMain, createServicesStub({
+      sessionManager: {
+        getSession: () => ({ worktreePath }),
+        getProjectContext: () => ({
+          pathResolver: {
+            toFileSystem: (value: string) => value,
+            isWithin: async () => true,
+          },
+        }),
+      },
+    } as Partial<AppServices>), registry);
+
+    await expect(registry.invoke('file:getPath', [{
+      sessionId: 'session-1',
+      filePath: 'index.html',
+    }])).resolves.toEqual({
+      success: true,
+      path: filePath,
+      url: pathToFileURL(filePath).href,
+    });
   });
 
   it('keeps browser and clipboard panel adapters outside the daemon registry surface', () => {

--- a/main/src/ipc/file.ts
+++ b/main/src/ipc/file.ts
@@ -2,6 +2,7 @@ import type { IpcMain } from 'electron';
 import { shell } from 'electron';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { pathToFileURL } from 'url';
 import { glob } from 'glob';
 import type { PaneCommandRegistry } from '../daemon/commandRegistry';
 import type { AppServices } from './types';
@@ -415,24 +416,8 @@ export function registerFileHandlers(
   // Get the full path for a file in a session's worktree
   commandRegistry.register('file:getPath', async (request: FilePathRequest) => {
     try {
-      const session = sessionManager.getSession(request.sessionId);
-      if (!session) {
-        throw new Error(`Session not found: ${request.sessionId}`);
-      }
-
-      const ctx = sessionManager.getProjectContext(request.sessionId);
-      if (!ctx) throw new Error('Project not found for session');
-      const { pathResolver } = ctx;
-
-      // Ensure the file path is relative and safe
-      const normalizedPath = path.normalize(request.filePath);
-      if (normalizedPath.startsWith('..') || path.isAbsolute(normalizedPath)) {
-        throw new Error('Invalid file path');
-      }
-
-      const basePath = pathResolver.toFileSystem(session.worktreePath);
-      const fullPath = path.join(basePath, normalizedPath);
-      return { success: true, path: fullPath };
+      const { fullPath } = await resolveWorktreePath(request.sessionId, request.filePath);
+      return { success: true, path: fullPath, url: pathToFileURL(fullPath).href };
     } catch (error) {
       console.error('Error getting file path:', error);
       return {


### PR DESCRIPTION
## Summary

- Add Preview actions for `.html` and `.htm` files in Explorer rows, search results, and a clearly labeled open-file header button before the file path.
- Open local HTML files in Pane's existing Browser panel with safe `file://` URLs.
- Reload the same preview URL so saved editor changes render when Preview is used again.

Closes #500

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter frontend test`: 276 passed
- `pnpm --dir main exec vitest run`: 632 passed
- `pnpm build`
- Manual isolated app QA with a real HTML file

GitHub Actions is unavailable because of the current organization billing outage, so validation was completed locally as requested.

<!-- pr-test-automation-summary:start -->
## PR QA

Status: PASS

Manual app testing verified:

- HTML opens in the source editor by default.
- Explorer rows expose Preview for `.html` files.
- The source header exposes a persistent `Preview as HTML` button before the file icon and path.
- Preview opens the local file through a `file://` URL in the existing Browser panel.
- Editing and saving the HTML, then using Preview again, reloads the same URL with the new content.

### Open-file Preview as HTML affordance

<img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-501-b434358f-d6bcbe6950df-preview-as-html-header.png" width="900" alt="Preview as HTML button before the file icon and path in the source header">

### Explorer Preview affordance

<img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-501-b434358f-c10bb6550043-explorer-row-preview.png" width="720" alt="Preview affordance on an HTML file row in Explorer">

### Initial HTML preview

<img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-501-b434358f-1ae1d103226f-browser-preview-version-1.png" width="720" alt="Version 1 of a local HTML file rendered in Pane's Browser panel">

### Re-preview after a saved edit

<img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-501-b434358f-1ea9be6b7d54-browser-repreview-version-2.png" width="720" alt="Saved Version 2 rendered after using Preview again">

Evidence assets are tied to commit `b434358f66dce063d9f2c4c49f6110c1300b91e5`. Uploaded copies were downloaded and verified against their local SHA-256 digests, byte sizes, and PNG signatures.

No merge or release was performed.
<!-- pr-test-automation-summary:end -->
