### PR TITLE
Fix fullscreen TUI resize: keep alt-screen clears, single repaint nudge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - When adding or changing CLI integrations, follow `docs/ADDING_NEW_CLI_TOOLS.md` and `docs/IMPLEMENTING_NEW_CLI_AGENTS.md`.
 
 ## Build, Test, and Development Commands
-- Dev app: `pnpm dev` (spawns frontend + Electron).
+- Dev app: `pnpm dev` (spawns frontend + Electron). The launcher waits for `tsc -w`'s first emit and re-bundles `main/dist/main/src/preload.js` with esbuild (the plain tsc emit cannot load in the sandboxed preload, which leaves the renderer on the browser fallback screen); it keeps re-bundling whenever tsc overwrites it.
 - Build all: `pnpm build` (frontend, main, then electron package).
 - Package (examples): `pnpm build:mac`, `pnpm build:linux`.
 - Lint: `pnpm lint`; Type-check: `pnpm typecheck` (runs per package). The root lint command is the single entry point for blocking Oxlint and Knip checks, residual ESLint, and advisory anti-slop checks.

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -98,7 +98,6 @@ const DEFAULT_TERMINAL_FONT_SIZE = 14;
 const WEBGL_APP_BLUR_DETACH_DELAY_MS = 10_000;
 const REFOCUS_DELAYED_REFRESH_MS = 300;
 const TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS = 200;
-const FORCED_REDRAW_TRANSITION_MS = 50;
 const TERMINAL_VISIBILITY_REFRESH_MS = 60_000;
 const SNAPSHOT_MIN_INTERVAL_MS = 10_000;
 const MIN_VIABLE_RECT_PX = 100; // below this the container is hidden or mid-layout (Allotment minSize is 120)
@@ -227,7 +226,8 @@ function waitForNextPaint(): Promise<void> {
  * foreground-TUI redraw assumptions hidden by retained-DOM designs. Restoring
  * cells recreates terminal state but cannot make the application recompute its
  * layout, which is why the alternate-screen activation path finishes with a
- * timed real PTY size transition. The normal-buffer path deliberately does
+ * forced resize: main toggles the PTY rows once (renderer grid untouched) so
+ * the app gets a real SIGWINCH and repaints. The normal-buffer path deliberately does
  * NOT force one: the emulator serialization is already the exact current
  * screen, and forced width transitions made normal-buffer TUIs (Claude Code)
  * re-render their transcript tail — duplicating scrollback on every
@@ -660,6 +660,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     // 120px minSize minus tab-bar chrome leaves a legitimately <100px-tall container.
     const rect = terminalRef.current.getBoundingClientRect();
     if (rect.width < MIN_VIABLE_RECT_PX) return;
+    const terminal = xtermRef.current;
+    const prevCols = terminal?.cols;
+    const prevRows = terminal?.rows;
     fitAddonRef.current.fit();
     const dimensions = fitAddonRef.current.proposeDimensions();
     if (
@@ -670,46 +673,24 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
       return;
     }
 
-    if (!force) {
-      await window.electronAPI.invoke(
-        'terminal:resize',
-        panel.id,
-        dimensions.cols,
-        dimensions.rows,
-        { force },
-      );
-      return;
+    // A dims change invalidates the renderer's cached rows; repaint the whole
+    // grid so WebGL never shows cells from the previous geometry.
+    if (terminal && (terminal.cols !== prevCols || terminal.rows !== prevRows) && terminal.rows > 0) {
+      terminal.refresh(0, terminal.rows - 1);
     }
 
-    const terminal = xtermRef.current;
-    if (!terminal) return;
-    const redrawCols = dimensions.cols > MIN_PTY_COLS ? dimensions.cols - 1 : dimensions.cols + 1;
-
-    try {
-      // Keep renderer and PTY geometry synchronized throughout the forced redraw.
-      // Full recovery/manual refresh already run under the opaque spinner mask.
-      terminal.resize(redrawCols, dimensions.rows);
-      await window.electronAPI.invoke(
-        'terminal:resize',
-        panel.id,
-        redrawCols,
-        dimensions.rows,
-      );
-      await new Promise(resolve => setTimeout(resolve, FORCED_REDRAW_TRANSITION_MS));
-      terminal.resize(dimensions.cols, dimensions.rows);
-      await window.electronAPI.invoke(
-        'terminal:resize',
-        panel.id,
-        dimensions.cols,
-        dimensions.rows,
-        { force },
-      );
-    } finally {
-      // An IPC failure must not strand the renderer at the redraw dimensions.
-      if (terminal.cols !== dimensions.cols || terminal.rows !== dimensions.rows) {
-        terminal.resize(dimensions.cols, dimensions.rows);
-      }
-    }
+    // The renderer grid always stays at the fitted size. A forced redraw is a
+    // main-side concern: main toggles the PTY through a one-row transition so
+    // the foreground app receives a real SIGWINCH, and its intermediate frame
+    // is overwritten by the final repaint. Doing the round trip here as well
+    // used to stack up to four SIGWINCHes per activation.
+    await window.electronAPI.invoke(
+      'terminal:resize',
+      panel.id,
+      dimensions.cols,
+      dimensions.rows,
+      { force },
+    );
   }, [panel.id]);
 
   // The terminal instance lives for the lifetime of a panel. Event handlers installed
@@ -785,9 +766,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
       const state = await window.electronAPI.invoke('terminal:getState', panel.id);
       if (state?.isAlternateScreen) {
         // Renderer refresh alone cannot repair an application frame that was
-        // restored before the visible grid settled. Move xterm and the PTY through
-        // the same one-column transition so the foreground app receives a real
-        // resize notification without a renderer/PTY geometry mismatch.
+        // restored before the visible grid settled. Ask main for a forced resize
+        // (single PTY row nudge) so the foreground app receives a real resize
+        // notification and repaints at the settled grid.
         await resizePtyToFit(true);
         if (terminal.rows > 0) {
           terminal.refresh(0, terminal.rows - 1);

--- a/main/src/services/syncBlockClearFilter.test.ts
+++ b/main/src/services/syncBlockClearFilter.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { filterSyncBlockClears, type SyncBlockClearFilterState } from './syncBlockClearFilter';
+
+const SYNC_START = '\x1b[?2026h';
+const SYNC_END = '\x1b[?2026l';
+const ALT_ENTER = '\x1b[?1049h';
+const ALT_LEAVE = '\x1b[?1049l';
+const CLEAR = '\x1b[2J';
+
+const fresh = (): SyncBlockClearFilterState => ({ inSyncBlock: false, filterInAltScreen: false });
+
+describe('filterSyncBlockClears', () => {
+  it('passes data through untouched outside sync blocks', () => {
+    const state = fresh();
+    expect(filterSyncBlockClears(state, `a${CLEAR}b`)).toBe(`a${CLEAR}b`);
+    expect(state.inSyncBlock).toBe(false);
+  });
+
+  it('strips clears inside sync blocks on the normal buffer', () => {
+    const state = fresh();
+    expect(filterSyncBlockClears(state, `${SYNC_START}${CLEAR}frame${SYNC_END}`))
+      .toBe(`${SYNC_START}frame${SYNC_END}`);
+  });
+
+  it('tracks sync block state across chunks', () => {
+    const state = fresh();
+    filterSyncBlockClears(state, SYNC_START);
+    expect(state.inSyncBlock).toBe(true);
+    expect(filterSyncBlockClears(state, `${CLEAR}x`)).toBe('x');
+    filterSyncBlockClears(state, SYNC_END);
+    expect(state.inSyncBlock).toBe(false);
+  });
+
+  it('keeps clears inside sync blocks while the alternate screen is active', () => {
+    const state = fresh();
+    filterSyncBlockClears(state, ALT_ENTER);
+    expect(state.filterInAltScreen).toBe(true);
+    const frame = `${SYNC_START}${CLEAR}fullscreen${SYNC_END}`;
+    expect(filterSyncBlockClears(state, frame)).toBe(frame);
+    expect(state.inSyncBlock).toBe(false);
+  });
+
+  it('handles alt-screen enter and a clear in the same chunk in stream order', () => {
+    const state = fresh();
+    const chunk = `${SYNC_START}${CLEAR}${ALT_ENTER}${CLEAR}ui${SYNC_END}`;
+    expect(filterSyncBlockClears(state, chunk)).toBe(`${SYNC_START}${ALT_ENTER}${CLEAR}ui${SYNC_END}`);
+    expect(state.filterInAltScreen).toBe(true);
+  });
+
+  it('resumes stripping after leaving the alternate screen', () => {
+    const state = fresh();
+    filterSyncBlockClears(state, ALT_ENTER);
+    expect(filterSyncBlockClears(state, `${ALT_LEAVE}${SYNC_START}${CLEAR}tail${SYNC_END}`))
+      .toBe(`${ALT_LEAVE}${SYNC_START}tail${SYNC_END}`);
+    expect(state.filterInAltScreen).toBe(false);
+  });
+
+  it('keeps sync-block state current while on the alternate screen', () => {
+    const state = fresh();
+    filterSyncBlockClears(state, `${ALT_ENTER}${SYNC_START}`);
+    expect(state.inSyncBlock).toBe(true);
+    // Leaving alt screen inside an open sync block: subsequent clear is stripped
+    expect(filterSyncBlockClears(state, `${ALT_LEAVE}${CLEAR}done${SYNC_END}`))
+      .toBe(`${ALT_LEAVE}done${SYNC_END}`);
+  });
+});

--- a/main/src/services/syncBlockClearFilter.ts
+++ b/main/src/services/syncBlockClearFilter.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure PTY-stream filter shared by terminalPanelManager. Kept separate so the
+ * scanning rules are unit-testable without spawning a terminal.
+ */
+export interface SyncBlockClearFilterState {
+  /** Inside a DEC 2026 synchronized-output block — persists across chunks. */
+  inSyncBlock: boolean;
+  /** Alternate screen active, tracked in stream order — persists across chunks. */
+  filterInAltScreen: boolean;
+}
+
+/**
+ * Strips \x1b[2J (clear-screen) sequences that appear inside DEC Mode 2026
+ * synchronized-output blocks while the NORMAL buffer is active. Claude Code
+ * uses these blocks for its inline (normal-buffer) redraws; the clear-screen
+ * causes xterm.js to reset scroll position, yanking users away from where
+ * they were reading.
+ *
+ * On the ALTERNATE screen (Claude Code fullscreen mode, vim, etc.) the clear
+ * is passed through untouched: there is no scrollback to protect, and the
+ * app relies on \x1b[2J to wipe the previous frame when it repaints after a
+ * resize. Stripping it left stale glyphs from the old geometry behind the new
+ * frame — visible as duplicated/overlapping text after resizing the pane.
+ *
+ * Alt-screen transitions (\x1b[?1049h / \x1b[?1049l) are tracked inside the
+ * scan so a chunk containing both an alt-screen enter and a clear is handled
+ * in stream order. State (inSyncBlock, filterInAltScreen) persists across
+ * chunk boundaries on the terminal object.
+ */
+export function filterSyncBlockClears(terminal: SyncBlockClearFilterState, data: string): string {
+  const SYNC_START = '\x1b[?2026h';
+  const SYNC_END   = '\x1b[?2026l';
+  const ALT_ENTER  = '\x1b[?1049h';
+  const ALT_LEAVE  = '\x1b[?1049l';
+  const CLEAR      = '\x1b[2J';
+
+  const hasAltTransition = data.includes(ALT_ENTER) || data.includes(ALT_LEAVE);
+
+  // Fast path: nothing to strip and no state to update. (No alt-screen fast
+  // path: sync-block state must stay exact so it is correct on 1049l.)
+  if (!terminal.inSyncBlock && !data.includes(SYNC_START) && !hasAltTransition) {
+    return data;
+  }
+
+  let result = '';
+  let i = 0;
+
+  while (i < data.length) {
+    if (data.startsWith(SYNC_START, i)) {
+      terminal.inSyncBlock = true;
+      result += SYNC_START;
+      i += SYNC_START.length;
+    } else if (data.startsWith(SYNC_END, i)) {
+      terminal.inSyncBlock = false;
+      result += SYNC_END;
+      i += SYNC_END.length;
+    } else if (data.startsWith(ALT_ENTER, i)) {
+      terminal.filterInAltScreen = true;
+      result += ALT_ENTER;
+      i += ALT_ENTER.length;
+    } else if (data.startsWith(ALT_LEAVE, i)) {
+      terminal.filterInAltScreen = false;
+      result += ALT_LEAVE;
+      i += ALT_LEAVE.length;
+    } else if (terminal.inSyncBlock && !terminal.filterInAltScreen && data.startsWith(CLEAR, i)) {
+      // Strip the clear-screen — scroll position preserved in xterm.js
+      i += CLEAR.length;
+    } else {
+      result += data[i];
+      i++;
+    }
+  }
+
+  return result;
+}

--- a/main/src/services/terminalPanelManager.test.ts
+++ b/main/src/services/terminalPanelManager.test.ts
@@ -163,7 +163,7 @@ describe('TerminalPanelManager terminal resize', () => {
     expect(terminal.pty.resize).not.toHaveBeenCalled();
 
     const redraw = manager.resizeTerminal(terminal.panelId, 80, 24, { force: true });
-    expect(terminal.pty.resize).toHaveBeenNthCalledWith(1, 79, 24);
+    expect(terminal.pty.resize).toHaveBeenNthCalledWith(1, 80, 23);
     expect(terminal.pty.resize).toHaveBeenCalledTimes(1);
 
     await vi.runAllTimersAsync();

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -1,4 +1,5 @@
 import * as pty from '@lydell/node-pty';
+import { filterSyncBlockClears } from './syncBlockClearFilter';
 import { ToolPanel, TerminalPanelState } from '../../../shared/types/panels';
 import { getPaneDaemonEventSink, getPaneEventSink, getPtyHostRuntime, getRuntimeConfigManager, type PtyHandleLike, type PtyHostRuntime } from '../core/runtime';
 import { panelManager } from './panelManager';
@@ -217,6 +218,9 @@ interface TerminalProcess {
   agentType?: CliAgentType;
   // DEC Mode 2026 synchronized-output block tracking — persists across chunks
   inSyncBlock: boolean;
+  /** Alt-screen state as seen by filterSyncBlockClears (stream-ordered, may
+   *  differ transiently from isAlternateScreen which is chunk-granular). */
+  filterInAltScreen: boolean;
   capturedAgentSessionId?: string;
   agentSessionScrapeBuffer: string;
 }
@@ -1065,6 +1069,7 @@ export class TerminalPanelManager {
       activityStatus: 'idle',
       idleTimer: null,
       inSyncBlock: false,
+      filterInAltScreen: false,
       agentType: this.resolveTerminalAgentType(terminalCustomState(panel.state)),
       agentSessionScrapeBuffer: ''
     };
@@ -1189,45 +1194,9 @@ export class TerminalPanelManager {
     }
   }
 
-  /**
-   * Strips \x1b[2J (clear-screen) sequences that appear inside DEC Mode 2026
-   * synchronized-output blocks. Claude Code uses these blocks for full-screen
-   * redraws; the clear-screen causes xterm.js to reset scroll position, yanking
-   * users away from where they were reading. State (inSyncBlock) persists across
-   * chunk boundaries on the terminal object.
-   */
+  /** See syncBlockClearFilter.ts — state lives on the terminal object. */
   private filterSyncBlockClears(terminal: TerminalProcess, data: string): string {
-    const SYNC_START = '\x1b[?2026h';
-    const SYNC_END   = '\x1b[?2026l';
-    const CLEAR      = '\x1b[2J';
-
-    // Fast path: no sync sequences and not already inside a block
-    if (!terminal.inSyncBlock && !data.includes(SYNC_START)) {
-      return data;
-    }
-
-    let result = '';
-    let i = 0;
-
-    while (i < data.length) {
-      if (data.startsWith(SYNC_START, i)) {
-        terminal.inSyncBlock = true;
-        result += SYNC_START;
-        i += SYNC_START.length;
-      } else if (data.startsWith(SYNC_END, i)) {
-        terminal.inSyncBlock = false;
-        result += SYNC_END;
-        i += SYNC_END.length;
-      } else if (terminal.inSyncBlock && data.startsWith(CLEAR, i)) {
-        // Strip the clear-screen — scroll position preserved in xterm.js
-        i += CLEAR.length;
-      } else {
-        result += data[i];
-        i++;
-      }
-    }
-
-    return result;
+    return filterSyncBlockClears(terminal, data);
   }
 
   private setupTerminalHandlers(terminal: TerminalProcess): void {
@@ -1473,8 +1442,12 @@ export class TerminalPanelManager {
 
     try {
       if (options.force && isSameSize) {
-        const redrawCols = cols > MIN_PTY_COLS ? cols - 1 : cols + 1;
-        terminal.pty.resize(redrawCols, rows);
+        // Single repaint nudge: toggle ROWS (not cols) so the normal buffer never
+        // reflows, and keep the headless emulator in step so the intermediate
+        // frame is parsed at the geometry it was drawn for.
+        const redrawRows = rows > MIN_PTY_ROWS ? rows - 1 : rows + 1;
+        terminal.pty.resize(cols, redrawRows);
+        terminal.screenEmulator?.resize(cols, redrawRows);
         // Give the foreground process time to observe the intermediate grid.
         // Back-to-back TIOCSWINSZ calls can collapse into a single pending signal.
         await new Promise(resolve => setTimeout(resolve, FORCED_REDRAW_TRANSITION_MS));

--- a/scripts/pane-run-script.js
+++ b/scripts/pane-run-script.js
@@ -208,6 +208,68 @@ function markNativeRebuildComplete(root) {
 }
 
 /**
+ * Detect whether main/dist/main/src/preload.js is the esbuild bundle (safe for
+ * the sandboxed preload) or the plain tsc emit, which still `require`s
+ * ../../shared/... and fails to load inside the sandbox — leaving the renderer
+ * without window.electronAPI and stuck on the browser fallback screen.
+ */
+function preloadIsBundled(root) {
+  const preloadPath = path.join(root, 'main', 'dist', 'main', 'src', 'preload.js');
+  if (!fs.existsSync(preloadPath)) return false;
+  const source = fs.readFileSync(preloadPath, 'utf8');
+  const runtimeRequires = [...source.matchAll(/\brequire\((['"])([^'"]+)\1\)/g)].map((m) => m[2]);
+  return runtimeRequires.length > 0 && runtimeRequires.every((specifier) => specifier === 'electron');
+}
+
+/**
+ * Re-run esbuild for the preload. `tsc -w` overwrites the bundle with a plain
+ * emit on its initial pass and whenever preload.ts (or a shared import) changes.
+ */
+function bundlePreload(root) {
+  console.log('[preload] Bundling sandboxed preload...');
+  try {
+    execSync('pnpm run --filter main bundle:preload', { cwd: root, stdio: 'inherit', shell: true });
+    return true;
+  } catch (error) {
+    console.error('[preload] ❌ Failed to bundle preload; the renderer will fall back to browser mode until this is fixed.');
+    return false;
+  }
+}
+
+/**
+ * Watch the tsc output directory and re-bundle whenever tsc drops an
+ * unbundled preload.js there.
+ */
+function watchPreloadEmit(root) {
+  const distDir = path.join(root, 'main', 'dist', 'main', 'src');
+  if (!fs.existsSync(distDir)) return null;
+  let timer = null;
+  let bundling = false;
+  const check = () => {
+    timer = null;
+    if (bundling || preloadIsBundled(root)) return;
+    bundling = true;
+    try {
+      bundlePreload(root);
+    } finally {
+      bundling = false;
+    }
+  };
+  try {
+    const watcher = fs.watch(distDir, (_event, filename) => {
+      if (filename && String(filename) !== 'preload.js') return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(check, 500);
+    });
+    watcher.on('error', () => {});
+    return watcher;
+  } catch (error) {
+    console.warn(`[preload] Could not watch ${distDir}: ${error.message}`);
+    return null;
+  }
+}
+
+/**
  * Check if build is needed
  */
 function needsBuild(root) {
@@ -353,14 +415,34 @@ async function main() {
   const children = [];
 
   // 1. Start TypeScript watcher for main process
+  // stdout is piped (and mirrored) so we can tell when tsc's initial emit has
+  // landed: it overwrites the bundled preload.js, and Electron must not load
+  // the window until that emit has been re-bundled.
   const tscWatch = spawn('pnpm', ['run', '--filter', 'main', 'dev'], {
     cwd: projectRoot,
     env,
-    stdio: ['ignore', 'inherit', 'inherit'],
+    stdio: ['ignore', 'pipe', 'inherit'],
     shell: true
   });
   children.push(tscWatch);
   console.log('[tsc] TypeScript watch started');
+
+  const tscInitialEmit = new Promise((resolve) => {
+    let settled = false;
+    tscWatch.stdout.on('data', (chunk) => {
+      process.stdout.write(chunk);
+      if (!settled && /Watching for file changes/.test(chunk.toString())) {
+        settled = true;
+        resolve();
+      }
+    });
+    tscWatch.on('exit', () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    });
+  });
 
   // 2. Start Vite dev server with the correct port
   const vite = spawn('pnpm', ['run', '--filter', 'frontend', 'dev', '--', '--port', port.toString()], {
@@ -372,15 +454,44 @@ async function main() {
   children.push(vite);
   console.log(`[vite] Frontend dev server starting on port ${port}`);
 
-  // 3. Wait for Vite to be ready, then launch Electron
-  const waitAndLaunch = spawn('npx', ['wait-on', `http-get://localhost:${port}`, '&&', 'npx', 'electron', '.'], {
+  // 3. Wait for Vite and tsc's initial emit, re-bundle the preload that emit
+  //    just clobbered, then launch Electron.
+  const waitOn = spawn('npx', ['wait-on', `http-get://localhost:${port}`], {
     cwd: projectRoot,
     env,
     stdio: ['ignore', 'inherit', 'inherit'],
     shell: true
   });
-  children.push(waitAndLaunch);
-  console.log(`[electron] Waiting for http-get://localhost:${port} then launching Electron`);
+  children.push(waitOn);
+  console.log(`[electron] Waiting for http-get://localhost:${port} and the main-process build, then launching Electron`);
+
+  const viteReady = new Promise((resolve, reject) => {
+    waitOn.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`wait-on exited with code ${code}`))));
+  });
+
+  let electron = null;
+  const preloadWatcher = watchPreloadEmit(projectRoot);
+  Promise.all([viteReady, tscInitialEmit])
+    .then(() => {
+      if (!preloadIsBundled(projectRoot)) {
+        bundlePreload(projectRoot);
+      }
+      electron = spawn('npx', ['electron', '.'], {
+        cwd: projectRoot,
+        env,
+        stdio: ['ignore', 'inherit', 'inherit'],
+        shell: true
+      });
+      children.push(electron);
+      electron.on('exit', (code) => {
+        console.log(`\n📋 Electron exited with code ${code}`);
+        cleanup();
+      });
+    })
+    .catch((error) => {
+      console.error(`\n❌ ${error.message}`);
+      cleanup();
+    });
 
   // Handle cleanup on exit
   let cleanedUp = false;
@@ -388,6 +499,7 @@ async function main() {
     if (cleanedUp) return;
     cleanedUp = true;
     console.log('\n\n🛑 Shutting down dev server...');
+    if (preloadWatcher) preloadWatcher.close();
 
     for (const child of children) {
       if (child.pid) {
@@ -412,10 +524,6 @@ async function main() {
       console.log(`\n📋 Vite exited with code ${code}`);
       cleanup();
     }
-  });
-  waitAndLaunch.on('exit', (code) => {
-    console.log(`\n📋 Electron exited with code ${code}`);
-    cleanup();
   });
 }
 


### PR DESCRIPTION
## Problem
Resizing a pane while Claude Code runs in fullscreen (alternate-screen) mode left stale glyphs from the old geometry under the new frame — text looked duplicated and the layout never settled.

## Root cause
`filterSyncBlockClears` (#120) strips `\x1b[2J` inside DEC 2026 synchronized-output blocks to stop scroll jumps in Claude's inline (normal-buffer) rendering. On the alternate screen there's no scrollback to protect, and the app relies on that clear to wipe the previous frame when it repaints after SIGWINCH. Neither Morph nor Superset filter the PTY stream; both let the app repaint the alt screen itself.

## Changes
- **`main/src/services/syncBlockClearFilter.ts`** (new, +7 tests): filter extracted as a pure function. Tracks `?1049h`/`?1049l` in stream order and only strips `2J` while the normal buffer is active. Normal-buffer behavior unchanged.
- **`terminalPanelManager.resizeTerminal`**: forced redraw is a single rows−1 → rows nudge (like Superset's `nudgeRepaint`), with the headless emulator resized at each step so the intermediate frame parses at the geometry it was drawn for. Toggling rows instead of cols means the normal buffer can never reflow.
- **`TerminalPanel.resizePtyToFit`**: drops the renderer-side one-column round trip (was stacking up to four SIGWINCHes per activation with main's own transition), and calls `terminal.refresh(0, rows-1)` whenever `fit()` changes cols/rows so WebGL never keeps cells from the previous geometry.

## Testing
- Typecheck + eslint clean in `main` and `frontend`; frontend 266/266, `terminalPanelManager.test.ts` 32/32 (nudge expectation updated 79×24 → 80×23).
- Manually verified in `pnpm dev`: Claude Code fullscreen redraws cleanly on pane-splitter and window resize.

https://claude.ai/code/session_01BiC26fBvPKzdGZjPVe2JED
