### PR TITLE
PR draft icon implemented instead of normal PR icon

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef, useId } from 'react';
-import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, Pin, Monitor, MessageSquare } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus, FolderPlus, GitBranch, MoreHorizontal, Home, Archive, ArchiveRestore, Trash2, GitPullRequest, GitPullRequestDraft, Pin, Monitor, MessageSquare } from 'lucide-react';
 import { SessionDetailTooltip } from './SessionDetailTooltip';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
@@ -566,13 +566,14 @@ function SessionRowContent({
 }) {
   const title = displayName || gs?.prTitle || session.name || 'Untitled';
   const prNumber = gs?.prNumber;
+  const PullRequestIcon = gs?.prIsDraft ? GitPullRequestDraft : GitPullRequest;
   const showMetadata = Boolean(prNumber || hasDiff);
 
   if (rowLayout === 'single') {
     return (
       <div className="flex min-w-0 w-full items-center gap-1.5">
         {prNumber ? (
-          <GitPullRequest className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
+          <PullRequestIcon className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
         ) : (
           <GitBranch className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
         )}
@@ -598,7 +599,7 @@ function SessionRowContent({
   return (
     <div className="flex min-w-0 w-full items-start gap-1.5">
       {prNumber ? (
-        <GitPullRequest className={`mt-0.5 w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
+        <PullRequestIcon className={`mt-0.5 w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
       ) : (
         <GitBranch className={`mt-0.5 w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
       )}

--- a/frontend/src/types/session.ts
+++ b/frontend/src/types/session.ts
@@ -131,6 +131,7 @@ export interface GitStatus {
   prUrl?: string;
   prTitle?: string;
   prState?: string; // 'OPEN' | 'MERGED' | 'CLOSED'
+  prIsDraft?: boolean;
   prBody?: string;
 }
 

--- a/main/src/services/__tests__/gitStatusManager.test.ts
+++ b/main/src/services/__tests__/gitStatusManager.test.ts
@@ -19,13 +19,13 @@ interface GitStatusManagerPrivates {
     branchName: string,
     projectPath: string,
     commandRunner: CommandRunner
-  ): Promise<{ prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string }>;
+  ): Promise<{ prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prIsDraft?: boolean; prBody?: string }>;
   enrichWithPrData(sessionId: string): Promise<void>;
   updateCache(sessionId: string, status: GitStatus): GitStatus;
   schedulePrEnrichment(sessionId: string, immediate?: boolean): void;
   cache: Record<string, { status: GitStatus; lastChecked: number }>;
   initialLoadQueue: string[];
-  prCache: Map<string, { prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string; fetchedAt: number }>;
+  prCache: Map<string, { prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prIsDraft?: boolean; prBody?: string; fetchedAt: number }>;
   activeSessionId: string | null;
 }
 
@@ -385,6 +385,7 @@ describe('GitStatusManager', () => {
           prUrl: 'https://github.com/example/repo/pull/12',
           prTitle: 'Ready review',
           prState: 'OPEN',
+          prIsDraft: true,
           prBody: 'Body',
         },
         lastChecked: Date.now(),
@@ -404,6 +405,7 @@ describe('GitStatusManager', () => {
         prUrl: 'https://github.com/example/repo/pull/12',
         prTitle: 'Ready review',
         prState: 'OPEN',
+        prIsDraft: true,
         prBody: 'Body',
       });
       expect(mockDatabaseService.saveSessionGitStatusCache).toHaveBeenLastCalledWith(
@@ -441,6 +443,7 @@ describe('GitStatusManager', () => {
           url: 'https://github.com/example/repo/pull/12',
           title: 'Ready review',
           state: 'OPEN',
+          isDraft: true,
           body: 'Body',
         }]),
       });
@@ -451,6 +454,7 @@ describe('GitStatusManager', () => {
         prUrl: 'https://github.com/example/repo/pull/12',
         prTitle: 'Ready review',
         prState: 'OPEN',
+        prIsDraft: true,
         prBody: 'Body',
         fetchedAt: Date.now() - 20_001,
       });
@@ -458,7 +462,13 @@ describe('GitStatusManager', () => {
       const result = await privates.fetchPrForSession('feature-branch', mockProject.path, commandRunner);
 
       expect(commandRunner.execAsync).toHaveBeenCalledTimes(1);
+      expect(commandRunner.execAsync).toHaveBeenCalledWith(
+        expect.stringContaining('isDraft'),
+        mockProject.path,
+        { timeout: 5000 }
+      );
       expect(result.prNumber).toBe(12);
+      expect(result.prIsDraft).toBe(true);
     });
 
     it('invalidates active-session PR misses when the app regains focus', async () => {
@@ -494,6 +504,7 @@ describe('GitStatusManager', () => {
           url: 'https://github.com/example/repo/pull/12',
           title: 'Ready review',
           state: 'OPEN',
+          isDraft: true,
           body: 'Body',
         }]),
       });
@@ -517,6 +528,7 @@ describe('GitStatusManager', () => {
       expect((mockProjectContext.commandRunner.execAsync as Mock).mock.calls[0][0]).not.toContain('not-the-branch');
       expect(status.prNumber).toBe(12);
       expect(status.prUrl).toBe('https://github.com/example/repo/pull/12');
+      expect(status.prIsDraft).toBe(true);
     });
 
     it('clears cached PR fields on a confirmed PR miss', async () => {
@@ -529,6 +541,7 @@ describe('GitStatusManager', () => {
           prUrl: 'https://github.com/example/repo/pull/12',
           prTitle: 'Ready review',
           prState: 'OPEN',
+          prIsDraft: true,
           prBody: 'Body',
         },
         lastChecked: Date.now(),
@@ -546,6 +559,7 @@ describe('GitStatusManager', () => {
       expect(status.prUrl).toBeUndefined();
       expect(status.prTitle).toBeUndefined();
       expect(status.prState).toBeUndefined();
+      expect(status.prIsDraft).toBeUndefined();
       expect(status.prBody).toBeUndefined();
       expect(status.ahead).toBe(1);
       expect(mockDatabaseService.saveSessionGitStatusCache).toHaveBeenLastCalledWith(
@@ -564,6 +578,7 @@ describe('GitStatusManager', () => {
         prUrl: 'https://github.com/example/repo/pull/12',
         prTitle: 'Ready review',
         prState: 'OPEN',
+        prIsDraft: true,
         prBody: 'Body',
       };
       privates.cache['test-session'] = {

--- a/main/src/services/gitStatusManager.ts
+++ b/main/src/services/gitStatusManager.ts
@@ -23,6 +23,7 @@ type PrData = {
   prUrl?: string;
   prTitle?: string;
   prState?: string;
+  prIsDraft?: boolean;
   prBody?: string;
 };
 
@@ -30,7 +31,7 @@ type PrLookupResult =
   | { ok: true; pr?: PrData }
   | { ok: false };
 
-const PR_FIELDS = ['prNumber', 'prUrl', 'prTitle', 'prState', 'prBody'] as const;
+const PR_FIELDS = ['prNumber', 'prUrl', 'prTitle', 'prState', 'prIsDraft', 'prBody'] as const;
 
 export class GitStatusManager extends EventEmitter {
   private cache: GitStatusCache = {};
@@ -65,7 +66,7 @@ export class GitStatusManager extends EventEmitter {
   private isWindowVisible = true;
 
   // PR data cache
-  private prCache = new Map<string, { prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string; fetchedAt: number }>();
+  private prCache = new Map<string, { prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prIsDraft?: boolean; prBody?: string; fetchedAt: number }>();
   private readonly PR_HIT_CACHE_TTL = 2.5 * 60 * 1000;
   private readonly PR_MISS_CACHE_TTL = 20 * 1000;
   private readonly PR_ENRICHMENT_JITTER_MS = 10_000;
@@ -572,7 +573,7 @@ export class GitStatusManager extends EventEmitter {
     branchName: string,
     projectPath: string,
     commandRunner: CommandRunner
-  ): Promise<{ prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prBody?: string }> {
+  ): Promise<{ prNumber?: number; prUrl?: string; prTitle?: string; prState?: string; prIsDraft?: boolean; prBody?: string }> {
     const result = await this.fetchPrForSessionResult(branchName, projectPath, commandRunner);
     return result.ok && result.pr ? result.pr : {};
   }
@@ -589,24 +590,25 @@ export class GitStatusManager extends EventEmitter {
       return {
         ok: true,
         pr: cached.prNumber !== undefined
-          ? { prNumber: cached.prNumber, prUrl: cached.prUrl, prTitle: cached.prTitle, prState: cached.prState, prBody: cached.prBody }
+          ? { prNumber: cached.prNumber, prUrl: cached.prUrl, prTitle: cached.prTitle, prState: cached.prState, prIsDraft: cached.prIsDraft, prBody: cached.prBody }
           : undefined,
       };
     }
 
     try {
       const result = await commandRunner.execAsync(
-        `gh pr list --head ${escapeShellArg(branchName)} --state all --json number,url,title,state,body --limit 1`,
+        `gh pr list --head ${escapeShellArg(branchName)} --state all --json number,url,title,state,isDraft,body --limit 1`,
         projectPath,
         { timeout: 5000 }
       );
-      const prs = JSON.parse(result.stdout.trim() || '[]') as Array<{ number?: number; url?: string; title?: string; state?: string; body?: string }>;
+      const prs = JSON.parse(result.stdout.trim() || '[]') as Array<{ number?: number; url?: string; title?: string; state?: string; isDraft?: boolean; body?: string }>;
       const pr = prs[0];
       const entry = {
         prNumber: pr?.number,
         prUrl: pr?.url,
         prTitle: pr?.title,
         prState: pr?.state,
+        prIsDraft: pr?.isDraft,
         prBody: pr?.body,
         fetchedAt: Date.now()
       };
@@ -614,7 +616,7 @@ export class GitStatusManager extends EventEmitter {
       return {
         ok: true,
         pr: entry.prNumber !== undefined
-          ? { prNumber: entry.prNumber, prUrl: entry.prUrl, prTitle: entry.prTitle, prState: entry.prState, prBody: entry.prBody }
+          ? { prNumber: entry.prNumber, prUrl: entry.prUrl, prTitle: entry.prTitle, prState: entry.prState, prIsDraft: entry.prIsDraft, prBody: entry.prBody }
           : undefined,
       };
     } catch {
@@ -706,6 +708,7 @@ export class GitStatusManager extends EventEmitter {
       if (currentStatus && (
         currentStatus.prNumber !== prData.prNumber ||
         currentStatus.prState !== prData.prState ||
+        currentStatus.prIsDraft !== prData.prIsDraft ||
         currentStatus.prTitle !== prData.prTitle ||
         currentStatus.prBody !== prData.prBody
       )) {
@@ -715,6 +718,7 @@ export class GitStatusManager extends EventEmitter {
           prUrl: prData.prUrl,
           prTitle: prData.prTitle,
           prState: prData.prState,
+          prIsDraft: prData.prIsDraft,
           prBody: prData.prBody
         };
         const lastChecked = this.cache[sessionId].lastChecked;
@@ -1052,6 +1056,7 @@ export class GitStatusManager extends EventEmitter {
       prUrl: previousStatus.prUrl,
       prTitle: previousStatus.prTitle,
       prState: previousStatus.prState,
+      prIsDraft: previousStatus.prIsDraft,
       prBody: previousStatus.prBody,
     };
   }

--- a/main/src/types/session.ts
+++ b/main/src/types/session.ts
@@ -57,6 +57,7 @@ export interface GitStatus {
   prUrl?: string;
   prTitle?: string;
   prState?: string; // 'OPEN' | 'MERGED' | 'CLOSED'
+  prIsDraft?: boolean;
   prBody?: string;
 }
 


### PR DESCRIPTION
## Description

  Fix the sidebar icon for draft GitHub pull requests.                                              
                                                                                                    
  Pane now retrieves GitHub's `isDraft` value and propagates it through the git status cache and    
  frontend types. Draft PRs use the `GitPullRequestDraft` icon, while regular PRs continue using the
  standard `GitPullRequest` icon.                                                                   

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Checklist

  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
  - [x] My code follows the code style of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings                                                         
  - [x] I have added tests that prove my fix is effective or that my feature works                  
  - [x] New and existing unit tests pass locally with my changes                                    
  - [x] I have run `pnpm typecheck` and `pnpm lint` locally                                                 
                                                                                                    
  ## Additional Notes                                                                               
                                                                                                    
  - Draft PR metadata is fetched using the GitHub CLI's `isDraft` field.
  - Regular PR and branch icons are unchanged.
  - The focused `GitStatusManager` suite passes all 23 tests.
  - Workspace type-checking and linting pass. Lint reports only existing unrelated warnings.