### PR TITLE
fix(usage): ignore OpenRouter's negative dynamic-pricing sentinel

### DIFF
--- a/main/src/services/usage/modelPricing.test.ts
+++ b/main/src/services/usage/modelPricing.test.ts
@@ -81,7 +81,7 @@ describe('getPricingSource', () => {
 
 describe('estimateCostUsd', () => {
   it('prices a Claude request across all four token classes', () => {
-    const { costUsd, complete, cacheReadCostUsd } = estimateCostUsd({
+    const { costUsd, complete } = estimateCostUsd({
       model: 'claude-opus-5',
       inputTokens: 1_000_000,
       outputTokens: 1_000_000,

--- a/main/src/services/usage/modelPricing.test.ts
+++ b/main/src/services/usage/modelPricing.test.ts
@@ -81,7 +81,7 @@ describe('getPricingSource', () => {
 
 describe('estimateCostUsd', () => {
   it('prices a Claude request across all four token classes', () => {
-    const { costUsd, complete } = estimateCostUsd({
+    const { costUsd, complete, cacheReadCostUsd } = estimateCostUsd({
       model: 'claude-opus-5',
       inputTokens: 1_000_000,
       outputTokens: 1_000_000,
@@ -91,6 +91,7 @@ describe('estimateCostUsd', () => {
     expect(complete).toBe(true);
     // Bundled: 15 + 75 + 1.5 + 18.75 = 110.25
     expect(costUsd).toBeCloseTo(15 + 75 + 1.5 + 18.75, 6);
+    expect(cacheReadCostUsd).toBeCloseTo(1.5, 6);
   });
 
   it('prices a Codex request', () => {
@@ -113,6 +114,48 @@ describe('estimateCostUsd', () => {
       cacheReadTokens: 0,
       cacheCreationTokens: 0,
     });
+    expect(complete).toBe(false);
+    expect(costUsd).toBe(0);
+  });
+
+  it('reports incomplete when a live price contains a negative rate', () => {
+    setLivePrices(
+      [{ model: 'negative-model', inputPerMTok: 1, outputPerMTok: 2, cacheReadPerMTok: -1, cacheWritePerMTok: 1 }],
+      'stale cache',
+    );
+
+    const { costUsd, complete } = estimateCostUsd({
+      model: 'negative-model',
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheCreationTokens: 1_000_000,
+    });
+
+    expect(complete).toBe(false);
+    expect(costUsd).toBe(0);
+  });
+
+  it('does not price codex-auto-review through a negative auto router entry', () => {
+    setLivePrices(
+      [{
+        model: 'auto',
+        inputPerMTok: -1_000_000,
+        outputPerMTok: -1_000_000,
+        cacheReadPerMTok: -1_000_000,
+        cacheWritePerMTok: -1_000_000,
+      }],
+      'stale cache',
+    );
+
+    const { costUsd, complete } = estimateCostUsd({
+      model: 'codex-auto-review',
+      inputTokens: 100_000_000,
+      outputTokens: 10_000_000,
+      cacheReadTokens: 50_000_000,
+      cacheCreationTokens: 0,
+    });
+
     expect(complete).toBe(false);
     expect(costUsd).toBe(0);
   });

--- a/main/src/services/usage/modelPricing.test.ts
+++ b/main/src/services/usage/modelPricing.test.ts
@@ -91,7 +91,6 @@ describe('estimateCostUsd', () => {
     expect(complete).toBe(true);
     // Bundled: 15 + 75 + 1.5 + 18.75 = 110.25
     expect(costUsd).toBeCloseTo(15 + 75 + 1.5 + 18.75, 6);
-    expect(cacheReadCostUsd).toBeCloseTo(1.5, 6);
   });
 
   it('prices a Codex request', () => {

--- a/main/src/services/usage/modelPricing.ts
+++ b/main/src/services/usage/modelPricing.ts
@@ -79,6 +79,7 @@ function findInTable(model: string, table: readonly ModelPrice[]): ModelPrice | 
   const normalized = model.toLowerCase();
   let best: ModelPrice | null = null;
   for (const price of table) {
+    // Substring matching lets short router ids like "auto" capture ids such as "codex-auto-review".
     if (!normalized.includes(price.model)) continue;
     if (!best || price.model.length > best.model.length) best = price;
   }
@@ -121,7 +122,7 @@ export function estimateCostUsd(
   input: CostInput
 ): CostEstimate {
   const price = findModelPrice(input.model);
-  if (!price) return { costUsd: 0, complete: false, cacheSavingsUsd: 0 };
+  if (!price || hasNegativeRate(price)) return { costUsd: 0, complete: false, cacheSavingsUsd: 0 };
 
   const perToken = 1_000_000;
   const costUsd =
@@ -136,6 +137,11 @@ export function estimateCostUsd(
   );
 
   return { costUsd, complete: true, cacheSavingsUsd };
+}
+
+function hasNegativeRate(price: ModelPrice): boolean {
+  return [price.inputPerMTok, price.outputPerMTok, price.cacheReadPerMTok, price.cacheWritePerMTok]
+    .some(rate => rate < 0);
 }
 
 export { BUNDLED_PRICES as MODEL_PRICES };

--- a/main/src/services/usage/openRouterPriceProvider.test.ts
+++ b/main/src/services/usage/openRouterPriceProvider.test.ts
@@ -135,4 +135,20 @@ describe('parseOpenRouterResponse', () => {
     expect(prices).toHaveLength(1);
     expect(prices[0].model).toBe('good');
   });
+
+  it('skips dynamic-pricing sentinels and negative cache rates', () => {
+    const prices = parseOpenRouterResponse({
+      data: [
+        { id: 'openrouter/auto', pricing: { prompt: '-1', completion: '0.002' } },
+        {
+          id: 'vendor/negative-cache',
+          pricing: { prompt: '0.001', completion: '0.002', input_cache_read: '-1' },
+        },
+        { id: 'vendor/good', pricing: { prompt: '0.001', completion: '0.002' } },
+      ],
+    });
+
+    expect(prices).toHaveLength(1);
+    expect(prices[0].model).toBe('good');
+  });
 });

--- a/main/src/services/usage/openRouterPriceProvider.ts
+++ b/main/src/services/usage/openRouterPriceProvider.ts
@@ -67,6 +67,10 @@ export function convertPricing(
     ? parseFloat(pricing.input_cache_write) : NaN;
   const cacheWritePerMTok = isNaN(cacheWriteRaw) ? inputPerMTok : cacheWriteRaw * 1_000_000;
 
+  if ([inputPerMTok, outputPerMTok, cacheReadPerMTok, cacheWritePerMTok].some(rate => rate < 0)) {
+    return null;
+  }
+
   return { model: bareId, inputPerMTok, outputPerMTok, cacheReadPerMTok, cacheWritePerMTok };
 }
 


### PR DESCRIPTION
## Why

Closes #534. OpenRouter returns `"-1"` as a dynamic-pricing sentinel on its router pseudo-models (`openrouter/auto`, `auto-beta`, `fusion`, `pareto-code`, `bodybuilder`). `convertPricing` only rejected `NaN`, so those became −$1M/MTok, and the substring model lookup matched `codex-auto-review` to `auto` — whole panes priced at −$23M in #532's per-pane table. Shipped in 2.4.79 and 2.4.80 via #525.

## What

Lifted from `b1447727` on the TM-667 branch (#532) so the hotfix ships independent of that feature's review.

- `openRouterPriceProvider.ts` — any negative rate component → no price (`null`).
- `modelPricing.ts` — `estimateCostUsd` treats a price with any negative rate as unpriced (`complete: false`), so no path yields a negative cost. Comment on the substring match noting why short router ids are dangerous.
- Tests from the same commit: sentinel → `null`; negative cache rate → `null`; `estimateCostUsd` returns 0/incomplete on a negative table entry.

## Tests

- `main` usage suite green locally; `tsc --noEmit` clean.

## Manual tests

- With OpenRouter reachable, open Usage & Limits: no negative dollar figure anywhere; Codex sub-agent profiles show as unpriced (`n/a` / `no price`), not −$.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M2Hn3SCxzvTpKbWYtSSRT