### PR TITLE
feat: add leaderboard client opt-in, submission, and tab UI

### DIFF
--- a/frontend/src/components/usage/LeaderboardTab.tsx
+++ b/frontend/src/components/usage/LeaderboardTab.tsx
@@ -1,0 +1,417 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ExternalLink, Loader2, RefreshCw, Send, Trophy, UserMinus } from 'lucide-react';
+import { API } from '../../utils/api';
+import type {
+  LeaderboardEntry,
+  LeaderboardResponse,
+  LeaderboardStatus,
+} from '../../../../shared/types/leaderboard';
+import { formatTokens, formatUsd } from '../ui/charts/chartScales';
+
+function JoinBanner({
+  status,
+  onJoin,
+  joining,
+}: {
+  status: LeaderboardStatus;
+  onJoin: () => void;
+  joining: boolean;
+}) {
+  return (
+    <div className="rounded border border-border-primary bg-surface-secondary p-4">
+      <h3 className="text-sm font-medium text-text-primary">Join the leaderboard</h3>
+      <p className="mt-1 text-xs text-text-secondary">
+        Share your aggregate usage with runpane.com to see where you rank.
+        Your GitHub name is used when <code className="font-mono text-[11px]">gh</code> is logged in;
+        otherwise you appear under an anonymous name.
+      </p>
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <div>
+          <h4 className="text-[10px] font-medium uppercase tracking-wider text-text-tertiary">Pane sends</h4>
+          <ul className="mt-1 space-y-0.5 text-[11px] text-text-secondary">
+            <li>GitHub username or a one-way hash of your git email</li>
+            <li>Token totals: input, output, cache read, cache write</li>
+            <li>Message count and estimated cost at API prices</li>
+            <li>Per-model totals, time window (30 days), Pane version</li>
+          </ul>
+        </div>
+        <div>
+          <h4 className="text-[10px] font-medium uppercase tracking-wider text-text-tertiary">Pane never sends</h4>
+          <ul className="mt-1 space-y-0.5 text-[11px] text-text-secondary">
+            <li>Prompts, responses, or any session content</li>
+            <li>File paths, project or folder names</li>
+            <li>Transcripts, session ids, message ids</li>
+            <li>Your email address</li>
+          </ul>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={onJoin}
+          disabled={joining || status.doNotTrack}
+          className="inline-flex items-center gap-1.5 rounded bg-interactive px-3 py-1.5 text-xs font-medium text-text-on-interactive transition-colors hover:bg-interactive-hover disabled:opacity-50"
+        >
+          {joining ? (
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+          ) : (
+            <Trophy className="h-3 w-3" aria-hidden="true" />
+          )}
+          Join the leaderboard
+        </button>
+        <button
+          type="button"
+          onClick={() => { window.electronAPI?.openExternal('https://runpane.com/leaderboard'); }}
+          className="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs text-text-secondary transition-colors hover:bg-surface-hover"
+        >
+          See it on runpane.com
+          <ExternalLink className="h-3 w-3" aria-hidden="true" />
+        </button>
+      </div>
+      {status.doNotTrack && (
+        <p className="mt-2 text-[11px] text-status-warning">
+          DO_NOT_TRACK is set in your environment — leaderboard submissions are blocked while it is active.
+        </p>
+      )}
+      <p className="mt-2 text-[10px] text-text-muted">
+        Sent on app open and when you open this tab. Leave any time — your row is deleted.
+      </p>
+    </div>
+  );
+}
+
+function JoinedBanner({
+  status,
+  onLeave,
+  onSendNow,
+  leaving,
+  sending,
+}: {
+  status: LeaderboardStatus;
+  onLeave: () => void;
+  onSendNow: () => void;
+  leaving: boolean;
+  sending: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-3 rounded border border-interactive/30 bg-interactive/5 p-4">
+      <div>
+        <h3 className="text-sm font-medium text-text-primary">
+          You're on the leaderboard
+          {status.lastRank != null && (
+            <span className="tabular-nums"> · ranked #{status.lastRank}</span>
+          )}
+          {status.lastDisplayName && (
+            <span> as <code className="font-mono text-[11px]">{status.lastDisplayName}</code></span>
+          )}
+        </h3>
+        {status.lastSubmittedAtMs && (
+          <p className="mt-0.5 text-[11px] text-text-tertiary">
+            Last sent {new Date(status.lastSubmittedAtMs).toLocaleString()}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onSendNow}
+          disabled={sending || status.doNotTrack}
+          className="inline-flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs text-text-secondary transition-colors hover:bg-surface-hover disabled:opacity-50"
+        >
+          {sending ? (
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+          ) : (
+            <Send className="h-3 w-3" aria-hidden="true" />
+          )}
+          Send now
+        </button>
+        <button
+          type="button"
+          onClick={onLeave}
+          disabled={leaving}
+          className="inline-flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs text-status-error/80 transition-colors hover:bg-status-error/10 disabled:opacity-50"
+        >
+          {leaving ? (
+            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+          ) : (
+            <UserMinus className="h-3 w-3" aria-hidden="true" />
+          )}
+          Leave
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LeaderboardTable({
+  entries,
+  total,
+  currentDisplayName,
+}: {
+  entries: LeaderboardEntry[];
+  total: number;
+  currentDisplayName: string | null;
+}) {
+  return (
+    <div className="rounded border border-border-primary bg-surface-secondary p-3">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[640px] border-collapse text-left text-xs">
+          <thead>
+            <tr className="border-b border-border-primary">
+              <th className="px-2 py-2 text-left text-[10px] font-medium uppercase tracking-wider text-text-tertiary w-10">#</th>
+              <th className="px-2 py-2 text-left text-[10px] font-medium uppercase tracking-wider text-text-tertiary">User</th>
+              <th className="px-2 py-2 text-right text-[10px] font-medium uppercase tracking-wider text-text-tertiary">Est. cost (30d)</th>
+              <th className="px-2 py-2 text-right text-[10px] font-medium uppercase tracking-wider text-text-tertiary">Output tokens</th>
+              <th className="px-2 py-2 text-right text-[10px] font-medium uppercase tracking-wider text-text-tertiary">Messages</th>
+              <th className="px-2 py-2 text-left text-[10px] font-medium uppercase tracking-wider text-text-tertiary">Top model</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map(entry => {
+              const isMe = currentDisplayName != null && entry.displayName === currentDisplayName;
+              return (
+                <tr
+                  key={`${entry.rank}-${entry.displayName}`}
+                  className={`border-b border-border-primary/60 last:border-b-0 ${
+                    isMe ? 'bg-interactive/8' : ''
+                  }`}
+                >
+                  <td className="px-2 py-2 tabular-nums text-text-muted">{entry.rank}</td>
+                  <td className="px-2 py-2">
+                    <span className={`font-medium ${isMe ? 'text-interactive' : 'text-text-primary'}`}>
+                      {entry.displayName}
+                    </span>
+                    {entry.verified && (
+                      <span className="ml-1 text-[10px] text-status-success" title="GitHub verified">✓</span>
+                    )}
+                    {isMe && (
+                      <span className="ml-1.5 text-[10px] text-text-muted">you</span>
+                    )}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums text-text-secondary">
+                    {entry.costIncomplete ? 'n/a' : formatUsd(entry.estimatedCostUsd)}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums text-text-secondary">
+                    {formatTokens(entry.outputTokens)}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums text-text-secondary">
+                    {entry.messageCount.toLocaleString()}
+                  </td>
+                  <td className="px-2 py-2 text-text-tertiary">
+                    {entry.topModel ?? '—'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {total > entries.length && (
+        <p className="mt-2 text-center text-[10px] text-text-muted">
+          Showing top {entries.length} of {total} users
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function LeaderboardTab() {
+  const [status, setStatus] = useState<LeaderboardStatus | null>(null);
+  const [board, setBoard] = useState<LeaderboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [joining, setJoining] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadAll = useCallback(async (): Promise<LeaderboardStatus | null> => {
+    try {
+      const [statusRes, boardRes] = await Promise.all([
+        API.leaderboard.getStatus(),
+        API.leaderboard.fetch(),
+      ]);
+      if (statusRes.success && statusRes.data) setStatus(statusRes.data);
+      if (boardRes.success && boardRes.data) setBoard(boardRes.data);
+      if (!statusRes.success) throw new Error(statusRes.error);
+      if (!boardRes.success) throw new Error(boardRes.error);
+      setError(null);
+      return statusRes.data ?? null;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load leaderboard');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAll().then(loadedStatus => {
+      if (!loadedStatus?.optIn || loadedStatus.doNotTrack) return;
+      void API.leaderboard.sendNow().then(submitRes => {
+        if (submitRes.success && submitRes.data) {
+          const data = submitRes.data;
+          setStatus(prev => prev ? {
+            ...prev,
+            lastRank: data.rank,
+            lastDisplayName: data.displayName,
+            lastSubmittedAtMs: Date.now(),
+          } : prev);
+        }
+      }).catch(() => {});
+    });
+  }, [loadAll]);
+
+  const handleJoin = useCallback(async () => {
+    setJoining(true);
+    try {
+      const res = await API.leaderboard.join();
+      if (!res.success) throw new Error(res.error);
+      setStatus(prev => prev ? {
+        ...prev,
+        optIn: true,
+        lastRank: res.data?.rank ?? null,
+        lastDisplayName: res.data?.displayName ?? null,
+        lastSubmittedAtMs: Date.now(),
+      } : prev);
+      // Refresh the board to show updated data
+      const boardRes = await API.leaderboard.fetch();
+      if (boardRes.success && boardRes.data) setBoard(boardRes.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to join');
+    } finally {
+      setJoining(false);
+    }
+  }, []);
+
+  const handleLeave = useCallback(async () => {
+    setLeaving(true);
+    try {
+      const res = await API.leaderboard.leave();
+      if (!res.success) throw new Error(res.error);
+      setStatus(prev => prev ? {
+        ...prev,
+        optIn: false,
+        lastRank: null,
+        lastDisplayName: null,
+        lastSubmittedAtMs: null,
+      } : prev);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to leave');
+    } finally {
+      setLeaving(false);
+    }
+  }, []);
+
+  const handleSendNow = useCallback(async () => {
+    setSending(true);
+    try {
+      const res = await API.leaderboard.sendNow();
+      if (!res.success) throw new Error(res.error);
+      setStatus(prev => prev ? {
+        ...prev,
+        lastRank: res.data?.rank ?? prev.lastRank,
+        lastDisplayName: res.data?.displayName ?? prev.lastDisplayName,
+        lastSubmittedAtMs: Date.now(),
+      } : prev);
+      // Refresh the board
+      const boardRes = await API.leaderboard.fetch();
+      if (boardRes.success && boardRes.data) setBoard(boardRes.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send');
+    } finally {
+      setSending(false);
+    }
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const boardRes = await API.leaderboard.fetch();
+      if (boardRes.success && boardRes.data) {
+        setBoard(boardRes.data);
+        setError(null);
+      }
+    } catch {
+      // silent
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-10 text-xs text-text-tertiary">
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        Loading leaderboard…
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-4">
+      {error && (
+        <div className="rounded border border-status-error/30 bg-status-error/10 p-3 text-xs text-status-error">
+          {error}
+        </div>
+      )}
+
+      {status && !status.optIn && (
+        <JoinBanner status={status} onJoin={handleJoin} joining={joining} />
+      )}
+
+      {status?.optIn && (
+        <JoinedBanner
+          status={status}
+          onLeave={handleLeave}
+          onSendNow={handleSendNow}
+          leaving={leaving}
+          sending={sending}
+        />
+      )}
+
+      <div className="flex items-center justify-between">
+        <p className="text-[10px] text-text-muted">
+          Last 30 days · all providers · top 100
+          {board?.generatedAtMs && (
+            <> · updated {formatRelativeTime(board.generatedAtMs)}</>
+          )}
+        </p>
+        <button
+          type="button"
+          onClick={() => { void handleRefresh(); }}
+          disabled={refreshing}
+          aria-label="Refresh leaderboard"
+          className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 text-text-tertiary ${refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
+        </button>
+      </div>
+
+      {board && board.entries.length > 0 ? (
+        <LeaderboardTable
+          entries={board.entries}
+          total={board.total}
+          currentDisplayName={status?.lastDisplayName ?? null}
+        />
+      ) : board ? (
+        <div className="rounded border border-border-primary bg-surface-secondary p-6 text-center text-xs text-text-muted">
+          No entries yet. Be the first to join!
+        </div>
+      ) : null}
+
+      <p className="text-[10px] text-text-muted">
+        Ranked by estimated cost at API prices. The rank comes from the server's reply to your last submission, never computed locally.
+      </p>
+    </div>
+  );
+}
+
+function formatRelativeTime(ms: number): string {
+  const seconds = Math.round((Date.now() - ms) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h ago`;
+}

--- a/frontend/src/components/usage/UsageView.tsx
+++ b/frontend/src/components/usage/UsageView.tsx
@@ -8,6 +8,7 @@ import { BarChart } from '../ui/charts/BarChart';
 import { DonutChart } from '../ui/charts/DonutChart';
 import { formatTokens, formatUsd } from '../ui/charts/chartScales';
 import { LimitBar, LimitStatusBanners, CreditsLine } from './ProviderLimits';
+import { LeaderboardTab } from './LeaderboardTab';
 import {
   DEFAULT_USAGE_RANGE_DAYS,
   type UsageByPane,
@@ -139,8 +140,11 @@ function PaneUsageRow({ pane }: { pane: UsageByPane }) {
  * - **Provider**: rate limits, credits, blocked state — reported by Codex in
  *   every token_count event. Anthropic does not expose plan limits locally.
  */
+type UsageTab = 'usage' | 'leaderboard';
+
 export function UsageView() {
   const contentRef = useRef<HTMLDivElement>(null);
+  const [activeTab, setActiveTab] = useState<UsageTab>('usage');
   const [report, setReport] = useState<UsageReport | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -400,94 +404,130 @@ export function UsageView() {
           <h1 className="text-sm font-medium text-text-primary">Usage &amp; limits</h1>
         </div>
 
-        <div className="ml-auto flex flex-wrap items-center gap-3">
-          <fieldset className="flex items-center gap-1">
-            <legend className="sr-only">Provider</legend>
-            {PROVIDER_OPTIONS.map(option => (
-              <button
-                key={option.value}
-                type="button"
-                aria-pressed={provider === option.value}
-                onClick={() => setProvider(option.value)}
-                className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
-                  provider === option.value
-                    ? 'bg-interactive text-text-on-interactive'
-                    : 'text-text-secondary hover:bg-surface-hover'
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </fieldset>
-
-          <span className="h-4 w-px bg-border-primary" aria-hidden="true" />
-
-          <fieldset className="flex items-center gap-1">
-            <legend className="sr-only">Time range</legend>
-            {RANGE_OPTIONS.map(option => (
-              <button
-                key={option.days}
-                type="button"
-                aria-pressed={rangeDays === option.days}
-                onClick={() => setRangeDays(option.days)}
-                className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
-                  rangeDays === option.days
-                    ? 'bg-interactive text-text-on-interactive'
-                    : 'text-text-secondary hover:bg-surface-hover'
-                }`}
-              >
-                {option.label}
-              </button>
-            ))}
-          </fieldset>
-
-          <span className="h-4 w-px bg-border-primary" aria-hidden="true" />
-
+        <nav className="flex items-center gap-1" role="tablist" aria-label="Usage views">
           <button
             type="button"
-            onClick={() => { void handleDownload(); }}
-            disabled={downloadStatus === 'capturing' || !report}
-            aria-label="Download usage as image"
-            title="Download usage as image"
-            className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
+            role="tab"
+            aria-selected={activeTab === 'usage'}
+            onClick={() => setActiveTab('usage')}
+            className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+              activeTab === 'usage'
+                ? 'bg-interactive text-text-on-interactive'
+                : 'text-text-secondary hover:bg-surface-hover'
+            }`}
           >
-            {downloadStatus === 'done'
-              ? <Check className="h-3.5 w-3.5 text-status-success" aria-hidden="true" />
-              : <Download className={`h-3.5 w-3.5 text-text-tertiary ${downloadStatus === 'capturing' ? 'animate-pulse' : ''}`} aria-hidden="true" />}
+            My usage
           </button>
-
           <button
             type="button"
-            onClick={() => { void handleShare(); }}
-            disabled={shareStatus === 'capturing' || !report}
-            aria-label="Share usage image"
-            title="Share usage image"
-            className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
+            role="tab"
+            aria-selected={activeTab === 'leaderboard'}
+            onClick={() => setActiveTab('leaderboard')}
+            className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+              activeTab === 'leaderboard'
+                ? 'bg-interactive text-text-on-interactive'
+                : 'text-text-secondary hover:bg-surface-hover'
+            }`}
           >
-            {shareStatus === 'done'
-              ? <Check className="h-3.5 w-3.5 text-status-success" aria-hidden="true" />
-              : <Share2 className={`h-3.5 w-3.5 text-text-tertiary ${shareStatus === 'capturing' ? 'animate-pulse' : ''}`} aria-hidden="true" />}
+            Leaderboard
           </button>
+        </nav>
 
-          <button
-            type="button"
-            onClick={() => { void handleRescan(); }}
-            disabled={refreshing}
-            aria-label="Rescan transcripts"
-            className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
-          >
-            <RefreshCw className={`h-3.5 w-3.5 text-text-tertiary ${refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
-          </button>
-        </div>
+        {activeTab === 'usage' && (
+          <div className="ml-auto flex flex-wrap items-center gap-3">
+            <fieldset className="flex items-center gap-1">
+              <legend className="sr-only">Provider</legend>
+              {PROVIDER_OPTIONS.map(option => (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={provider === option.value}
+                  onClick={() => setProvider(option.value)}
+                  className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
+                    provider === option.value
+                      ? 'bg-interactive text-text-on-interactive'
+                      : 'text-text-secondary hover:bg-surface-hover'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </fieldset>
+
+            <span className="h-4 w-px bg-border-primary" aria-hidden="true" />
+
+            <fieldset className="flex items-center gap-1">
+              <legend className="sr-only">Time range</legend>
+              {RANGE_OPTIONS.map(option => (
+                <button
+                  key={option.days}
+                  type="button"
+                  aria-pressed={rangeDays === option.days}
+                  onClick={() => setRangeDays(option.days)}
+                  className={`rounded px-2 py-0.5 text-[11px] transition-colors ${
+                    rangeDays === option.days
+                      ? 'bg-interactive text-text-on-interactive'
+                      : 'text-text-secondary hover:bg-surface-hover'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </fieldset>
+
+            <span className="h-4 w-px bg-border-primary" aria-hidden="true" />
+
+            <button
+              type="button"
+              onClick={() => { void handleDownload(); }}
+              disabled={downloadStatus === 'capturing' || !report}
+              aria-label="Download usage as image"
+              title="Download usage as image"
+              className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
+            >
+              {downloadStatus === 'done'
+                ? <Check className="h-3.5 w-3.5 text-status-success" aria-hidden="true" />
+                : <Download className={`h-3.5 w-3.5 text-text-tertiary ${downloadStatus === 'capturing' ? 'animate-pulse' : ''}`} aria-hidden="true" />}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => { void handleShare(); }}
+              disabled={shareStatus === 'capturing' || !report}
+              aria-label="Share usage image"
+              title="Share usage image"
+              className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
+            >
+              {shareStatus === 'done'
+                ? <Check className="h-3.5 w-3.5 text-status-success" aria-hidden="true" />
+                : <Share2 className={`h-3.5 w-3.5 text-text-tertiary ${shareStatus === 'capturing' ? 'animate-pulse' : ''}`} aria-hidden="true" />}
+            </button>
+
+            <button
+              type="button"
+              onClick={() => { void handleRescan(); }}
+              disabled={refreshing}
+              aria-label="Rescan transcripts"
+              className="rounded p-1 transition-colors hover:bg-surface-hover disabled:opacity-50"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 text-text-tertiary ${refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
+            </button>
+          </div>
+        )}
       </header>
 
-      {report?.index.scanning && (
+      {activeTab === 'usage' && report?.index.scanning && (
         <div className="flex flex-shrink-0 items-center gap-2 border-b border-border-primary bg-surface-tertiary px-4 py-1 text-[11px] text-text-tertiary">
           <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
           Indexing transcripts… {report.index.filesScanned}/{report.index.filesTotal} files
         </div>
       )}
 
+      {activeTab === 'leaderboard' ? (
+        <div className="min-h-0 flex-1 overflow-auto p-4">
+          <LeaderboardTab />
+        </div>
+      ) : (
       <div ref={contentRef} className="relative min-h-0 flex-1 overflow-auto p-4">
         {loading ? (
           <div className="flex items-center justify-center gap-2 py-10 text-xs text-text-tertiary">
@@ -759,6 +799,7 @@ export function UsageView() {
           </div>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -36,6 +36,7 @@ import type { PanelAgentStatusEvent } from '../../../shared/types/agentStatus';
 import type { AgentUsageSnapshot } from '../../../shared/types/agentUsage';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
 import type { UsageIndexStatus, UsageReport, UsageReportRequest } from '../../../shared/types/usage';
+import type { LeaderboardResponse, LeaderboardStatus, LeaderboardSubmitResult } from '../../../shared/types/leaderboard';
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
@@ -130,6 +131,15 @@ interface ElectronAPI {
     getReport: (request?: UsageReportRequest) => Promise<IPCResponse<UsageReport>>;
     getStatus: () => Promise<IPCResponse<UsageIndexStatus>>;
     rescan: () => Promise<IPCResponse<UsageIndexStatus>>;
+  };
+
+  // Leaderboard opt-in and submission
+  leaderboard: {
+    getStatus: () => Promise<IPCResponse<LeaderboardStatus>>;
+    join: () => Promise<IPCResponse<LeaderboardSubmitResult>>;
+    leave: () => Promise<IPCResponse>;
+    sendNow: () => Promise<IPCResponse<LeaderboardSubmitResult>>;
+    fetch: () => Promise<IPCResponse<LeaderboardResponse>>;
   };
 
   // Image export (save-to-file / OS share sheet)

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -5,6 +5,7 @@ import type { UpdateConfigRequest } from '../types/config';
 import type { SessionCreationPreferences } from '../stores/sessionPreferencesStore';
 import type { PaneChatAgent, PaneChatState } from '../../../shared/types/paneChat';
 import type { UsageReportRequest } from '../../../shared/types/usage';
+import type { LeaderboardResponse, LeaderboardStatus, LeaderboardSubmitResult } from '../../../shared/types/leaderboard';
 import type {
   RemoteDaemonClientRecord,
   RemoteDaemonClientSettings,
@@ -92,6 +93,30 @@ export class API {
     async rescan() {
       if (!isElectron()) throw new Error('Electron API not available');
       return window.electronAPI.usage.rescan();
+    },
+  };
+
+  // Leaderboard
+  static leaderboard = {
+    async getStatus(): Promise<IPCResponse<LeaderboardStatus>> {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.leaderboard.getStatus();
+    },
+    async join(): Promise<IPCResponse<LeaderboardSubmitResult>> {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.leaderboard.join();
+    },
+    async leave(): Promise<IPCResponse> {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.leaderboard.leave();
+    },
+    async sendNow(): Promise<IPCResponse<LeaderboardSubmitResult>> {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.leaderboard.sendNow();
+    },
+    async fetch(): Promise<IPCResponse<LeaderboardResponse>> {
+      if (!isElectron()) throw new Error('Electron API not available');
+      return window.electronAPI.leaderboard.fetch();
     },
   };
 

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -96,6 +96,8 @@ import { terminalPanelManager } from './services/terminalPanelManager';
 import { panelManager } from './services/panelManager';
 import { worktreePoolManager } from './services/worktreePoolManager';
 import { usageManager } from './services/usage/usageManager';
+import { LeaderboardService } from './services/leaderboardService';
+import { registerLeaderboardHandlers } from './ipc/leaderboard';
 import { PtyHostSupervisor } from './ptyHost/ptyHostSupervisor';
 import { syncAutoStartOnBoot } from './utils/autoStart';
 import { createPaneDaemonHost, type PaneDaemonHost } from './daemon/bootstrap';
@@ -210,6 +212,7 @@ let databaseService: DatabaseService;
 let runCommandManager: RunCommandManager;
 let versionChecker: VersionChecker;
 let archiveProgressManager: ArchiveProgressManager;
+let leaderboardService: LeaderboardService;
 let analyticsManager: AnalyticsManager;
 let paneDaemonHost: PaneDaemonHost | null = null;
 let powerSaveManager: PowerSaveManager | null = null;
@@ -999,6 +1002,9 @@ async function initializeServices() {
   powerSaveManager = new PowerSaveManager(configManager, sessionManager);
   powerSaveManager.sync();
 
+  leaderboardService = new LeaderboardService(configManager);
+  registerLeaderboardHandlers(ipcMain, leaderboardService);
+
   ipcMain.handle('analytics:get-identity', async () => {
     try {
       const installId = await configManager.getOrCreateAnalyticsInstallId();
@@ -1273,9 +1279,11 @@ if (launchRemoteSetup) {
   // Index agent CLI transcripts for the usage page. Read-only, and deferred so
   // a first pass over a large ~/.claude never delays window creation.
   setTimeout(() => {
-    void usageManager.start().catch(error => {
-      console.warn('[Usage] Failed to start transcript indexing:', error);
-    });
+    void usageManager.start()
+      .then(() => leaderboardService.submitOnAppOpen())
+      .catch(error => {
+        console.warn('[Usage] Failed to start transcript indexing:', error);
+      });
   }, 8000);
 
     app.on('activate', () => {

--- a/main/src/ipc/leaderboard.ts
+++ b/main/src/ipc/leaderboard.ts
@@ -1,0 +1,66 @@
+import type { IpcMain } from 'electron';
+import type { LeaderboardService } from '../services/leaderboardService';
+
+export function registerLeaderboardHandlers(
+  ipcMain: IpcMain,
+  leaderboardService: LeaderboardService,
+): void {
+  ipcMain.handle('leaderboard:get-status', async () => {
+    try {
+      return { success: true, data: leaderboardService.getStatus() };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get leaderboard status',
+      };
+    }
+  });
+
+  ipcMain.handle('leaderboard:join', async () => {
+    try {
+      const result = await leaderboardService.join();
+      return { success: true, data: result };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to join leaderboard',
+      };
+    }
+  });
+
+  ipcMain.handle('leaderboard:leave', async () => {
+    try {
+      await leaderboardService.leave();
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to leave leaderboard',
+      };
+    }
+  });
+
+  ipcMain.handle('leaderboard:send-now', async () => {
+    try {
+      const result = await leaderboardService.submit();
+      return { success: true, data: result };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to submit leaderboard data',
+      };
+    }
+  });
+
+  ipcMain.handle('leaderboard:fetch', async () => {
+    try {
+      const data = await leaderboardService.fetchLeaderboard();
+      return { success: true, data };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to fetch leaderboard',
+      };
+    }
+  });
+}

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -481,6 +481,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     rescan: (): Promise<IPCResponse> => invokeIpc('usage:rescan'),
   },
 
+  // Leaderboard opt-in and submission
+  leaderboard: {
+    getStatus: (): Promise<IPCResponse> => invokeIpc('leaderboard:get-status'),
+    join: (): Promise<IPCResponse> => invokeIpc('leaderboard:join'),
+    leave: (): Promise<IPCResponse> => invokeIpc('leaderboard:leave'),
+    sendNow: (): Promise<IPCResponse> => invokeIpc('leaderboard:send-now'),
+    fetch: (): Promise<IPCResponse> => invokeIpc('leaderboard:fetch'),
+  },
+
   // Image export (save-to-file / OS share sheet)
   export: {
     saveImage: (data: string, defaultFilename: string): Promise<IPCResponse> =>

--- a/main/src/services/leaderboardService.ts
+++ b/main/src/services/leaderboardService.ts
@@ -1,0 +1,254 @@
+import { app } from 'electron';
+import { execFileSync } from 'child_process';
+import * as os from 'os';
+import { usageManager } from './usage/usageManager';
+import { ShellDetector } from '../utils/shellDetector';
+import type { ConfigManager } from './configManager';
+import type { AnalyticsIdentity } from '../types/config';
+import type {
+  LeaderboardSubmission,
+  LeaderboardSubmitResult,
+  LeaderboardResponse,
+  LeaderboardStatus,
+} from '../../../shared/types/leaderboard';
+import type { UsageReport } from '../../../shared/types/usage';
+
+const LEADERBOARD_API_BASE =
+  process.env.PANE_LEADERBOARD_URL || 'https://runpane.com';
+const SUBMIT_TIMEOUT_MS = 10_000;
+const SCAN_WAIT_MS = 15_000;
+
+function resolveDoNotTrack(): boolean {
+  let value = process.env.DO_NOT_TRACK;
+
+  if (value === undefined || value === '') {
+    try {
+      const shell = ShellDetector.getDefaultShell().path;
+      const output = execFileSync(shell, ['-l', '-c', 'echo $DO_NOT_TRACK'], {
+        encoding: 'utf8',
+        timeout: 5000,
+        cwd: os.homedir(),
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      if (output) value = output;
+    } catch {
+      // Shell probe failed — treat as unset
+    }
+  }
+
+  if (value === undefined || value === '') return false;
+  if (value === '0' || value.toLowerCase() === 'false') return false;
+  return true;
+}
+
+function buildSubmission(
+  report: UsageReport,
+  identity: AnalyticsIdentity,
+  paneVersion: string,
+): LeaderboardSubmission {
+  return {
+    installId: identity.installId!,
+    githubUsername: identity.githubUsername || undefined,
+    gitEmailHash: identity.gitEmailHash || undefined,
+    totalTokens: report.totals.totalTokens,
+    inputTokens: report.totals.inputTokens,
+    outputTokens: report.totals.outputTokens,
+    cacheReadTokens: report.totals.cacheReadTokens,
+    cacheCreationTokens: report.totals.cacheCreationTokens,
+    messageCount: report.totals.messageCount,
+    estimatedCostUsd: report.totals.estimatedCostUsd,
+    costIncomplete: report.totals.costIncomplete,
+    cacheSavingsUsd: report.totals.cacheSavingsUsd,
+    byModel: report.byModel.slice(0, 50).map(m => ({
+      model: m.model,
+      provider: m.provider,
+      inputTokens: m.inputTokens,
+      outputTokens: m.outputTokens,
+      cacheReadTokens: m.cacheReadTokens,
+      cacheCreationTokens: m.cacheCreationTokens,
+      totalTokens: m.totalTokens,
+      estimatedCostUsd: m.estimatedCostUsd,
+      costIncomplete: m.costIncomplete,
+    })),
+    windowDays: 30,
+    submittedAtMs: Date.now(),
+    paneVersion,
+  };
+}
+
+export class LeaderboardService {
+  private doNotTrack: boolean;
+
+  constructor(private configManager: ConfigManager) {
+    this.doNotTrack = resolveDoNotTrack();
+  }
+
+  getStatus(): LeaderboardStatus {
+    const config = this.configManager.getConfig().leaderboard;
+    return {
+      optIn: config?.optIn ?? false,
+      lastRank: config?.lastRank ?? null,
+      lastDisplayName: config?.lastDisplayName ?? null,
+      lastSubmittedAtMs: config?.lastSubmittedAtMs ?? null,
+      doNotTrack: this.doNotTrack,
+    };
+  }
+
+  async join(): Promise<LeaderboardSubmitResult> {
+    if (this.doNotTrack) {
+      throw new Error('DO_NOT_TRACK is set — leaderboard submissions are blocked');
+    }
+
+    await this.configManager.updateConfig({
+      leaderboard: {
+        ...this.configManager.getConfig().leaderboard,
+        optIn: true,
+        joinedAtMs: Date.now(),
+      },
+    });
+
+    return this.submit();
+  }
+
+  async leave(): Promise<void> {
+    const config = this.configManager.getConfig();
+    const installId = config.analytics?.installId;
+
+    if (installId) {
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), SUBMIT_TIMEOUT_MS);
+        await fetch(`${LEADERBOARD_API_BASE}/api/runpane/leaderboard/submit`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ installId }),
+          signal: controller.signal,
+        });
+        clearTimeout(timer);
+      } catch (error) {
+        console.warn('[Leaderboard] DELETE failed (row will expire):', error);
+      }
+    }
+
+    await this.configManager.updateConfig({
+      leaderboard: {
+        optIn: false,
+      },
+    });
+  }
+
+  async submit(): Promise<LeaderboardSubmitResult> {
+    if (this.doNotTrack) {
+      throw new Error('DO_NOT_TRACK is set — leaderboard submissions are blocked');
+    }
+
+    const config = this.configManager.getConfig();
+    if (!config.leaderboard?.optIn) {
+      throw new Error('Not opted in to the leaderboard');
+    }
+
+    const analytics = config.analytics;
+    if (!analytics?.installId) {
+      throw new Error('No install ID available');
+    }
+
+    const identity: AnalyticsIdentity = {
+      distinctId: analytics.distinctId || '',
+      identitySource: analytics.identitySource || 'anonymous',
+      installId: analytics.installId,
+      githubUsername: analytics.githubUsername,
+      gitEmail: analytics.gitEmail,
+      gitEmailHash: analytics.gitEmailHash,
+    };
+
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const toMs = Date.now();
+    const report = usageManager.getReport({
+      fromMs: toMs - 30 * DAY_MS,
+      toMs,
+    });
+
+    const submission = buildSubmission(report, identity, app.getVersion());
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SUBMIT_TIMEOUT_MS);
+
+    const response = await fetch(
+      `${LEADERBOARD_API_BASE}/api/runpane/leaderboard/submit`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(submission),
+        signal: controller.signal,
+      },
+    );
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Leaderboard submit failed (${response.status}): ${text}`);
+    }
+
+    const result: LeaderboardSubmitResult = await response.json();
+
+    await this.configManager.updateConfig({
+      leaderboard: {
+        ...config.leaderboard,
+        lastSubmittedAtMs: Date.now(),
+        lastRank: result.rank,
+        lastDisplayName: result.displayName,
+      },
+    });
+
+    return result;
+  }
+
+  async fetchLeaderboard(): Promise<LeaderboardResponse> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SUBMIT_TIMEOUT_MS);
+
+    const response = await fetch(
+      `${LEADERBOARD_API_BASE}/api/runpane/leaderboard`,
+      { signal: controller.signal },
+    );
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch leaderboard (${response.status})`);
+    }
+
+    return response.json();
+  }
+
+  async submitOnAppOpen(): Promise<void> {
+    if (this.doNotTrack) return;
+    if (!this.configManager.getConfig().leaderboard?.optIn) return;
+
+    const status = usageManager.getStatus();
+    if (status.scanning) {
+      const started = Date.now();
+      await new Promise<void>(resolve => {
+        const check = () => {
+          if (!usageManager.getStatus().scanning || Date.now() - started > SCAN_WAIT_MS) {
+            resolve();
+            return;
+          }
+          setTimeout(check, 1000);
+        };
+        check();
+      });
+    }
+
+    if (usageManager.getStatus().scanning) {
+      console.log('[Leaderboard] Scan still running after wait bound — skipping app-open submission');
+      return;
+    }
+
+    try {
+      await this.submit();
+      console.log('[Leaderboard] App-open submission succeeded');
+    } catch (error) {
+      console.warn('[Leaderboard] App-open submission failed:', error);
+    }
+  }
+}

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -1,4 +1,5 @@
 import type { CloudVmConfig } from '../../../shared/types/cloud';
+import type { LeaderboardConfig } from '../../../shared/types/leaderboard';
 import type { RemoteDaemonConfig } from '../../../shared/types/remoteDaemon';
 import type { PaneChatAgent } from '../../../shared/types/paneChat';
 import type { VoiceTranscriptionMode } from '../../../shared/types/voiceTranscription';
@@ -149,6 +150,8 @@ export interface AppConfig {
   remoteDaemon?: RemoteDaemonConfig;
   terminalFontFamily?: string;
   terminalFontSize?: number;
+  // Leaderboard opt-in and cached state
+  leaderboard?: LeaderboardConfig;
 }
 
 export interface UpdateConfigRequest {

--- a/shared/types/leaderboard.ts
+++ b/shared/types/leaderboard.ts
@@ -1,0 +1,76 @@
+import type { UsageProvider } from './usage';
+
+export interface LeaderboardSubmission {
+  installId: string;
+  githubUsername?: string;
+  gitEmailHash?: string;
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  messageCount: number;
+  estimatedCostUsd: number;
+  costIncomplete: boolean;
+  cacheSavingsUsd: number;
+  byModel: LeaderboardModelEntry[];
+  windowDays: 30;
+  submittedAtMs: number;
+  paneVersion: string;
+}
+
+export interface LeaderboardModelEntry {
+  model: string;
+  provider: UsageProvider;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalTokens: number;
+  estimatedCostUsd: number;
+  costIncomplete: boolean;
+}
+
+export interface LeaderboardSubmitResult {
+  rank: number;
+  displayName: string;
+  verified: boolean;
+  total: number;
+  installs: number;
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  displayName: string;
+  verified: boolean;
+  estimatedCostUsd: number;
+  costIncomplete: boolean;
+  outputTokens: number;
+  messageCount: number;
+  topModel: string | null;
+  installs: number;
+  updatedAtMs: number;
+}
+
+export interface LeaderboardResponse {
+  windowDays: 30;
+  total: number;
+  entries: LeaderboardEntry[];
+  generatedAtMs: number;
+}
+
+export interface LeaderboardConfig {
+  optIn: boolean;
+  joinedAtMs?: number;
+  lastSubmittedAtMs?: number;
+  lastRank?: number;
+  lastDisplayName?: string;
+}
+
+export interface LeaderboardStatus {
+  optIn: boolean;
+  lastRank: number | null;
+  lastDisplayName: string | null;
+  lastSubmittedAtMs: number | null;
+  doNotTrack: boolean;
+}

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -50,6 +50,8 @@ type ElectronApiMockOptions = {
   initialTerminalStates?: Record<string, JsonObject>;
   initialAgentUsage?: JsonObject;
   initialUsageReport?: JsonObject;
+  initialLeaderboardStatus?: JsonObject;
+  initialLeaderboard?: JsonObject;
   forcedAgentUsageError?: string;
   detectedBranch?: string | null;
   detectedBranchByPath?: Record<string, string | null>;
@@ -485,6 +487,24 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
           filesTotal: 0,
           lastError: null,
         }),
+      }),
+      leaderboard: namespace({
+        getStatus: () => success(clone(mockOptions.initialLeaderboardStatus ?? {
+          optIn: false,
+          lastRank: null,
+          lastDisplayName: null,
+          lastSubmittedAtMs: null,
+          doNotTrack: false,
+        })),
+        join: () => success({ rank: 1, displayName: '@testuser', verified: true, total: 1, installs: 1 }),
+        leave: () => success(undefined),
+        sendNow: () => success({ rank: 1, displayName: '@testuser', verified: true, total: 1, installs: 1 }),
+        fetch: () => success(clone(mockOptions.initialLeaderboard ?? {
+          windowDays: 30,
+          total: 0,
+          entries: [],
+          generatedAtMs: Date.now(),
+        })),
       }),
       cloud: namespace({
         getState: () => success(clone(cloudState)),

--- a/tests/leaderboard.spec.ts
+++ b/tests/leaderboard.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+const project = {
+  id: 400,
+  name: 'Leaderboard fixture',
+  path: '/tmp/lb-fixture',
+  active: true,
+  created_at: '2026-08-01T00:00:00.000Z',
+  updated_at: '2026-08-01T00:00:00.000Z',
+};
+
+const leaderboardEntries = {
+  windowDays: 30 as const,
+  total: 3,
+  entries: [
+    { rank: 1, displayName: '@jdoe', verified: true, estimatedCostUsd: 1204.10, costIncomplete: false, outputTokens: 41_200_000, messageCount: 6102, topModel: 'claude-opus-4', installs: 1, updatedAtMs: Date.now() },
+    { rank: 2, displayName: 'quiet-heron-91c0', verified: false, estimatedCostUsd: 688.55, costIncomplete: false, outputTokens: 22_000_000, messageCount: 3880, topModel: 'claude-opus-4', installs: 1, updatedAtMs: Date.now() },
+    { rank: 3, displayName: '@testuser', verified: true, estimatedCostUsd: 312.40, costIncomplete: false, outputTokens: 14_200_000, messageCount: 18204, topModel: 'claude-sonnet-5', installs: 1, updatedAtMs: Date.now() },
+  ],
+  generatedAtMs: Date.now(),
+};
+
+async function capture(page: Page, testInfo: TestInfo, filename: string): Promise<void> {
+  const path = testInfo.outputPath(filename);
+  await page.screenshot({ path, fullPage: true });
+  await testInfo.attach(filename, { path, contentType: 'image/png' });
+}
+
+test('leaderboard tab shows join banner and table before opt-in', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    activeProjectId: project.id,
+    initialLeaderboard: leaderboardEntries,
+  });
+  await page.setViewportSize({ width: 1200, height: 800 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await page.getByTestId('usage-nav').click();
+  await expect(page.getByRole('heading', { name: 'Usage & limits' })).toBeVisible();
+
+  // Click the Leaderboard tab
+  await page.getByRole('tab', { name: 'Leaderboard' }).click();
+
+  // Join banner is visible
+  await expect(page.getByRole('heading', { name: 'Join the leaderboard' })).toBeVisible();
+  await expect(page.getByText('Pane sends')).toBeVisible();
+  await expect(page.getByText('Pane never sends')).toBeVisible();
+
+  // Table is rendered (read-only, before consent)
+  await expect(page.getByText('@jdoe')).toBeVisible();
+  await expect(page.getByText('quiet-heron-91c0')).toBeVisible();
+  await expect(page.getByText('$1204.10')).toBeVisible();
+
+  // Provider/range toggles are hidden on leaderboard tab
+  await expect(page.getByRole('group', { name: 'Provider' })).toBeHidden();
+  await expect(page.getByRole('group', { name: 'Time range' })).toBeHidden();
+
+  await capture(page, testInfo, '01-leaderboard-before-join.png');
+});
+
+test('leaderboard tab shows joined banner when opted in', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    activeProjectId: project.id,
+    initialLeaderboardStatus: {
+      optIn: true,
+      lastRank: 3,
+      lastDisplayName: '@testuser',
+      lastSubmittedAtMs: Date.now() - 60_000,
+      doNotTrack: false,
+    },
+    initialLeaderboard: leaderboardEntries,
+  });
+  await page.setViewportSize({ width: 1200, height: 800 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await page.getByTestId('usage-nav').click();
+  await page.getByRole('tab', { name: 'Leaderboard' }).click();
+
+  // Joined banner — sendNow auto-fires on tab visit and the mock returns rank 1
+  const banner = page.getByText("You're on the leaderboard");
+  await expect(banner).toBeVisible();
+  await expect(page.getByText('ranked #1')).toBeVisible();
+
+  // Send now and Leave buttons
+  await expect(page.getByRole('button', { name: 'Send now' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Leave' })).toBeVisible();
+
+  // User's own row is highlighted with "you" label
+  const userRow = page.locator('tr').filter({ hasText: 'you' });
+  await expect(userRow).toBeVisible();
+  await expect(userRow.getByText('@testuser')).toBeVisible();
+
+  await capture(page, testInfo, '02-leaderboard-joined.png');
+});
+
+test('tab navigation switches between My usage and Leaderboard', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    activeProjectId: project.id,
+    initialLeaderboard: leaderboardEntries,
+  });
+  await page.setViewportSize({ width: 1200, height: 800 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await page.getByTestId('usage-nav').click();
+
+  // Default is My usage tab
+  const myUsageTab = page.getByRole('tab', { name: 'My usage' });
+  await expect(myUsageTab).toHaveAttribute('aria-selected', 'true');
+
+  // Switch to Leaderboard
+  await page.getByRole('tab', { name: 'Leaderboard' }).click();
+  await expect(page.getByRole('heading', { name: 'Join the leaderboard' })).toBeVisible();
+
+  // Switch back to My usage
+  await myUsageTab.click();
+  await expect(page.getByRole('group', { name: 'Provider' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Join the leaderboard' })).toBeHidden();
+
+  await capture(page, testInfo, '03-tab-navigation.png');
+});
+
+test('DO_NOT_TRACK disables join button', async ({ page }, testInfo) => {
+  await installElectronApiMock(page, {
+    initialProjects: [project],
+    activeProjectId: project.id,
+    initialLeaderboardStatus: {
+      optIn: false,
+      lastRank: null,
+      lastDisplayName: null,
+      lastSubmittedAtMs: null,
+      doNotTrack: true,
+    },
+    initialLeaderboard: leaderboardEntries,
+  });
+  await page.setViewportSize({ width: 1200, height: 800 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  await page.getByTestId('usage-nav').click();
+  await page.getByRole('tab', { name: 'Leaderboard' }).click();
+
+  // Join button is disabled
+  const joinButton = page.getByRole('button', { name: 'Join the leaderboard' });
+  await expect(joinButton).toBeDisabled();
+
+  // Warning message is visible
+  await expect(page.getByText('DO_NOT_TRACK is set')).toBeVisible();
+
+  await capture(page, testInfo, '04-do-not-track.png');
+});


### PR DESCRIPTION
## Summary

Phase 2 of the leaderboard feature — wires the desktop client to the server endpoints shipped in PR #155.

- **Leaderboard tab** in Usage & Limits with "My usage" / "Leaderboard" tab navigation
- **Join/leave flow** with full disclosure banner (what's sent vs what's never sent), join button, leave button, and Send Now
- **Automatic submission** on app open (after usage scan completes, bounded 15s wait) and on tab visit when opted in
- **DO_NOT_TRACK support** via login shell probe (`$SHELL -l -c 'echo $DO_NOT_TRACK'`), disables Join when set
- **Wire contract types** shared between main and renderer, matching the server API field-for-field
- **Config**: additive `leaderboard.optIn` on `AppConfig`, no migration

## Verification

- **Socrates gate**: pass (round 1) — necessity, fidelity, and completeness all satisfied; no simpler alternative delivers the same intent
- **Code review**: 1 must-fix found and resolved (DO_NOT_TRACK shell probe was a no-op — fixed to spawn login shell directly), 1 should-fix resolved (redundant IPC call on tab mount)
- **Build gate**: `pnpm typecheck` + `pnpm lint` (oxlint, eslint, boundary conformance, knip) all pass clean

Visual overview: none — backend service + IPC wiring + one new React component in an existing tab view; no new visual surfaces beyond the leaderboard table and join/leave banners that match the existing Usage & Limits design system.

## Residual risks

- No unit tests for `LeaderboardService` — the service has branching logic and a privacy-critical consent gate (DO_NOT_TRACK). AGENTS.md recommends colocated Vitest tests for backend logic. Should be added as follow-up.
- `submitOnAppOpen` exits after 15s even if the usage scan is still running, skipping that submission. This is by design (never block app start), but means the first submission for very large transcript sets may be deferred to the first tab visit.

<!-- pr-test-automation-summary:start -->
## QA results

**Status**: All automated tests pass (6/6)

**E2E tests** (`tests/leaderboard.spec.ts` — 4 tests, all pass):
1. **Join banner + table before opt-in** — Leaderboard tab renders the disclosure banner and the public board table (read-only, no POST)
2. **Joined banner when opted in** — Shows rank, display name, Send Now, Leave buttons; user's row highlighted with "you" label
3. **Tab navigation** — Switches between My usage and Leaderboard; provider/range controls hidden on Leaderboard tab, restored on My usage
4. **DO_NOT_TRACK** — Join button disabled with warning when `doNotTrack: true`

**Existing tests** (`tests/usage-and-limits.spec.ts` — 2 tests, all pass):
- Usage dashboard navigation and per-pane cost table unaffected by tab changes

**Build gate**: typecheck + lint (oxlint, eslint, boundary conformance, knip) all clean

**Remaining for human review**:
- Live app verification of actual leaderboard submission against runpane.com (requires running Electron app with real usage data)
- Visual polish check of the leaderboard table and banners in the running app across themes
<!-- pr-test-automation-summary:end -->
