### PR TITLE
Reduce terminal output overhead and simplify session history loading

### DIFF
--- a/docs/SESSION_OUTPUT_PERFORMANCE.md
+++ b/docs/SESSION_OUTPUT_PERFORMANCE.md
@@ -1,0 +1,80 @@
+# Session output audit
+
+This audit builds on the startup and Git-scan fixes in #591. It targets work
+repeated during terminal activity and history loading, without changing
+terminal rendering, scrollback limits, or database schema.
+
+## Changes
+
+- `App`, `HomePage`, and `useIPCEvents` subscribe to the session fields/actions
+  they use. Updating the separate terminal output buffer no longer schedules
+  either top-level component to render. The event hook's unused fake socket
+  return value and unused action dependency are removed.
+- Prompt markers use an indexed SQLite `COUNT(*)` instead of materializing
+  every output payload to read the array length. Both existing marker offset
+  conventions are preserved, and the count includes every output type.
+- Session history loading reads backward, retaining the newest 300 text
+  outputs and 100 JSON messages independently, then restores chronological
+  order. The old synchronous “batching” loop never yielded and could stop
+  before reaching the newest messages. Normalization now runs only for
+  retained JSON messages. Late history for a deleted session is ignored.
+- Panel JSON is decoded at the database boundary, including legacy
+  string-wrapped state/metadata. This also fixes legacy state throwing before
+  the active-panel flag could be assigned. The manager no longer performs
+  two exception-driven string checks per panel or repeats JSON parsing.
+  Malformed legacy serialized values retain a fallback, while archived-panel
+  cache guards and summary reads that omit scrollback are preserved.
+
+## Measurements
+
+Local Linux measurements with Node 22.18.0, compared with `80b8b621` (v2.4.100).
+These are isolated measurements, not an end-to-end application speedup claim.
+
+| Workload | Before | After |
+| --- | ---: | ---: |
+| Count 10,000 output rows with 78.125 MiB of payload, median of 9 reads | 253.476 ms | 0.353 ms |
+| Heap growth during those reads, median of 9 | 83.772 MiB | 0.001 MiB |
+| App renders recorded during 100 background output chunks | 100 | 0 |
+| HomePage renders recorded during the same burst | 64 | 0 |
+| Output chunks retained after the burst | 100 | 100 |
+
+The SQL benchmark warms both paths and requests GC before each measured read.
+Heap growth measures temporary JavaScript allocation, not retained memory or
+total process RSS. React Scan records component renders in a development
+Chromium renderer with mocked Electron IPC; it does not measure native PTY,
+xterm/WebGL, or packaged Windows performance.
+
+## Reproduce
+
+Use the repository's supported Node/pnpm toolchain and a SQLite native module
+built for that Node version.
+
+```bash
+pnpm build:main
+node --expose-gc scripts/benchmark-session-output.js
+pnpm --filter frontend test src/stores/sessionStore.test.ts
+pnpm --filter main test --run src/database/database.panel-loading.test.ts src/services/sessionManager.output-count.test.ts
+PANE_REACT_SCAN=1 pnpm test -- tests/session-output-perf.spec.ts --workers=1
+```
+
+The render check requires a fresh dev server started with `PANE_REACT_SCAN=1`;
+an already-running server without that option cannot produce the evidence.
+The check is opt-in so ordinary Playwright runs do not require React Scan.
+The benchmark creates and removes its own temporary database.
+
+## Verification
+
+- All 334 frontend unit tests passed.
+- Full main unit run: 910 passed, 2 skipped, 15 failed. All 15 failures were
+  Unix-socket `EPERM` errors in `daemon/server.test.ts` and
+  `permissionIpcServer.test.ts`; the same 15 failures reproduced on unchanged
+  `80b8b621` in this environment.
+- Chromium: render regression and two renderer startup smoke checks passed.
+  The render regression failed on the baseline as expected. The new history
+  and legacy-panel assertions also failed on the baseline and passed with
+  these changes.
+- Root lint and typecheck passed. Lint reports five existing unused-variable
+  warnings in `skillCacheManager.ts`.
+
+The browser checks used a Vite-only Playwright web server with the repository's
+Electron API mock. Native desktop/Windows interaction was not exercised.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,7 +120,8 @@ function App() {
     }
   }, [sidebarCollapsed, setSidebarCollapsed]);
   const { currentError, clearError } = useErrorStore();
-  const { sessions, isLoaded } = useSessionStore();
+  const sessions = useSessionStore(state => state.sessions);
+  const isLoaded = useSessionStore(state => state.isLoaded);
   const activeSessionId = useSessionStore(state => state.activeSessionId);
   const { fetchConfig, config: appConfig } = useConfigStore();
   const terminalShortcuts = appConfig?.terminalShortcuts ?? EMPTY_TERMINAL_SHORTCUTS;

--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -231,7 +231,8 @@ export function HomePage() {
   const { theme, appearance, activeSystemSlot, setTheme } = useTheme();
   const homeThemeOptions = themeOptionsForSlot(appearance.appearanceMode === 'fixed' ? 'any' : activeSystemSlot ?? 'light');
   const { config, updateConfig } = useConfigStore();
-  const { sessions, setActiveSession } = useSessionStore();
+  const sessions = useSessionStore(state => state.sessions);
+  const setActiveSession = useSessionStore(state => state.setActiveSession);
   const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
 
   const [projects, setProjects] = useState<Project[]>([]);

--- a/frontend/src/hooks/useIPCEvents.ts
+++ b/frontend/src/hooks/useIPCEvents.ts
@@ -105,8 +105,11 @@ function createThrottledWithDrain<T extends (...args: never[]) => void>(
 }
 
 export function useIPCEvents() {
-  const { setSessions, loadSessions, addSession, updateSession, deleteSession } = useSessionStore();
-  const { showError } = useErrorStore();
+  const loadSessions = useSessionStore(state => state.loadSessions);
+  const addSession = useSessionStore(state => state.addSession);
+  const updateSession = useSessionStore(state => state.updateSession);
+  const deleteSession = useSessionStore(state => state.deleteSession);
+  const showError = useErrorStore(state => state.showError);
   
   // Create throttled handlers for git status events (with drain support)
   const [gitStatusLoading] = useState(() =>
@@ -435,11 +438,5 @@ export function useIPCEvents() {
       // Clean up all event listeners
       unsubscribeFunctions.forEach(unsubscribe => unsubscribe());
     };
-  }, [setSessions, loadSessions, addSession, updateSession, deleteSession, showError, gitStatusLoading, gitStatusUpdated]);
-  
-  // Return a mock socket object for compatibility
-  return {
-    connected: true,
-    disconnect: () => {},
-  };
+  }, [loadSessions, addSession, updateSession, deleteSession, showError, gitStatusLoading, gitStatusUpdated]);
 }

--- a/frontend/src/stores/sessionStore.test.ts
+++ b/frontend/src/stores/sessionStore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { GitStatus, Session } from '../types/session';
+import type { GitStatus, Session, SessionOutput } from '../types/session';
 import { useSessionStore } from './sessionStore';
 
 function session(overrides: Partial<Session> = {}): Session {
@@ -61,6 +61,63 @@ describe('sessionStore', () => {
     }));
 
     expect(useSessionStore.getState().activeSessionId).toBe('session-foreground');
+  });
+
+  it('retains the latest output and JSON messages independently in chronological order', () => {
+    const target = session();
+    const other = session({ id: 'other' });
+    useSessionStore.setState({ sessions: [target, other], activeMainRepoSession: target });
+    const outputs: SessionOutput[] = [];
+    for (let i = 0; i < 1000; i++) {
+      outputs.push({ sessionId: target.id, type: i % 2 ? 'stderr' : 'stdout', data: `line-${i}`, timestamp: '' });
+      outputs.push({ sessionId: target.id, type: 'json', data: { type: 'assistant', text: `message-${i}`, timestamp: '' }, timestamp: '2026-09-06T00:00:00.000Z' });
+    }
+    const original = outputs.slice();
+
+    useSessionStore.getState().setSessionOutputs(target.id, outputs);
+
+    const state = useSessionStore.getState();
+    const updated = state.sessions[0];
+    expect(updated.output).toEqual(Array.from({ length: 300 }, (_, i) => `line-${i + 700}`));
+    expect(updated.jsonMessages.map(message => message.text)).toEqual(Array.from({ length: 100 }, (_, i) => `message-${i + 900}`));
+    expect(updated.jsonMessages[99].timestamp).toBe('2026-09-06T00:00:00.000Z');
+    expect(state.activeMainRepoSession?.output).toEqual(updated.output);
+    expect(state.activeMainRepoSession?.jsonMessages).toEqual(updated.jsonMessages);
+    expect(state.sessions[1]).toBe(other);
+    expect(target.output).toEqual([]);
+    expect(outputs).toEqual(original);
+  });
+
+  it('keeps sparse message categories even when the other category fills first', () => {
+    useSessionStore.setState({ activeMainRepoSession: session() });
+    const outputs: SessionOutput[] = [{
+      sessionId: 'session-new', type: 'json', data: { type: 'user', text: 'initial prompt', timestamp: '' }, timestamp: '',
+    }];
+    for (let i = 0; i < 1000; i++) {
+      outputs.push({ sessionId: 'session-new', type: 'stdout', data: `line-${i}`, timestamp: '' });
+    }
+
+    useSessionStore.getState().setSessionOutputs('session-new', outputs);
+
+    const updated = useSessionStore.getState().activeMainRepoSession;
+    expect(updated?.output).toEqual(Array.from({ length: 300 }, (_, i) => `line-${i + 700}`));
+    expect(updated?.jsonMessages.map(message => message.text)).toEqual(['initial prompt']);
+    useSessionStore.getState().setSessionOutputs('session-new', []);
+    expect(useSessionStore.getState().activeMainRepoSession?.output).toEqual([]);
+    expect(useSessionStore.getState().activeMainRepoSession?.jsonMessages).toEqual([]);
+  });
+
+  it('ignores history that arrives after its session has been deleted', () => {
+    const before = useSessionStore.getState();
+    const listener = vi.fn();
+    const unsubscribe = useSessionStore.subscribe(listener);
+    try {
+      before.setSessionOutputs('deleted-session', [{ sessionId: 'deleted-session', type: 'stdout', data: 'late output', timestamp: '' }]);
+      expect(useSessionStore.getState()).toBe(before);
+      expect(listener).not.toHaveBeenCalled();
+    } finally {
+      unsubscribe();
+    }
   });
 
   it('queues and flushes git status updates without mutating map snapshots', () => {

--- a/frontend/src/stores/sessionStore.ts
+++ b/frontend/src/stores/sessionStore.ts
@@ -361,73 +361,40 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
   
   setSessionOutputs: (sessionId, outputs) => set((state) => {
     
-    // PERFORMANCE: Process arrays in chunks to avoid V8 optimization bailouts
+    const sessionIndex = state.sessions.findIndex(session => session.id === sessionId);
+    if (sessionIndex === -1 && state.activeMainRepoSession?.id !== sessionId) return state;
+
+    const MAX_STORED_OUTPUTS = 300;
+    const MAX_STORED_MESSAGES = 100;
     const stdOutputs: string[] = [];
     const jsonMessages: ClaudeJsonMessage[] = [];
-    
-    // Process in smaller batches to avoid long-running loops that trigger V8 deoptimization
-    const BATCH_SIZE = 100;
-    for (let batch = 0; batch < outputs.length; batch += BATCH_SIZE) {
-      const batchEnd = Math.min(batch + BATCH_SIZE, outputs.length);
-      
-      for (let i = batch; i < batchEnd; i++) {
-        const output = normalizeSessionOutput(outputs[i]);
-        if (output.type === 'json') {
-          // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
-          jsonMessages.push({ ...(output.data as ClaudeJsonMessage), timestamp: output.timestamp });
-        } else if (output.type === 'stdout' || output.type === 'stderr') {
-          // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
-          stdOutputs.push(output.data as string);
-        }
+
+    // Read newest first so each category retains its own tail. Only normalize
+    // messages we keep, and stop when both bounded buffers are full.
+    for (let i = outputs.length - 1; i >= 0; i--) {
+      const output = outputs[i];
+      if (output.type === 'json' && jsonMessages.length < MAX_STORED_MESSAGES) {
+        // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
+        jsonMessages.push({ ...(output.data as ClaudeJsonMessage), timestamp: normalizeSessionOutput(output).timestamp });
+      } else if ((output.type === 'stdout' || output.type === 'stderr') && stdOutputs.length < MAX_STORED_OUTPUTS) {
+        // SAFETY: The output type discriminator is paired with this payload shape by the IPC contract.
+        stdOutputs.push(output.data as string);
       }
-      
-      // Allow event loop to breathe between batches for very large arrays
-      if (batchEnd < outputs.length && outputs.length > 500) {
-        // This is a synchronous operation, so we can't truly yield,
-        // but we can at least break up the work
-        if (stdOutputs.length > 300 || jsonMessages.length > 100) {
-          // Stop early if we already have enough data
-          break;
-        }
-      }
+      if (stdOutputs.length === MAX_STORED_OUTPUTS && jsonMessages.length === MAX_STORED_MESSAGES) break;
     }
-    
-    // CRITICAL PERFORMANCE FIX: Even more aggressive limits to prevent V8 optimization failures
-    // V8 was getting stuck in recursive array iterations with large arrays
-    const MAX_STORED_OUTPUTS = 300; // Further reduced to prevent CPU spikes
-    const MAX_STORED_MESSAGES = 100; // Further reduced to prevent memory pressure
-    
-    const trimmedOutputs = stdOutputs.length > MAX_STORED_OUTPUTS 
-      ? stdOutputs.slice(-MAX_STORED_OUTPUTS) 
-      : stdOutputs;
-    
-    const trimmedMessages = jsonMessages.length > MAX_STORED_MESSAGES
-      ? jsonMessages.slice(-MAX_STORED_MESSAGES)
-      : jsonMessages;
-    
-    
-    // Performance optimization: Only create new array if session is found
+    stdOutputs.reverse();
+    jsonMessages.reverse();
+
     let updatedSessions = state.sessions;
-    let sessionFound = false;
-    
-    // Use a for loop for better performance with large arrays
-    for (let i = 0; i < state.sessions.length; i++) {
-      if (state.sessions[i].id === sessionId) {
-        const newSession = { ...state.sessions[i], output: trimmedOutputs, jsonMessages: trimmedMessages };
-        // Only create new array when we actually find the session to update
-        if (!sessionFound) {
-          updatedSessions = state.sessions.slice(); // Shallow copy is more efficient than spread
-          sessionFound = true;
-        }
-        updatedSessions[i] = newSession;
-        break;
-      }
+    if (sessionIndex !== -1) {
+      updatedSessions = state.sessions.slice();
+      updatedSessions[sessionIndex] = { ...state.sessions[sessionIndex], output: stdOutputs, jsonMessages };
     }
-    
+
     // Also update activeMainRepoSession if it matches
     let updatedActiveMainRepoSession = state.activeMainRepoSession;
     if (state.activeMainRepoSession && state.activeMainRepoSession.id === sessionId) {
-      updatedActiveMainRepoSession = { ...state.activeMainRepoSession, output: trimmedOutputs, jsonMessages: trimmedMessages };
+      updatedActiveMainRepoSession = { ...state.activeMainRepoSession, output: stdOutputs, jsonMessages };
     }
     
     return {

--- a/main/src/database/database.panel-loading.test.ts
+++ b/main/src/database/database.panel-loading.test.ts
@@ -43,6 +43,36 @@ describe('panel history loading', () => {
       });
       expect(db.getPanelsForSession('session-0', false).find(panel => panel.id === 'legacy')?.state.customState)
         .toEqual({ cwd: tempDir });
+      expect(db.getPanel('legacy')?.state.customState).toEqual({ scrollbackBuffer: [history], cwd: tempDir });
+      expect(db.getPanelsForSession('session-0').find(panel => panel.id === 'legacy')?.state.customState)
+        .toEqual({ scrollbackBuffer: [history], cwd: tempDir });
+    } finally {
+      db.close();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('decodes legacy state and metadata consistently before resolving active panels', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-panel-legacy-'));
+    const db = new DatabaseService(path.join(tempDir, 'sessions.db'));
+    try {
+      db.initialize();
+      db.createSession({ id: 'session', name: 'Session', initial_prompt: '', worktree_name: 'session', worktree_path: tempDir, project_id: null, tool_type: 'none' });
+      const state = { isActive: false, hasBeenViewed: true, customState: { isRunning: false } };
+      const metadata = { createdAt: '2026-09-06T00:00:00.000Z', lastActiveAt: '2026-09-06T00:00:00.000Z', position: 2 };
+      db.createPanel({ id: 'legacy', sessionId: 'session', type: 'logs', title: 'Legacy', state: JSON.stringify(state), metadata: JSON.stringify(metadata) });
+      db.setActivePanel('session', 'legacy');
+
+      for (const panel of [db.getPanel('legacy'), db.getActivePanel('session'), db.getPanelsForSession('session')[0], db.getPanelsForSession('session', false)[0]]) {
+        expect(panel?.state).toEqual({ ...state, isActive: true });
+        expect(panel?.metadata).toEqual(metadata);
+      }
+      for (const panel of [db.getPanelsForStartup()[0], db.getActivePanels()[0]]) {
+        expect(panel.state).toEqual(state);
+        expect(panel.metadata).toEqual(metadata);
+      }
+      db.createPanel({ id: 'malformed', sessionId: 'session', type: 'terminal', title: 'Malformed', state, metadata: 'invalid legacy JSON' });
+      expect(db.getPanel('malformed')?.metadata).toMatchObject({ position: 0 });
     } finally {
       db.close();
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -79,6 +79,23 @@ interface SessionGitStatusCacheRow {
   last_checked_ms: number;
 }
 
+/** Decode panel JSON once, including the string-wrapped format used by legacy callers. */
+function parsePanelJson<T extends ToolPanelState | ToolPanelMetadata>(serialized: string | null, fallback: T): T {
+  if (!serialized) return fallback;
+  if (serialized.trimStart().startsWith('"')) {
+    try {
+      const json = decodeBoundary(JSON.parse(serialized), boundary.string);
+      // SAFETY: Legacy callers supplied the same typed panel JSON wrapped in a string.
+      return JSON.parse(json) as T;
+    } catch {
+      // Preserve the manager's recovery for malformed legacy serialized values.
+      return fallback;
+    }
+  }
+  // SAFETY: These columns are written by the typed panel state and metadata serializers.
+  return JSON.parse(serialized) as T;
+}
+
 const DEBUG_DB_PANEL_STATE = process.env.PANE_DEBUG_DB_PANEL_STATE === "1";
 interface PanelStateLogSummary {
   readonly serializedLength: number;
@@ -3484,6 +3501,14 @@ export class DatabaseService {
       .run(sessionId, type, data);
   }
 
+  getSessionOutputCount(sessionId: string): number {
+    // SAFETY: COUNT always returns one row with a numeric count, including zero for an empty session.
+    const row = this.db
+      .prepare("SELECT COUNT(*) AS count FROM session_outputs WHERE session_id = ?")
+      .get(sessionId) as { count: number };
+    return row.count;
+  }
+
   getSessionOutputs(sessionId: string, limit?: number): SessionOutput[] {
     const effectiveLimit = limit ?? Number.NaN;
     if (Number.isFinite(effectiveLimit) && effectiveLimit > 0) {
@@ -4566,10 +4591,7 @@ export class DatabaseService {
     const isActive = activePanel?.active_panel_id === panelId;
 
     // SAFETY: Panel state JSON is written from ToolPanelState by createPanel/updatePanel.
-    const state = row.state
-      // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-      ? (JSON.parse(row.state) as ToolPanelState)
-      : { isActive: false, hasBeenViewed: false, customState: {} };
+    const state = parsePanelJson<ToolPanelState>(row.state, { isActive: false, hasBeenViewed: false, customState: {} });
     // Update isActive based on whether this panel is the active one
     state.isActive = isActive;
 
@@ -4581,14 +4603,11 @@ export class DatabaseService {
       type: row.type as ToolPanelType,
       title: row.title,
       state,
-      metadata: row.metadata
-        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-        ? (JSON.parse(row.metadata) as ToolPanelMetadata)
-        : {
-            createdAt: row.created_at,
-            lastActiveAt: row.created_at,
-            position: 0,
-          },
+      metadata: parsePanelJson<ToolPanelMetadata>(row.metadata, {
+        createdAt: row.created_at,
+        lastActiveAt: row.created_at,
+        position: 0,
+      }),
     };
   }
 
@@ -4616,10 +4635,7 @@ export class DatabaseService {
 
     return rows.map((row) => {
       // SAFETY: Panel state JSON is written from ToolPanelState by createPanel/updatePanel.
-      const state = row.state
-        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-        ? (JSON.parse(row.state) as ToolPanelState)
-        : { isActive: false, hasBeenViewed: false, customState: {} };
+      const state = parsePanelJson<ToolPanelState>(row.state, { isActive: false, hasBeenViewed: false, customState: {} });
       // Update isActive based on whether this panel is the active one
       state.isActive = row.id === activePanelId;
 
@@ -4631,14 +4647,11 @@ export class DatabaseService {
         type: row.type as ToolPanelType,
         title: row.title,
         state,
-        metadata: row.metadata
-          // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-          ? (JSON.parse(row.metadata) as ToolPanelMetadata)
-          : {
-              createdAt: row.created_at,
-              lastActiveAt: row.created_at,
-              position: 0,
-            },
+        metadata: parsePanelJson<ToolPanelMetadata>(row.metadata, {
+          createdAt: row.created_at,
+          lastActiveAt: row.created_at,
+          position: 0,
+        }),
       };
     });
   }
@@ -4658,18 +4671,12 @@ export class DatabaseService {
       // SAFETY: The panel type column is constrained to values written from ToolPanelType.
       type: row.type as ToolPanelType,
       title: row.title,
-      state: row.state
-        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-        ? (JSON.parse(row.state) as ToolPanelState)
-        : { isActive: false },
-      metadata: row.metadata
-        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-        ? (JSON.parse(row.metadata) as ToolPanelMetadata)
-        : {
-            createdAt: row.created_at,
-            lastActiveAt: row.created_at,
-            position: 0,
-          },
+      state: parsePanelJson<ToolPanelState>(row.state, { isActive: false }),
+      metadata: parsePanelJson<ToolPanelMetadata>(row.metadata, {
+        createdAt: row.created_at,
+        lastActiveAt: row.created_at,
+        position: 0,
+      }),
     }));
   }
 
@@ -4693,18 +4700,12 @@ export class DatabaseService {
       // SAFETY: The panel type column is constrained to values written from ToolPanelType.
       type: row.type as ToolPanelType,
       title: row.title,
-      state: row.state
-        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-        ? (JSON.parse(row.state) as ToolPanelState)
-        : { isActive: false },
-      metadata: row.metadata
-        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-        ? (JSON.parse(row.metadata) as ToolPanelMetadata)
-        : {
-            createdAt: row.created_at,
-            lastActiveAt: row.created_at,
-            position: 0,
-          },
+      state: parsePanelJson<ToolPanelState>(row.state, { isActive: false }),
+      metadata: parsePanelJson<ToolPanelMetadata>(row.metadata, {
+        createdAt: row.created_at,
+        lastActiveAt: row.created_at,
+        position: 0,
+      }),
     }));
   }
 
@@ -4745,10 +4746,7 @@ export class DatabaseService {
     if (!row) return null;
 
     // SAFETY: Panel state JSON is written from ToolPanelState by createPanel/updatePanel.
-    const state = row.state
-      // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-      ? (JSON.parse(row.state) as ToolPanelState)
-      : { isActive: true, hasBeenViewed: false };
+    const state = parsePanelJson<ToolPanelState>(row.state, { isActive: true, hasBeenViewed: false });
     // This panel is the active one by definition (we joined on active_panel_id)
     state.isActive = true;
 
@@ -4760,14 +4758,11 @@ export class DatabaseService {
       type: row.type as ToolPanelType,
       title: row.title,
       state,
-      metadata: row.metadata
-        // SAFETY: Persisted JSON in this column is produced by the matching typed serializer.
-        ? (JSON.parse(row.metadata) as ToolPanelMetadata)
-        : {
-            createdAt: row.created_at,
-            lastActiveAt: row.created_at,
-            position: 0,
-          },
+      metadata: parsePanelJson<ToolPanelMetadata>(row.metadata, {
+        createdAt: row.created_at,
+        lastActiveAt: row.created_at,
+        position: 0,
+      }),
     };
   }
 

--- a/main/src/services/panelManager.ts
+++ b/main/src/services/panelManager.ts
@@ -8,16 +8,6 @@ import type { AnalyticsManager } from './analyticsManager';
 import type { PaneEventArgument } from '../core/eventSink';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 
-type PersistedPanelValue = ToolPanelState | ToolPanelMetadata | string;
-
-function serializedPanelValue(value: PersistedPanelValue): string | null {
-  try {
-    return decodeBoundary(value, boundary.string);
-  } catch {
-    return null;
-  }
-}
-
 function logsPanelState(panel: ToolPanel): LogsPanelState {
   // SAFETY: Callers first discriminate `panel.type === 'logs'`; this state is
   // created and persisted by the logs manager as LogsPanelState.
@@ -366,25 +356,6 @@ class PanelManager {
     // Load from database if not cached
     const panel = databaseService.getPanel(panelId);
     if (panel) {
-      // Fix any panels that have state stored as a string (defensive programming)
-      const serializedState = serializedPanelValue(panel.state);
-      if (serializedState !== null) {
-        try {
-          panel.state = JSON.parse(serializedState);
-        } catch (e) {
-          console.error(`[PanelManager] Failed to parse panel state for ${panel.id}:`, e);
-          panel.state = { isActive: false, hasBeenViewed: false, customState: {} };
-        }
-      }
-      const serializedMetadata = serializedPanelValue(panel.metadata);
-      if (serializedMetadata !== null) {
-        try {
-          panel.metadata = JSON.parse(serializedMetadata);
-        } catch (e) {
-          console.error(`[PanelManager] Failed to parse panel metadata for ${panel.id}:`, e);
-          panel.metadata = { createdAt: new Date().toISOString(), lastActiveAt: new Date().toISOString(), position: 0 };
-        }
-      }
       // Skip caching if this panel belongs to a session we've already
       // archived in this process. Prevents a post-archive event from
       // resurrecting the cache entry and undoing L3 cleanup.
@@ -407,31 +378,11 @@ class PanelManager {
     // Summary reads must never replace complete cached state with missing buffers.
     const shouldCache = includeScrollback && !this.archivedSessionIds.has(sessionId);
 
-    // Fix any panels that have state stored as a string (defensive programming)
-    panels.forEach(panel => {
-      const serializedState = serializedPanelValue(panel.state);
-      if (serializedState !== null) {
-        try {
-          panel.state = JSON.parse(serializedState);
-        } catch (e) {
-          console.error(`[PanelManager] Failed to parse panel state for ${panel.id}:`, e);
-          panel.state = { isActive: false, hasBeenViewed: false, customState: {} };
-        }
-      }
-      const serializedMetadata = serializedPanelValue(panel.metadata);
-      if (serializedMetadata !== null) {
-        try {
-          panel.metadata = JSON.parse(serializedMetadata);
-        } catch (e) {
-          console.error(`[PanelManager] Failed to parse panel metadata for ${panel.id}:`, e);
-          panel.metadata = { createdAt: new Date().toISOString(), lastActiveAt: new Date().toISOString(), position: 0 };
-        }
-      }
-      // Update cache unless we've archived this session
-      if (shouldCache) {
+    if (shouldCache) {
+      for (const panel of panels) {
         this.panels.set(panel.id, panel);
       }
-    });
+    }
 
     return panels;
   }

--- a/main/src/services/sessionManager.output-count.test.ts
+++ b/main/src/services/sessionManager.output-count.test.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { DatabaseService } from '../database/database';
+import { SessionManager } from './sessionManager';
+
+describe('prompt marker output counts', () => {
+  it('preserves marker offsets across all output types without reading history payloads', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-prompt-count-'));
+    const db = new DatabaseService(path.join(tempDir, 'sessions.db'));
+    const manager = new SessionManager(db);
+    try {
+      db.initialize();
+      for (const id of ['target', 'other']) {
+        db.createSession({ id, name: id, initial_prompt: '', worktree_name: id, worktree_path: tempDir, project_id: null, tool_type: 'none' });
+      }
+      expect(db.getSessionOutputCount('target')).toBe(0);
+      expect(db.getSessionOutputCount('missing')).toBe(0);
+      db.addSessionOutput('other', 'stdout', 'unrelated output');
+      for (const type of ['stdout', 'stderr', 'system', 'json', 'error'] as const) {
+        db.addSessionOutput('target', type, 'x'.repeat(64 * 1024));
+      }
+      const historyRead = vi.spyOn(db, 'getSessionOutputs').mockImplementation(() => {
+        throw new Error('Prompt markers must not load output payloads');
+      });
+
+      manager.addSessionOutput('target', {
+        type: 'json', data: { type: 'user', message: { content: 'new prompt' } }, timestamp: new Date(),
+      });
+      expect(db.getSessionOutputCount('target')).toBe(6);
+      expect(db.getPromptMarkers('target').map(marker => marker.output_index)).toEqual([5]);
+
+      await manager.continueConversation('target', 'follow-up');
+      expect(db.getSessionOutputCount('target')).toBe(7);
+      expect(db.getPromptMarkers('target').map(marker => marker.output_index)).toEqual([5, 7]);
+      expect(historyRead).not.toHaveBeenCalled();
+      db.clearSessionOutputs('target');
+      expect(db.getSessionOutputCount('target')).toBe(0);
+      expect(db.getSessionOutputCount('other')).toBe(1);
+    } finally {
+      await manager.cleanup();
+      db.close();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -733,8 +733,8 @@ export class SessionManager extends EventEmitter {
       
       if (promptText) {
         // Get current output count to use as index
-        const outputs = this.db.getSessionOutputs(id);
-        this.db.addPromptMarker(id, promptText, outputs.length - 1);
+        const outputCount = this.db.getSessionOutputCount(id);
+        this.db.addPromptMarker(id, promptText, outputCount - 1);
         // Also add to conversation messages for continuation support
         this.db.addConversationMessage(id, 'user', promptText);
       }
@@ -1104,8 +1104,8 @@ export class SessionManager extends EventEmitter {
       
       // Add a prompt marker for this continued conversation
       // Get current output count to use as index
-      const outputs = this.db.getSessionOutputs(id);
-      this.db.addPromptMarker(id, userMessage, outputs.length);
+      const outputCount = this.db.getSessionOutputCount(id);
+      this.db.addPromptMarker(id, userMessage, outputCount);
       
       // Emit event for the Claude Code manager to handle
       this.emit('conversation-continue', { sessionId: id, message: userMessage });

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,20 @@
 
 This directory contains build and maintenance scripts for the Pane application.
 
+## benchmark-session-output.js
+
+Compares loading terminal history just to count it with an indexed SQLite
+count on a temporary 10,000-row database. Reports median read time and heap
+growth, then deletes the fixture.
+
+```bash
+pnpm build:main
+node --expose-gc scripts/benchmark-session-output.js
+```
+
+See [the session output audit](../docs/SESSION_OUTPUT_PERFORMANCE.md) for
+results, regression checks, and measurement limits.
+
 ## generate-notices.js
 
 Generates a NOTICES file containing all third-party licenses for dependencies included in the Pane distribution.

--- a/scripts/benchmark-session-output.js
+++ b/scripts/benchmark-session-output.js
@@ -1,0 +1,50 @@
+// Run after pnpm build:main with the same Node version used for native modules:
+// node --expose-gc scripts/benchmark-session-output.js
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+const { DatabaseService } = require('../main/dist/main/src/database/database.js');
+
+const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'pane-output-benchmark-'));
+const db = new DatabaseService(path.join(directory, 'sessions.db'));
+const rowCount = 10000;
+const payload = 'x'.repeat(8192);
+
+function measure(readCount) {
+  const times = [];
+  const heaps = [];
+  for (let i = 0; i < 9; i++) {
+    global.gc?.();
+    const heapBefore = process.memoryUsage().heapUsed;
+    const started = performance.now();
+    assert.equal(readCount(), rowCount);
+    times.push(performance.now() - started);
+    heaps.push(process.memoryUsage().heapUsed - heapBefore);
+  }
+  times.sort((a, b) => a - b);
+  heaps.sort((a, b) => a - b);
+  return { medianMs: Number(times[4].toFixed(3)), medianHeapMiB: Number((heaps[4] / 1024 / 1024).toFixed(3)) };
+}
+
+try {
+  db.initialize();
+  db.createSession({ id: 'benchmark', name: 'Benchmark', initial_prompt: '', worktree_name: 'benchmark', worktree_path: directory, project_id: null, tool_type: 'none' });
+  db.transaction(() => {
+    for (let i = 0; i < rowCount; i++) db.addSessionOutput('benchmark', 'stdout', payload);
+  });
+  // Warm both query paths before collecting median measurements.
+  db.getSessionOutputs('benchmark');
+  db.getSessionOutputCount('benchmark');
+  console.log(JSON.stringify({
+    node: process.version,
+    rows: rowCount,
+    payloadMiB: rowCount * payload.length / 1024 / 1024,
+    loadHistoryThenCount: measure(() => db.getSessionOutputs('benchmark').length),
+    countInDatabase: measure(() => db.getSessionOutputCount('benchmark')),
+  }, null, 2));
+} finally {
+  db.close();
+  fs.rmSync(directory, { recursive: true, force: true });
+}

--- a/tests/electronApiMock.ts
+++ b/tests/electronApiMock.ts
@@ -336,6 +336,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         if (prop === 'onGitStatusUpdated') {
           return (callback: MockEventCallback) => subscribe('git-status-updated', callback);
         }
+        if (prop === 'onTerminalOutput') {
+          return (callback: MockEventCallback) => subscribe('terminal-output', callback);
+        }
         if (prop === 'onTerminalFontUpdated') {
           return (callback: MockEventCallback) => subscribe('config:terminal-font-updated', callback);
         }
@@ -1132,6 +1135,9 @@ export async function installElectronApiMock(page: Page, options: ElectronApiMoc
         },
         emitGitStatusUpdated(sessionId: string, gitStatus: JsonObject) {
           emit('git-status-updated', { sessionId, gitStatus: clone(gitStatus) });
+        },
+        emitTerminalOutput(sessionId: string, data: string) {
+          emit('terminal-output', { sessionId, type: 'stdout', data });
         },
         emitSessionUpdated(session: JsonObject) {
           emit('session:updated', clone(session));

--- a/tests/session-output-perf.spec.ts
+++ b/tests/session-output-perf.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+import { boundary, decodeBoundary } from '../shared/validation/boundaryDecoder';
+import { installElectronApiMock } from './electronApiMock';
+
+const renderEvidenceSchema = boundary.object({
+  components: boundary.array(boundary.object({ component: boundary.string, renders: boundary.number })),
+});
+
+test('background terminal output does not rerender the app shell or home page', async ({ page }) => {
+  test.skip(process.env.PANE_REACT_SCAN !== '1', 'Run with PANE_REACT_SCAN=1 and a fresh dev server to collect component render evidence.');
+  const renders = new Map<string, number>();
+  let reports = 0;
+  page.on('console', message => {
+    const prefix = '[render-evidence] ';
+    if (!message.text().startsWith(prefix)) return;
+    const evidence = decodeBoundary(JSON.parse(message.text().slice(prefix.length)), renderEvidenceSchema);
+    reports++;
+    for (const { component, renders: count } of evidence.components) {
+      renders.set(component, (renders.get(component) ?? 0) + count);
+    }
+  });
+  await installElectronApiMock(page);
+  await page.goto('/');
+  await expect(page.getByTestId('sidebar').first()).toBeVisible();
+  await expect.poll(() => reports).toBeGreaterThan(0);
+  // Let startup effects and the one-second render reporter finish before the burst.
+  await page.waitForTimeout(2200);
+  expect(renders.get('App')).toBeGreaterThan(0);
+  expect(renders.get('HomePage')).toBeGreaterThan(0);
+  renders.clear();
+
+  await page.evaluate(async () => {
+    // SAFETY: installElectronApiMock installs this typed controller before the renderer starts.
+    const mock = (window as typeof window & {
+      __paneTestElectronMock: { emitTerminalOutput(sessionId: string, data: string): void };
+    }).__paneTestElectronMock;
+    for (let index = 0; index < 100; index++) {
+      mock.emitTerminalOutput('background-session', `chunk-${index}`);
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+    }
+  });
+  await page.waitForTimeout(1200);
+  const retained = await page.evaluate(async modulePath => {
+    const { useSessionStore }: typeof import('../frontend/src/stores/sessionStore') = await import(modulePath);
+    return useSessionStore.getState().getTerminalOutput('background-session');
+  }, '/src/stores/sessionStore.ts');
+  expect(retained).toEqual(Array.from({ length: 100 }, (_, index) => `chunk-${index}`));
+  const result = { chunks: retained.length, appRenders: renders.get('App') ?? 0, homeRenders: renders.get('HomePage') ?? 0 };
+  console.log(JSON.stringify(result));
+  expect(result.appRenders).toBe(0);
+  expect(result.homeRenders).toBe(0);
+});


### PR DESCRIPTION
## Why

Terminal activity still caused avoidable renderer and main-process work after #591. Background output subscribed the entire app shell to buffer updates, prompt markers loaded all historical payloads just to count rows, and history loading's synchronous “batching” could discard the newest messages.

## Changes

- Subscribe App, HomePage, and the IPC hook only to the session fields/actions they use; remove the hook's unused fake socket return.
- Count output rows in SQLite while preserving both prompt-marker offset conventions and every output type.
- Retain the newest 300 text outputs and 100 JSON messages independently, in chronological order; ignore history arriving for deleted sessions.
- Decode panel JSON at the database boundary, including legacy string-wrapped values and malformed-legacy fallbacks. Remove the manager's duplicate parsing and exception-driven string checks.

Net removal of 88 implementation lines. No schema, dependency, or terminal scrollback-limit changes.

## Measured results

Compared with `80b8b621` (v2.4.100), on Linux / Node 22.18.0:

| Workload | Before | After |
| --- | ---: | ---: |
| Count 10,000 output rows / 78.125 MiB of payload, median of 9 | 253.476 ms | 0.353 ms |
| Temporary JS heap growth for the count | 83.772 MiB | 0.001 MiB |
| App renders recorded for 100 background output chunks | 100 | 0 |
| HomePage renders recorded for that burst | 64 | 0 |
| Chunks retained | 100 | 100 |

These are isolated measurements, not an end-to-end speedup claim. Reproduction commands and limits are in [docs/SESSION_OUTPUT_PERFORMANCE.md](https://github.com/dcouple/Pane/blob/perf/trim-terminal-event-overhead/docs/SESSION_OUTPUT_PERFORMANCE.md).

## Validation

- `pnpm lint` and `pnpm typecheck`: pass. Five existing unused-variable ESLint warnings remain in `skillCacheManager.ts`.
- `pnpm build:main` and `pnpm build:frontend`: pass, including preload, xterm request-mode, and production React Scan exclusion checks.
- Frontend Vitest: **334 passed**.
- Full main Vitest: **910 passed, 2 skipped, 15 failed**. All failures are Unix-socket `EPERM` restrictions in this environment; the same 15 failures reproduce on unchanged main.
- Final focused database, prompt-marker, and terminal-manager run: **43 passed**.
- Chromium with the existing Electron IPC mock: render regression and two startup smoke checks, **3 passed**.
- New history, legacy-panel, and render regressions fail against the baseline and pass with this change.

The browser checks used a Vite-only web server. Native desktop and packaged Windows interaction were not exercised.