### PR TITLE
Fix flaky Pane Chat radio accessibility test

### DIFF
--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 import { expectNoAxeViolations } from './axeTest';
 import { installElectronApiMock } from './electronApiMock';
 import type { JsonValue } from '../shared/validation/boundaryDecoder';
@@ -351,6 +351,15 @@ test('seeded pane exposes separate compound actions and arrow-keyed panel tabs',
   await expectNoAxeViolations(page, { include: '.pane-session-shell' });
 });
 
+async function pressAgentChoice(page: Page, aimAt: Locator, key: string, expected: Locator): Promise<void> {
+  await expect(async () => {
+    await aimAt.focus();
+    await page.keyboard.press(key);
+    await expect(expected).toBeFocused({ timeout: 1_000 });
+    await expect(expected).toBeChecked({ timeout: 2_000 });
+  }).toPass({ timeout: 10_000 });
+}
+
 test('Pane Chat agent choice uses native radio semantics', async ({ page }) => {
   await openDesktop(page, { paneChatAgentChangeDelayMs: 200 });
 
@@ -358,14 +367,9 @@ test('Pane Chat agent choice uses native radio semantics', async ({ page }) => {
   const radios = page.getByRole('radio');
   await expect(radios).toHaveCount(3);
   await expect(page.getByRole('radio', { checked: true })).toHaveCount(1);
-  await radios.first().focus();
-  await page.keyboard.press('ArrowRight');
-  await expect(radios.nth(1)).toBeFocused();
-  await expect(radios.nth(1)).toBeChecked();
 
-  await radios.nth(2).focus();
-  await page.keyboard.press('Space');
-  await expect(radios.nth(2)).toBeChecked();
+  await pressAgentChoice(page, radios.first(), 'ArrowRight', radios.nth(1));
+  await pressAgentChoice(page, radios.nth(2), 'Space', radios.nth(2));
   const cursorState = await page.evaluate(async () => window.electronAPI.paneChat.getOrCreate());
   expect(cursorState.data?.panel.id).toBe('__pane_chat_terminal_cursor__');
   expect(cursorState.data?.panel.state.customState?.initialCommand).toBe('cursor-agent --force --trust');


### PR DESCRIPTION
## Summary

- **Flake, not regression.** The release commit `82e46c30` only bumped version numbers; the prior run on `728ceba0` (identical app code) passed. Earlier CI failures were billing-related (all jobs failed across all matrices).
- **Root cause:** the test focuses a radio and presses a key as two separate Playwright commands. Switching agents mounts a new Pane Chat terminal that takes focus ~50 ms after it appears, so on a loaded CI runner the keypress arrives after the terminal has stolen the keyboard and lands there instead of on the radio. The radio never changes; the 5 s timeout expires.
- **Fix:** a `pressAgentChoice` retry helper wraps focus + press + assert in `expect().toPass({ timeout: 10_000 })`, re-aiming and pressing again until both focus and checked state hold. This also covers the shorter window where the radio group ignores input while a switch is still in flight.

## Evidence

| Metric | Before | After |
|---|---|---|
| `--repeat-each=15` | 11/15 (4 failures) | 15/15 |
| Full accessibility spec | 8/8 | 8/8 |
| Full smoke spec | 18/18 | 18/18 |
| Lint + typecheck | clean | clean |

CI log from the failing run showed the Cursor radio locator resolving 9 times as unchecked over 5 s — the terminal had taken the keyboard before `Space` arrived.

A fix for this exact race was developed on `feature/mission-control` (`6f9ae825`) but never merged to main. This PR ports that fix.

## Test plan

- [x] Reproduced the flake locally with `--repeat-each=15` (4/15 failures)
- [x] Applied the retry helper and confirmed 15/15 passes
- [x] Full accessibility spec passes (8/8)
- [x] Full smoke spec passes (18/18)
- [x] Lint and typecheck clean

https://claude.ai/code/session_01LZ362e4MFqaAndm71YvaPi