### PR TITLE
fix: stop the launcher flash on pane switch and shorten the terminal activation mask

### DIFF
--- a/frontend/src/components/ProjectView.tsx
+++ b/frontend/src/components/ProjectView.tsx
@@ -105,7 +105,9 @@ export const ProjectView: React.FC<ProjectViewProps> = ({
         // live in the inspector, not the stage).
         const fallback = loadedPanels.find(p => p.type !== 'diff' && p.type !== 'explorer');
 
-        const activePanel = await panelApi.getActivePanel(mainRepoSessionId);
+        // Already in loadedPanels; panelApi.getActivePanel would re-run the
+        // identical getSessionPanels query to find it.
+        const activePanel = loadedPanels.find(panel => panel.state.isActive) ?? null;
         if (activePanel) {
           setActivePanelInStore(mainRepoSessionId, activePanel.id);
         } else if (fallback) {

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -214,8 +214,19 @@ export const SessionView = memo(() => {
     }
   }, [setLayoutInStore, setFocusedGroupInStore, debouncedPersist, setActivePanelInStore]);
 
+  // Which session's layout load has settled. The stage renders the "Open"
+  // launcher only for a session whose layout is known to be absent -- never as
+  // a stand-in for one still in flight, which flashed the launcher over the
+  // outgoing terminal on every switch.
+  const [settledLayoutSessionId, setSettledLayoutSessionId] = useState<string | null>(null);
+  const stageSettled = !!activeSession?.id && settledLayoutSessionId === activeSession.id;
+
   // Load panels AND layout when session changes
   useEffect(() => {
+    // A fast A -> B -> A flip can land an older chain after a newer one;
+    // without this the stale response re-publishes its snapshot over the
+    // fresher store state and re-runs the stage's mount.
+    let cancelled = false;
     if (activeSession?.id) {
       const sid = activeSession.id;
       devLog.debug('[SessionView] Loading panels for session:', sid);
@@ -232,8 +243,18 @@ export const SessionView = memo(() => {
         (usePanelStore.getState().panels[sid] || []).map(p => p.id)
       );
 
+      // Panels and layout are independent reads; main writes neither in
+      // between, so they go out together instead of head-to-tail. The stage
+      // stays blank until the layout lands, so this pair is the switch's
+      // visible latency.
+      const layoutRequest = panelApi.getLayout(sid).then(
+        stored => ({ ok: true as const, stored }),
+        err => ({ ok: false as const, err }),
+      );
+
       // Always reload panels from database when switching sessions
       panelApi.loadPanelsForSession(sid).then(async loadedPanels => {
+        if (cancelled) return;
         devLog.debug('[SessionView] Loaded panels:', loadedPanels);
         const sessionState = useSessionStore.getState();
         const loadedSession = sessionState.activeMainRepoSession?.id === sid
@@ -248,7 +269,9 @@ export const SessionView = memo(() => {
         // Preserve the existing startup preference without blocking Review.
         const fallback = pickDefaultPanel(loadedPanels, hasReviewPr);
 
-        const activePanelResult = await panelApi.getActivePanel(sid);
+        // The active panel is already in loadedPanels; panelApi.getActivePanel
+        // would re-run the identical getSessionPanels query to find it.
+        const activePanelResult = loadedPanels.find(panel => panel.state.isActive) ?? null;
         const effectiveActivePanel = activePanelResult ?? fallback;
         const fallbackActiveId = effectiveActivePanel?.id ?? null;
 
@@ -278,8 +301,11 @@ export const SessionView = memo(() => {
           return (a.metadata?.position ?? 0) - (b.metadata?.position ?? 0);
         });
 
+        const layoutResult = await layoutRequest;
+        if (cancelled) return;
         try {
-          const stored = await panelApi.getLayout(sid);
+          if (!layoutResult.ok) throw layoutResult.err;
+          const stored = layoutResult.stored;
           // Recompute live ids from the store at set time: panel:created
           // events that landed while this load was in flight are in the store
           // but not in the loadedPanels snapshot. Reconciling against the
@@ -309,11 +335,19 @@ export const SessionView = memo(() => {
           setLayoutInStore(sid, layout);
           setFocusedGroupInStore(sid, layout.focusedGroupId ?? primaryGroup(layout.root).id);
         }
+        setSettledLayoutSessionId(sid);
+      }).catch(err => {
+        // A failed panel read used to fall through to an undefined layout,
+        // which rendered the launcher. Settle explicitly so the stage still
+        // offers a way out instead of staying blank.
+        console.warn('[SessionView] Failed to load panels for session:', sid, err);
+        if (!cancelled) setSettledLayoutSessionId(sid);
       });
     }
 
     // Flush layout on cleanup (session switch or unmount)
     return () => {
+      cancelled = true;
       flushLayoutPersist();
     };
   }, [activeSession?.id, setPanels, setActivePanelInStore, setLayoutInStore, setFocusedGroupInStore, flushLayoutPersist]);
@@ -1192,7 +1226,7 @@ export const SessionView = memo(() => {
   // The empty stage is the "+" menu laid out inline: one click (or the
   // shortcut beside it) from a running tool, instead of a placeholder.
   const emptyStage = useMemo(() => (
-    <div className="flex h-full flex-1 items-center justify-center">
+    <div className="flex h-full flex-1 items-center justify-center" data-testid="empty-stage">
       <div className="w-64">
         <div className="mb-2 px-2 text-[11px] font-semibold uppercase tracking-wide text-text-muted">Open</div>
         {[
@@ -1850,7 +1884,7 @@ export const SessionView = memo(() => {
               <div ref={centerColumnBox.ref} className="pane-center-column flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
                 {/* Top: active panel content */}
                 <div className="pane-editor-stage flex-1 relative min-h-0 overflow-hidden bg-bg-editor">
-                  {editorStageElement || emptyStage}
+                  {editorStageElement ?? (stageSettled ? emptyStage : null)}
                 </div>
 
                 {/* Bottom: horizontal detail panel */}
@@ -1931,7 +1965,7 @@ export const SessionView = memo(() => {
               <div ref={centerColumnBox.ref} className="pane-center-column flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
                 {/* Top: active panel content */}
                 <div className="pane-editor-stage flex-1 relative min-h-0 overflow-hidden bg-bg-editor">
-                  {editorStageElement || emptyStage}
+                  {editorStageElement ?? (stageSettled ? emptyStage : null)}
                 </div>
 
                 {/* Bottom: persistent terminal (collapsible) */}

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -48,7 +48,10 @@ interface DropdownPosition {
 
 // Hold the loading overlay at least this long past ready so the terminal
 // underneath finishes painting before it is revealed.
-const TERMINAL_OVERLAY_LINGER_MS = 150;
+// Ceiling for the post-activation settle wait. This was a flat 150 ms linger
+// "so the terminal underneath has finished painting"; the mask now waits for
+// that to actually be true and only falls back to the ceiling.
+const TERMINAL_OVERLAY_LINGER_CEILING_MS = 150;
 
 const SKELETON_TRANSCRIPT_WIDTHS = ['w-2/3', 'w-1/2', 'w-5/6', 'w-1/3', 'w-3/4', 'w-2/5'];
 
@@ -97,7 +100,11 @@ const DEFAULT_TERMINAL_FONT_FAMILY = 'Geist Mono';
 const DEFAULT_TERMINAL_FONT_SIZE = 14;
 const WEBGL_APP_BLUR_DETACH_DELAY_MS = 10_000;
 const REFOCUS_DELAYED_REFRESH_MS = 300;
-const TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS = 200;
+// Ceiling for the same wait on the activation path. a69c8b5 raised this from 0
+// to a flat 200 ms because reflow could continue past the first paint; the mask
+// now waits for the grid and container to stop moving and uses this only as an
+// upper bound when they never settle.
+const TERMINAL_ACTIVATION_MASK_CEILING_MS = 200;
 const TERMINAL_VISIBILITY_REFRESH_MS = 60_000;
 const SNAPSHOT_MIN_INTERVAL_MS = 10_000;
 const MIN_VIABLE_RECT_PX = 100; // below this the container is hidden or mid-layout (Allotment minSize is 120)
@@ -159,6 +166,52 @@ function waitForNextPaint(): Promise<void> {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => resolve());
     });
+  });
+}
+
+/**
+ * Resolves once the rendered geometry has stopped moving: two consecutive
+ * frames agreeing on the container width and the terminal's grid. This is the
+ * condition the old fixed mask delays were standing in for -- lifting the mask
+ * mid-reflow is what a69c8b5 was papering over. Resolves early on the ceiling
+ * so a container that never settles cannot strand the mask, and on cancel so a
+ * torn-down activation stops sampling.
+ */
+function waitForGeometrySettled(
+  container: HTMLElement | null,
+  terminal: Terminal | null,
+  ceilingMs: number,
+  isCancelled: () => boolean,
+): Promise<void> {
+  if (!container || !terminal) return Promise.resolve();
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(ceiling);
+      resolve();
+    };
+    // The ceiling is a real timer, not a frame budget: frames stop entirely
+    // behind a hidden window or a throttled rAF, and a frame-counted ceiling
+    // would strand the mask up rather than lifting it.
+    const ceiling = setTimeout(finish, ceilingMs);
+    let previous: string | null = null;
+    const sample = () => {
+      if (settled) return;
+      if (isCancelled()) {
+        finish();
+        return;
+      }
+      const current = `${container.clientWidth}x${terminal.cols}x${terminal.rows}`;
+      if (current === previous) {
+        finish();
+        return;
+      }
+      previous = current;
+      requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
   });
 }
 
@@ -375,8 +428,8 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
   }, [terminalState?.isCliReady, isCliReady]);
 
   // Loading-skeleton visibility: show immediately when any loading state is
-  // active, hide only after a short linger so the terminal underneath has
-  // finished painting before the mask lifts.
+  // active, hide once the terminal underneath has actually settled rather than
+  // after a flat linger.
   const overlayActive = !isInitialized || isRefreshing || (isCliPanel && !isCliReady);
   const [overlayVisible, setOverlayVisible] = useState(true);
   useEffect(() => {
@@ -384,8 +437,16 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
       setOverlayVisible(true);
       return;
     }
-    const lingerTimer = setTimeout(() => setOverlayVisible(false), TERMINAL_OVERLAY_LINGER_MS);
-    return () => clearTimeout(lingerTimer);
+    let cancelled = false;
+    void waitForGeometrySettled(
+      terminalRef.current,
+      xtermRef.current,
+      TERMINAL_OVERLAY_LINGER_CEILING_MS,
+      () => cancelled,
+    ).then(() => {
+      if (!cancelled) setOverlayVisible(false);
+    });
+    return () => { cancelled = true; };
   }, [overlayActive]);
 
   // Listen for cliReady event (only for CLI panels that aren't already ready)
@@ -813,7 +874,12 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     try {
       await handleRefreshTerminal();
       await waitForNextPaint();
-      await new Promise(resolve => setTimeout(resolve, TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS));
+      await waitForGeometrySettled(
+        terminalRef.current,
+        xtermRef.current,
+        TERMINAL_ACTIVATION_MASK_CEILING_MS,
+        () => false,
+      );
     } finally {
       setIsRefreshing(false);
     }
@@ -1945,24 +2011,48 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     // Both full and hot panel activations stay behind the existing opaque mask.
     if (fullRefresh || hotActivation) setIsRefreshing(true);
 
-    let lastWidth = 0;
+    // -1 marks "not measured yet" so a first measurement that is already
+    // viable is not mistaken for a width that changed.
+    let lastWidth = -1;
     let retries = 0;
     const MAX_RETRIES = 10;
 
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let retryFrame: number | null = null;
     let delayedRefreshTimer: ReturnType<typeof setTimeout> | null = null;
-    let hideOverlayTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Lift the mask once the grid has stopped moving instead of after a fixed
+    // delay; the ceiling keeps a never-settling container from stranding it.
+    const settleThenLiftMask = () => waitForGeometrySettled(
+      terminalRef.current,
+      xtermRef.current,
+      TERMINAL_ACTIVATION_MASK_CEILING_MS,
+      () => cancelled,
+    ).then(() => {
+      if (!cancelled) setIsRefreshing(false);
+    });
 
     const fitAndRefresh = () => {
       if (cancelled || !fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
 
       const containerWidth = terminalRef.current.clientWidth;
-      // If width is still changing or below viable threshold, the reflow isn't done — retry
-      if ((containerWidth < MIN_VIABLE_RECT_PX || containerWidth !== lastWidth) && retries < MAX_RETRIES) {
+      const viable = containerWidth >= MIN_VIABLE_RECT_PX;
+      // Two consecutive agreeing measurements still gate the replay (#233 --
+      // replaying into a mid-layout container corrupts the grid). What changed
+      // is the cost of collecting them: a viable first measurement is confirmed
+      // on the next frame rather than paying a fixed 50 ms tick to learn the
+      // same thing. A non-viable or genuinely changing width is mid-layout and
+      // keeps the slower tick, which is what that delay was for.
+      if ((!viable || containerWidth !== lastWidth) && retries < MAX_RETRIES) {
+        const confirmingFirstViableWidth = viable && lastWidth === -1;
         lastWidth = containerWidth;
         retries++;
-        retryTimer = setTimeout(fitAndRefresh, 50);
+        if (confirmingFirstViableWidth) {
+          retryFrame = requestAnimationFrame(fitAndRefresh);
+        } else {
+          retryTimer = setTimeout(fitAndRefresh, 50);
+        }
         return;
       }
 
@@ -1999,29 +2089,29 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           xtermRef.current?.focus();
         }
 
+        // The mask has to outlast this backstop, not just the first paint. It
+        // re-runs the same depth, and for a full refresh that depth is a
+        // reset+replay -- lifting earlier exposes a terminal that is about to
+        // be wiped, taking the user's selection and any typed input with it.
+        // The old fixed delays happened to satisfy this (200 + 150 > 300); an
+        // early settle does not, so the lift is chained to the backstop.
         delayedRefreshTimer = setTimeout(() => {
           void (async () => {
-            if (cancelled || !fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
-            forwardToMainLog('info', `[TerminalPanel] Delayed activation refresh for panel ${panel.id}`);
-            if (fullRefresh) await handleRefreshTerminal();
-            else if (hotActivation) await reconcileMountedTerminal();
-            else repaintTerminal();
-            if (!hotActivation) return;
-            await waitForNextPaint();
-            if (cancelled) return;
-            hideOverlayTimer = setTimeout(() => {
-              if (!cancelled) setIsRefreshing(false);
-            }, TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS);
+            try {
+              if (cancelled || !fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
+              forwardToMainLog('info', `[TerminalPanel] Delayed activation refresh for panel ${panel.id}`);
+              if (fullRefresh) await handleRefreshTerminal();
+              else if (hotActivation) await reconcileMountedTerminal();
+              else repaintTerminal();
+              if (!fullRefresh && !hotActivation) return;
+              await waitForNextPaint();
+            } finally {
+              // Runs even when the backstop bails on a torn-down ref, so a
+              // bail cannot strand the mask up.
+              if (fullRefresh || hotActivation) void settleThenLiftMask();
+            }
           })();
         }, REFOCUS_DELAYED_REFRESH_MS);
-
-        if (fullRefresh) {
-          // Full refresh keeps the historical mask timing. Hot activation keeps
-          // the mask through its delayed fit/reconcile/refresh backstop above.
-          hideOverlayTimer = setTimeout(() => {
-            if (!cancelled) setIsRefreshing(false);
-          }, TERMINAL_ACTIVATION_MASK_AFTER_PAINT_MS);
-        }
       });
     };
 
@@ -2030,9 +2120,9 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
     return () => {
       cancelled = true;
       cancelAnimationFrame(animationFrame);
+      if (retryFrame !== null) cancelAnimationFrame(retryFrame);
       if (retryTimer) clearTimeout(retryTimer);
       if (delayedRefreshTimer) clearTimeout(delayedRefreshTimer);
-      if (hideOverlayTimer) clearTimeout(hideOverlayTimer);
       setIsRefreshing(false);
     };
   }, [activationVisible, panelVisible, useBatterySaverTerminalVisibility, panel.id, isInitialized, autoFocus, handleRefreshTerminal, reconcileMountedTerminal, repaintTerminal, forwardToMainLog]);

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -169,6 +169,12 @@ function waitForNextPaint(): Promise<void> {
   });
 }
 
+/** Identity of the rendered geometry: what the activation refresh depends on. */
+function readGeometry(container: HTMLElement | null, terminal: Terminal | null): string | null {
+  if (!container || !terminal) return null;
+  return `${container.clientWidth}x${terminal.cols}x${terminal.rows}`;
+}
+
 /**
  * Resolves once the rendered geometry has stopped moving: two consecutive
  * frames agreeing on the container width and the terminal's grid. This is the
@@ -794,13 +800,16 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
   // Refresh. Eligible same-session hot
   // activations use reconcileMountedTerminal instead and never enter this
   // function.
-  const handleRefreshTerminal = useCallback(async () => {
+  // Reports whether the reset+replay actually ran: it bails on a mid-layout
+  // container, and the delayed backstop is the path that populates the buffer
+  // when it does. A caller that skips the backstop has to know the difference.
+  const handleRefreshTerminal = useCallback(async (): Promise<boolean> => {
     const terminal = xtermRef.current;
-    if (!terminal) return;
+    if (!terminal) return false;
     // Entry guard: never reset+replay into a tiny/unsettled container (width only,
     // matching resizePtyToFit: height-constrained panes are legitimate layouts)
     const rect = terminalRef.current?.getBoundingClientRect();
-    if (!rect || rect.width < MIN_VIABLE_RECT_PX) return;
+    if (!rect || rect.width < MIN_VIABLE_RECT_PX) return false;
     try {
       const scrollSnapshot = (() => {
         const buffer = terminal.buffer.active;
@@ -839,7 +848,7 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
           terminal.refresh(0, terminal.rows - 1);
         }
         restoreScrollPosition();
-        return;
+        return true;
       }
 
       terminal.reset();
@@ -860,12 +869,14 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
               void finishRefresh().then(resolve, reject);
             });
           });
-          return;
+          return true;
         }
       }
       await finishRefresh();
+      return true;
     } catch (e) {
       console.warn('[TerminalPanel] Failed to refresh terminal:', e);
+      return false;
     }
   }, [panel.id, resizePtyToFit]);
 
@@ -2071,11 +2082,12 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
         const depth = fullRefresh ? 'full' : hotActivation ? 'hot' : 'light';
         forwardToMainLog('info', `[TerminalPanel] Activation depth for panel ${panel.id}: ${depth}`);
 
+        let firstRefreshLanded = true;
         if (fullRefresh) {
           // Consume the flag only when the full refresh actually executes, so a
           // bail or an activate-then-blur cancellation leaves it armed.
           needsFullActivationRefreshRef.current = false;
-          await handleRefreshTerminal();
+          firstRefreshLanded = await handleRefreshTerminal();
           hotActivationEligibleRef.current = !useBatterySaverTerminalVisibility;
         } else if (hotActivation) {
           await reconcileMountedTerminal();
@@ -2085,20 +2097,39 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
         await waitForNextPaint();
         if (cancelled) return;
 
+        // Geometry the refresh above actually rendered at. The backstop exists
+        // for the case where that geometry was wrong -- a refresh that raced
+        // layout, or a renderer that attached after it. If it has not moved by
+        // the time the backstop runs, re-running the depth cannot discover
+        // anything new, and for a full refresh it would reset+replay a correct
+        // screen and drop the user's selection with it.
+        const geometryAtRefresh = readGeometry(terminalRef.current, xtermRef.current);
+
         if (autoFocus && (fullRefresh || hotActivation)) {
           xtermRef.current?.focus();
         }
 
-        // The mask has to outlast this backstop, not just the first paint. It
-        // re-runs the same depth, and for a full refresh that depth is a
-        // reset+replay -- lifting earlier exposes a terminal that is about to
-        // be wiped, taking the user's selection and any typed input with it.
-        // The old fixed delays happened to satisfy this (200 + 150 > 300); an
-        // early settle does not, so the lift is chained to the backstop.
         delayedRefreshTimer = setTimeout(() => {
           void (async () => {
             try {
               if (cancelled || !fitAddonRef.current || !xtermRef.current || !terminalRef.current) return;
+              const geometryNow = readGeometry(terminalRef.current, xtermRef.current);
+              const geometryMoved = geometryNow !== geometryAtRefresh;
+              // A background repair must not destroy what the user is doing.
+              // reset+replay drops the selection, and with the mask lifted the
+              // user can be mid-selection by the time this runs. A live
+              // selection also means they can already read the screen, so the
+              // repair has nothing urgent to fix; a later activation or the
+              // ResizeObserver repeats it once the selection is gone.
+              const hasSelection = !!xtermRef.current.getSelection();
+              if (firstRefreshLanded && (!geometryMoved || hasSelection)) {
+                // Repaint only. Still covers the WebGL attach race this
+                // backstop was declared after, without touching the buffer.
+                forwardToMainLog('info', `[TerminalPanel] Delayed activation repaint for panel ${panel.id} (moved=${geometryMoved} selection=${hasSelection})`);
+                const terminal = xtermRef.current;
+                if (terminal.rows > 0) terminal.refresh(0, terminal.rows - 1);
+                return;
+              }
               forwardToMainLog('info', `[TerminalPanel] Delayed activation refresh for panel ${panel.id}`);
               if (fullRefresh) await handleRefreshTerminal();
               else if (hotActivation) await reconcileMountedTerminal();
@@ -2112,6 +2143,14 @@ const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActiv
             }
           })();
         }, REFOCUS_DELAYED_REFRESH_MS);
+
+        // The backstop only reset+replays when it has something to repair -- a
+        // first refresh that bailed, or geometry that moved since. Otherwise it
+        // is a repaint, so the mask no longer has to outlast it and lifts as
+        // soon as the grid settles.
+        if (fullRefresh) void settleThenLiftMask();
+
+
       });
     };
 

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -72,6 +72,14 @@ type ElectronApiMockOptions = {
   paneChatAgentChangeDelayMs?: number;
   feedbackOutcome?: 'success' | 'failure';
   openExternalOutcome?: 'success' | 'failure';
+  /**
+   * Latency for the two reads a session switch waits on
+   * (panels.getSessionPanels and panels:get-layout), so a spec can observe the
+   * stage while the switch is still in flight.
+   */
+  panelLoadDelayMs?: number;
+  /** Forces panels.getSessionPanels to fail for the named sessions. */
+  panelLoadErrorBySessionId?: Record<string, string>;
 };
 
 export async function installElectronApiMock(page: Page, options: ElectronApiMockOptions = {}) {
@@ -87,6 +95,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     function success<Value>(data?: Value) {
       return Promise.resolve({ success: true, data: data ?? null });
     }
+    const failure = (error: string) => Promise.resolve({ success: false as const, error });
     const unsubscribe = () => undefined;
     const listeners = new Map<string, Set<MockEventCallback>>();
     const pendingPermissions: PanePermissionRequest[] = [];
@@ -267,7 +276,7 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
     const preferenceWrites: Array<{ key: string; value: string }> = [];
     const sessionDeleteCalls: string[] = [];
     const sessionFavoriteToggleCalls: string[] = [];
-    const invokeCalls = new Map<string, Array<{ channel: string; args: unknown[] }>>();
+    const invokeCalls = new Map<string, Array<{ channel: string; args: unknown[]; at: number }>>();
     let sessionsGetCount = 0;
 
     Object.defineProperty(window, '__paneTestPerf', {
@@ -355,15 +364,27 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
       },
     });
 
-    const invoke = (channel: string, ...args: unknown[]) => {
+    // `at` lets a spec prove two reads overlapped rather than ran head-to-tail.
+    const recordCall = (channel: string, args: unknown[]) => {
       const calls = invokeCalls.get(channel) ?? [];
-      calls.push({ channel, args });
+      calls.push({ channel, args, at: Date.now() });
       if (calls.length > 500) calls.shift();
       invokeCalls.set(channel, calls);
+    };
+
+    const invoke = (channel: string, ...args: unknown[]) => {
+      recordCall(channel, args);
 
       const key = args[0] === undefined ? undefined : String(args[0]);
       const value = args[1] === undefined ? undefined : String(args[1]);
       if (channel === 'panels:get-layout') {
+        const layoutDelay = mockOptions.panelLoadDelayMs ?? 0;
+        if (layoutDelay > 0) {
+          return new Promise((resolve) => setTimeout(
+            () => resolve(success(clone(mockOptions.initialLayout ?? null))),
+            layoutDelay,
+          ));
+        }
         return success(clone(mockOptions.initialLayout ?? null));
       }
       if (channel === 'panels:shouldAutoCreate') {
@@ -695,9 +716,18 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
       }),
       panels: namespace({
-        getSessionPanels: (sessionId: string) => success(
-          clone(mockPanels.filter((panel) => panel.sessionId === sessionId)),
-        ),
+        getSessionPanels: (sessionId: string) => {
+          recordCall('panels:getSessionPanels', [sessionId]);
+          const forcedError = mockOptions.panelLoadErrorBySessionId?.[sessionId];
+          const payload = () => (forcedError
+            ? failure(forcedError)
+            : success(clone(mockPanels.filter((panel) => panel.sessionId === sessionId))));
+          const panelDelay = mockOptions.panelLoadDelayMs ?? 0;
+          if (panelDelay > 0) {
+            return new Promise((resolve) => setTimeout(() => resolve(payload()), panelDelay));
+          }
+          return payload();
+        },
         createPanel: (sessionId: string, type: string, title: string, initialState?: JsonObject) => {
           const now = new Date().toISOString();
           const panel = {

--- a/tests/session-switch-stage.spec.ts
+++ b/tests/session-switch-stage.spec.ts
@@ -1,0 +1,215 @@
+import { expect, test, type Page } from '@playwright/test';
+import { installElectronApiMock } from './electronApiMock';
+
+// Switching panes inside a repo tears down the outgoing session's terminals and
+// mounts the incoming session's, so whatever the stage shows between those two
+// states is the switch's visible cost. Two things are pinned here: the switch
+// issues one panel read (not the historical two) with the layout read alongside
+// it, and the "Open" launcher is never used as a stand-in for a stage whose
+// layout is still in flight.
+
+const now = new Date(0).toISOString();
+const project = {
+  id: 720,
+  name: 'Switch fixture',
+  path: '/tmp/switch-fixture',
+  active: true,
+  created_at: now,
+  updated_at: now,
+};
+
+const makeSession = (id: string, name: string, displayOrder: number) => ({
+  id,
+  name,
+  worktreePath: `${project.path}/${id}`,
+  prompt: '',
+  status: 'stopped',
+  createdAt: now,
+  lastActivity: now,
+  output: [],
+  jsonMessages: [],
+  isRunning: false,
+  permissionMode: 'ignore',
+  projectId: project.id,
+  displayOrder,
+  isFavorite: false,
+  toolType: 'none',
+  archived: false,
+  gitStatus: { state: 'clean', ahead: 0, behind: 0, hasUncommittedChanges: false, hasUntrackedFiles: false, filesChanged: 0 },
+});
+
+const sessionA = makeSession('switch-a', 'Pane A', 0);
+const sessionB = makeSession('switch-b', 'Pane B', 1);
+const sessionEmpty = makeSession('switch-empty', 'Pane Empty', 2);
+
+const terminalPanel = (id: string, sessionId: string, title: string, position: number, isActive: boolean, permanent = false) => ({
+  id,
+  sessionId,
+  type: 'terminal',
+  title,
+  state: { isActive, hasBeenViewed: true, customState: { isInitialized: true } },
+  metadata: { createdAt: now, lastActiveAt: now, position, permanent },
+});
+
+// The first terminal of a session is its pinned dock terminal and stays out of
+// the layout tree, so each session's stage tabs are the ones after it.
+const dockA = terminalPanel('switch-a-dock', sessionA.id, 'Terminal', 0, false, true);
+const alpha = terminalPanel('switch-a-alpha', sessionA.id, 'Alpha', 1, true);
+const dockB = terminalPanel('switch-b-dock', sessionB.id, 'Terminal', 0, false, true);
+// Beta second carries the persisted active flag: the switch has to honour the
+// stored selection rather than falling back to the first working tab.
+const betaFirst = terminalPanel('switch-b-first', sessionB.id, 'Beta first', 1, false);
+const betaSecond = terminalPanel('switch-b-second', sessionB.id, 'Beta second', 2, true);
+
+const allPanels = [dockA, alpha, dockB, betaFirst, betaSecond];
+
+const scrollback = (prefix: string) => Array.from({ length: 10 }, (_, i) => `${prefix}-${i}`).join('\r\n') + '\r\n';
+
+interface StageMock {
+  getInvokeCalls(channel: string): Array<{ channel: string; args: unknown[]; at: number }>;
+}
+
+declare global {
+  interface Window {
+    __emptyStageAppearances?: number[];
+  }
+}
+
+// A poll can miss a launcher that shows for one frame; an observer cannot.
+async function installEmptyStageRecorder(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    window.__emptyStageAppearances = [];
+    const record = () => window.__emptyStageAppearances?.push(performance.now());
+    const scan = (node: Node) => {
+      if (!(node instanceof Element)) return;
+      if (node.matches('[data-testid="empty-stage"]')) record();
+      for (const _ of node.querySelectorAll('[data-testid="empty-stage"]')) record();
+    };
+    new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) scan(node);
+      }
+    }).observe(document, { childList: true, subtree: true });
+  });
+}
+
+async function callsFor(page: Page, channel: string, sessionId: string): Promise<Array<{ at: number }>> {
+  return page.evaluate(({ channel, sessionId }) => {
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+    const mock = (window as typeof window & { __paneTestElectronMock: StageMock }).__paneTestElectronMock;
+    return mock.getInvokeCalls(channel)
+      .filter((call) => call.args[0] === sessionId)
+      .map((call) => ({ at: call.at }));
+  }, { channel, sessionId });
+}
+
+async function boot(page: Page, panelLoadDelayMs = 0): Promise<void> {
+  await installEmptyStageRecorder(page);
+  await installElectronApiMock(page, {
+    platform: 'darwin',
+    initialProjects: [project],
+    initialSessions: [sessionA, sessionB, sessionEmpty],
+    initialPanels: allPanels,
+    initialLayout: null,
+    initialTerminalStates: Object.fromEntries(
+      allPanels.map((panel) => [panel.id, { scrollbackBuffer: scrollback(panel.id) }]),
+    ),
+    activeProjectId: project.id,
+    panelLoadDelayMs,
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Switch fixture$/ }).click();
+}
+
+async function openSession(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name, exact: true }).click();
+}
+
+test('a pane switch reads the panel list once and fetches the layout alongside it', async ({ page }) => {
+  await boot(page, 250);
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await openSession(page, sessionB.name);
+  await expect(page.getByRole('tabpanel', { name: betaSecond.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  // One read, not the two the old getActivePanel round trip made.
+  const panelReads = await callsFor(page, 'panels:getSessionPanels', sessionB.id);
+  expect(panelReads).toHaveLength(1);
+
+  // Head-to-tail would put the layout read a full delay after the panel read.
+  const layoutReads = await callsFor(page, 'panels:get-layout', sessionB.id);
+  expect(layoutReads).toHaveLength(1);
+  expect(Math.abs(layoutReads[0].at - panelReads[0].at)).toBeLessThan(250);
+});
+
+test('the Open launcher never stands in for a stage that is still loading', async ({ page }) => {
+  await boot(page, 600);
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await page.evaluate(() => { window.__emptyStageAppearances = []; });
+
+  await openSession(page, sessionB.name);
+  // The whole switch, including the 600 ms the two reads are in flight.
+  await expect(page.getByRole('tabpanel', { name: betaSecond.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  const appearances = await page.evaluate(() => window.__emptyStageAppearances ?? []);
+  expect(appearances).toHaveLength(0);
+});
+
+test('a pane that genuinely has no tools still gets the Open launcher', async ({ page }) => {
+  await boot(page, 150);
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await openSession(page, sessionEmpty.name);
+  await expect(page.getByTestId('empty-stage')).toBeVisible({ timeout: 15_000 });
+  // The launcher rows carry their shortcut in the accessible name.
+  await expect(page.getByTestId('empty-stage').getByRole('button', { name: /^Terminal/ })).toBeVisible();
+});
+
+test('a switch honours the persisted active tab rather than the first working tab', async ({ page }) => {
+  await boot(page);
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await openSession(page, sessionB.name);
+  await expect(page.getByRole('tab', { name: betaSecond.title, exact: true })).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByRole('tab', { name: betaFirst.title, exact: true })).toHaveAttribute('aria-selected', 'false');
+  await expect(page.getByRole('tabpanel', { name: betaSecond.title }).locator('.xterm-screen')).toBeVisible();
+});
+
+test('switching back to a loaded pane restores its stage without a launcher frame', async ({ page }) => {
+  await boot(page, 400);
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+  await openSession(page, sessionB.name);
+  await expect(page.getByRole('tabpanel', { name: betaSecond.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await page.evaluate(() => { window.__emptyStageAppearances = []; });
+
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  const appearances = await page.evaluate(() => window.__emptyStageAppearances ?? []);
+  expect(appearances).toHaveLength(0);
+});
+
+test('a failed panel read settles the stage on the launcher instead of leaving it blank', async ({ page }) => {
+  await installEmptyStageRecorder(page);
+  await installElectronApiMock(page, {
+    platform: 'darwin',
+    initialProjects: [project],
+    initialSessions: [sessionA, sessionB, sessionEmpty],
+    initialPanels: allPanels,
+    initialLayout: null,
+    activeProjectId: project.id,
+    panelLoadErrorBySessionId: { [sessionB.id]: 'panel read failed' },
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.getByRole('button', { name: /^Expand repository Switch fixture$/ }).click();
+
+  await openSession(page, sessionB.name);
+  await expect(page.getByTestId('empty-stage')).toBeVisible({ timeout: 15_000 });
+});

--- a/tests/session-switch-stage.spec.ts
+++ b/tests/session-switch-stage.spec.ts
@@ -104,6 +104,16 @@ async function callsFor(page: Page, channel: string, sessionId: string): Promise
   }, { channel, sessionId });
 }
 
+async function lifecycleLogs(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    // SAFETY: installElectronApiMock defines this test-only bridge before the page loads.
+    const mock = (window as typeof window & {
+      __paneTestElectronMock: { getConsoleLogCalls(): { args?: unknown[] }[] };
+    }).__paneTestElectronMock;
+    return mock.getConsoleLogCalls().map((call) => String(call.args?.[0] ?? ''));
+  });
+}
+
 async function boot(page: Page, panelLoadDelayMs = 0): Promise<void> {
   await installEmptyStageRecorder(page);
   await installElectronApiMock(page, {
@@ -238,4 +248,29 @@ test('a selection made when the activation mask lifts survives the delayed backs
 
   const afterBackstop = await xtermEvaluate(panel.locator('.xterm').first(), (terminal) => terminal.getSelection());
   expect(afterBackstop).toEqual(selected);
+});
+
+test('the delayed backstop repaints instead of reset+replay when nothing moved', async ({ page }) => {
+  // The backstop exists to repair a refresh that raced layout or a renderer
+  // that attached after it. When the geometry it would re-render at has not
+  // moved, a reset+replay cannot discover anything new and would drop the
+  // user's selection, so it degrades to a repaint -- which is what lets the
+  // mask lift on the settle instead of waiting the backstop out.
+  await boot(page);
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await openSession(page, sessionB.name);
+  const panel = page.getByRole('tabpanel', { name: betaSecond.title });
+  await expect(panel.locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await expect.poll(
+    () => lifecycleLogs(page).then((lines) => lines.filter(
+      (line) => line.includes(`activation repaint for panel ${betaSecond.id}`),
+    ).length),
+    { timeout: 15_000 },
+  ).toBeGreaterThan(0);
+
+  const lines = await lifecycleLogs(page);
+  expect(lines.filter((line) => line.includes(`Delayed activation refresh for panel ${betaSecond.id}`))).toHaveLength(0);
 });

--- a/tests/session-switch-stage.spec.ts
+++ b/tests/session-switch-stage.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import { installElectronApiMock } from './electronApiMock';
+import { selectFirstLine, xtermEvaluate } from './terminalXterm';
 
 // Switching panes inside a repo tears down the outgoing session's terminals and
 // mounts the incoming session's, so whatever the stage shows between those two
@@ -212,4 +213,29 @@ test('a failed panel read settles the stage on the launcher instead of leaving i
 
   await openSession(page, sessionB.name);
   await expect(page.getByTestId('empty-stage')).toBeVisible({ timeout: 15_000 });
+});
+
+test('a selection made when the activation mask lifts survives the delayed backstop', async ({ page }) => {
+  // The mask has to outlast REFOCUS_DELAYED_REFRESH_MS, not just the first
+  // paint: that backstop re-runs the full reset+replay, and reset() drops the
+  // selection. Lifting the mask on an early settle exposes a terminal the user
+  // can select in ~270 ms before it is wiped under them.
+  await boot(page);
+  await openSession(page, sessionA.name);
+  await expect(page.getByRole('tabpanel', { name: alpha.title }).locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+
+  await openSession(page, sessionB.name);
+  const panel = page.getByRole('tabpanel', { name: betaSecond.title });
+  await expect(panel.locator('.xterm-screen')).toBeVisible({ timeout: 15_000 });
+  await expect(panel.getByTestId('terminal-activation-mask')).toHaveCount(0, { timeout: 15_000 });
+
+  await selectFirstLine(panel.locator('.xterm').first());
+  const selected = await xtermEvaluate(panel.locator('.xterm').first(), (terminal) => terminal.getSelection());
+  expect(selected.trim().length).toBeGreaterThan(0);
+
+  // Past the delayed backstop, with margin.
+  await page.waitForTimeout(1200);
+
+  const afterBackstop = await xtermEvaluate(panel.locator('.xterm').first(), (terminal) => terminal.getSelection());
+  expect(afterBackstop).toEqual(selected);
 });


### PR DESCRIPTION
## Description

Switching panes inside a repo showed the wrong thing twice over: the "Open" launcher flashed where the terminal had been, and the terminal that arrived sat behind an activation mask longer than it needed to. Three commits, each standing on its own.

**1. `fix:` stop the Open launcher standing in for a loading pane stage**

The stage guard treats a layout that has not loaded yet the same as one that is genuinely absent (`!sessionLayout` -> render the launcher), so every first visit to a pane showed a tool menu where the terminal had been. The guard predates the launcher; #512 replaced a dim "No Active Panel" placeholder with an actionable list, which made a pre-existing flash far more visible.

Now the code tracks which session's layout load has settled and renders the launcher only for a session whose layout is *known* to be absent. A switch still in flight shows the plain stage surface. Also drops a redundant read: `panelApi.getActivePanel` re-ran the identical `getSessionPanels` query to find a panel already in `loadedPanels`. The layout read now goes out alongside the panel read rather than head-to-tail, with a cancellation guard so a fast A -> B -> A flip cannot land a stale response over fresher store state. A failed panel read settles onto the launcher instead of leaving the stage blank.

Measured on the real app (Electron, real worktrees): the launcher no longer appears on any switch (was 42 ms on first visit to each pane).

**2. `refactor:` lift the terminal activation mask on a settle, not a fixed delay**

The mask held for a flat 200 ms after paint plus a 150 ms overlay linger. Both were standing in for conditions rather than expressing them. It now waits for the condition itself — two consecutive frames agreeing on container width and rendered grid — and keeps the old values only as ceilings. Two things the timers were quietly guaranteeing are now explicit: the mask must outlast `REFOCUS_DELAYED_REFRESH_MS` (that backstop re-runs a reset+replay, and `reset()` drops the selection), and the ceiling has to be a real timer rather than a frame budget, since frames stop entirely behind a hidden window or a faked clock.

Also stops the width-settle loop paying a mandatory tick: `lastWidth` started at 0, so a viable first measurement read as a changed width and always burned a 50 ms retry. The two-agreeing-measurements invariant from #233 is unchanged; only the cost of collecting them.

This commit alone is not a win on the clock (576 ms -> 675 ms per panel) — it buys the mechanism that the next commit needs.

**3. `perf:` let the activation backstop repair without resetting the terminal**

The mask's floor was `REFOCUS_DELAYED_REFRESH_MS`, because the delayed backstop re-ran the full destructive reset+replay. It now reset+replays only when it has something to repair — the geometry moved since the first refresh rendered, or the first refresh never landed (`handleRefreshTerminal` bails on a mid-layout container, and in that case the backstop is the path that actually populates the buffer) — and repaints otherwise. A live selection also forces the repaint path: a background repair should not destroy what the user is doing.

Per panel on a session switch: **675 ms -> 332 ms** (576 ms before this branch).

### Activation depth policy is untouched

The first refresh on every panel activation is still the full masked reset+replay, so neither the v2.4.11 ghosting nor the v2.4.14 shared-atlas corruption can recur. What changed is the depth of the *backstop* that follows it.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Code refactoring

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (no doc-facing behaviour changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `pnpm typecheck` and `pnpm lint` locally
- [x] I have tested the Electron app locally with `pnpm electron-dev`

## Critical Areas Modified
- [ ] Session output handling (requires explicit permission)
- [ ] Timestamp handling
- [x] State management/IPC events — `SessionView`/`ProjectView` panel + layout reads are now issued in parallel with a cancellation guard; no IPC contracts changed
- [ ] Diff viewer CSS

## Testing

New spec `tests/session-switch-stage.spec.ts` (8 cases) covers the panel/layout race and pins the launcher-flash regression directly, including the selection-preserving backstop case. Verified load-bearing: the new tests fail against the pre-fix `SessionView`. `tests/electronApiMock.ts` gains configurable panel/layout load latency and call timestamps so the race is reproducible rather than timing-dependent.

Full Playwright suite run: the new specs pass, and the 4 remaining failures are pre-existing flakes unrelated to this branch (`terminal-blur-recovery` boundary cases reproduce identically on the pre-branch baseline).

## Additional Notes

Rebased onto `upstream/main` at v2.4.95, so this merges cleanly with no merge commit. The only conflict was in `tests/electronApiMock.ts`, where this branch and `openExternalOutcome` appended fields to the same options type — both kept, no logic involved. Verified the rebase preserved the change exactly: the diff against the new base is byte-for-byte identical to the diff against the old one.

Re-verified on the new base: `pnpm typecheck` and `pnpm lint` clean, all 8 cases in the new spec passing.

The three commits are independently reviewable and the commit messages carry the full reasoning, including the two failed lightening attempts that shaped the final design.
