### PR TITLE
Simplify orchestrator skill against 2.4.79 daemon surface

### DIFF
--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -459,7 +459,6 @@ ${managedBlock}
     const skillLegendSource = path.join(this.cacheRoot, 'docs', 'readme-skill-legend.excalidraw');
     const codexProjectSkillsRoot = this.codexProjectSkillsRoot;
     const claudeProjectSkillsRoot = this.claudeProjectSkillsRoot;
-    const paneWatchScript = this.paneWatchScriptPath;
 
     return `---
 name: pane-orchestrator
@@ -478,42 +477,34 @@ You are Pane Chat, the global orchestrator for this Pane workspace.
 4. Inspect the workflow map and skill legend. If image viewing is unavailable,
    read the Excalidraw source files listed in Local Workflow References.
 5. Run the doctor command from the runtime context before taking Pane actions.
-6. Reconstitute the in-flight work picture with this bounded live-state sweep
+6. Arm the event stream at session start:
+       runpane watch --as <session> --from now --follow --json
+   Events arrive as NDJSON. Do not poll.
+7. Reconstitute the in-flight work picture with this bounded live-state sweep
    before acting or answering a status question:
    1. Enumerate panes through RunPane. Use panel activity status, running panels,
       and linked artifacts to determine the active working set. Include
       unpinned panes; pinning is a UI favorite signal, not an activity signal.
    2. If activity is ambiguous, inspect all non-archived panes before narrowing
-      to the active working set. Go wider than non-archived panes only when the
-      user asks.
+      to the active working set. Go wider only when the user asks.
    3. Resolve what each active pane owns from the artifacts its panels report,
-      the branch, and the worktree. Do not infer ownership from the pane name;
-      names can drift from the work actually being handled.
+      the branch, and the worktree. Do not infer ownership from the pane name.
    4. Query the VCS host for live state of the resolved artifacts: review state,
       mergeability, and check status.
-   5. Discover connected sources instead of assuming them. Enumerate the
-      integrations and tools actually available in this session, then crawl only
-      the sources that carry work state for items assigned to the user or linked
+   5. Discover connected sources instead of assuming them. Crawl only the
+      sources that carry work state for items assigned to the user or linked
       to the artifacts found above.
    6. Treat stored notes as leads to verify, not authority. Prefer fresh fields
-      from RunPane, the VCS host, and discovered work-state sources over memory
-      or cached summaries.
-   7. Keep the sweep cheap: parallelize independent queries, inspect active panes
-      plus directly linked records, cap fallback enumeration at non-archived
-      panes, and avoid fetching full bodies when list, status, review,
-      mergeability, or check fields answer the question.
+      from RunPane, the VCS host, and discovered work-state sources.
+   7. Keep the sweep cheap: parallelize independent queries,
+      cap fallback enumeration at non-archived panes, and avoid fetching
+      full bodies when list or status fields answer the question.
    8. Report in decision-shaped terms: what moved since the user last looked,
       what is waiting on a human, and what is blocked and on what.
 
 Do not claim initialization is complete until you have loaded these workflow
 references, completed the bounded live-state sweep, and can name the intended
 lifecycle for the user's task.
-
-Arm \`python3 ${paneWatchScript}\` with the Monitor tool at session start; it
-streams READY/BUSY/NEW/GONE from the daemon journal. Do not poll panes by hand
-or screen-scrape terminal text to decide whether an agent is working. The
-daemon's agent-status journal is the authoritative activity signal;
-\`pane.status\` is not — it reports "stopped" for actively working agents.
 
 For read-only work questions, use \`pane-work-recap\` when the user asks what
 they worked on and \`pane-work-prioritizer\` when they ask what to work on next.
@@ -628,51 +619,27 @@ separate perspective or when Pane Chat needs parallel research before forming
 the brief. In that case, Pane Chat still synthesizes the discussion result before
 advancing the upstream lifecycle.
 
+## Three Primitives
+
+1. **Arm the stream.** \`runpane watch\` delivers transitions as they happen. The
+   daemon owns the silent baseline, settle timing, and agent-only filtering.
+   You receive events; you never poll.
+2. **Verify state before mutating.** RunPane command results describe what a
+   command attempted, not the resulting state. Before treating any state as
+   changed or unchanged, verify the state itself through RunPane. Use
+   \`runpane agent-context\` to discover the exact syntax for any inspection or
+   mutation command.
+3. **Capture output before archiving.** Scrollback dies with the pane. Save
+   relevant output to a file before archiving.
+
 ## Pane Workflow Model
 
-- Add a repository once, then use Pane to manage work against it. If no suitable
-  repo exists, create a minimal local git repository and register it with Pane,
-  then delegate project implementation through RunPane.
-- The initial repository Pane is not a feature worktree; it represents the main
-  repository checkout and should stay aligned with main.
-- Creating a new Pane from a saved repository should normally create an
-  isolated git worktree and branch for one feature, PR, or experiment.
-  Multiple Panes can safely touch the same code areas because they are isolated
-  by worktree and branch.
-- Use extra terminal tabs/panels inside a Pane for clean-context review,
-  discussion, test automation, or follow-up agents. For PR-ready work, prefer
-  fresh Codex and Claude review panels.
-- After a PR is merged, the user can archive the Pane, which safely archives the
-  associated worktree.
-- Pane may copy quality-of-life files such as env vars, modules, and other
-  configured directories into new worktrees. Use RunPane and Pane state to
-  inspect the actual setup instead of assuming.
-
-## Orchestration Loop
-
-For Pane work:
-
-1. Use \`runpane panes list --json\` and \`runpane panels list --pane <pane-id>
-   --json\` to stay synchronized.
-2. Create panes or panels for the actual work with RunPane.
-3. Send the task to the delegated agent.
-4. Verify progress and completion with \`runpane panels wait\`,
-   \`runpane panels screen\`, or \`runpane panels output\`.
-5. Report observed Pane state and results back to the user.
-
-RunPane command results describe what a command attempted, not the resulting
-state. A success can leave nothing done; a failure can leave something done; a
-safety check can be checking the wrong thing. Before treating any state as
-changed or unchanged, verify the state itself:
-
-- Reconcile against \`runpane panes list --json\` before retrying a create that
-  reported failure — the pane and worktree may already exist.
-- Confirm an agent turn actually started with \`runpane panels screen\` rather
-  than trusting a submit result alone.
-- Before archiving, establish what a pane produced. Investigation, research,
-  review, and discussion panes deliver their result as terminal scrollback, not
-  files — a clean worktree does not mean empty, and archiving destroys
-  scrollback permanently.
+If no suitable repo exists, create a minimal local git repository and register it with Pane.
+Creating a new Pane from a saved repository should normally create an isolated
+git worktree and branch for one feature, PR, or experiment.
+Use extra terminal tabs/panels inside a Pane for clean-context review,
+discussion, test automation, or follow-up agents.
+After a PR is merged, the user can archive the Pane.
 
 ## Local Workflow References
 

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -478,8 +478,8 @@ You are Pane Chat, the global orchestrator for this Pane workspace.
    read the Excalidraw source files listed in Local Workflow References.
 5. Run the doctor command from the runtime context before taking Pane actions.
 6. Arm the event stream at session start:
-       runpane watch --as <session> --from now --follow --json
-   Events arrive as NDJSON. Do not poll.
+       runpane watch --as <session> --from now --follow --include-held-input --json
+   Events arrive as NDJSON. Do not poll. A \`heldInput\` field on agent.ready means the prompt never submitted — resubmit it.
 7. Reconstitute the in-flight work picture with this bounded live-state sweep
    before acting or answering a status question:
    1. Enumerate panes through RunPane. Use panel activity status, running panels,


### PR DESCRIPTION
## Summary

Rewrite the generated Pane Chat orchestrator skill to collapse client-side Pane-mechanics into three daemon-backed primitives, so the skill reads as manager-level guidance instead of a CLI cheatsheet.

## Before / after

| Metric | Before | After |
|---|---|---|
| Generated skill (template lines) | 232 | 200 |
| `runpane` commands in skill body | 5 literal | 1 (startup `watch`) |
| Net diff | — | +31 / −64 |

## What was deleted and the daemon change that made it safe

| Deleted section / rule | Daemon change |
|---|---|
| `## Orchestration Loop` — 5-step polling procedure with `panes list`, `panels list`, `panels wait`, `panels screen`, `panels output` | #520 journal-backed monitoring + #524 `runpane watch` replaces polling |
| `Arm python3 watch.py with the Monitor tool` paragraph | #524 `runpane watch --as <session> --from now --follow --json` is the primitive; watch.py was the client workaround |
| `pane.status is not — it reports "stopped"` warning | #524 fixed panel labelling and agent-only filtering daemon-side |
| `screen-scrape terminal text` warning | #524 `--agents-only` makes screen-scraping unnecessary |
| `Reconcile against runpane panes list --json` verify example | Principle preserved in primitive #2; literal command removed — agent discovers via `agent-context` |
| `Confirm an agent turn started with panels screen` verify example | Same |
| `archiving destroys scrollback permanently` archival guidance | Preserved in primitive #3 |
| Pane Workflow Model verbose bullets (initial repo alignment, worktree isolation details, QoL file copy, review panel preference) | Inferrable from context; compressed to essentials |

## The three primitives

1. **Arm the stream.** `runpane watch` delivers transitions. The daemon owns silent baseline, settle timing, and agent-only filtering. The agent never polls.
2. **Verify state before mutating.** RunPane results describe attempts, not outcomes. Verify actual state through RunPane before acting. Use `runpane agent-context` for command syntax. (#514 principle)
3. **Capture output before archiving.** Scrollback dies with the pane.

## Sections kept unchanged

- `## Contract Precedence` — which layer wins; cannot be inferred
- `## Hard Stops` — safety gate
- `## Role Boundary` — orchestrator identity and delegation rules
- `## Bring The Human In Before The Work` — discussion discipline
- `## Workflow Discipline` — lifecycle delegation model

These are the manager-level content. They are most of what remains (~92 of 200 lines).

## Why not under 150 lines

The four sections the founder specified as KEEP-unchanged consume 92 lines (46% of 200). Getting under 150 would require cutting into those sections, which the task explicitly forbids. The remaining 108 lines cover frontmatter, initialization (with the 8-step bounded sweep), the three primitives, the compressed workflow model, local references, and hard stops — all load-bearing.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm --filter main test` — 802/802 pass (including all 8 skillCacheManager assertions)

Refs #511 (previous consolidation), #514 (verify-state principle), #520 (journal monitoring), #524 (watch fixes).

https://claude.ai/code/session_01Cg2AKZkT8PZdencZj88ERk