### PR TITLE
Fix Explorer action in add-tool menu

### DIFF
--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -381,6 +381,7 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
             onPanelSelect={handlePanelSelect}
             onPanelClose={handlePanelClose}
             onPanelCreate={handlePanelCreate}
+            onShowExplorer={() => { setInspectorTab('files'); setDetailVisible(true); }}
             projectEnvironment={projectEnvironment}
             context="project"
             onToggleDetailPanel={() => setDetailVisible(v => !v)}

--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -245,6 +245,12 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
     },
     [mainRepoSessionId, addPanel, setActivePanelInStore]
   );
+
+  const handleShowExplorer = useCallback(async () => {
+    if (!filesPanel) await handlePanelCreate('explorer');
+    setInspectorTab('files');
+    setDetailVisible(true);
+  }, [filesPanel, handlePanelCreate]);
   
   // Expose this view's tab / inspector actions to the global hotkeys.
   const setProjectViewActions = useProjectViewActionsStore((state) => state.setActions);
@@ -381,7 +387,7 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
             onPanelSelect={handlePanelSelect}
             onPanelClose={handlePanelClose}
             onPanelCreate={handlePanelCreate}
-            onShowExplorer={() => { setInspectorTab('files'); setDetailVisible(true); }}
+            onShowExplorer={() => { void handleShowExplorer(); }}
             projectEnvironment={projectEnvironment}
             context="project"
             onToggleDetailPanel={() => setDetailVisible(v => !v)}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1018,6 +1018,11 @@ export const SessionView = memo(() => {
     [activeSession, addPanel, setActivePanelInStore, applyLayout]
   );
 
+  const handleShowExplorer = useCallback(async () => {
+    if (!filesPanel) await handlePanelCreate('explorer');
+    openInspector('files');
+  }, [filesPanel, handlePanelCreate, openInspector]);
+
   // --- SplitLayout callbacks ---
   const handleSizesChange = useCallback((splitNodeId: string, sizes: number[]) => {
     if (!activeSession) return;
@@ -1796,7 +1801,7 @@ export const SessionView = memo(() => {
           onPanelSelect={handlePanelSelect}
           onPanelClose={handlePanelClose}
           onPanelCreate={handlePanelCreate}
-          onShowExplorer={() => openInspector('files')}
+          onShowExplorer={() => { void handleShowExplorer(); }}
           projectEnvironment={activeProjectEnvironment}
           onToggleDetailPanel={handleToggleDetailPanel}
           detailPanelVisible={detailVisible}

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1796,6 +1796,7 @@ export const SessionView = memo(() => {
           onPanelSelect={handlePanelSelect}
           onPanelClose={handlePanelClose}
           onPanelCreate={handlePanelCreate}
+          onShowExplorer={() => openInspector('files')}
           projectEnvironment={activeProjectEnvironment}
           onToggleDetailPanel={handleToggleDetailPanel}
           detailPanelVisible={detailVisible}

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -99,6 +99,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   onPanelSelect,
   onPanelClose,
   onPanelCreate,
+  onShowExplorer,
   projectEnvironment,
   context = 'worktree',  // Default to worktree for backward compatibility
   onToggleDetailPanel,
@@ -632,7 +633,10 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                   ref={(el) => { dropdownItemsRef.current[refIndex++] = el; }}
                   role="menuitem"
                   className={menuItemClass}
-                  onClick={() => handleAddPanel('explorer')}
+                  onClick={() => {
+                    onShowExplorer();
+                    setShowDropdown(false);
+                  }}
                 >
                   <FolderTree className="w-3.5 h-3.5 flex-shrink-0" />
                   <span className="truncate">Explorer</span>

--- a/frontend/src/types/panelComponents.ts
+++ b/frontend/src/types/panelComponents.ts
@@ -21,6 +21,7 @@ export interface PanelTabBarProps {
   onPanelSelect: (panel: ToolPanel) => void;
   onPanelClose: (panel: ToolPanel) => void;
   onPanelCreate: (type: ToolPanelType, options?: PanelCreateOptions) => void;
+  onShowExplorer: () => void;
   projectEnvironment?: ProjectEnvironment;
   context?: PanelContext;  // Optional context to filter available panels
   onToggleDetailPanel?: () => void;

--- a/tests/tab-popover.spec.ts
+++ b/tests/tab-popover.spec.ts
@@ -14,6 +14,11 @@ const panel = {
   state: { isActive: true, hasBeenViewed: true, customState: { isInitialized: false } },
   metadata: { createdAt: now, lastActiveAt: now, position: 0, permanent: true },
 };
+const explorerPanel = {
+  id: 'popover-explorer', sessionId: session.id, type: 'explorer', title: 'Explorer',
+  state: { isActive: false, hasBeenViewed: true, customState: {} },
+  metadata: { createdAt: now, lastActiveAt: now, position: 1, permanent: true },
+};
 
 test('add-tool popover supports keyboard navigation and dismissal', async ({ page }, testInfo) => {
   await installElectronApiMock(page, {
@@ -39,4 +44,19 @@ test('add-tool popover supports keyboard navigation and dismissal', async ({ pag
   await page.keyboard.press('Escape');
   await expect(menu).toBeHidden();
   await expect(trigger).toBeFocused();
+});
+
+test('Explorer in the add-tool menu opens the Files inspector', async ({ page }) => {
+  await installElectronApiMock(page, {
+    platform: 'darwin', initialProjects: [project], initialSessions: [session],
+    initialPanels: [panel, explorerPanel], activeProjectId: project.id,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Popover$/ }).click();
+  await page.getByRole('button', { name: 'Tool menu', exact: true }).click();
+
+  await page.getByRole('button', { name: 'Add tool', exact: true }).click();
+  await page.getByRole('menuitem', { name: 'Explorer', exact: false }).click();
+
+  await expect(page.getByRole('tab', { name: 'Files', exact: true })).toHaveAttribute('aria-selected', 'true');
 });

--- a/tests/tab-popover.spec.ts
+++ b/tests/tab-popover.spec.ts
@@ -14,12 +14,6 @@ const panel = {
   state: { isActive: true, hasBeenViewed: true, customState: { isInitialized: false } },
   metadata: { createdAt: now, lastActiveAt: now, position: 0, permanent: true },
 };
-const explorerPanel = {
-  id: 'popover-explorer', sessionId: session.id, type: 'explorer', title: 'Explorer',
-  state: { isActive: false, hasBeenViewed: true, customState: {} },
-  metadata: { createdAt: now, lastActiveAt: now, position: 1, permanent: true },
-};
-
 test('add-tool popover supports keyboard navigation and dismissal', async ({ page }, testInfo) => {
   await installElectronApiMock(page, {
     platform: 'darwin', initialProjects: [project], initialSessions: [session], initialPanels: [panel], activeProjectId: project.id,
@@ -46,10 +40,10 @@ test('add-tool popover supports keyboard navigation and dismissal', async ({ pag
   await expect(trigger).toBeFocused();
 });
 
-test('Explorer in the add-tool menu opens the Files inspector', async ({ page }) => {
+test('Explorer in the add-tool menu creates a missing panel and opens the Files inspector', async ({ page }) => {
   await installElectronApiMock(page, {
     platform: 'darwin', initialProjects: [project], initialSessions: [session],
-    initialPanels: [panel, explorerPanel], activeProjectId: project.id,
+    initialPanels: [panel], activeProjectId: project.id,
   });
   await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
   await page.getByRole('button', { name: /^Expand repository Popover$/ }).click();


### PR DESCRIPTION
## Summary
- route the add-tool menu's Explorer action to the Files inspector introduced by #512
- preserve the refreshed inspector-rail design in worktree and main-repository views
- add Playwright coverage for the exact `+` → `Explorer` regression

## Root cause
PR #512 moved Explorer out of the stage and into the Files inspector, and updated the Explorer hotkey to open that inspector. The `+` menu kept calling the legacy `onPanelCreate("explorer")` path, so it created a hidden Explorer panel without changing the inspector tab. Because Explorer remains non-singleton, the item stayed available and failed silently on every click.

## Testing
- `pnpm test -- tests/tab-popover.spec.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

Regression from #512.