### PR TITLE
fix: watch baseline replay, post-restart agent.unknown, panel labelling

### DIFF
--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -223,6 +223,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
         paneId: panel.sessionId,
         isCliPanel: snapshot?.isCliPanel ?? customState.isCliPanel ?? false,
         agentType: snapshot?.agentType ?? customState.agentType,
+        panelTitle: panel.title,
         lastActivityAt: snapshot?.lastActivityTime,
         heldInput: snapshot?.screenText ? extractWorkspaceHeldInput(snapshot.screenText) : undefined,
       };

--- a/main/src/ipc/runpane.test.ts
+++ b/main/src/ipc/runpane.test.ts
@@ -324,8 +324,11 @@ describe('runpane IPC handlers', () => {
       ok: true,
       generation: 0,
       entries: [
-        { kind: 'pane.created', paneId: session.id, baseline: true },
-        { kind: 'agent.ready', paneId: session.id, panelId: terminalPanel.id, baseline: true },
+        {
+          kind: 'pane.created', paneId: session.id, baseline: true,
+          panels: [{ panelId: terminalPanel.id, title: terminalPanel.title, agentType: 'codex', agentState: 'idle' }],
+        },
+        { kind: 'agent.ready', paneId: session.id, panelId: terminalPanel.id, panelTitle: terminalPanel.title, baseline: true },
       ],
     });
   });
@@ -379,6 +382,91 @@ describe('runpane IPC handlers', () => {
     expect(result.entries).toContainEqual(
       expect.objectContaining({ kind: 'pane.created', baseline: true }),
     );
+  });
+
+  it('emits zero data events for a new --from now cursor on a populated workspace', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-runpane-cursor-test-'));
+    tempDirs.push(directory);
+    const workspaceJournal = new WorkspaceJournal();
+    const workspaceCursorStore = new WorkspaceCursorStore(
+      path.join(directory, 'workspace-cursors.json'),
+    );
+    const sessions = Array.from({ length: 60 }, (_, i) => ({
+      ...session,
+      id: `session-${i}`,
+      name: `pane-${i}`,
+    }));
+    const panels = sessions.map((s, i) => ({
+      ...terminalPanel,
+      id: `panel-${i}`,
+      sessionId: s.id,
+    }));
+    const services = createServices({ workspaceJournal, workspaceCursorStore });
+    vi.mocked(services.sessionManager.getAllSessions).mockReturnValue(sessions);
+    vi.mocked(services.sessionManager.getSessionsForProject).mockReturnValue(sessions);
+    vi.mocked(panelManager.getPanelsForSession).mockImplementation((sessionId: string) => {
+      const panel = panels.find(p => p.sessionId === sessionId);
+      return panel ? [panel] : [];
+    });
+    const registry = createRegistry(services);
+
+    const result = await registry.invoke('runpane:workspace:wait', [{
+      as: 'from-now-test',
+      from: 'now',
+      timeoutMs: 0,
+    }]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      reset: { reason: 'first-use' },
+      entries: [],
+    });
+  });
+
+  it('emits baseline entries for a new --from earliest cursor', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-runpane-cursor-test-'));
+    tempDirs.push(directory);
+    const workspaceJournal = new WorkspaceJournal();
+    const workspaceCursorStore = new WorkspaceCursorStore(
+      path.join(directory, 'workspace-cursors.json'),
+    );
+    const registry = createRegistry(createServices({ workspaceJournal, workspaceCursorStore }));
+
+    const result = await registry.invoke('runpane:workspace:wait', [{
+      as: 'earliest-test',
+      from: 'earliest',
+      timeoutMs: 0,
+    }]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      reset: { reason: 'first-use' },
+    });
+    expect(result.entries.length).toBeGreaterThan(0);
+    expect(result.entries).toContainEqual(
+      expect.objectContaining({ kind: 'pane.created', baseline: true }),
+    );
+  });
+
+  it('emits zero data events for a new cursor with default from (implicit now)', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-runpane-cursor-test-'));
+    tempDirs.push(directory);
+    const workspaceJournal = new WorkspaceJournal();
+    const workspaceCursorStore = new WorkspaceCursorStore(
+      path.join(directory, 'workspace-cursors.json'),
+    );
+    const registry = createRegistry(createServices({ workspaceJournal, workspaceCursorStore }));
+
+    const result = await registry.invoke('runpane:workspace:wait', [{
+      as: 'default-from-test',
+      timeoutMs: 0,
+    }]);
+
+    expect(result).toMatchObject({
+      ok: true,
+      reset: { reason: 'first-use' },
+      entries: [],
+    });
   });
 
   it('advances a truncated named cursor when its filter excludes retained entries', async () => {

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -80,6 +80,7 @@ import type {
   RunpaneResolvedTool,
   RunpaneToolSpec,
   RunpaneWorktreeCleanupState,
+  RunpaneWorkspaceEntry,
   RunpaneWorkspaceEntryKind,
   RunpaneWorkspaceStateResult,
   RunpaneWorkspaceWaitRequest,
@@ -738,8 +739,10 @@ export function registerRunpaneHandlers(
       const filter: WorkspaceJournalFilter = {
         kinds: normalized.kinds,
         paneIds: normalized.paneIds,
+        excludePaneIds: normalized.excludePaneIds,
         repoId: project?.id,
         nameContains: normalized.nameContains,
+        agentsOnly: normalized.agentsOnly,
         includeHeldInput: normalized.includeHeldInput,
       };
       const timeoutMs = Math.min(normalized.timeoutMs ?? DEFAULT_WORKSPACE_WAIT_TIMEOUT_MS, MAX_WORKSPACE_WAIT_TIMEOUT_MS);
@@ -767,7 +770,8 @@ export function registerRunpaneHandlers(
       }
 
       if (reset) {
-        const baseline = workspaceStateReader.read(project?.id).entries
+        const silentBaseline = reset.reason === 'first-use' && normalized.from !== 'earliest';
+        const baseline = silentBaseline ? [] : workspaceStateReader.read(project?.id).entries
           .filter(entry => workspaceEntryMatches(entry, filter))
           .map(entry => reset?.reason === 'epoch-changed' ? { ...entry, changedWhileAway: true as const } : entry);
         return {
@@ -1951,8 +1955,10 @@ function parseWorkspaceWaitRequest(value: PaneCommandValue): RunpaneWorkspaceWai
     limit: parsePositiveInteger(value.limit, 'limit'),
     kinds: parseWorkspaceKinds(value.kinds),
     paneIds: parseStringArray(value.paneIds, 'paneIds'),
+    excludePaneIds: parseStringArray(value.excludePaneIds, 'excludePaneIds'),
     repo: value.repo === undefined || value.repo === null || value.repo === '' ? undefined : parseRepoSelector(value.repo),
     nameContains: optionalString(value.nameContains),
+    agentsOnly: optionalBoolean(value.agentsOnly),
     ackNow: optionalBoolean(value.ackNow),
     includeHeldInput: optionalBoolean(value.includeHeldInput),
   };
@@ -2844,13 +2850,15 @@ function createWorkspaceJournal(services: AppServices): WorkspaceJournal {
 }
 
 function workspaceEntryMatches(
-  entry: { kind: RunpaneWorkspaceEntryKind; paneId: string; repoId?: number; paneName: string },
+  entry: RunpaneWorkspaceEntry,
   filter: WorkspaceJournalFilter,
 ): boolean {
   if (filter.kinds && !filter.kinds.includes(entry.kind)) return false;
   if (filter.paneIds && !filter.paneIds.includes(entry.paneId)) return false;
+  if (filter.excludePaneIds && filter.excludePaneIds.includes(entry.paneId)) return false;
   if (filter.repoId !== undefined && entry.repoId !== filter.repoId) return false;
   if (filter.nameContains && !entry.paneName.toLocaleLowerCase().includes(filter.nameContains.toLocaleLowerCase())) return false;
+  if (filter.agentsOnly && !entry.agentType && entry.kind !== 'pane.created' && entry.kind !== 'pane.gone') return false;
   return true;
 }
 

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -858,7 +858,7 @@ def emit_pane_entry(entry):
 
 def watch_panes(name_filter, once):
     command = resolve_runpane() + [
-        "watch", "--as", "watch.py", "--json",
+        "watch", "--as", "watch.py", "--json", "--agents-only",
         "--include-held-input", "--timeout-ms", "0" if once else "60000",
     ]
     if name_filter:

--- a/main/src/services/workspaceJournal.ts
+++ b/main/src/services/workspaceJournal.ts
@@ -20,6 +20,7 @@ interface WorkspacePanelMetadata {
   paneId: string;
   isCliPanel?: boolean;
   agentType?: string;
+  panelTitle?: string;
   lastActivityAt?: string;
   heldInput?: string;
 }
@@ -27,8 +28,10 @@ interface WorkspacePanelMetadata {
 export interface WorkspaceJournalFilter {
   kinds?: readonly RunpaneWorkspaceEntryKind[];
   paneIds?: readonly string[];
+  excludePaneIds?: readonly string[];
   repoId?: number;
   nameContains?: string;
+  agentsOnly?: boolean;
   includeHeldInput?: boolean;
 }
 
@@ -87,6 +90,7 @@ export class WorkspaceJournal implements PaneEventSink {
   private readonly ring: RunpaneWorkspaceEntry[] = [];
   private readonly paneById = new Map<string, WorkspacePaneMetadata>();
   private readonly stateByPanel = new Map<string, AgentState>();
+  private readonly exitedPanels = new Set<string>();
   private readonly waiters = new Set<WorkspaceWaiter>();
   private readonly capacity: number;
   private readonly now: () => number;
@@ -211,13 +215,18 @@ export class WorkspaceJournal implements PaneEventSink {
       const payload = decodeOptionalBoundary(args[0], panelExitEventSchema);
       if (!payload || payload.type !== 'terminal:exit') return;
       const { panelId, sessionId: paneId } = payload.source;
+      if (this.exitedPanels.has(panelId)) return;
+      this.exitedPanels.add(panelId);
       this.stateByPanel.delete(panelId);
       const pane = this.lookupPane(paneId);
       if (!pane) return;
+      const panel = this.resolvePanel?.(panelId);
       this.append({
         ...pane,
         kind: 'panel.exited',
         panelId,
+        panelTitle: panel?.panelTitle,
+        agentType: panel?.agentType,
         source: 'exit',
         exitCode: payload.data.exitCode,
         reason: payload.data.signal === undefined ? 'terminal:exit' : `signal:${payload.data.signal}`,
@@ -261,6 +270,7 @@ export class WorkspaceJournal implements PaneEventSink {
       ...pane,
       kind,
       panelId,
+      panelTitle: panel?.panelTitle,
       agentType: panel?.agentType,
       from: previous,
       to: state,
@@ -302,8 +312,10 @@ function agentEntryKind(state: AgentState, previous: AgentState | undefined): Ru
 function matchesFilter(entry: RunpaneWorkspaceEntry, filter: WorkspaceJournalFilter): boolean {
   if (filter.kinds && !filter.kinds.includes(entry.kind)) return false;
   if (filter.paneIds && !filter.paneIds.includes(entry.paneId)) return false;
+  if (filter.excludePaneIds && filter.excludePaneIds.includes(entry.paneId)) return false;
   if (filter.repoId !== undefined && entry.repoId !== filter.repoId) return false;
   if (filter.nameContains && !entry.paneName.toLocaleLowerCase().includes(filter.nameContains.toLocaleLowerCase())) return false;
+  if (filter.agentsOnly && !entry.agentType && entry.kind !== 'pane.created' && entry.kind !== 'pane.gone') return false;
   return true;
 }
 

--- a/main/src/services/workspaceStateReader.ts
+++ b/main/src/services/workspaceStateReader.ts
@@ -6,6 +6,7 @@ import type { AgentState } from '../../../shared/types/agentStatus';
 import type {
   RunpaneWorkspaceEntry,
   RunpaneWorkspaceEntryKind,
+  RunpaneWorkspacePanelSummary,
   RunpaneWorkspaceStateResult,
 } from '../../../shared/types/runpaneOrchestration';
 
@@ -37,28 +38,49 @@ export class WorkspaceStateReader {
         worktreePath: session.worktreePath,
         baseline: true as const,
       };
-      entries.push({ ...common, kind: 'pane.created', source: 'session' });
+
+      const panelSummaries: RunpaneWorkspacePanelSummary[] = [];
+      const agentEntries: RunpaneWorkspaceEntry[] = [];
 
       for (const panel of panelManager.getPanelsForSession(session.id)) {
+        if (panel.type !== 'terminal') continue;
         const customState = decodeBoundary(panel.state.customState ?? {}, boundary.object({
           isCliPanel: boundary.optional(boundary.boolean),
           agentType: boundary.optional(boundary.string),
         }));
-        if (panel.type !== 'terminal' || customState?.isCliPanel !== true) continue;
-        const agentState = terminalPanelManager.getAgentStatus(panel.id) ?? 'unknown';
-        entries.push({
+        const agentState = resolveAgentState(panel.id);
+        panelSummaries.push({
+          panelId: panel.id,
+          title: panel.title,
+          agentType: customState.agentType,
+          agentState,
+        });
+
+        if (customState?.isCliPanel !== true) continue;
+        agentEntries.push({
           ...common,
           kind: entryKindForState(agentState),
           panelId: panel.id,
+          panelTitle: panel.title,
           agentType: customState.agentType,
           to: agentState,
           source: 'agent',
         });
       }
+
+      entries.push({ ...common, kind: 'pane.created', source: 'session', panels: panelSummaries });
+      entries.push(...agentEntries);
     }
 
     return { ok: true, epoch: this.getEpoch(), generation, entries };
   }
+}
+
+function resolveAgentState(panelId: string): AgentState {
+  const tracked = terminalPanelManager.getAgentStatus(panelId);
+  if (tracked) return tracked;
+  const initialized = terminalPanelManager.isTerminalInitialized(panelId);
+  return initialized ? 'unknown' : 'idle';
 }
 
 function entryKindForState(state: AgentState): RunpaneWorkspaceEntryKind {

--- a/packages/runpane/src/commands.ts
+++ b/packages/runpane/src/commands.ts
@@ -60,8 +60,10 @@ export interface ParsedArgs {
   watchFrom?: 'now' | 'earliest';
   watchKinds?: string[];
   watchPaneIds?: string[];
+  watchExcludePaneIds?: string[];
   nameContains?: string;
   follow?: boolean;
+  agentsOnly?: boolean;
   ackNow?: boolean;
   includeHeldInput?: boolean;
   remoteSetupArgs: string[];
@@ -303,6 +305,10 @@ function parseLocalBooleanFlag(flag: string, parsed: ParsedArgs): void {
     parsed.includeHeldInput = true;
     return;
   }
+  if (flag === '--agents-only') {
+    parsed.agentsOnly = true;
+    return;
+  }
 
   throw new Error(`Unknown option for ${parsed.command}: ${flag}`);
 }
@@ -322,6 +328,10 @@ function parseLocalValueFlag(flag: string, value: string, parsed: ParsedArgs): v
     } else {
       parsed.paneId = value;
     }
+    return;
+  }
+  if (flag === '--exclude-pane') {
+    (parsed.watchExcludePaneIds ??= []).push(value);
     return;
   }
   if (flag === '--panel') {

--- a/packages/runpane/src/localControl.ts
+++ b/packages/runpane/src/localControl.ts
@@ -410,6 +410,13 @@ type WorkspaceEntryKind =
   | 'pane.gone'
   | 'panel.exited';
 
+interface WorkspacePanelSummary {
+  panelId: string;
+  title: string;
+  agentType?: string;
+  agentState?: 'blocked' | 'working' | 'idle' | 'unknown';
+}
+
 interface WorkspaceEntry {
   gen: number;
   at: string;
@@ -420,6 +427,7 @@ interface WorkspaceEntry {
   repoName?: string;
   worktreePath?: string;
   panelId?: string;
+  panelTitle?: string;
   agentType?: string;
   from?: 'blocked' | 'working' | 'idle' | 'unknown';
   to?: 'blocked' | 'working' | 'idle' | 'unknown';
@@ -430,6 +438,7 @@ interface WorkspaceEntry {
   exitCode?: number;
   baseline?: true;
   changedWhileAway?: boolean;
+  panels?: WorkspacePanelSummary[];
 }
 
 interface WorkspaceStateResult {
@@ -806,6 +815,12 @@ const workspaceEntryKindSchema = boundary.enumeration(
   'panel.exited',
 );
 const agentStateSchema = boundary.enumeration('blocked', 'working', 'idle', 'unknown');
+const workspacePanelSummarySchema: BoundarySchema<WorkspacePanelSummary> = boundary.object({
+  panelId: boundary.string,
+  title: boundary.string,
+  agentType: boundary.optional(boundary.string),
+  agentState: boundary.optional(agentStateSchema),
+});
 const workspaceEntrySchema: BoundarySchema<WorkspaceEntry> = boundary.object({
   gen: boundary.number,
   at: boundary.string,
@@ -816,6 +831,7 @@ const workspaceEntrySchema: BoundarySchema<WorkspaceEntry> = boundary.object({
   repoName: boundary.optional(boundary.string),
   worktreePath: boundary.optional(boundary.string),
   panelId: boundary.optional(boundary.string),
+  panelTitle: boundary.optional(boundary.string),
   agentType: boundary.optional(boundary.string),
   from: boundary.optional(agentStateSchema),
   to: boundary.optional(agentStateSchema),
@@ -826,6 +842,7 @@ const workspaceEntrySchema: BoundarySchema<WorkspaceEntry> = boundary.object({
   exitCode: boundary.optional(boundary.number),
   baseline: boundary.optional(boundary.literal(true)),
   changedWhileAway: boundary.optional(boundary.boolean),
+  panels: boundary.optional(boundary.array(workspacePanelSummarySchema)),
 });
 const workspaceStateResultSchema: BoundarySchema<WorkspaceStateResult> = boundary.object({
   ok: boundary.literal(true),
@@ -954,6 +971,7 @@ export async function runWatch(parsed: ParsedArgs): Promise<number> {
   if (parsed.watchAs && parsed.watchSince !== undefined) {
     throw new Error('runpane watch accepts either --as or --since, not both.');
   }
+  const effectiveAgentsOnly = parsed.agentsOnly ?? (parsed.follow ? true : undefined);
   const request = {
     as: parsed.watchAs,
     since: parsed.watchSince,
@@ -962,8 +980,10 @@ export async function runWatch(parsed: ParsedArgs): Promise<number> {
     limit: parsed.limit,
     kinds: parsed.watchKinds,
     paneIds: parsed.watchPaneIds,
+    excludePaneIds: parsed.watchExcludePaneIds,
     repo: parsed.repo,
     nameContains: parsed.nameContains,
+    agentsOnly: effectiveAgentsOnly,
     ackNow: parsed.ackNow || undefined,
     includeHeldInput: parsed.includeHeldInput || undefined,
   };

--- a/shared/types/runpaneOrchestration.ts
+++ b/shared/types/runpaneOrchestration.ts
@@ -25,6 +25,7 @@ export interface RunpaneWorkspaceEntry {
   repoName?: string;
   worktreePath?: string;
   panelId?: string;
+  panelTitle?: string;
   agentType?: string;
   from?: AgentState;
   to?: AgentState;
@@ -35,6 +36,14 @@ export interface RunpaneWorkspaceEntry {
   exitCode?: number;
   baseline?: true;
   changedWhileAway?: boolean;
+  panels?: RunpaneWorkspacePanelSummary[];
+}
+
+export interface RunpaneWorkspacePanelSummary {
+  panelId: string;
+  title: string;
+  agentType?: string;
+  agentState?: AgentState;
 }
 
 export interface RunpaneWorkspaceWaitRequest {
@@ -45,8 +54,10 @@ export interface RunpaneWorkspaceWaitRequest {
   limit?: number;
   kinds?: RunpaneWorkspaceEntryKind[];
   paneIds?: string[];
+  excludePaneIds?: string[];
   repo?: RunpaneRepoSelector;
   nameContains?: string;
+  agentsOnly?: boolean;
   ackNow?: boolean;
   includeHeldInput?: boolean;
 }


### PR DESCRIPTION
## Summary

Consolidated fixes and improvements to `runpane watch` / the workspace journal shipped in v2.4.78 (#520), from the first hour of real orchestration use. Addresses three items plus two small folds — all the same surface, all the same root cause: **the daemon knows; the daemon should say.**

> "the consumer should never have to remember to fetch, never have to pick which panel matters, and never have to filter noise client-side."

### Item 1 — `--from now` on a first-use named cursor replays entire baseline

**Repro (2.4.78):**
```
runpane watch --as pane-chat-main --from now --follow --json
```
Emitted `{"kind":"_reset","reason":"first-use"}` then **137 events** (57 `pane.created` + 80 `agent.unknown`) before any real transition. The `if (reset)` block in `runpane.ts` unconditionally returned `workspaceStateReader.read()` for all reset reasons, including `first-use` with `--from now`.

**Fix:** One-line `silentBaseline` guard — `first-use` + `from !== 'earliest'` → empty entries. The `_reset` control frame still emits. `--from earliest` keeps full replay as the explicit opt-in.

**Note:** The prior verification (PR #520's verify pass) missed this because its isolated daemon had a near-empty baseline.

### Item 2 — after daemon restart, every existing agent is `agent.unknown` indefinitely

**Motivating case (observed live):** Pane `mac-arch-split-phase1` was mid-turn when the daemon restarted at ~04:34 UTC. Afterwards `panels wait` on its agent panel returned `ok:false`, `initialized:false`, `activityStatus:null`, `lastActivity` frozen at 04:29:33, and its screen was a stale "still thinking" fragment — for 20 minutes. The Claude process was gone; the panel was a ghost the daemon never reconciled. The journal showed only `agent.unknown` for it. Neither the wait API nor the journal could distinguish "dead" from "unknown".

**Root cause:** After daemon restart, terminals are lazily initialized (only when the user opens them). Panels exist in DB but aren't in `terminalPanelManager.terminals` and aren't registered with `agentStatusMonitor`. `getAgentStatus()` returns `undefined` → defaults to `'unknown'`.

**Fix:** Added `resolveAgentState()` in `workspaceStateReader.ts`:
- Uninitialized terminal (dead PTY from old daemon) → `'idle'` — the process is gone, not ambiguous
- Initialized but untracked by monitor → `'unknown'` — genuine ambiguity

**Decision:** `'idle'` for dead PTY, not a new `agent.exited` kind. Rationale: the PTY process died with the old daemon, not as a workspace event the consumer should react to. The agent is effectively idle from the consumer's perspective — it needs a redispatch, same as any idle agent. Adding `agent.exited` would require consumers to handle a new kind for a case that maps to the same action as `idle`.

### Item 3 — panel labelling and daemon-side filtering

Every pane has at least two terminal panels: a plain shell and the agent panel. Without labels, filtering on `type == terminal` selects the shell first, showing a `pnpm install` prompt that looks like "the agent never started."

**Schema changes:**
- `RunpaneWorkspaceEntry` gains `panelTitle?: string` — identifies which terminal transitioned
- `pane.created` entries gain `panels: RunpaneWorkspacePanelSummary[]` — full terminal panel list with `panelId`, `title`, `agentType`, `agentState`
- `RunpaneWorkspaceWaitRequest` gains `excludePaneIds?: string[]` and `agentsOnly?: boolean`

**CLI changes:**
- `--agents-only` flag: suppresses events from panels with no `agentType` (`pane.created` and `pane.gone` always pass through). **Default ON for `--follow`** — a monitoring consumer wants agent transitions, not shell noise. Explicit `--agents-only` is still available for non-follow use.
- `--exclude-pane <id>` (repeatable): for self-filtering (the orchestrator's own pane shows up as READY/BUSY every turn)

### Folds

- **`panel.exited` double-fire:** Archive kills PTY via `closeTerminalSession` → `onExit` fires, then `destroyTerminal` calls `pty.kill()` → potential second `onExit`. Deduped with `exitedPanels: Set<string>` in journal.
- **`--exclude-pane`:** Covered by Item 3.
- **watch.py:** Updated embedded (skillCacheManager.ts) and on-disk (`~/.pane/tools/watch.py`) to pass `--agents-only`.

## Files changed (9 files, +181 −9)

| File | Change |
|------|--------|
| `shared/types/runpaneOrchestration.ts` | `panelTitle`, `panels`, `excludePaneIds`, `agentsOnly` |
| `main/src/ipc/runpane.ts` | `silentBaseline` guard, filter plumbing, parser |
| `main/src/services/workspaceStateReader.ts` | `resolveAgentState()`, panels summary, `panelTitle` |
| `main/src/services/workspaceJournal.ts` | `excludePaneIds`/`agentsOnly` filter, `panelTitle`, exit dedup |
| `main/src/daemon/bootstrap.ts` | `panelTitle` in `resolvePanel` callback |
| `packages/runpane/src/commands.ts` | `--agents-only`, `--exclude-pane` parsers |
| `packages/runpane/src/localControl.ts` | Schema + runtime for new fields |
| `main/src/services/skillCacheManager.ts` | `--agents-only` in embedded watch.py |
| `main/src/ipc/runpane.test.ts` | 3 regression tests + updated existing test |

## Hotfix assessment

**This warrants a 2.4.79 hotfix.** Item 1 hits every fresh orchestrator session on 2.4.78 — `--from now` is the default path for `watch.py` and any named-cursor consumer. 137 spurious events on a 57-pane workspace is not cosmetic noise; it causes the orchestrator to misread baseline as live transitions and take wrong action. Items 2 and 3 compound it: the 80 baseline agent entries are all `agent.unknown`, and without `panelTitle`/`agentType` the consumer cannot distinguish them from real transitions on real agents.

## Test plan

- [x] 3 new regression tests for Item 1: 60-pane workspace × `--from now` → zero data events; `--from earliest` → baseline returned; default `from` → zero data events
- [x] Updated existing `workspace state` test for `panels` and `panelTitle` fields
- [x] 80 test files, 779 tests pass
- [x] Typecheck clean across all 4 packages
- [x] Lint clean (oxlint, eslint, boundary conformance, knip)
- [ ] Live verification: `--as <name> --from now --follow` against 57+ pane workspace (requires daemon rebuild — deferred to hotfix deployment)

Refs #515, #520, #514

https://claude.ai/code/session_01VVKdNKBcorrz2MVBTNK1vs