### PR TITLE
Fix pnpm dev: re-bundle the sandboxed preload after tsc emits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - When adding or changing CLI integrations, follow `docs/ADDING_NEW_CLI_TOOLS.md` and `docs/IMPLEMENTING_NEW_CLI_AGENTS.md`.
 
 ## Build, Test, and Development Commands
-- Dev app: `pnpm dev` (spawns frontend + Electron).
+- Dev app: `pnpm dev` (spawns frontend + Electron). The launcher waits for `tsc -w`'s first emit and re-bundles `main/dist/main/src/preload.js` with esbuild (the plain tsc emit cannot load in the sandboxed preload, which leaves the renderer on the browser fallback screen); it keeps re-bundling whenever tsc overwrites it.
 - Build all: `pnpm build` (frontend, main, then electron package).
 - Package (examples): `pnpm build:mac`, `pnpm build:linux`.
 - Lint: `pnpm lint`; Type-check: `pnpm typecheck` (runs per package). The root lint command is the single entry point for blocking Oxlint and Knip checks, residual ESLint, and advisory anti-slop checks.

--- a/scripts/pane-run-script.js
+++ b/scripts/pane-run-script.js
@@ -208,6 +208,68 @@ function markNativeRebuildComplete(root) {
 }
 
 /**
+ * Detect whether main/dist/main/src/preload.js is the esbuild bundle (safe for
+ * the sandboxed preload) or the plain tsc emit, which still `require`s
+ * ../../shared/... and fails to load inside the sandbox — leaving the renderer
+ * without window.electronAPI and stuck on the browser fallback screen.
+ */
+function preloadIsBundled(root) {
+  const preloadPath = path.join(root, 'main', 'dist', 'main', 'src', 'preload.js');
+  if (!fs.existsSync(preloadPath)) return false;
+  const source = fs.readFileSync(preloadPath, 'utf8');
+  const runtimeRequires = [...source.matchAll(/\brequire\((['"])([^'"]+)\1\)/g)].map((m) => m[2]);
+  return runtimeRequires.length > 0 && runtimeRequires.every((specifier) => specifier === 'electron');
+}
+
+/**
+ * Re-run esbuild for the preload. `tsc -w` overwrites the bundle with a plain
+ * emit on its initial pass and whenever preload.ts (or a shared import) changes.
+ */
+function bundlePreload(root) {
+  console.log('[preload] Bundling sandboxed preload...');
+  try {
+    execSync('pnpm run --filter main bundle:preload', { cwd: root, stdio: 'inherit', shell: true });
+    return true;
+  } catch (error) {
+    console.error('[preload] ❌ Failed to bundle preload; the renderer will fall back to browser mode until this is fixed.');
+    return false;
+  }
+}
+
+/**
+ * Watch the tsc output directory and re-bundle whenever tsc drops an
+ * unbundled preload.js there.
+ */
+function watchPreloadEmit(root) {
+  const distDir = path.join(root, 'main', 'dist', 'main', 'src');
+  if (!fs.existsSync(distDir)) return null;
+  let timer = null;
+  let bundling = false;
+  const check = () => {
+    timer = null;
+    if (bundling || preloadIsBundled(root)) return;
+    bundling = true;
+    try {
+      bundlePreload(root);
+    } finally {
+      bundling = false;
+    }
+  };
+  try {
+    const watcher = fs.watch(distDir, (_event, filename) => {
+      if (filename && String(filename) !== 'preload.js') return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(check, 500);
+    });
+    watcher.on('error', () => {});
+    return watcher;
+  } catch (error) {
+    console.warn(`[preload] Could not watch ${distDir}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
  * Check if build is needed
  */
 function needsBuild(root) {
@@ -353,14 +415,34 @@ async function main() {
   const children = [];
 
   // 1. Start TypeScript watcher for main process
+  // stdout is piped (and mirrored) so we can tell when tsc's initial emit has
+  // landed: it overwrites the bundled preload.js, and Electron must not load
+  // the window until that emit has been re-bundled.
   const tscWatch = spawn('pnpm', ['run', '--filter', 'main', 'dev'], {
     cwd: projectRoot,
     env,
-    stdio: ['ignore', 'inherit', 'inherit'],
+    stdio: ['ignore', 'pipe', 'inherit'],
     shell: true
   });
   children.push(tscWatch);
   console.log('[tsc] TypeScript watch started');
+
+  const tscInitialEmit = new Promise((resolve) => {
+    let settled = false;
+    tscWatch.stdout.on('data', (chunk) => {
+      process.stdout.write(chunk);
+      if (!settled && /Watching for file changes/.test(chunk.toString())) {
+        settled = true;
+        resolve();
+      }
+    });
+    tscWatch.on('exit', () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
+  });
 
   // 2. Start Vite dev server with the correct port
   const vite = spawn('pnpm', ['run', '--filter', 'frontend', 'dev', '--', '--port', port.toString()], {
@@ -372,15 +454,44 @@ async function main() {
   children.push(vite);
   console.log(`[vite] Frontend dev server starting on port ${port}`);
 
-  // 3. Wait for Vite to be ready, then launch Electron
-  const waitAndLaunch = spawn('npx', ['wait-on', `http-get://localhost:${port}`, '&&', 'npx', 'electron', '.'], {
+  // 3. Wait for Vite and tsc's initial emit, re-bundle the preload that emit
+  //    just clobbered, then launch Electron.
+  const waitOn = spawn('npx', ['wait-on', `http-get://localhost:${port}`], {
     cwd: projectRoot,
     env,
     stdio: ['ignore', 'inherit', 'inherit'],
     shell: true
   });
-  children.push(waitAndLaunch);
-  console.log(`[electron] Waiting for http-get://localhost:${port} then launching Electron`);
+  children.push(waitOn);
+  console.log(`[electron] Waiting for http-get://localhost:${port} and the main-process build, then launching Electron`);
+
+  const viteReady = new Promise((resolve, reject) => {
+    waitOn.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`wait-on exited with code ${code}`))));
+  });
+
+  let electron = null;
+  const preloadWatcher = watchPreloadEmit(projectRoot);
+  Promise.all([viteReady, tscInitialEmit])
+    .then(() => {
+      if (!preloadIsBundled(projectRoot)) {
+        bundlePreload(projectRoot);
+      }
+      electron = spawn('npx', ['electron', '.'], {
+        cwd: projectRoot,
+        env,
+        stdio: ['ignore', 'inherit', 'inherit'],
+        shell: true
+      });
+      children.push(electron);
+      electron.on('exit', (code) => {
+        console.log(`\n📋 Electron exited with code ${code}`);
+        cleanup();
+      });
+    })
+    .catch((error) => {
+      console.error(`\n❌ ${error.message}`);
+      cleanup();
+    });
 
   // Handle cleanup on exit
   let cleanedUp = false;
@@ -388,6 +499,7 @@ async function main() {
     if (cleanedUp) return;
     cleanedUp = true;
     console.log('\n\n🛑 Shutting down dev server...');
+    if (preloadWatcher) preloadWatcher.close();
 
     for (const child of children) {
       if (child.pid) {
@@ -412,10 +524,6 @@ async function main() {
       console.log(`\n📋 Vite exited with code ${code}`);
       cleanup();
     }
-  });
-  waitAndLaunch.on('exit', (code) => {
-    console.log(`\n📋 Electron exited with code ${code}`);
-    cleanup();
   });
 }
 


### PR DESCRIPTION
## Problem

Running `pnpm dev` shows the **"Open Pane from the desktop app"** browser-fallback screen inside the Electron window instead of the app.

`pnpm dev` starts `tsc -w` for `main/`, and tsc's plain emit of `main/dist/main/src/preload.js` does `require('../../shared/validation/boundaryDecoder')`. The preload runs sandboxed and may only `require('electron')`, so it throws on load, `window.electronAPI` is never exposed, and the renderer takes the browser-fallback branch. `pnpm build:main` avoids this by running `bundle:preload` (esbuild) after tsc, but the dev watcher overwrites that bundle on its first pass and on every later `preload.ts` change.

## Fix (`scripts/pane-run-script.js`)

- Pipe tsc's stdout (still mirrored to the terminal) to detect its initial emit.
- Launch Electron only after **both** Vite is reachable and tsc has emitted, running `pnpm --filter main bundle:preload` first if the emitted preload isn't the esbuild bundle.
- Watch `main/dist/main/src` and re-bundle whenever tsc drops an unbundled `preload.js` there, so edits to `preload.ts` / shared imports keep working without a manual step.
- `AGENTS.md` notes the behaviour.

## Verification

- `PANE_DIR=~/.pane_test pnpm dev`: log shows `Watching for file changes` → `[preload] Bundling sandboxed preload...` → `Sandboxed preload bundle verified` → window created; renderer console lines arrive over the preload's IPC bridge (they didn't before).
- Appended a line to `main/src/preload.ts` while running: tsc re-emitted and the launcher re-bundled automatically; `preload.js` stayed the esbuild bundle.
- `pnpm lint` clean.

https://claude.ai/code/session_0146Zyp3oXfcsWZJxeCuatb5