### PR TITLE
Fix repositories section collapse regression

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -32,6 +32,7 @@ const SIDEBAR_ROW_PADDING = 'px-4';
 const SIDEBAR_ROW_GAP = 'gap-2';
 const SIDEBAR_SECTION_ROW = 'mt-1.5 flex w-full items-center justify-between gap-2 pl-3.5 pr-2 py-0.5';
 const SIDEBAR_SECTION_LABEL = 'truncate text-[11px] font-semibold uppercase tracking-wide leading-4 text-text-tertiary';
+const SIDEBAR_SECTION_TOGGLE = 'group/section relative z-20 -my-1 flex min-h-6 min-w-0 flex-1 items-center justify-between gap-2 py-1 text-left text-sm text-text-tertiary transition-colors hover:text-text-primary focus-visible:text-text-primary';
 
 interface ProjectSessionListProps {
   projects: Project[];
@@ -39,7 +40,9 @@ interface ProjectSessionListProps {
   onProjectsRefresh: () => void;
   sessionSortAscending: boolean;
   pinnedSectionExpanded: boolean;
+  repositoriesSectionExpanded: boolean;
   onPinnedSectionExpandedChange: (expanded: boolean) => void;
+  onRepositoriesSectionExpandedChange: (expanded: boolean) => void;
   /** Lets the sidebar footer's "Add repository" open this list's dialog. */
   onRegisterAddRepository?: (open: () => void) => void;
   showRemoteDesktopLink?: boolean;
@@ -53,7 +56,9 @@ export function ProjectSessionList({
   onProjectsRefresh,
   sessionSortAscending,
   pinnedSectionExpanded,
+  repositoriesSectionExpanded,
   onPinnedSectionExpandedChange,
+  onRepositoriesSectionExpandedChange,
   onRegisterAddRepository,
   showRemoteDesktopLink = false,
   onRemoteDesktopClick,
@@ -362,7 +367,7 @@ export function ProjectSessionList({
               <button
                 type="button"
                 onClick={() => onPinnedSectionExpandedChange(!pinnedSectionExpanded)}
-                className="group/section flex min-w-0 flex-1 items-center justify-between gap-2 text-left text-sm text-text-tertiary hover:text-text-primary focus-visible:text-text-primary transition-colors"
+                className={SIDEBAR_SECTION_TOGGLE}
               >
                 <span className={SIDEBAR_SECTION_LABEL}>Pinned</span>
                 <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover/section:opacity-100 group-focus-visible/section:opacity-100">
@@ -394,8 +399,25 @@ export function ProjectSessionList({
           </>
         )}
 
+        <div className={SIDEBAR_SECTION_ROW}>
+          <button
+            type="button"
+            onClick={() => onRepositoriesSectionExpandedChange(!repositoriesSectionExpanded)}
+            className={SIDEBAR_SECTION_TOGGLE}
+          >
+            <span className={SIDEBAR_SECTION_LABEL}>Repositories</span>
+            <span className="flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center opacity-0 transition-opacity group-hover/section:opacity-100 group-focus-visible/section:opacity-100">
+              {repositoriesSectionExpanded ? (
+                <ChevronDown className="h-3.5 w-3.5 text-current" />
+              ) : (
+                <ChevronRight className="h-3.5 w-3.5 text-current" />
+              )}
+            </span>
+          </button>
+        </div>
+
         {/* Projects */}
-        {projects.map((project, projectIndex) => {
+        {repositoriesSectionExpanded && projects.map((project, projectIndex) => {
           const isExpanded = expandedProjects.has(project.id);
           const projectSessions = sessionsByProject.get(project.id) || [];
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -710,7 +710,9 @@ export function Sidebar({ onAboutClick, onSettingsClick, onRemoteSettingsClick, 
             onProjectsRefresh={loadProjects}
             sessionSortAscending={sessionSortAscending}
             pinnedSectionExpanded={sidebarSectionExpansion.pinned}
+            repositoriesSectionExpanded={sidebarSectionExpansion.repositories}
             onPinnedSectionExpandedChange={handlePinnedSectionExpandedChange}
+            onRepositoriesSectionExpandedChange={handleRepositoriesSectionExpandedChange}
             onRegisterAddRepository={registerAddRepository}
             showRemoteDesktopLink={showRemoteDesktopLink}
             onRemoteDesktopClick={handleOpenRemoteDesktop}

--- a/tests/sidebar-compact.spec.ts
+++ b/tests/sidebar-compact.spec.ts
@@ -55,6 +55,47 @@ async function collapseSidebar(page: Page) {
 }
 
 test.describe('compact sidebar', () => {
+  test('collapses repositories from the full sidebar using the shared section state', async ({ page }) => {
+    await installElectronApiMock(page, {
+      initialConfig: { theme: 'night-owl' },
+      initialProjects: projects,
+      initialSessions: [
+        session('pinned', 'Pinned work', 1, {
+          isFavorite: true,
+          favoritePinnedAt: '2026-01-03T00:00:00.000Z',
+        }),
+        session('regular', 'Regular work', 1),
+      ],
+      initialUiState: {
+        expandedProjects: [1],
+        pinnedSectionExpanded: true,
+        repositoriesSectionExpanded: true,
+      },
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const pinnedToggle = page.getByRole('button', { name: 'Pinned', exact: true });
+    const repositoriesToggle = page.getByRole('button', { name: 'Repositories', exact: true });
+    await expect(pinnedToggle).toBeVisible();
+    await expect(repositoriesToggle).toBeVisible();
+    await expect(page.getByText('Alpha', { exact: true })).toBeVisible();
+
+    const [pinnedBox, repositoriesBox] = await Promise.all([
+      pinnedToggle.boundingBox(),
+      repositoriesToggle.boundingBox(),
+    ]);
+    expect(repositoriesBox?.height).toBe(pinnedBox?.height);
+
+    await repositoriesToggle.click();
+    await expect(page.getByText('Alpha', { exact: true })).toHaveCount(0);
+
+    await collapseSidebar(page);
+    await expect(page.getByTestId('compact-repositories-toggle')).toHaveAttribute('aria-expanded', 'false');
+    await page.getByTestId('compact-repositories-toggle').click();
+    await expect(page.getByTestId('compact-repository-1')).toBeVisible();
+  });
+
   test('shows the full pane title when hovering a long sidebar label', async ({ page }) => {
     const longPaneTitle = 'TIP416A · Show the complete descriptive pane title in the sidebar hover popover';
 
@@ -287,6 +328,8 @@ test.describe('compact sidebar', () => {
     });
 
     await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('button', { name: 'Repositories', exact: true })).toBeVisible();
+    await expect(page.getByText('Alpha', { exact: true })).toHaveCount(0);
     await collapseSidebar(page);
 
     await expect(page.getByTestId('compact-pinned-toggle')).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
## Summary
- restore the expanded-sidebar Repositories collapse toggle removed by #512
- keep the UI density refresh by matching the current 20px Pinned section header styling and interaction
- reuse the existing persisted sidebar section state shared with compact mode
- add regression coverage for initial hydration, shared state, and matching header height

## Testing
- `pnpm typecheck`
- `pnpm lint` (passes; five pre-existing warnings in `main/src/services/skillCacheManager.ts`)
- `pnpm test -- tests/sidebar-compact.spec.ts` (8 passed)

Fixes the Repositories collapse regression introduced by #512.