### PR TITLE
Fetch model prices from OpenRouter, fix stale rate-limit scope

### DIFF
--- a/main/src/services/usage/modelPricing.test.ts
+++ b/main/src/services/usage/modelPricing.test.ts
@@ -1,8 +1,19 @@
-import { describe, it, expect } from 'vitest';
-import { findModelPrice, estimateCostUsd, MODEL_PRICES, PRICING_AS_OF } from './modelPricing';
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  findModelPrice,
+  estimateCostUsd,
+  MODEL_PRICES,
+  PRICING_AS_OF,
+  setLivePrices,
+  getPricingSource,
+} from './modelPricing';
+
+afterEach(() => {
+  setLivePrices([], null);
+});
 
 describe('findModelPrice', () => {
-  it('resolves Claude models', () => {
+  it('resolves Claude models from the bundled table', () => {
     expect(findModelPrice('claude-opus-5')?.model).toBe('claude-opus-5');
     expect(findModelPrice('claude-sonnet-5-20260101')?.model).toBe('claude-sonnet-5');
   });
@@ -15,7 +26,6 @@ describe('findModelPrice', () => {
   });
 
   it('prefers the longest matching id so variants beat their base model', () => {
-    // Every one of these also contains the shorter "gpt-5".
     expect(findModelPrice('gpt-5-mini')?.model).toBe('gpt-5-mini');
     expect(findModelPrice('gpt-5-nano')?.model).toBe('gpt-5-nano');
     expect(findModelPrice('gpt-5-pro')?.model).toBe('gpt-5-pro');
@@ -33,14 +43,44 @@ describe('findModelPrice', () => {
   it('returns null for unknown or empty models', () => {
     expect(findModelPrice('llama-4-70b')).toBeNull();
     expect(findModelPrice('')).toBeNull();
-    // The Codex parser's fallback label is deliberately unpriced.
     expect(findModelPrice('codex')).toBeNull();
+  });
+
+  it('prefers live prices over bundled when both have the model', () => {
+    setLivePrices(
+      [{ model: 'claude-opus-5', inputPerMTok: 5, outputPerMTok: 25, cacheReadPerMTok: 0.5, cacheWritePerMTok: 6.25 }],
+      'OpenRouter · 2026-08-26',
+    );
+
+    const price = findModelPrice('claude-opus-5');
+    expect(price?.inputPerMTok).toBe(5);
+    expect(price?.outputPerMTok).toBe(25);
+  });
+
+  it('falls back to bundled when the model is not in live prices', () => {
+    setLivePrices(
+      [{ model: 'some-other-model', inputPerMTok: 1, outputPerMTok: 2, cacheReadPerMTok: 0.1, cacheWritePerMTok: 1 }],
+      'OpenRouter · 2026-08-26',
+    );
+
+    expect(findModelPrice('claude-haiku-4-5')?.model).toBe('claude-haiku-4-5');
+  });
+});
+
+describe('getPricingSource', () => {
+  it('returns the bundled source when no live prices are set', () => {
+    expect(getPricingSource()).toContain('bundled');
+    expect(getPricingSource()).toContain(PRICING_AS_OF);
+  });
+
+  it('returns the live source after setLivePrices', () => {
+    setLivePrices([], 'OpenRouter · 2026-08-26');
+    expect(getPricingSource()).toBe('OpenRouter · 2026-08-26');
   });
 });
 
 describe('estimateCostUsd', () => {
   it('prices a Claude request across all four token classes', () => {
-    // opus-5: 15 in / 75 out / 1.5 cache-read / 18.75 cache-write per Mtok.
     const { costUsd, complete } = estimateCostUsd({
       model: 'claude-opus-5',
       inputTokens: 1_000_000,
@@ -49,6 +89,7 @@ describe('estimateCostUsd', () => {
       cacheCreationTokens: 1_000_000,
     });
     expect(complete).toBe(true);
+    // Bundled: 15 + 75 + 1.5 + 18.75 = 110.25
     expect(costUsd).toBeCloseTo(15 + 75 + 1.5 + 18.75, 6);
   });
 
@@ -85,6 +126,21 @@ describe('estimateCostUsd', () => {
       cacheCreationTokens: 0,
     }).costUsd).toBe(0);
   });
+
+  it('uses live prices when available', () => {
+    setLivePrices(
+      [{ model: 'claude-opus-5', inputPerMTok: 5, outputPerMTok: 25, cacheReadPerMTok: 0.5, cacheWritePerMTok: 6.25 }],
+      'test',
+    );
+    const { costUsd } = estimateCostUsd({
+      model: 'claude-opus-5',
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheCreationTokens: 1_000_000,
+    });
+    expect(costUsd).toBeCloseTo(5 + 25 + 0.5 + 6.25, 6);
+  });
 });
 
 describe('price table integrity', () => {
@@ -107,7 +163,7 @@ describe('price table integrity', () => {
     }
   });
 
-  it('carries a parseable as-of date, which the UI footer shows', () => {
+  it('carries a parseable bundled as-of date', () => {
     expect(Number.isNaN(Date.parse(PRICING_AS_OF))).toBe(false);
   });
 });

--- a/main/src/services/usage/modelPricing.ts
+++ b/main/src/services/usage/modelPricing.ts
@@ -1,20 +1,22 @@
 import type { ModelPrice } from '../../../../shared/types/usage';
 
 /**
- * Bundled price table, USD per 1M tokens.
- *
- * Hard-coded prices go stale, so {@link PRICING_AS_OF} is rendered in the
- * usage page footer and unknown models are reported as `costIncomplete`
- * rather than silently priced at zero.
+ * Date the bundled price table was last verified. Shown in the UI footer
+ * when no live prices are available.
  */
-export const PRICING_AS_OF = '2026-08-10';
+const BUNDLED_PRICING_AS_OF = '2026-08-10';
 
 /**
+ * Bundled price table — the offline-last-resort fallback. Prices are USD per
+ * 1M tokens. These go stale (which is why OpenRouter prices are preferred),
+ * but they guarantee every model shipped in this build gets a price even with
+ * no network.
+ *
  * OpenAI publishes no separate cache-write price — writing to the prompt cache
  * bills at the standard input rate — so `cacheWritePerMTok` mirrors input for
  * those models.
  */
-const PRICES: ModelPrice[] = [
+const BUNDLED_PRICES: ModelPrice[] = [
   // --- Anthropic (Claude Code) ---
   // Claude 5 family
   { model: 'claude-opus-5', inputPerMTok: 15, outputPerMTok: 75, cacheReadPerMTok: 1.5, cacheWritePerMTok: 18.75 },
@@ -53,20 +55,45 @@ const PRICES: ModelPrice[] = [
   { model: 'gpt-5', inputPerMTok: 1.25, outputPerMTok: 10, cacheReadPerMTok: 0.125, cacheWritePerMTok: 1.25 },
 ];
 
-/**
- * Match by longest prefix so dated ids (`claude-sonnet-5-20260101`) and
- * region-prefixed ids resolve to their base model.
- */
-export function findModelPrice(model: string): ModelPrice | null {
-  if (!model) return null;
-  const normalized = model.toLowerCase();
+// ---------------------------------------------------------------------------
+// Live price tier — set by the OpenRouter provider, checked first.
+// ---------------------------------------------------------------------------
 
+let livePrices: ModelPrice[] = [];
+let livePricingSource: string | null = null;
+
+export function setLivePrices(prices: ModelPrice[], source: string | null): void {
+  livePrices = prices;
+  livePricingSource = source;
+}
+
+export function getPricingSource(): string {
+  return livePricingSource ?? `bundled · ${BUNDLED_PRICING_AS_OF}`;
+}
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+function findInTable(model: string, table: readonly ModelPrice[]): ModelPrice | null {
+  const normalized = model.toLowerCase();
   let best: ModelPrice | null = null;
-  for (const price of PRICES) {
+  for (const price of table) {
     if (!normalized.includes(price.model)) continue;
     if (!best || price.model.length > best.model.length) best = price;
   }
   return best;
+}
+
+/**
+ * Match by longest prefix so dated ids (`claude-sonnet-5-20260101`) and
+ * region-prefixed ids resolve to their base model.
+ *
+ * Checks live (OpenRouter) prices first, then falls back to the bundled table.
+ */
+export function findModelPrice(model: string): ModelPrice | null {
+  if (!model) return null;
+  return findInTable(model, livePrices) ?? findInTable(model, BUNDLED_PRICES);
 }
 
 export interface CostInput {
@@ -111,4 +138,5 @@ export function estimateCostUsd(
   return { costUsd, complete: true, cacheSavingsUsd };
 }
 
-export { PRICES as MODEL_PRICES };
+export { BUNDLED_PRICES as MODEL_PRICES };
+export { BUNDLED_PRICING_AS_OF as PRICING_AS_OF };

--- a/main/src/services/usage/openRouterPriceProvider.test.ts
+++ b/main/src/services/usage/openRouterPriceProvider.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeOpenRouterId,
+  convertPricing,
+  parseOpenRouterResponse,
+} from './openRouterPriceProvider';
+
+describe('normalizeOpenRouterId', () => {
+  it('strips the vendor prefix', () => {
+    expect(normalizeOpenRouterId('anthropic/claude-opus-5')).toBe('claude-opus-5');
+    expect(normalizeOpenRouterId('openai/gpt-5.6-sol')).toBe('gpt-5.6-sol');
+  });
+
+  it('passes through ids with no prefix', () => {
+    expect(normalizeOpenRouterId('claude-opus-5')).toBe('claude-opus-5');
+  });
+
+  it('skips batch variants', () => {
+    expect(normalizeOpenRouterId('openai/gpt-5:batch')).toBeNull();
+    expect(normalizeOpenRouterId('anthropic/claude-sonnet-5:batch')).toBeNull();
+  });
+
+  it('skips fast variants', () => {
+    expect(normalizeOpenRouterId('anthropic/claude-opus-5-fast')).toBeNull();
+  });
+
+  it('keeps non-fast suffixed models', () => {
+    expect(normalizeOpenRouterId('openai/gpt-5.6-luna-pro')).toBe('gpt-5.6-luna-pro');
+    expect(normalizeOpenRouterId('openai/gpt-5.1-codex-max')).toBe('gpt-5.1-codex-max');
+  });
+});
+
+describe('convertPricing', () => {
+  it('converts USD-per-token strings to USD-per-MTok numbers', () => {
+    const price = convertPricing('claude-opus-5', {
+      prompt: '0.000005',
+      completion: '0.000025',
+      input_cache_read: '0.0000005',
+      input_cache_write: '0.00000625',
+    });
+    expect(price).toEqual({
+      model: 'claude-opus-5',
+      inputPerMTok: 5,
+      outputPerMTok: 25,
+      cacheReadPerMTok: 0.5,
+      cacheWritePerMTok: 6.25,
+    });
+  });
+
+  it('defaults null cache_read to the input rate', () => {
+    const price = convertPricing('gpt-5.5-pro', {
+      prompt: '0.00003',
+      completion: '0.00018',
+      input_cache_read: null,
+      input_cache_write: null,
+    });
+    expect(price?.cacheReadPerMTok).toBe(30);
+    expect(price?.cacheWritePerMTok).toBe(30);
+  });
+
+  it('defaults missing cache_write to the input rate (OpenAI convention)', () => {
+    const price = convertPricing('gpt-5', {
+      prompt: '0.00000125',
+      completion: '0.00001',
+      input_cache_read: '0.000000125',
+    });
+    expect(price?.cacheWritePerMTok).toBe(1.25);
+  });
+
+  it('returns null when prompt pricing is missing', () => {
+    expect(convertPricing('x', {})).toBeNull();
+    expect(convertPricing('x', { prompt: null, completion: '0.01' })).toBeNull();
+    expect(convertPricing('x', undefined)).toBeNull();
+  });
+
+  it('handles free models (zero pricing)', () => {
+    const price = convertPricing('free-model', {
+      prompt: '0',
+      completion: '0',
+    });
+    expect(price?.inputPerMTok).toBe(0);
+    expect(price?.outputPerMTok).toBe(0);
+  });
+});
+
+describe('parseOpenRouterResponse', () => {
+  it('parses a realistic response, skipping batch and fast variants', () => {
+    const prices = parseOpenRouterResponse({
+      data: [
+        {
+          id: 'anthropic/claude-opus-5',
+          pricing: { prompt: '0.000005', completion: '0.000025', input_cache_read: '0.0000005', input_cache_write: '0.00000625' },
+        },
+        {
+          id: 'anthropic/claude-opus-5:batch',
+          pricing: { prompt: '0.0000025', completion: '0.0000125' },
+        },
+        {
+          id: 'anthropic/claude-opus-5-fast',
+          pricing: { prompt: '0.00001', completion: '0.00005' },
+        },
+        {
+          id: 'openai/gpt-5',
+          pricing: { prompt: '0.00000125', completion: '0.00001', input_cache_read: '0.000000125' },
+        },
+      ],
+    });
+
+    expect(prices).toHaveLength(2);
+    expect(prices[0].model).toBe('claude-opus-5');
+    expect(prices[1].model).toBe('gpt-5');
+  });
+
+  it('deduplicates by bare id, keeping the first occurrence', () => {
+    const prices = parseOpenRouterResponse({
+      data: [
+        { id: 'anthropic/claude-opus-5', pricing: { prompt: '0.000005', completion: '0.000025' } },
+        { id: 'claude-opus-5', pricing: { prompt: '0.000010', completion: '0.000050' } },
+      ],
+    });
+
+    expect(prices).toHaveLength(1);
+    expect(prices[0].inputPerMTok).toBe(5);
+  });
+
+  it('skips models with no usable pricing', () => {
+    const prices = parseOpenRouterResponse({
+      data: [
+        { id: 'vendor/good', pricing: { prompt: '0.001', completion: '0.002' } },
+        { id: 'vendor/no-pricing' },
+        { id: 'vendor/null-pricing', pricing: { prompt: null, completion: null } },
+      ],
+    });
+
+    expect(prices).toHaveLength(1);
+    expect(prices[0].model).toBe('good');
+  });
+});

--- a/main/src/services/usage/openRouterPriceProvider.ts
+++ b/main/src/services/usage/openRouterPriceProvider.ts
@@ -1,0 +1,180 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import type { ModelPrice } from '../../../../shared/types/usage';
+import { setLivePrices } from './modelPricing';
+
+const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
+const CACHE_FILENAME = 'openrouter-prices.json';
+const REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 15_000;
+
+interface OpenRouterPricing {
+  prompt?: string | null;
+  completion?: string | null;
+  input_cache_read?: string | null;
+  input_cache_write?: string | null;
+}
+
+interface OpenRouterModel {
+  id: string;
+  pricing?: OpenRouterPricing;
+}
+
+interface OpenRouterResponse {
+  data: OpenRouterModel[];
+}
+
+export interface PersistedPriceTable {
+  fetchedAtMs: number;
+  fetchedAtIso: string;
+  models: ModelPrice[];
+}
+
+/**
+ * Strip the vendor prefix and filter out batch/fast variants.
+ * Returns null for ids that should be skipped.
+ */
+export function normalizeOpenRouterId(id: string): string | null {
+  if (id.includes(':')) return null;
+  if (id.endsWith('-fast')) return null;
+
+  const slashIdx = id.indexOf('/');
+  return slashIdx >= 0 ? id.slice(slashIdx + 1) : id;
+}
+
+/**
+ * Convert OpenRouter's USD-per-token string prices to USD-per-MTok numbers.
+ * Returns null when the model has no usable pricing.
+ */
+export function convertPricing(
+  bareId: string,
+  pricing: OpenRouterPricing | undefined,
+): ModelPrice | null {
+  if (!pricing) return null;
+
+  const prompt = pricing.prompt != null ? parseFloat(pricing.prompt) : NaN;
+  const completion = pricing.completion != null ? parseFloat(pricing.completion) : NaN;
+  if (isNaN(prompt) || isNaN(completion)) return null;
+
+  const inputPerMTok = prompt * 1_000_000;
+  const outputPerMTok = completion * 1_000_000;
+
+  const cacheReadRaw = pricing.input_cache_read != null
+    ? parseFloat(pricing.input_cache_read) : NaN;
+  const cacheReadPerMTok = isNaN(cacheReadRaw) ? inputPerMTok : cacheReadRaw * 1_000_000;
+
+  const cacheWriteRaw = pricing.input_cache_write != null
+    ? parseFloat(pricing.input_cache_write) : NaN;
+  const cacheWritePerMTok = isNaN(cacheWriteRaw) ? inputPerMTok : cacheWriteRaw * 1_000_000;
+
+  return { model: bareId, inputPerMTok, outputPerMTok, cacheReadPerMTok, cacheWritePerMTok };
+}
+
+/** Parse the full OpenRouter response into a deduplicated ModelPrice table. */
+export function parseOpenRouterResponse(data: OpenRouterResponse): ModelPrice[] {
+  const seen = new Set<string>();
+  const result: ModelPrice[] = [];
+
+  for (const model of data.data) {
+    const bareId = normalizeOpenRouterId(model.id);
+    if (!bareId || seen.has(bareId)) continue;
+
+    const price = convertPricing(bareId, model.pricing);
+    if (!price) continue;
+
+    seen.add(bareId);
+    result.push(price);
+  }
+
+  return result;
+}
+
+export class OpenRouterPriceProvider {
+  private refreshTimer: NodeJS.Timeout | undefined;
+  private cachePath: string;
+
+  constructor(appDir: string) {
+    this.cachePath = join(appDir, CACHE_FILENAME);
+  }
+
+  /** Load from disk (fast, sync) then schedule an async network fetch. */
+  start(): void {
+    this.loadFromDisk();
+    void this.fetchAndUpdate();
+    this.refreshTimer = setInterval(() => {
+      void this.fetchAndUpdate();
+    }, REFRESH_INTERVAL_MS);
+    this.refreshTimer.unref?.();
+  }
+
+  stop(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = undefined;
+    }
+  }
+
+  private loadFromDisk(): void {
+    try {
+      const raw = readFileSync(this.cachePath, 'utf-8');
+      const table: PersistedPriceTable = JSON.parse(raw);
+      if (Array.isArray(table.models) && table.models.length > 0) {
+        setLivePrices(table.models, `OpenRouter · ${table.fetchedAtIso}`);
+        console.log(
+          `[Usage] Loaded ${table.models.length} prices from disk cache (${table.fetchedAtIso})`,
+        );
+      }
+    } catch {
+      // No cached file yet — expected on first run.
+    }
+  }
+
+  private async fetchAndUpdate(): Promise<void> {
+    try {
+      const response = await fetch(OPENROUTER_MODELS_URL, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        headers: { Accept: 'application/json' },
+      });
+
+      if (!response.ok) {
+        console.warn(`[Usage] OpenRouter fetch failed: HTTP ${response.status}`);
+        return;
+      }
+
+      // SAFETY: The OpenRouter /models endpoint returns { data: OpenRouterModel[] }.
+      // parseOpenRouterResponse validates each model's shape before use.
+      const data = (await response.json()) as OpenRouterResponse;
+      const prices = parseOpenRouterResponse(data);
+
+      if (prices.length === 0) {
+        console.warn('[Usage] OpenRouter returned no usable prices');
+        return;
+      }
+
+      const now = new Date();
+      const isoDate = now.toISOString().slice(0, 10);
+
+      setLivePrices(prices, `OpenRouter · ${isoDate}`);
+      this.persistToDisk({ fetchedAtMs: now.getTime(), fetchedAtIso: isoDate, models: prices });
+
+      console.log(`[Usage] Updated ${prices.length} model prices from OpenRouter`);
+    } catch (error) {
+      console.warn(
+        '[Usage] OpenRouter price fetch failed:',
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  private persistToDisk(table: PersistedPriceTable): void {
+    try {
+      mkdirSync(dirname(this.cachePath), { recursive: true });
+      writeFileSync(this.cachePath, JSON.stringify(table), 'utf-8');
+    } catch (error) {
+      console.warn(
+        '[Usage] Failed to persist price cache:',
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+}

--- a/main/src/services/usage/usageManager.ts
+++ b/main/src/services/usage/usageManager.ts
@@ -8,7 +8,9 @@ import { databaseService } from '../database';
 import { UsageRepository } from './usageRepository';
 import { UsageAggregator, resolveReportRange } from './usageAggregator';
 import { isFileUnchanged, resolveStartOffset, scanJsonlFile } from './jsonlScanner';
-import { PRICING_AS_OF } from './modelPricing';
+import { getPricingSource } from './modelPricing';
+import { OpenRouterPriceProvider } from './openRouterPriceProvider';
+import { getAppDirectory } from '../../utils/appDirectory';
 import {
   DEFAULT_USAGE_RANGE_DAYS,
   USAGE_PARSER_VERSION,
@@ -92,6 +94,7 @@ class UsageManager {
   // load time and the database handle is only guaranteed after initialisation.
   private repositoryRef: UsageRepository | null = null;
   private aggregatorRef: UsageAggregator | null = null;
+  private priceProvider: OpenRouterPriceProvider | null = null;
   private watchers: UsageWatcher[] = [];
   private pendingFiles = new Map<string, UsageProvider>();
   private debounceTimer: NodeJS.Timeout | undefined;
@@ -125,6 +128,9 @@ class UsageManager {
     if (this.started) return;
     this.started = true;
 
+    this.priceProvider = new OpenRouterPriceProvider(getAppDirectory());
+    this.priceProvider.start();
+
     try {
       this.repository.pruneOlderThan(Date.now() - USAGE_RETENTION_DAYS * DAY_MS);
     } catch (error) {
@@ -137,6 +143,8 @@ class UsageManager {
 
   stop(): void {
     this.started = false;
+    this.priceProvider?.stop();
+    this.priceProvider = null;
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     for (const watcher of this.watchers) void watcher.close();
     this.watchers = [];
@@ -169,7 +177,7 @@ class UsageManager {
       window: this.aggregator.getWindow(nowMs, request?.limitTokens ?? null, providers),
       rateLimits: this.safeRateLimits(nowMs, providers),
       index: this.getStatus(),
-      pricingAsOf: PRICING_AS_OF,
+      pricingAsOf: getPricingSource(),
     };
   }
 

--- a/main/src/services/usage/usageRepository.test.ts
+++ b/main/src/services/usage/usageRepository.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import Database from 'better-sqlite3-multiple-ciphers';
+import { UsageRepository } from './usageRepository';
+import type { UsageRateLimitSample } from '../../../../shared/types/usage';
+
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 7, 26, 12, 0, 0);
+
+function createDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS usage_rate_limits (
+      provider TEXT NOT NULL,
+      limit_id TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      used_percent REAL NOT NULL,
+      window_minutes INTEGER,
+      resets_at_ms INTEGER,
+      plan_type TEXT,
+      captured_at_ms INTEGER NOT NULL,
+      PRIMARY KEY (provider, limit_id, scope)
+    );
+    CREATE TABLE IF NOT EXISTS usage_files (
+      path TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      mtime_ms INTEGER NOT NULL,
+      offset_bytes INTEGER NOT NULL DEFAULT 0,
+      last_scanned_ms INTEGER NOT NULL,
+      parser_version INTEGER,
+      parse_context TEXT
+    );
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      timestamp_ms INTEGER NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      agent_session_id TEXT,
+      cwd TEXT,
+      source_path TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+let db: ReturnType<typeof createDb>;
+let repo: UsageRepository;
+
+function seedRateLimit(sample: UsageRateLimitSample) {
+  repo.recordRateLimits([sample]);
+}
+
+beforeEach(() => {
+  db = createDb();
+  repo = new UsageRepository(db);
+});
+
+describe('UsageRepository.getRateLimits', () => {
+  it('returns one row per provider+scope, newest wins', () => {
+    seedRateLimit({
+      provider: 'codex', limitId: 'old', scope: 'primary',
+      usedPercent: 10, windowMinutes: 300, resetsAtMs: NOW + HOUR_MS,
+      planType: 'plus', capturedAtMs: NOW - 2 * HOUR_MS,
+    });
+    seedRateLimit({
+      provider: 'codex', limitId: 'new', scope: 'primary',
+      usedPercent: 20, windowMinutes: 300, resetsAtMs: NOW + HOUR_MS,
+      planType: 'plus', capturedAtMs: NOW - HOUR_MS,
+    });
+
+    const limits = repo.getRateLimits(NOW);
+    expect(limits).toHaveLength(1);
+    expect(limits[0].usedPercent).toBe(20);
+  });
+
+  it('drops expired windows', () => {
+    seedRateLimit({
+      provider: 'codex', limitId: 'x', scope: 'primary',
+      usedPercent: 50, windowMinutes: 300,
+      resetsAtMs: NOW - 1000,
+      planType: null, capturedAtMs: NOW - 6 * HOUR_MS,
+    });
+
+    expect(repo.getRateLimits(NOW)).toHaveLength(0);
+  });
+
+  /**
+   * Regression: OpenAI plan change drops the 5h window and promotes 7d into
+   * the primary slot. Pre-change records had primary=300 + secondary=10080.
+   * Post-change records have primary=10080 + no secondary. The old secondary
+   * lingered because nothing displaced it and its 7d window hadn't expired.
+   * Result: two "7d window" rows instead of one.
+   */
+  it('retires a scope when a newer capture for the same provider omits it', () => {
+    // Pre-Aug-24 regime: primary=5h, secondary=7d
+    seedRateLimit({
+      provider: 'codex', limitId: 'old-plan', scope: 'primary',
+      usedPercent: 20, windowMinutes: 300, resetsAtMs: NOW + HOUR_MS,
+      planType: 'pro', capturedAtMs: NOW - 48 * HOUR_MS,
+    });
+    seedRateLimit({
+      provider: 'codex', limitId: 'old-plan', scope: 'secondary',
+      usedPercent: 0, windowMinutes: 10080, resetsAtMs: NOW + 5 * 24 * HOUR_MS,
+      planType: 'pro', capturedAtMs: NOW - 48 * HOUR_MS,
+    });
+
+    // Post-Aug-24 regime: primary=7d only, secondary=null (no record emitted)
+    seedRateLimit({
+      provider: 'codex', limitId: 'new-plan', scope: 'primary',
+      usedPercent: 20, windowMinutes: 10080, resetsAtMs: NOW + 6 * 24 * HOUR_MS,
+      planType: 'pro', capturedAtMs: NOW - HOUR_MS,
+    });
+
+    const limits = repo.getRateLimits(NOW);
+    expect(limits).toHaveLength(1);
+    expect(limits[0].scope).toBe('primary');
+    expect(limits[0].windowMinutes).toBe(10080);
+    expect(limits[0].planType).toBe('pro');
+  });
+
+  it('keeps both scopes when they share the same capture time', () => {
+    const capturedAt = NOW - HOUR_MS;
+    seedRateLimit({
+      provider: 'codex', limitId: 'plan', scope: 'primary',
+      usedPercent: 30, windowMinutes: 300, resetsAtMs: NOW + HOUR_MS,
+      planType: 'plus', capturedAtMs: capturedAt,
+    });
+    seedRateLimit({
+      provider: 'codex', limitId: 'plan', scope: 'secondary',
+      usedPercent: 5, windowMinutes: 10080, resetsAtMs: NOW + 6 * 24 * HOUR_MS,
+      planType: 'plus', capturedAtMs: capturedAt,
+    });
+
+    const limits = repo.getRateLimits(NOW);
+    expect(limits).toHaveLength(2);
+  });
+
+  it('does not cross-retire between providers', () => {
+    seedRateLimit({
+      provider: 'codex', limitId: 'a', scope: 'primary',
+      usedPercent: 10, windowMinutes: 10080, resetsAtMs: NOW + 6 * 24 * HOUR_MS,
+      planType: null, capturedAtMs: NOW - HOUR_MS,
+    });
+    seedRateLimit({
+      provider: 'claude', limitId: 'b', scope: 'primary',
+      usedPercent: 20, windowMinutes: 300, resetsAtMs: NOW + HOUR_MS,
+      planType: null, capturedAtMs: NOW - 4 * HOUR_MS,
+    });
+
+    const limits = repo.getRateLimits(NOW);
+    expect(limits).toHaveLength(2);
+  });
+});

--- a/main/src/services/usage/usageRepository.ts
+++ b/main/src/services/usage/usageRepository.ts
@@ -237,6 +237,27 @@ export class UsageRepository {
       }
     }
 
+    // Retire scopes that no longer appear in the provider's latest events.
+    // When a plan change drops a window (e.g. OpenAI removes the 5h primary
+    // and promotes 7d into that slot), the absent scope stops getting new
+    // samples but its old row lingers until its window expires. Comparing
+    // capture timestamps detects this: within one token_count event, all
+    // active scopes share the same timestamp, so a scope lagging behind the
+    // provider's newest capture was not present in that event.
+    const maxCapturePerProvider = new Map<string, number>();
+    for (const sample of newestPerWindow.values()) {
+      const prev = maxCapturePerProvider.get(sample.provider) ?? 0;
+      if (sample.capturedAtMs > prev) {
+        maxCapturePerProvider.set(sample.provider, sample.capturedAtMs);
+      }
+    }
+    for (const [key, sample] of newestPerWindow) {
+      const providerMax = maxCapturePerProvider.get(sample.provider);
+      if (providerMax && sample.capturedAtMs < providerMax) {
+        newestPerWindow.delete(key);
+      }
+    }
+
     return [...newestPerWindow.values()]
       .sort((a, b) => a.provider.localeCompare(b.provider) || a.scope.localeCompare(b.scope));
   }

--- a/shared/types/usage.ts
+++ b/shared/types/usage.ts
@@ -159,7 +159,7 @@ export interface UsageReport {
   /** Provider-reported quota state; empty when nobody reported any. */
   rateLimits: UsageRateLimitSample[];
   index: UsageIndexStatus;
-  /** Date the bundled price table was last verified, shown in the footer. */
+  /** Pricing source and date, shown in the footer (e.g. "OpenRouter · 2026-08-26"). */
   pricingAsOf: string;
 }
 


### PR DESCRIPTION
## Summary

- **Live pricing from OpenRouter**: replaces the hardcoded model price table with `GET https://openrouter.ai/api/v1/models` (free, keyless, public list). Fetches at launch + every 6h, persists to `<PANE_DIR>/openrouter-prices.json`, falls back to the disk cache offline, then to the bundled table as last resort.
- **Rate-limit scope retirement**: fixes a bug where an OpenAI plan change (dropping the 5h window, promoting 7d into primary) left a stale secondary row showing "0% · 7d window" alongside the real one.

Closes TM-669. Fixes #383.

## Newly priced models

| Model ID | OpenRouter price (in/out per MTok) | Previously |
|---|---|---|
| `claude-fable-5` | $10 / $50 | Was in bundled table at Sonnet's rate ($3/$15) — wrong |
| `gpt-5.6-sol` | $2 / $10 | Was in bundled table at $5/$30 — wrong |

## Still unpriced

| Model ID | Reason |
|---|---|
| `gpt-daybreak-blue-latest` | Not on OpenRouter, not in bundled table |
| `codex-auto-review` | Codex sub-agent profile, not a billable model |

## Before/after headline totals — why they change

The "At API prices" card says "what API billing would cost, not your plan." The hardcoded table carried billing-tier rates for newer Claude models instead of the current API prices:

| Model | Old (bundled) | New (OpenRouter) | Ratio |
|---|---|---|---|
| `claude-opus-5` | $15 / $75 | $5 / $25 | 0.33× — hardcoded had Opus 4's rate |
| `claude-sonnet-5` | $3 / $15 | $2 / $10 | 0.67× — hardcoded had Sonnet 4's rate |
| `claude-fable-5` | $3 / $15 | $10 / $50 | 3.3× — was mispriced at Sonnet's rate |
| `gpt-5.6-sol` | $5 / $30 | $2 / $10 | 0.40× — hardcoded had inflated rates |

20 other models match exactly. Users with heavy Opus 5 or Sonnet 5 traffic will see lower "At API prices" totals — this is a correction to match what the screen claims to show, not a regression.

## Freshness and fallback

Footer now shows the pricing source: `"Prices as of OpenRouter · 2026-08-26"` when live, or `"Prices as of bundled · 2026-08-10"` when offline.

Tiered lookup order:
1. Live OpenRouter table (from latest fetch or disk cache)
2. Bundled table (ships with the app, covers `claude-haiku-4-5`, `claude-3-5-haiku`, `gpt-5-codex` which aren't on OpenRouter)

## Normalizer design

Exact match only after stripping vendor prefix (`anthropic/`, `openai/`) and filtering `:batch` / `-fast` variants. No fuzzy matching — a wrong price is worse than no price. Unmatched IDs fall to the bundled table.

## Rate-limit scope retirement (bug fix)

**Diagnosis**: OpenAI changed the founder's Codex plan around 2026-08-24. Before: `primary=300min (5h), secondary=10080min (7d)`. After: `primary=10080min (7d), secondary=null`. The parser correctly emitted only a primary sample for post-change transcripts. But the old secondary=7d record lingered in the DB — `secondary: null` wrote nothing to displace it, and its 7d window hadn't expired. Result: two rows both showing "OpenAI 7d window · pro".

**Fix**: After dedup by `provider:scope`, compare capture timestamps per provider. A scope whose newest capture is older than the provider's max was absent in the latest event and gets retired. This handles any future plan restructuring.

Regression test in `usageRepository.test.ts`: pre-change records (primary=5h, secondary=7d) + post-change record (primary=7d only) → exactly one row returned.

## Privacy

The OpenRouter call is a `GET` of a public model list. No API key, no user data, no usage data leaves the machine. The response is a price catalogue identical to what's on openrouter.ai/models.

## Test plan

- [ ] 105 usage tests pass (8 files, including 3 new test files)
- [ ] `pnpm lint && pnpm typecheck` clean
- [ ] Verify the four previously-unpriced ids price correctly (or are reported as unmatchable)
- [ ] Offline test: kill network, relaunch — screen still prices from persisted table
- [ ] Rate-limit panel shows exactly one row per active window after an OpenAI plan change

https://claude.ai/code/session_01RE2dxP1ib6bL87rWshnCkk