### PR TITLE
Skill: never resubmit heldInput — it is usually a placeholder suggestion

### DIFF
--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -479,7 +479,7 @@ You are Pane Chat, the global orchestrator for this Pane workspace.
 5. Run the doctor command from the runtime context before taking Pane actions.
 6. Arm the event stream at session start:
        runpane watch --as <session> --from now --follow --include-held-input --json
-   Events arrive as NDJSON. Do not poll. A \`heldInput\` field on agent.ready means text follows the idle prompt; on Claude panes that is usually a greyed placeholder suggestion, not typed input. Never resubmit it — \`panels screen\` and \`composer.hasUndeliveredText\` decide.
+   Events arrive as NDJSON. Do not poll. A \`heldInput\` field on agent.ready means text follows the idle prompt; on an idle pane that is usually the agent's greyed placeholder suggestion, not typed input. Never resubmit it — \`panels screen\` and \`composer.hasUndeliveredText\` decide.
 7. Reconstitute the in-flight work picture with this bounded live-state sweep
    before acting or answering a status question:
    1. Enumerate panes through RunPane. Use panel activity status, running panels,

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -479,7 +479,7 @@ You are Pane Chat, the global orchestrator for this Pane workspace.
 5. Run the doctor command from the runtime context before taking Pane actions.
 6. Arm the event stream at session start:
        runpane watch --as <session> --from now --follow --include-held-input --json
-   Events arrive as NDJSON. Do not poll. A \`heldInput\` field on agent.ready means the prompt never submitted — resubmit it.
+   Events arrive as NDJSON. Do not poll. A \`heldInput\` field on agent.ready means text follows the idle prompt; on Claude panes that is usually a greyed placeholder suggestion, not typed input. Never resubmit it — \`panels screen\` and \`composer.hasUndeliveredText\` decide.
 7. Reconstitute the in-flight work picture with this bounded live-state sweep
    before acting or answering a status question:
    1. Enumerate panes through RunPane. Use panel activity status, running panels,
@@ -820,7 +820,7 @@ def emit_pane_entry(entry):
     emit(f"{label:<6} {name}")
     held_input = entry.get("heldInput")
     if held_input:
-        emit(f"STUCK  {name} :: {held_input[:70]}")
+        emit(f"HELD?  {name} :: {held_input[:70]}")  # may be a placeholder suggestion — verify before acting
 
 
 def watch_panes(name_filter, once):


### PR DESCRIPTION
## Why

#527's regenerated skill says: *"A `heldInput` field on agent.ready means the prompt never submitted — resubmit it."* `heldInput` is a screen scrape (`composerEvidenceText`), and on Claude panes it reports Claude Code's greyed placeholder suggestions — "go ahead, implement it", "run the e2e tests…" — as held input (#529, with a journal replay showing ~20 such entries today). An orchestrator following the skill literally would submit those into panes that were waiting on a human.

## What

- `skillCacheManager.ts:482` — wording now: heldInput means text follows the idle prompt; on Claude panes that is usually a greyed placeholder; never resubmit it; `panels screen` + `composer.hasUndeliveredText` decide.
- `watch.py` asset — the emitted label changes `STUCK` → `HELD?` with a comment, so the monitor's own output stops asserting a stall.

Skill line count unchanged (200). No daemon change — that is #529.

## Tests

- `skillCacheManager.test.ts` 8/8 locally.

## Manual tests

- Regenerate the skill in a dev build and read the Journal section: the resubmit sentence is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M2Hn3SCxzvTpKbWYtSSRT