### PR TITLE
Enable seamless signed macOS updates

### DIFF
--- a/frontend/src/components/UpdateDialog.tsx
+++ b/frontend/src/components/UpdateDialog.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { isMac } from '../utils/platformUtils';
 import { LiveRegion } from './ui/LiveRegion';
+import type { UpdateCapabilities } from '../../../shared/types/updater';
 
 interface UpdateDialogProps {
   isOpen: boolean;
@@ -35,6 +36,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [isPackaged, setIsPackaged] = useState(false);
+  const [updateCapabilities, setUpdateCapabilities] = useState<UpdateCapabilities | null>(null);
   const userStartedUpdateRef = useRef(false);
   const downloadStartedRef = useRef(false);
   const installStartedRef = useRef(false);
@@ -71,7 +73,21 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
         setIsPackaged(packaged);
       });
     }
+    if (window.electronAPI?.updater?.getCapabilities) {
+      window.electronAPI.updater.getCapabilities().then((response) => {
+        if (response.success && response.data) {
+          setUpdateCapabilities(response.data);
+        } else {
+          setUpdateCapabilities({ mode: 'manual', reason: 'untrusted-signature' });
+        }
+      }).catch(() => {
+        setUpdateCapabilities({ mode: 'manual', reason: 'untrusted-signature' });
+      });
+    }
   }, []);
+
+  const canUseSeamlessUpdater = !isMac() || updateCapabilities?.mode === 'seamless';
+  const isResolvingUpdateMode = isMac() && updateCapabilities === null;
 
   const startDownloadUpdate = useCallback(async () => {
     if (!window.electronAPI?.updater) {
@@ -145,7 +161,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     cleanupFns.push(
       window.electronAPI.events.onUpdaterUpdateAvailable(() => {
         setUpdateState('available');
-        if (userStartedUpdateRef.current && !isMac()) {
+        if (userStartedUpdateRef.current && canUseSeamlessUpdater) {
           void startDownloadUpdate();
         }
       })
@@ -169,6 +185,8 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       window.electronAPI.events.onUpdaterUpdateDownloaded(() => {
         setUpdateState('downloaded');
         setDownloadProgress(null);
+        // macOS presents an explicit restart prompt; preserve the existing
+        // automatic install behavior on other platforms.
         if (userStartedUpdateRef.current && !isMac()) {
           void installDownloadedUpdate();
         }
@@ -190,7 +208,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
     return () => {
       cleanupFns.forEach(fn => fn());
     };
-  }, [clearInstallTimeout, installDownloadedUpdate, isOpen, startDownloadUpdate]);
+  }, [canUseSeamlessUpdater, clearInstallTimeout, installDownloadedUpdate, isOpen, startDownloadUpdate]);
 
   const handleStartUpdate = async () => {
     if (!window.electronAPI?.updater) {
@@ -207,7 +225,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
       setMessage(null);
       setDownloadProgress(null);
 
-      if (isPackaged && isMac()) {
+      if (isMac() && !canUseSeamlessUpdater) {
         setUpdateState('checking');
         const response = await window.electronAPI.updater.openTerminalWithCommand();
         userStartedUpdateRef.current = false;
@@ -406,27 +424,21 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                 <h3 className="text-lg font-medium text-text-primary mb-2">Update Available</h3>
                 <p className="text-text-secondary mb-4">
                   A new version of Pane is available.
-                  {isPackaged && isMac()
+                  {isPackaged && isMac() && !canUseSeamlessUpdater
                     ? ' Click below to open the installer helper.'
                     : isPackaged
                       ? ' Click below to download and install the update.'
                       : ' Auto-update is only available in the packaged app.'}
                 </p>
 
-                {/*
-                 * Temporary workaround pending Apple code signing:
-                 * On macOS, electron-updater's quitAndInstall() fails because Gatekeeper
-                 * quarantines unsigned .zip replacements. Until the builds are signed, we
-                 * skip the in-app download flow entirely on macOS and direct users to
-                 * manually download and drag-install from GitHub instead.
-                 */}
                 {isPackaged ? (
                   <Button
                     onClick={handleStartUpdate}
                     variant="primary"
                     icon={<Download className="w-4 h-4" />}
+                    disabled={isResolvingUpdateMode}
                   >
-                    Update Pane
+                    {isResolvingUpdateMode ? 'Preparing update...' : 'Update Pane'}
                   </Button>
                 ) : (
                   <Button
@@ -442,7 +454,7 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
             {updateState === 'checking' && (
               <div className="flex items-center gap-3 text-text-secondary">
                 <Loader2 className="w-5 h-5 animate-spin" />
-                <span>{isMac() ? 'Opening installer helper...' : 'Checking for update...'}</span>
+                <span>{isMac() && !canUseSeamlessUpdater ? 'Opening installer helper...' : 'Checking for update...'}</span>
               </div>
             )}
 
@@ -497,14 +509,25 @@ export function UpdateDialog({ isOpen, onClose, versionInfo }: UpdateDialogProps
                   <CheckCircle className="w-5 h-5 text-status-success mt-0.5" />
                   <div className="flex-1">
                     <h3 className="text-lg font-medium text-status-success mb-2">Update Downloaded</h3>
-                    {/* Safety guard: quitAndInstall() doesn't work on unsigned macOS builds */}
-                    {isMac() ? (
+                    {isMac() && !canUseSeamlessUpdater ? (
                       <div className="space-y-4">
                         <p className="text-text-secondary">
                           Please install the update manually to ensure it works correctly on macOS.
                         </p>
                         {renderMacUpdateActions()}
                       </div>
+                    ) : isMac() ? (
+                      <>
+                        <p className="text-text-secondary mb-4">
+                          The update is ready. Restart Pane to finish installing it.
+                        </p>
+                        <Button
+                          onClick={() => void installDownloadedUpdate()}
+                          variant="primary"
+                        >
+                          Restart now
+                        </Button>
+                      </>
                     ) : (
                       <>
                         <p className="text-text-secondary mb-4">

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -41,6 +41,7 @@ import type { LeaderboardResponse, LeaderboardStatus, LeaderboardSubmitResult } 
 import type { CreateSessionRequest } from './session';
 import type { DetectedProjectConfig } from '../../../shared/types/projectConfig';
 import type { CloudVmState } from '../../../shared/types/cloud';
+import type { UpdateCapabilities } from '../../../shared/types/updater';
 import type {
   ProjectDashboardData,
   ProjectDashboardSessionUpdateEvent,
@@ -105,6 +106,7 @@ interface ElectronAPI {
   
   // Auto-updater
   updater: {
+    getCapabilities: () => Promise<IPCResponse<UpdateCapabilities>>;
     checkAndDownload: () => Promise<IPCResponse>;
     downloadUpdate: () => Promise<IPCResponse>;
     installUpdate: () => Promise<IPCResponse>;

--- a/main/src/ipc/updater.ts
+++ b/main/src/ipc/updater.ts
@@ -7,10 +7,20 @@ import { execFile } from 'child_process';
 import { commandExecutor } from '../utils/commandExecutor';
 import { getCurrentWorktreeName } from '../utils/worktreeUtils';
 import { getAppDirectory } from '../utils/appDirectory';
+import { getUpdateCapabilities } from '../utils/updateCapabilities';
 
 const MAC_UPDATE_COMMAND = 'curl -fsSL https://runpane.com/install.sh | sh';
 
 export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker }: AppServices): void {
+  ipcMain.handle('updater:get-capabilities', async () => ({
+    success: true,
+    data: await getUpdateCapabilities({
+      platform: process.platform,
+      isPackaged: app.isPackaged,
+      executablePath: process.execPath,
+    }),
+  }));
+
   // Version checking handlers
   ipcMain.handle('version:check-for-updates', async () => {
     try {
@@ -190,15 +200,6 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
     }
   });
 
-  /**
-   * Temporary workaround pending Apple code signing:
-   * `quitAndInstall()` does not work on unsigned macOS builds because Gatekeeper
-   * quarantines the downloaded update, preventing it from replacing the running app.
-   * The frontend guards against calling this handler on macOS — users are directed to
-   * download and drag-install manually from GitHub instead. This handler remains in
-   * place for Windows (where auto-update works correctly) and as a no-op path for any
-   * unexpected macOS invocations until builds are signed with an Apple Developer ID.
-   */
   ipcMain.handle('updater:install-update', () => {
     try {
       if (!app.isPackaged && !process.env.TEST_UPDATES) {

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -448,6 +448,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   
   // Auto-updater
   updater: {
+    getCapabilities: (): Promise<IPCResponse> => invokeIpc('updater:get-capabilities'),
     checkAndDownload: (): Promise<IPCResponse> => invokeIpc('updater:check-and-download'),
     downloadUpdate: (): Promise<IPCResponse> => invokeIpc('updater:download-update'),
     installUpdate: (): Promise<IPCResponse> => invokeIpc('updater:install-update'),

--- a/main/src/utils/updateCapabilities.test.ts
+++ b/main/src/utils/updateCapabilities.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getMacAppBundlePath,
+  getUpdateCapabilities,
+  verifyDcoupleMacSignature,
+} from './updateCapabilities';
+
+describe('update capabilities', () => {
+  it('preserves seamless updates on non-macOS platforms', async () => {
+    await expect(getUpdateCapabilities({
+      platform: 'win32',
+      isPackaged: true,
+      executablePath: 'C:\\Pane\\Pane.exe',
+    })).resolves.toEqual({ mode: 'seamless', reason: 'platform-supported' });
+  });
+
+  it('keeps development and unsigned macOS builds on the manual path', async () => {
+    await expect(getUpdateCapabilities({
+      platform: 'darwin',
+      isPackaged: false,
+      executablePath: '/Applications/Pane.app/Contents/MacOS/Pane',
+    })).resolves.toEqual({ mode: 'manual', reason: 'development-build' });
+
+    await expect(getUpdateCapabilities({
+      platform: 'darwin',
+      isPackaged: true,
+      executablePath: '/Applications/Pane.app/Contents/MacOS/Pane',
+      verifySignature: async () => false,
+    })).resolves.toEqual({ mode: 'manual', reason: 'untrusted-signature' });
+  });
+
+  it('enables seamless updates for a trusted packaged macOS build', async () => {
+    const verifySignature = vi.fn(async () => true);
+    await expect(getUpdateCapabilities({
+      platform: 'darwin',
+      isPackaged: true,
+      executablePath: '/Applications/Pane.app/Contents/MacOS/Pane',
+      verifySignature,
+    })).resolves.toEqual({ mode: 'seamless', reason: 'trusted-dcouple-signature' });
+    expect(verifySignature).toHaveBeenCalledWith('/Applications/Pane.app');
+  });
+
+  it('falls back safely when signature verification fails', async () => {
+    await expect(getUpdateCapabilities({
+      platform: 'darwin',
+      isPackaged: true,
+      executablePath: '/Applications/Pane.app/Contents/MacOS/Pane',
+      verifySignature: async () => { throw new Error('codesign unavailable'); },
+    })).resolves.toEqual({ mode: 'manual', reason: 'untrusted-signature' });
+  });
+
+  it('requires both the Dcouple authority and team identifier', async () => {
+    const command = vi.fn(async (_file: string, args: string[]) => ({
+      stderr: args.includes('-dv')
+        ? 'Authority=Developer ID Application: Dcouple Inc (FBM5YSF467)\nTeamIdentifier=FBM5YSF467\n'
+        : '',
+    }));
+    await expect(verifyDcoupleMacSignature('/Applications/Pane.app', command)).resolves.toBe(true);
+    expect(command).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects executable paths outside an app bundle', () => {
+    expect(getMacAppBundlePath('/usr/local/bin/pane')).toBeNull();
+  });
+});

--- a/main/src/utils/updateCapabilities.ts
+++ b/main/src/utils/updateCapabilities.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import path from 'path';
+import { posix as path } from 'path';
 import type { UpdateCapabilities } from '../../../shared/types/updater';
 
 const DCOUPLE_DEVELOPER_ID = 'Authority=Developer ID Application: Dcouple Inc (FBM5YSF467)';

--- a/main/src/utils/updateCapabilities.ts
+++ b/main/src/utils/updateCapabilities.ts
@@ -1,0 +1,74 @@
+import { execFile } from 'child_process';
+import path from 'path';
+import type { UpdateCapabilities } from '../../../shared/types/updater';
+
+const DCOUPLE_DEVELOPER_ID = 'Authority=Developer ID Application: Dcouple Inc (FBM5YSF467)';
+const DCOUPLE_TEAM_ID = 'TeamIdentifier=FBM5YSF467';
+
+interface CommandResult {
+  stderr: string;
+}
+
+type RunCommand = (file: string, args: string[]) => Promise<CommandResult>;
+type VerifySignature = (appBundlePath: string) => Promise<boolean>;
+
+interface UpdateCapabilitiesOptions {
+  platform: NodeJS.Platform;
+  isPackaged: boolean;
+  executablePath: string;
+  verifySignature?: VerifySignature;
+}
+
+function runCommand(file: string, args: string[]): Promise<CommandResult> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { encoding: 'utf8' }, (error, _stdout, stderr) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve({ stderr });
+    });
+  });
+}
+
+export function getMacAppBundlePath(executablePath: string): string | null {
+  const appBundlePath = path.resolve(executablePath, '..', '..', '..');
+  return appBundlePath.endsWith('.app') ? appBundlePath : null;
+}
+
+export async function verifyDcoupleMacSignature(
+  appBundlePath: string,
+  command: RunCommand = runCommand,
+): Promise<boolean> {
+  await command('/usr/bin/codesign', ['--verify', '--deep', '--strict', appBundlePath]);
+  const details = await command('/usr/bin/codesign', ['-dv', '--verbose=2', appBundlePath]);
+  return details.stderr.includes(DCOUPLE_DEVELOPER_ID) && details.stderr.includes(DCOUPLE_TEAM_ID);
+}
+
+export async function getUpdateCapabilities({
+  platform,
+  isPackaged,
+  executablePath,
+  verifySignature = verifyDcoupleMacSignature,
+}: UpdateCapabilitiesOptions): Promise<UpdateCapabilities> {
+  if (platform !== 'darwin') {
+    return { mode: 'seamless', reason: 'platform-supported' };
+  }
+  if (!isPackaged) {
+    return { mode: 'manual', reason: 'development-build' };
+  }
+
+  const appBundlePath = getMacAppBundlePath(executablePath);
+  if (!appBundlePath) {
+    return { mode: 'manual', reason: 'untrusted-signature' };
+  }
+
+  try {
+    const isTrusted = await verifySignature(appBundlePath);
+    return isTrusted
+      ? { mode: 'seamless', reason: 'trusted-dcouple-signature' }
+      : { mode: 'manual', reason: 'untrusted-signature' };
+  } catch {
+    return { mode: 'manual', reason: 'untrusted-signature' };
+  }
+}

--- a/shared/types/updater.ts
+++ b/shared/types/updater.ts
@@ -1,0 +1,12 @@
+export type UpdateMode = 'seamless' | 'manual';
+
+export type UpdateModeReason =
+  | 'platform-supported'
+  | 'development-build'
+  | 'trusted-dcouple-signature'
+  | 'untrusted-signature';
+
+export interface UpdateCapabilities {
+  mode: UpdateMode;
+  reason: UpdateModeReason;
+}


### PR DESCRIPTION
## Summary

- detect whether the running macOS app has a valid Dcouple Developer ID signature (team `FBM5YSF467`)
- route trusted stable installs through `electron-updater` while preserving the Terminal/DMG helper for unsigned, nightly, development, or unverifiable builds
- download the update from one click and show an explicit **Restart now** action once it is ready
- preserve the existing manual fallback when automatic updating fails

This is intentionally stacked on #566, which enables signed and notarized stable macOS artifacts. The first transition from an older unsigned Pane build still uses the manual installer; after installing a signed build containing this change, later stable releases use the seamless path.

Doozy's updater was reviewed as a reference. Pane follows its downloaded/ready/`quitAndInstall()` lifecycle, with an additional runtime signature gate because Pane continues to publish intentionally unsigned nightly builds.

## Testing

- `pnpm --filter main exec vitest run src/utils/updateCapabilities.test.ts` (6 tests passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 5 pre-existing warnings in `skillCacheManager.ts`)
- `pnpm --filter main build`
- `pnpm --filter frontend build`
- runtime capability check against the locally signed Phase A app: `{"mode":"seamless","reason":"trusted-dcouple-signature"}`

## Dependency

- stacked on #566; merge that signing PR first
- no secrets or release artifacts are added by this PR
