### PR TITLE
Enable conditional Apple signing for mac builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,8 +70,13 @@ jobs:
         fi
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-        CSC_DISABLE: 'true'
+        CSC_LINK: ${{ secrets.CSC_LINK }}
+        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        CSC_IDENTITY_AUTO_DISCOVERY: ${{ runner.os == 'macOS' && secrets.CSC_LINK != '' && secrets.CSC_KEY_PASSWORD != '' && secrets.APPLE_ID != '' && secrets.APPLE_TEAM_ID != '' && secrets.APPLE_APP_SPECIFIC_PASSWORD != '' }}
+        CSC_DISABLE: ${{ runner.os != 'macOS' || secrets.CSC_LINK == '' || secrets.CSC_KEY_PASSWORD == '' || secrets.APPLE_ID == '' || secrets.APPLE_TEAM_ID == '' || secrets.APPLE_APP_SPECIFIC_PASSWORD == '' }}
 
     - run: ls -la dist-electron/
 

--- a/scripts/configure-build.js
+++ b/scripts/configure-build.js
@@ -16,7 +16,11 @@ function configureBuild() {
   const signingDisabled = process.env.CSC_DISABLE === 'true';
   
   // Check if we have Apple signing credentials
-  const hasAppleCertificate = !!(process.env.CSC_LINK || process.env.APPLE_CERTIFICATE);
+  const hasAppleCertificate = !!(
+    process.env.CSC_LINK
+    || process.env.APPLE_CERTIFICATE
+    || process.env.CSC_IDENTITY_AUTO_DISCOVERY === 'true'
+  );
   const hasAppleId = !!(process.env.APPLE_ID);
   const hasTeamId = !!(process.env.APPLE_TEAM_ID);
   const hasAppPassword = !!(process.env.APPLE_APP_SPECIFIC_PASSWORD || process.env.APPLE_APP_PASSWORD);


### PR DESCRIPTION
## Summary

- allow local macOS builds to sign through Keychain identity auto-discovery
- prepare the release workflow to sign and notarize only when the complete GitHub secret set is available
- preserve today's unsigned/no-op behavior whenever any required secret is absent

The August 24 signing discussion scoped signing to the dcouple launcher. Parsa has since changed that decision: the standalone Pane pipeline should be signed directly. The discussion file is intentionally unchanged.

## Local verification

Built Pane 2.4.88 for arm64 with hardened runtime and the existing `build/entitlements.mac.plist`, using only Keychain auto-discovery. electron-builder selected:

```text
identityName=Developer ID Application: Dcouple Inc (FBM5YSF467)
```

The arm64 app passed `codesign --verify --deep --strict`; `codesign -dv` reported `flags=0x10000(runtime)`, the Dcouple Developer ID authority, and team `FBM5YSF467`. The DMG container was also signed locally with the same Keychain identity and passed strict verification. Gatekeeper reported `source=Unnotarized Developer ID` for both, which is the expected remaining gap. The signed app was launched against an isolated Pane directory and remained running until closed after the smoke check.

Notarization was not attempted because `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD` are absent from the local environment.

## CI signing/notarization runbook

Do not commit certificate material or passwords.

1. In Keychain Access, find `Developer ID Application: Dcouple Inc (FBM5YSF467)` under **login > My Certificates**.
2. Expand the certificate, select the certificate and its associated private key together, then choose **File > Export Items**.
3. Export as Personal Information Exchange (`.p12`) and choose a new strong export password. This password becomes `CSC_KEY_PASSWORD`.
4. Base64-encode the exported file without printing it to the terminal:

   ```sh
   base64 -i DeveloperIDApplication.p12 | pbcopy
   ```

5. In GitHub, open **dcouple/Pane > Settings > Secrets and variables > Actions** and create these repository secrets:
   - `CSC_LINK`: paste the base64 value from the clipboard
   - `CSC_KEY_PASSWORD`: the `.p12` export password
   - `APPLE_ID`: the Apple ID email for the Dcouple developer account
   - `APPLE_TEAM_ID`: `FBM5YSF467`
   - `APPLE_APP_SPECIFIC_PASSWORD`: generate a new app-specific password at https://appleid.apple.com and paste it here
6. Delete the temporary `.p12` from local storage after the secrets are saved, and clear the clipboard.
7. Run the workflow manually with publishing disabled first. Confirm the macOS job logs show signing and successful notarization, then download the artifact and verify:

   ```sh
   codesign --verify --deep --strict --verbose=2 Pane.app
   spctl --assess --type execute --verbose=4 Pane.app
   xcrun stapler validate Pane.app
   ```

All five secrets must be present. The workflow sets `CSC_DISABLE=true` unless the runner is macOS and the full set is available.

## GitHub Actions status

Actions is currently usable for the dcouple organization/repository: the billing usage API responds, repository Actions permissions are enabled for all actions, and current Pane workflows are running and completing successfully. This differs from the billing lock recorded on August 24.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- unsigned/no-secrets `scripts/configure-build.js` dry run (no package diff)
- signed arm64 local package build
- strict app and DMG signature verification
- Gatekeeper assessment (expected unnotarized rejection)
- signed app launch smoke test
