### PR TITLE
probe: docs-only CI filter check (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,3 +454,4 @@ Run releases only from a clean `main` checkout that matches `origin/main`. The r
 <p align="center">
   <sub>Built by <a href="https://dcouple.ai">Dcouple Inc</a></sub>
 </p>
+


### PR DESCRIPTION
Throwaway probe to verify #558 path filters skip wrapper + cross-OS jobs. Will be closed.