### PR TITLE
Fix release notification race: gate on checksums, not tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,3 +311,15 @@ jobs:
           --repo "${{ github.repository }}" --clobber
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-website:
+    if: github.ref_type == 'tag'
+    needs: [checksums]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to runpane-website
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.SITE_REPO_DISPATCH_TOKEN }}
+          repository: parsakhaz/runpane-website
+          event-type: pane-release

--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,8 +1,5 @@
 name: Notify website on release
 on:
-  push:
-    tags: ["v*"]
-  # Manual trigger for validation
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Closes #517

## Summary

- **Moved** the website release notification (`pane-release` dispatch to `parsakhaz/runpane-website`) into `build.yml` as a `notify-website` job with `needs: [checksums]`, so it fires only after the GitHub Release is published AND checksums are uploaded
- **Removed** the `push: tags: ["v*"]` trigger from `notify-website.yml`, keeping only `workflow_dispatch` for manual validation

## The race (before)

Two independent workflows both trigger on `push: tags: ["v*"]`:

```
tag pushed ──┬─> notify-website.yml ──> website notified (IMMEDIATE)
             │
             └─> build.yml ──> build ──> publish-windows ──> publish-release ──> checksums
                                                              (~15-20 min later)
```

Users are told a release exists 15-20 minutes before `publish-release` undrafts the GitHub Release and uploads platform assets. Clicking through yields a 404 or a release missing their platform's binary.

## The fix (after)

One workflow, one dependency chain:

```
tag pushed ──> build.yml ──> build ──> publish-windows ──> publish-release ──> checksums ──> notify-website
```

The notification cannot fire until every artifact — including `SHA256SUMS.txt` — is present on the release.

## Why option 1 over option 2

Option 2 (`on: release: types: [published]`) would fire when `publish-release` undrafts the release via `gh release edit --draft=false`, but that's *before* the `checksums` job uploads `SHA256SUMS.txt`. Option 1 with `needs: [checksums]` ensures the notification waits for everything.

It also keeps the entire release pipeline visible in a single file.

## Receiving side

The dispatch targets `parsakhaz/runpane-website` with event-type `pane-release`. The website uses this to trigger a rebuild that surfaces "new version available" to users. Nothing on the receiving side depends on the notification arriving at tag-push time — it just needs the release to exist, which is now guaranteed.

## Sibling scan

Scanned all workflows in `.github/workflows/` for the same announce-before-ready pattern. Only `notify-website.yml` and `build.yml` trigger on `v*` tags. No other siblings found.

## Manual dispatch preserved

`notify-website.yml` retains its `workflow_dispatch` trigger for manual validation and debugging.

## Validation without cutting a release

- The dependency graph (`needs: [checksums]`) is structurally enforced by GitHub Actions — visible in the YAML
- `workflow_dispatch` on `build.yml` with `publish: false`: the `notify-website` job is skipped (`if: github.ref_type == 'tag'`), confirming no spurious notification
- `workflow_dispatch` on `notify-website.yml`: still works for manual dispatch

## Test plan

- [ ] Verify `build.yml` parses correctly (GitHub Actions validates on push)
- [ ] Verify `notify-website.yml` `workflow_dispatch` still works manually
- [ ] On next real release: confirm notification arrives only after release assets are published

https://claude.ai/code/session_01QqELWGJBqAynZRyHDipfad