### PR TITLE
fix: expand ~ and relative paths in Add Repository

### DIFF
--- a/frontend/src/components/AddProjectDialog.tsx
+++ b/frontend/src/components/AddProjectDialog.tsx
@@ -17,19 +17,31 @@ interface AddProjectDialogProps {
 export function AddProjectDialog({ isOpen, onClose }: AddProjectDialogProps) {
   const [newProject, setNewProject] = useState<CreateProjectRequest>({ name: '', path: '', buildScript: '', runScript: '' });
   const [detectedBranch, setDetectedBranch] = useState<string | null>(null);
+  const [branchDetectionFailed, setBranchDetectionFailed] = useState(false);
   const [showValidationErrors, setShowValidationErrors] = useState(false);
 
   const navigateToProject = useNavigationStore(s => s.navigateToProject);
 
   const detectCurrentBranch = async (path: string) => {
-    if (!path) { setDetectedBranch(null); return; }
+    if (!path) {
+      setDetectedBranch(null);
+      setBranchDetectionFailed(false);
+      return;
+    }
+    setDetectedBranch(null);
+    setBranchDetectionFailed(false);
     try {
       const response = await API.projects.detectBranch(path);
       if (response.success && response.data) {
         setDetectedBranch(response.data);
+        setBranchDetectionFailed(false);
+      } else {
+        setDetectedBranch(null);
+        setBranchDetectionFailed(true);
       }
     } catch {
       setDetectedBranch(null);
+      setBranchDetectionFailed(true);
     }
   };
 
@@ -68,6 +80,7 @@ export function AddProjectDialog({ isOpen, onClose }: AddProjectDialogProps) {
   const resetAndClose = () => {
     setNewProject({ name: '', path: '', buildScript: '', runScript: '' });
     setDetectedBranch(null);
+    setBranchDetectionFailed(false);
     setShowValidationErrors(false);
     onClose();
   };
@@ -102,7 +115,7 @@ export function AddProjectDialog({ isOpen, onClose }: AddProjectDialogProps) {
 
           <FieldWithTooltip
             label="Repository Path"
-            tooltip="The absolute path to a git repository on your machine"
+            tooltip="Path to a git repository. ~ and relative paths are expanded to an absolute path."
           >
             <div className="space-y-2">
               <EnhancedInput
@@ -146,8 +159,8 @@ export function AddProjectDialog({ isOpen, onClose }: AddProjectDialogProps) {
               <Card variant="bordered" padding="md">
                 <div className="flex items-center gap-2 text-sm text-text-secondary">
                   <GitBranch className="w-4 h-4" />
-                  <span className="font-mono">
-                    {detectedBranch || 'Detecting...'}
+                  <span className={`font-mono ${branchDetectionFailed ? 'text-status-error' : ''}`}>
+                    {detectedBranch ?? (branchDetectionFailed ? 'Could not detect a git branch' : 'Detecting...')}
                   </span>
                 </div>
               </Card>

--- a/main/src/ipc/project.ts
+++ b/main/src/ipc/project.ts
@@ -7,8 +7,9 @@ import type { CreateProjectRequest, UpdateProjectRequest } from '../../../fronte
 import { scriptExecutionTracker } from '../services/scriptExecutionTracker';
 import { panelManager } from '../services/panelManager';
 import { parseWSLPath, validateWSLAvailable } from '../utils/wslUtils';
-import { PathResolver } from '../utils/pathResolver';
+import { PathResolver, expandUserRepoPath } from '../utils/pathResolver';
 import { CommandRunner } from '../utils/commandRunner';
+import { detectProjectBranch } from '../utils/detectProjectBranch';
 import { getGitAttributionEnv } from '../utils/attribution';
 import { detectProjectConfig } from '../services/projectConfigDetector';
 import { ensureProjectAgentContext } from '../services/agentContextManager';
@@ -114,9 +115,11 @@ export function registerProjectHandlers(
     try {
       console.log('[Main] Creating project:', projectData);
 
+      const requestedPath = expandUserRepoPath(projectData.path);
+
       // Parse WSL path if applicable
-      const wslInfo = parseWSLPath(projectData.path);
-      let actualPath = projectData.path;
+      const wslInfo = parseWSLPath(requestedPath);
+      let actualPath = requestedPath;
       let wslEnabled = false;
       let wslDistribution: string | null = null;
       let isGitRepo = false;
@@ -462,21 +465,10 @@ export function registerProjectHandlers(
     }
   });
 
-  commandRegistry.register('projects:detect-branch', async (path: string) => {
-    try {
-      const wslInfo = parseWSLPath(path);
-      const tempProject = {
-        path: wslInfo ? wslInfo.linuxPath : path,
-        wsl_enabled: !!wslInfo,
-        wsl_distribution: wslInfo?.distro ?? null
-      };
-      const commandRunner = new CommandRunner(tempProject);
-      const branch = await worktreeManager.getProjectMainBranch(tempProject.path, commandRunner);
-      return { success: true, data: branch };
-    } catch (error) {
-      console.log('[Main] Could not detect branch:', error);
-      return { success: true, data: 'main' }; // Return default if detection fails
-    }
+  commandRegistry.register('projects:detect-branch', async (repoPath: string) => {
+    return detectProjectBranch(repoPath, (projectPath, commandRunner) => (
+      worktreeManager.getProjectMainBranch(projectPath, commandRunner)
+    ));
   });
 
   commandRegistry.register('projects:list-branches', async (projectId: string) => {

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import type { IpcMain } from 'electron';
 import type { AppServices } from './types';
 import type { PaneCommandRegistry, PaneCommandValue } from '../daemon/commandRegistry';
-import { PathResolver, ProjectEnvironment } from '../utils/pathResolver';
+import { PathResolver, ProjectEnvironment, expandUserRepoPath } from '../utils/pathResolver';
 import { sanitizeTerminalOutput } from '../utils/terminalOutputSanitizer';
 import { escapeShellArg } from '../utils/shellEscape';
 import { panelManager } from '../services/panelManager';
@@ -2622,7 +2622,7 @@ function parseRepoAddRequest(value: PaneCommandValue): Required<Pick<RunpaneRepo
     throw new Error('Repo add request must include a path');
   }
 
-  const repoPath = path.resolve(requestedPath);
+  const repoPath = expandUserRepoPath(requestedPath);
   const providedName = optionalString(value.name)?.trim();
   const defaultName = path.basename(repoPath) || repoPath;
 
@@ -2908,20 +2908,21 @@ function parsePaneCreateItem(value: PaneCommandValue, index: number): RunpanePan
 }
 
 function validateRepositoryPath(repoPath: string): void {
+  const resolvedPath = expandUserRepoPath(repoPath);
   let stat: fs.Stats;
   try {
-    stat = fs.statSync(repoPath);
+    stat = fs.statSync(resolvedPath);
   } catch {
-    throw new Error(`Repo path does not exist: ${repoPath}`);
+    throw new Error(`Repo path does not exist: ${resolvedPath}`);
   }
 
   if (!stat.isDirectory()) {
-    throw new Error(`Repo path must be a directory: ${repoPath}`);
+    throw new Error(`Repo path must be a directory: ${resolvedPath}`);
   }
 
   try {
     const output = execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
-      cwd: repoPath,
+      cwd: resolvedPath,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
@@ -2930,7 +2931,7 @@ function validateRepositoryPath(repoPath: string): void {
       throw new Error('not inside work tree');
     }
   } catch {
-    throw new Error(`Repo path must be an existing git repository: ${repoPath}`);
+    throw new Error(`Repo path must be an existing git repository: ${resolvedPath}`);
   }
 }
 

--- a/main/src/utils/detectProjectBranch.test.ts
+++ b/main/src/utils/detectProjectBranch.test.ts
@@ -1,0 +1,45 @@
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { detectProjectBranch } from './detectProjectBranch';
+
+describe('detectProjectBranch', () => {
+  it('returns success false instead of a fake main branch when detection fails', async () => {
+    const getProjectMainBranch = vi.fn(async () => {
+      throw new Error('Failed to get main branch for project at /missing: not a git repository');
+    });
+
+    const result = await detectProjectBranch('/missing', getProjectMainBranch);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Failed to get main branch for project at /missing: not a git repository',
+    });
+    expect(result).not.toMatchObject({ data: 'main' });
+  });
+
+  it('expands a tilde path before asking git for the current branch', async () => {
+    const getProjectMainBranch = vi.fn(async () => 'develop');
+    const relativeHomePath = 'pane-detect-branch-tilde-test';
+
+    const result = await detectProjectBranch(`~/${relativeHomePath}`, getProjectMainBranch);
+
+    expect(result).toEqual({ success: true, data: 'develop' });
+    expect(getProjectMainBranch).toHaveBeenCalledWith(
+      path.resolve(os.homedir(), relativeHomePath),
+      expect.anything(),
+    );
+  });
+
+  it('keeps WSL UNC paths intact and detects against the linux path', async () => {
+    const getProjectMainBranch = vi.fn(async () => 'main');
+
+    const result = await detectProjectBranch(
+      '\\\\wsl.localhost\\Ubuntu\\home\\user\\repo',
+      getProjectMainBranch,
+    );
+
+    expect(result).toEqual({ success: true, data: 'main' });
+    expect(getProjectMainBranch).toHaveBeenCalledWith('/home/user/repo', expect.anything());
+  });
+});

--- a/main/src/utils/detectProjectBranch.ts
+++ b/main/src/utils/detectProjectBranch.ts
@@ -1,0 +1,27 @@
+import { parseWSLPath } from './wslUtils';
+import { CommandRunner } from './commandRunner';
+import { expandUserRepoPath } from './pathResolver';
+
+export async function detectProjectBranch(
+  repoPath: string,
+  getProjectMainBranch: (projectPath: string, commandRunner: CommandRunner) => Promise<string>,
+): Promise<{ success: true; data: string } | { success: false; error: string }> {
+  try {
+    const requestedPath = expandUserRepoPath(repoPath);
+    const wslInfo = parseWSLPath(requestedPath);
+    const tempProject = {
+      path: wslInfo ? wslInfo.linuxPath : requestedPath,
+      wsl_enabled: !!wslInfo,
+      wsl_distribution: wslInfo?.distro ?? null,
+    };
+    const commandRunner = new CommandRunner(tempProject);
+    const branch = await getProjectMainBranch(tempProject.path, commandRunner);
+    return { success: true, data: branch };
+  } catch (error) {
+    console.log('[Main] Could not detect branch:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Could not detect branch',
+    };
+  }
+}

--- a/main/src/utils/pathResolver.test.ts
+++ b/main/src/utils/pathResolver.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { expandUserRepoPath } from './pathResolver';
+
+const homeDir = path.join(os.tmpdir(), 'pane-expand-home');
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0).reverse()) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('expandUserRepoPath', () => {
+  it('expands a lone tilde to the home directory', () => {
+    expect(expandUserRepoPath('~', { homeDir })).toBe(path.resolve(homeDir));
+  });
+
+  it('expands ~/ and ~\\ prefixes to home', () => {
+    expect(expandUserRepoPath('~/src/pane', { homeDir })).toBe(path.resolve(homeDir, 'src/pane'));
+    expect(expandUserRepoPath('~\\src\\pane', { homeDir })).toBe(path.resolve(homeDir, 'src', 'pane'));
+  });
+
+  it('trims whitespace before expanding', () => {
+    expect(expandUserRepoPath('  ~/repo  ', { homeDir })).toBe(path.resolve(homeDir, 'repo'));
+  });
+
+  it('resolves relative paths against home instead of process.cwd()', () => {
+    expect(expandUserRepoPath('src/pane', { homeDir })).toBe(path.resolve(homeDir, 'src/pane'));
+    expect(expandUserRepoPath('./repo', { homeDir })).toBe(path.resolve(homeDir, 'repo'));
+  });
+
+  it('normalizes existing absolute paths without treating them as home-relative', () => {
+    const absolute = path.resolve(os.tmpdir(), 'pane-absolute-repo');
+    expect(expandUserRepoPath(absolute, { homeDir })).toBe(absolute);
+  });
+
+  it('does not expand ~otheruser paths as another home', () => {
+    expect(expandUserRepoPath('~other/repo', { homeDir })).toBe(path.resolve(homeDir, '~other/repo'));
+  });
+
+  it('leaves WSL UNC paths unchanged so parseWSLPath still matches', () => {
+    const wslLocalhost = '\\\\wsl.localhost\\Ubuntu\\home\\user\\repo';
+    const wslDollar = '\\\\wsl$\\Debian\\home\\user\\repo';
+    expect(expandUserRepoPath(wslLocalhost, { homeDir })).toBe(wslLocalhost);
+    expect(expandUserRepoPath(wslDollar, { homeDir })).toBe(wslDollar);
+  });
+
+  it('returns an empty string for blank input', () => {
+    expect(expandUserRepoPath('   ', { homeDir })).toBe('');
+  });
+
+  it('returns the realpath of an existing directory', () => {
+    const realDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-expand-real-'));
+    tempDirs.push(realDir);
+    expect(expandUserRepoPath(realDir, { homeDir })).toBe(fs.realpathSync(realDir));
+  });
+
+  it.skipIf(process.platform === 'win32')('resolves symlinks when the path exists', () => {
+    const realDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-expand-real-'));
+    tempDirs.push(realDir);
+    const linkParent = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-expand-link-'));
+    tempDirs.push(linkParent);
+    const linkPath = path.join(linkParent, 'alias');
+    fs.symlinkSync(realDir, linkPath);
+
+    expect(expandUserRepoPath(linkPath, { homeDir })).toBe(fs.realpathSync(realDir));
+  });
+});

--- a/main/src/utils/pathResolver.test.ts
+++ b/main/src/utils/pathResolver.test.ts
@@ -52,13 +52,13 @@ describe('expandUserRepoPath', () => {
     expect(expandUserRepoPath('   ', { homeDir })).toBe('');
   });
 
-  it('returns the realpath of an existing directory', () => {
+  it('preserves the spelling of an existing directory', () => {
     const realDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-expand-real-'));
     tempDirs.push(realDir);
-    expect(expandUserRepoPath(realDir, { homeDir })).toBe(fs.realpathSync(realDir));
+    expect(expandUserRepoPath(realDir, { homeDir })).toBe(path.resolve(realDir));
   });
 
-  it.skipIf(process.platform === 'win32')('resolves symlinks when the path exists', () => {
+  it.skipIf(process.platform === 'win32')('preserves an existing symlink spelling', () => {
     const realDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-expand-real-'));
     tempDirs.push(realDir);
     const linkParent = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-expand-link-'));
@@ -66,6 +66,6 @@ describe('expandUserRepoPath', () => {
     const linkPath = path.join(linkParent, 'alias');
     fs.symlinkSync(realDir, linkPath);
 
-    expect(expandUserRepoPath(linkPath, { homeDir })).toBe(fs.realpathSync(realDir));
+    expect(expandUserRepoPath(linkPath, { homeDir })).toBe(path.resolve(linkPath));
   });
 });

--- a/main/src/utils/pathResolver.ts
+++ b/main/src/utils/pathResolver.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import os from 'os';
-import { realpathSync } from 'fs';
 import fs from 'fs/promises';
 import { linuxToUNCPath, parseWSLPath, posixJoin } from './wslUtils';
 
@@ -15,7 +14,8 @@ interface ExpandUserRepoPathOptions {
  *
  * Relative paths resolve against home rather than Electron's cwd (often `/` or
  * the app directory). WSL UNC paths are returned unchanged so parseWSLPath
- * still works. If the resolved path exists, return its realpath.
+ * still works. Existing paths retain the spelling supplied by the user, which
+ * keeps stored project-path identity stable on platforms with aliases.
  */
 export function expandUserRepoPath(input: string, options: ExpandUserRepoPathOptions = {}): string {
   const trimmed = input.trim();
@@ -40,11 +40,7 @@ export function expandUserRepoPath(input: string, options: ExpandUserRepoPathOpt
     ? path.resolve(expanded)
     : path.resolve(homeDir, expanded);
 
-  try {
-    return realpathSync(resolved);
-  } catch {
-    return resolved;
-  }
+  return resolved;
 }
 
 export class PathResolver {

--- a/main/src/utils/pathResolver.ts
+++ b/main/src/utils/pathResolver.ts
@@ -1,8 +1,51 @@
 import path from 'path';
+import os from 'os';
+import { realpathSync } from 'fs';
 import fs from 'fs/promises';
-import { linuxToUNCPath, posixJoin } from './wslUtils';
+import { linuxToUNCPath, parseWSLPath, posixJoin } from './wslUtils';
 
 export type ProjectEnvironment = 'wsl' | 'windows' | 'linux' | 'macos';
+
+interface ExpandUserRepoPathOptions {
+  homeDir?: string;
+}
+
+/**
+ * Expand `~` / `~/…` to the user home directory, then make the path absolute.
+ *
+ * Relative paths resolve against home rather than Electron's cwd (often `/` or
+ * the app directory). WSL UNC paths are returned unchanged so parseWSLPath
+ * still works. If the resolved path exists, return its realpath.
+ */
+export function expandUserRepoPath(input: string, options: ExpandUserRepoPathOptions = {}): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  if (parseWSLPath(trimmed)) {
+    return trimmed;
+  }
+
+  const homeDir = options.homeDir ?? os.homedir();
+  let expanded = trimmed;
+  if (trimmed === '~') {
+    expanded = homeDir;
+  } else if (trimmed.startsWith('~') && (trimmed[1] === '/' || trimmed[1] === '\\')) {
+    const rest = trimmed.slice(2).split(/[\\/]+/).filter(Boolean);
+    expanded = rest.length > 0 ? path.join(homeDir, ...rest) : homeDir;
+  }
+
+  const resolved = path.isAbsolute(expanded)
+    ? path.resolve(expanded)
+    : path.resolve(homeDir, expanded);
+
+  try {
+    return realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
 
 export class PathResolver {
   readonly environment: ProjectEnvironment;


### PR DESCRIPTION
## Description

Fixes Add Repository and RunPane repository validation so typed `~/…` and relative paths expand before branch detection, project creation, and repository validation. Branch detection now reports failure instead of falsely showing `main`.

Existing absolute paths retain the user's normalized spelling rather than being canonicalized through `realpath`. On macOS this prevents `/var/...` paths from becoming `/private/var/...`, which could bypass the existing-project match and create a duplicate stored repository.

WSL UNC paths (`\\wsl.localhost\\…`, `\\wsl$\\…`) remain unchanged for WSL parsing.

Closes #577.

## Verification

- Isolated checkout dependency resolution: `pnpm install --frozen-lockfile --offline --ignore-scripts`
- Focused utility tests: `13/13` passed (`pathResolver` and `detectProjectBranch`)
- `pnpm typecheck` passed
- `pnpm lint` passed (five pre-existing ESLint warnings in `skillCacheManager.ts`)
- The IPC suite requires the SQLite native binding. It was not rebuilt in the isolated checkout because lifecycle scripts were intentionally skipped; the fresh Code Quality macOS job is the integration verification and is running after workflow approval.

## Manual checks still useful

- Add an existing repository through a typed `~/…` path.
- Add a repository below `/var/...` on macOS and confirm its stored path keeps that spelling.
- Confirm a bogus path shows branch-detection failure rather than `main`.
