### PR TITLE
probe: main-only CI filter check (do not merge)

### DIFF
--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -1541,3 +1541,5 @@ if (launchRemoteSetup) {
 export function getMainWindow(): BrowserWindow | null {
   return mainWindow;
 }
+
+// ci probe


### PR DESCRIPTION
Throwaway probe to verify #558 path filters run cross-OS main tests but skip the wrapper matrix. Will be closed.