### PR TITLE
Refactor Pane runtime: centralize routing and remove blocking command paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@
 - Development runs capture renderer and main-process output in root `frontend-debug.log` and `backend-debug.log`; inspect those logs when reproducing app failures. They are reset when development starts.
 - Update docs alongside code; do not alter build targets without discussion.
 - Use repository scripts (pnpm) and keep formatting consistent with existing files.
+- Route preload invokes with `isDaemonOwnedChannel` from `shared/types/daemon.ts`; the preload bundle inlines it. Keep ownership lists in that shared module, including the distinction between Electron-only actions and daemon active-session hints. Run `pnpm build:main` to verify sandbox compatibility.
+- Use the asynchronous `CommandRunner`/`CommandExecutor` APIs for project commands. Await results through IPC and lifecycle callers, discard results from stopped/replaced watchers, and serialize Spotlight checkouts with restoration.
 - For RunPane local-control debugging on macOS, test against an isolated Pane directory (for example `PANE_DIR=~/.pane_test pnpm dev`) and validate with the local wrapper (`node packages/runpane/dist/cli.js doctor --json --pane-dir ~/.pane_test`, then `repos list`, `repos add --path ... --yes`, and `panes list`). Use Node 22 for repo scripts; if switching between Vitest/plain Node and Electron dev runs, rebuild native modules for the target runtime (`npm rebuild better-sqlite3-multiple-ciphers` for Node, `pnpm electron:rebuild` for Electron).
 
 <!-- pane-agent-context:start -->

--- a/main/src/core/importBoundary.test.ts
+++ b/main/src/core/importBoundary.test.ts
@@ -1,11 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import {
-  DAEMON_OWNED_CHANNEL_PREFIXES,
-  DAEMON_OWNED_EXACT_CHANNELS,
-  ELECTRON_ADAPTER_ONLY_CHANNELS,
-} from '../../../shared/types/daemon';
 
 const MAIN_SRC_ROOT = path.resolve(process.cwd(), 'src');
 
@@ -85,30 +80,13 @@ describe('daemon/client import boundary', () => {
   it('routes daemon-owned preload invokes through the runtime-safe bridge helper', () => {
     const source = readMainSrcFile('preload.ts');
 
-    expect(source).toContain('function isDaemonOwnedChannel');
-    expect(source).toContain('isDaemonOwnedChannel');
-    expect(source).not.toContain("../../shared/types/daemon");
+    expect(source).toContain("import { isDaemonOwnedChannel } from '../../shared/types/daemon'");
+    expect(source).not.toContain('function isDaemonOwnedChannel');
     expect(source).not.toContain("from './daemon/daemonChannels'");
     expect(source).toContain("ipcRenderer.invoke('daemon:invoke', channel, ...args)");
     expect(source).not.toMatch(
       /ipcRenderer\.invoke\('(sessions:|projects:|folders:|prompts:|resource-monitor:|panels:|terminal:|logs:|git:(cancel-status-for-project|clone-repo|commit|execute-project|file-status|get-github-remote|restore|revert)|permission:(getPending|respond)|file:(copy|delete|duplicate|exists|getPath|list|move|read|read-binary|read-project|readAtRevision|rename|resolveAbsolutePath|search|write|write-binary|write-project))/,
     );
-  });
-
-  it('keeps preload channel ownership literals aligned with the shared daemon contract', () => {
-    const source = readMainSrcFile('preload.ts');
-
-    for (const prefix of DAEMON_OWNED_CHANNEL_PREFIXES) {
-      expect(source).toContain(`'${prefix}'`);
-    }
-
-    for (const channel of DAEMON_OWNED_EXACT_CHANNELS) {
-      expect(source).toContain(`'${channel}'`);
-    }
-
-    for (const channel of ELECTRON_ADAPTER_ONLY_CHANNELS) {
-      expect(source).toContain(`'${channel}'`);
-    }
   });
 
   it('keeps task queue environment selection free of Electron globals', () => {

--- a/main/src/daemon/bootstrap.ts
+++ b/main/src/daemon/bootstrap.ts
@@ -342,7 +342,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
 
   if (options.restoreSpotlights !== false) {
     try {
-      spotlightManager.restoreAll();
+      await spotlightManager.restoreAll();
     } catch (error) {
       console.error('[Main] Failed to restore spotlight state:', error);
     }
@@ -359,7 +359,7 @@ export async function createPaneDaemonHost(options: PaneDaemonHostOptions): Prom
     permissionIpcServer,
     async shutdown(): Promise<void> {
       resourceMonitorService.stop();
-      spotlightManager.disableAll();
+      await spotlightManager.disableAll();
       await sessionManager.cleanup();
       await runCommandManager.stopAllRunCommands();
       gitStatusManager.stopPolling();

--- a/main/src/daemon/socketFraming.test.ts
+++ b/main/src/daemon/socketFraming.test.ts
@@ -108,6 +108,10 @@ describe('Pane daemon shared protocol helpers', () => {
     expect(isDaemonOwnedChannel('git:commit')).toBe(true);
     expect(isDaemonOwnedChannel('file:write')).toBe(true);
     expect(isDaemonOwnedChannel('file:showInFolder')).toBe(false);
+    expect(isDaemonOwnedChannel('sessions:open-ide')).toBe(false);
+    // Active-session hints also prioritize polling on remote daemons.
+    expect(isDaemonOwnedChannel('sessions:set-active-session')).toBe(true);
+    expect(isDaemonOwnedChannel('terminal:clipboard-paste-image')).toBe(false);
     expect(isDaemonOwnedChannel('openExternal')).toBe(false);
   });
 

--- a/main/src/events.ts
+++ b/main/src/events.ts
@@ -44,6 +44,81 @@ export function setupEventListeners(services: AppServices): void {
     analyticsManager
   } = services;
 
+  async function appendSessionSummary(sessionId: string, failed: boolean): Promise<void> {
+    try {
+      const session = sessionManager.getSession(sessionId);
+      if (session && session.worktreePath) {
+        const timestamp = new Date().toLocaleTimeString();
+        let commitInfo = `\r\n\x1b[36m[${timestamp}]\x1b[0m \x1b[1m${failed ? '\x1b[41m' : '\x1b[44m'}\x1b[37m 📊 SESSION SUMMARY${failed ? ' (ERROR)' : ''} \x1b[0m\r\n\r\n`;
+
+        // Get project context for this session
+        const summaryCtx = sessionManager.getProjectContext(session.id);
+        if (!summaryCtx) {
+          console.error(`[Events] No project context for session ${session.id}`);
+          return;
+        }
+
+        // Check for uncommitted changes
+        const statusOutput = (await summaryCtx.commandRunner.execAsync('git status --porcelain', session.worktreePath)).stdout.trim();
+
+        if (statusOutput) {
+          const uncommittedFiles = statusOutput.split('\n').length;
+          commitInfo += `\x1b[1m\x1b[33m⚠️  Uncommitted Changes:\x1b[0m ${uncommittedFiles} file${uncommittedFiles > 1 ? 's' : ''}\r\n`;
+
+          // Show first few uncommitted files
+          const filesToShow = statusOutput.split('\n').slice(0, 5);
+          filesToShow.forEach(file => {
+            const [status, ...nameParts] = file.trim().split(/\s+/);
+            const fileName = nameParts.join(' ');
+            commitInfo += `   \x1b[2m${status}\x1b[0m ${fileName}\r\n`;
+          });
+
+          if (uncommittedFiles > 5) {
+            commitInfo += `   \x1b[2m... and ${uncommittedFiles - 5} more\x1b[0m\r\n`;
+          }
+          commitInfo += '\r\n';
+        }
+
+        // Get commit history for this branch
+        const comparisonBranch = await worktreeManager.getSessionComparisonBranch(session, summaryCtx);
+
+        let commits: GitCommit[] = [];
+        try {
+          commits = await gitDiffManager.getCommitHistory(session.worktreePath, 10, comparisonBranch, summaryCtx.commandRunner);
+        } catch (error) {
+          console.error(`[Events] Error getting commit history:`, error);
+        }
+
+        if (commits.length > 0) {
+          commitInfo += `\x1b[1m\x1b[32m📝 Commits ${failed ? 'before error' : 'in this session'}:\x1b[0m\r\n`;
+          commits.forEach((commit, index) => {
+            const shortHash = commit.hash.substring(0, 7);
+            const date = commit.date.toLocaleString();
+            const stats = commit.stats;
+            commitInfo += `\r\n  \x1b[1m${index + 1}.\x1b[0m \x1b[33m${shortHash}\x1b[0m - ${commit.message}\r\n`;
+            commitInfo += `     \x1b[2mby ${commit.author} on ${date}\x1b[0m\r\n`;
+            if (stats.filesChanged > 0) {
+              commitInfo += `     \x1b[32m+${stats.additions}\x1b[0m \x1b[31m-${stats.deletions}\x1b[0m (${stats.filesChanged} file${stats.filesChanged > 1 ? 's' : ''})\r\n`;
+            }
+          });
+        } else if (!statusOutput) {
+          commitInfo += `\x1b[2mNo commits were made ${failed ? 'before the error' : 'in this session'}.\x1b[0m\r\n`;
+        }
+
+        commitInfo += `\r\n\x1b[2m─────────────────────────────────────────\x1b[0m\r\n`;
+
+        // Add this summary to the session output
+        sessionManager.addSessionOutput(sessionId, {
+          type: 'stdout',
+          data: commitInfo,
+          timestamp: new Date()
+        });
+      }
+    } catch (error) {
+      console.error(`Failed to generate session summary for ${sessionId}:`, error);
+    }
+  }
+
   // Wire up analytics manager to panel managers
   if (analyticsManager) {
     panelManager.setAnalyticsManager(analyticsManager);
@@ -245,90 +320,7 @@ export function setupEventListeners(services: AppServices): void {
       console.error(`Failed to refresh git status for session ${sessionId} after exit:`, error);
     }
 
-    // Add commit information when session ends
-    try {
-      const session = sessionManager.getSession(sessionId);
-      if (session && session.worktreePath) {
-        const timestamp = new Date().toLocaleTimeString();
-        let commitInfo = `\r\n\x1b[36m[${timestamp}]\x1b[0m \x1b[1m\x1b[44m\x1b[37m 📊 SESSION SUMMARY \x1b[0m\r\n\r\n`;
-
-        // Get project context for this session
-        const summaryCtx = sessionManager.getProjectContext(session.id);
-        if (!summaryCtx) {
-          console.error(`[Events] No project context for session ${session.id}`);
-          return;
-        }
-
-        // Check for uncommitted changes
-        const statusOutput = summaryCtx.commandRunner.exec('git status --porcelain', session.worktreePath).trim();
-
-        if (statusOutput) {
-          const uncommittedFiles = statusOutput.split('\n').length;
-          commitInfo += `\x1b[1m\x1b[33m⚠️  Uncommitted Changes:\x1b[0m ${uncommittedFiles} file${uncommittedFiles > 1 ? 's' : ''}\r\n`;
-
-          // Show first few uncommitted files
-          const filesToShow = statusOutput.split('\n').slice(0, 5);
-          filesToShow.forEach(file => {
-            const [status, ...nameParts] = file.trim().split(/\s+/);
-            const fileName = nameParts.join(' ');
-            commitInfo += `   \x1b[2m${status}\x1b[0m ${fileName}\r\n`;
-          });
-
-          if (uncommittedFiles > 5) {
-            commitInfo += `   \x1b[2m... and ${uncommittedFiles - 5} more\x1b[0m\r\n`;
-          }
-          commitInfo += '\r\n';
-        }
-
-        // Get commit history for this branch
-        const historyCtx = sessionManager.getProjectContext(session.id);
-        if (!historyCtx) {
-          throw new Error('Project context not found for session');
-        }
-        const comparisonBranch = await worktreeManager.getSessionComparisonBranch(session, historyCtx);
-
-        let commits: GitCommit[] = [];
-        try {
-          commits = gitDiffManager.getCommitHistory(session.worktreePath, 10, comparisonBranch, historyCtx.commandRunner);
-        } catch (error) {
-          console.error(`[Events] Error getting commit history:`, error);
-          // If there's an error, try without specifying main branch (get all commits)
-          try {
-            const fallbackCommand = `git log --format="%H|%s|%ai|%an" --numstat -n 10`;
-            historyCtx.commandRunner.exec(fallbackCommand, session.worktreePath);
-          } catch (fallbackError) {
-            console.error(`[Events] Fallback also failed:`, fallbackError);
-          }
-        }
-
-        if (commits.length > 0) {
-          commitInfo += `\x1b[1m\x1b[32m📝 Commits in this session:\x1b[0m\r\n`;
-          commits.forEach((commit, index) => {
-            const shortHash = commit.hash.substring(0, 7);
-            const date = commit.date.toLocaleString();
-            const stats = commit.stats;
-            commitInfo += `\r\n  \x1b[1m${index + 1}.\x1b[0m \x1b[33m${shortHash}\x1b[0m - ${commit.message}\r\n`;
-            commitInfo += `     \x1b[2mby ${commit.author} on ${date}\x1b[0m\r\n`;
-            if (stats.filesChanged > 0) {
-              commitInfo += `     \x1b[32m+${stats.additions}\x1b[0m \x1b[31m-${stats.deletions}\x1b[0m (${stats.filesChanged} file${stats.filesChanged > 1 ? 's' : ''})\r\n`;
-            }
-          });
-        } else if (!statusOutput) {
-          commitInfo += `\x1b[2mNo commits were made in this session.\x1b[0m\r\n`;
-        }
-
-        commitInfo += `\r\n\x1b[2m─────────────────────────────────────────\x1b[0m\r\n`;
-
-        // Add this summary to the session output
-        sessionManager.addSessionOutput(sessionId, {
-          type: 'stdout',
-          data: commitInfo,
-          timestamp: new Date()
-        });
-      }
-    } catch (error) {
-      console.error(`Failed to generate session summary for ${sessionId}:`, error);
-    }
+    await appendSessionSummary(sessionId, false);
   });
 
   claudeCodeManager.on('error', async ({ panelId, sessionId, error }: { panelId?: string; sessionId: string; error: string }) => {
@@ -361,90 +353,7 @@ export function setupEventListeners(services: AppServices): void {
       console.error(`Failed to cancel execution tracking for session ${sessionId}:`, trackingError);
     }
 
-    // Add commit information when session errors
-    try {
-      const session = sessionManager.getSession(sessionId);
-      if (session && session.worktreePath) {
-        const timestamp = new Date().toLocaleTimeString();
-        let commitInfo = `\r\n\x1b[36m[${timestamp}]\x1b[0m \x1b[1m\x1b[41m\x1b[37m 📊 SESSION SUMMARY (ERROR) \x1b[0m\r\n\r\n`;
-
-        // Get project context for this session
-        const errorCtx = sessionManager.getProjectContext(session.id);
-        if (!errorCtx) {
-          console.error(`[Events] No project context for session ${session.id} in error handler`);
-          return;
-        }
-
-        // Check for uncommitted changes
-        const statusOutput = errorCtx.commandRunner.exec('git status --porcelain', session.worktreePath).trim();
-
-        if (statusOutput) {
-          const uncommittedFiles = statusOutput.split('\n').length;
-          commitInfo += `\x1b[1m\x1b[33m⚠️  Uncommitted Changes:\x1b[0m ${uncommittedFiles} file${uncommittedFiles > 1 ? 's' : ''}\r\n`;
-
-          // Show first few uncommitted files
-          const filesToShow = statusOutput.split('\n').slice(0, 5);
-          filesToShow.forEach(file => {
-            const [status, ...nameParts] = file.trim().split(/\s+/);
-            const fileName = nameParts.join(' ');
-            commitInfo += `   \x1b[2m${status}\x1b[0m ${fileName}\r\n`;
-          });
-
-          if (uncommittedFiles > 5) {
-            commitInfo += `   \x1b[2m... and ${uncommittedFiles - 5} more\x1b[0m\r\n`;
-          }
-          commitInfo += '\r\n';
-        }
-
-        // Get commit history for this branch
-        const errorHistoryCtx = sessionManager.getProjectContext(session.id);
-        if (!errorHistoryCtx) {
-          throw new Error('Project context not found for session');
-        }
-        const comparisonBranch = await worktreeManager.getSessionComparisonBranch(session, errorHistoryCtx);
-
-        let commits: GitCommit[] = [];
-        try {
-          commits = gitDiffManager.getCommitHistory(session.worktreePath, 10, comparisonBranch, errorHistoryCtx.commandRunner);
-        } catch (error) {
-          console.error(`[Events] Error getting commit history:`, error);
-          // If there's an error, try without specifying main branch (get all commits)
-          try {
-            const fallbackCommand = `git log --format="%H|%s|%ai|%an" --numstat -n 10`;
-            errorHistoryCtx.commandRunner.exec(fallbackCommand, session.worktreePath);
-          } catch (fallbackError) {
-            console.error(`[Events] Fallback also failed:`, fallbackError);
-          }
-        }
-
-        if (commits.length > 0) {
-          commitInfo += `\x1b[1m\x1b[32m📝 Commits before error:\x1b[0m\r\n`;
-          commits.forEach((commit, index) => {
-            const shortHash = commit.hash.substring(0, 7);
-            const date = commit.date.toLocaleString();
-            const stats = commit.stats;
-            commitInfo += `\r\n  \x1b[1m${index + 1}.\x1b[0m \x1b[33m${shortHash}\x1b[0m - ${commit.message}\r\n`;
-            commitInfo += `     \x1b[2mby ${commit.author} on ${date}\x1b[0m\r\n`;
-            if (stats.filesChanged > 0) {
-              commitInfo += `     \x1b[32m+${stats.additions}\x1b[0m \x1b[31m-${stats.deletions}\x1b[0m (${stats.filesChanged > 1 ? 's' : ''})\r\n`;
-            }
-          });
-        } else if (!statusOutput) {
-          commitInfo += `\x1b[2mNo commits were made before the error.\x1b[0m\r\n`;
-        }
-
-        commitInfo += `\r\n\x1b[2m─────────────────────────────────────────\x1b[0m\r\n`;
-
-        // Add this summary to the session output
-        sessionManager.addSessionOutput(sessionId, {
-          type: 'stdout',
-          data: commitInfo,
-          timestamp: new Date()
-        });
-      }
-    } catch (summaryError) {
-      console.error(`Failed to generate session summary for ${sessionId}:`, summaryError);
-    }
+    await appendSessionSummary(sessionId, true);
   });
 
   // Listen to terminal output events (independent terminal, not run scripts)

--- a/main/src/ipc/dashboard.ts
+++ b/main/src/ipc/dashboard.ts
@@ -307,53 +307,6 @@ export function registerDashboardHandlers(ipcMain: IpcMain, services: AppService
   });
 }
 
-// Deprecated: This function is not currently used. Use getMainBranchStatusAsync instead.
-// Keeping for potential future use.
-// function getMainBranchStatus(
-//   ctx: { commandRunner: CommandRunner },
-//   projectPath: string,
-//   mainBranch: string
-// ): MainBranchStatus {
-//   try {
-//     const remoteBranch = `origin/${mainBranch}`;
-//     try {
-//       ctx.commandRunner.exec(`git rev-parse --verify ${remoteBranch}`, projectPath);
-//     } catch {
-//       return {
-//         status: 'up-to-date',
-//         lastFetched: formatForDatabase()
-//       };
-//     }
-//     const aheadBehind = ctx.commandRunner.exec(
-//       `git rev-list --left-right --count ${mainBranch}...${remoteBranch}`,
-//       projectPath
-//     ).trim();
-//     const [ahead, behind] = aheadBehind.split('\t').map((n: string) => parseInt(n, 10));
-//     let status: MainBranchStatus['status'];
-//     if (ahead === 0 && behind === 0) {
-//       status = 'up-to-date';
-//     } else if (ahead > 0 && behind === 0) {
-//       status = 'ahead';
-//     } else if (ahead === 0 && behind > 0) {
-//       status = 'behind';
-//     } else {
-//       status = 'diverged';
-//     }
-//     return {
-//       status,
-//       aheadCount: ahead || undefined,
-//       behindCount: behind || undefined,
-//       lastFetched: formatForDatabase()
-//     };
-//   } catch (error) {
-//     console.error('Error getting main branch status:', error);
-//     return {
-//       status: 'up-to-date',
-//       lastFetched: formatForDatabase()
-//     };
-//   }
-// }
-
 async function getRemoteStatuses(
   ctx: { commandRunner: CommandRunner },
   projectPath: string,
@@ -498,95 +451,6 @@ async function getMainBranchStatusAsync(
   }
 }
 
-// Deprecated: This function is not currently used. Use getSessionBranchInfoAsync instead.
-// Keeping for potential future use.
-// async function getSessionBranchInfo(
-//   ctx: { commandRunner: CommandRunner; pathResolver: PathResolver },
-//   session: { id: string; name: string; worktree_path: string; base_commit?: string; base_branch?: string },
-//   projectPath: string,
-//   mainBranch: string
-// ): Promise<SessionBranchInfo | null> {
-//   try {
-//     const worktreeFsPath = ctx.pathResolver.toFileSystem(session.worktree_path);
-//     if (!fs.existsSync(worktreeFsPath)) {
-//       return null;
-//     }
-//     const branchName = ctx.commandRunner.exec('git branch --show-current', session.worktree_path).trim();
-//     if (!branchName) {
-//       return null;
-//     }
-//     let baseCommit = session.base_commit;
-//     const baseBranch = session.base_branch || mainBranch;
-//     if (!baseCommit) {
-//       try {
-//         baseCommit = ctx.commandRunner.exec(`git merge-base ${branchName} ${mainBranch}`, session.worktree_path).trim();
-//       } catch {
-//         baseCommit = 'unknown';
-//       }
-//     }
-//     let isStale = false;
-//     let staleSince: string | undefined;
-//     if (baseCommit && baseCommit !== 'unknown') {
-//       try {
-//         const currentBaseCommit = ctx.commandRunner.exec(`git rev-parse ${baseBranch}`, projectPath).trim();
-//         isStale = currentBaseCommit !== baseCommit;
-//         if (isStale) {
-//           const commitDate = ctx.commandRunner.exec(`git log -1 --format=%cd --date=iso-strict ${currentBaseCommit}`, projectPath).trim();
-//           staleSince = commitDate;
-//         }
-//       } catch {
-//         // Ignore errors
-//       }
-//     }
-//     const hasUncommittedChanges = checkUncommittedChanges(ctx, session.worktree_path);
-//     let commitsAhead = 0;
-//     let commitsBehind = 0;
-//     try {
-//       const aheadBehind = ctx.commandRunner.exec(`git rev-list --left-right --count ${branchName}...${baseBranch}`, session.worktree_path).trim();
-//       const [ahead, behind] = aheadBehind.split('\t').map((n: string) => parseInt(n, 10));
-//       commitsAhead = ahead;
-//       commitsBehind = behind;
-//     } catch {
-//       // Ignore errors
-//     }
-//     let pullRequest: SessionBranchInfo['pullRequest'];
-//     try {
-//       const prOutput = ctx.commandRunner.exec(`gh pr list --head ${branchName} --state all --json number,title,state,url --limit 1`, projectPath).trim();
-//       if (prOutput) {
-//         const prs = JSON.parse(prOutput);
-//         if (prs.length > 0) {
-//           const pr = prs[0];
-//           pullRequest = {
-//             number: pr.number,
-//             title: pr.title,
-//             state: pr.state.toLowerCase() as 'open' | 'closed' | 'merged',
-//             url: pr.url
-//           };
-//         }
-//       }
-//     } catch {
-//       // gh command might not be available or configured
-//     }
-//     return {
-//       sessionId: session.id,
-//       sessionName: session.name,
-//       branchName,
-//       worktreePath: session.worktree_path,
-//       baseCommit,
-//       baseBranch,
-//       isStale,
-//       staleSince,
-//       hasUncommittedChanges,
-//       pullRequest,
-//       commitsAhead,
-//       commitsBehind
-//     };
-//   } catch (error) {
-//     console.error(`Error getting branch info for session ${session.id}:`, error);
-//     return null;
-//   }
-// }
-
 async function getSessionBranchInfoAsync(
   ctx: { commandRunner: CommandRunner; pathResolver: PathResolver },
   session: { id: string; name: string; worktree_path: string; base_commit?: string; base_branch?: string },
@@ -729,20 +593,6 @@ async function getSessionBranchInfoAsync(
     return null;
   }
 }
-
-// Deprecated: This function is not currently used. Use checkUncommittedChangesAsync instead.
-// Keeping for potential future use.
-// function checkUncommittedChanges(
-//   ctx: { commandRunner: CommandRunner },
-//   worktreePath: string
-// ): boolean {
-//   try {
-//     const status = ctx.commandRunner.exec('git status --porcelain', worktreePath);
-//     return status.trim().length > 0;
-//   } catch {
-//     return false;
-//   }
-// }
 
 async function checkUncommittedChangesAsync(
   ctx: { commandRunner: CommandRunner },

--- a/main/src/ipc/file.ts
+++ b/main/src/ipc/file.ts
@@ -1142,7 +1142,7 @@ export function registerFileHandlers(
       }).join(' ')}`;
 
       // Execute git command using CommandRunner
-      const result = commandRunner.exec(command, project.path);
+      const result = (await commandRunner.execAsync(command, project.path)).stdout;
 
       console.log('[git:execute-project] Command successful');
       return { success: true, output: result };

--- a/main/src/ipc/git.ts
+++ b/main/src/ipc/git.ts
@@ -207,7 +207,7 @@ export function registerGitHandlers(
     let useFallback = false;
 
     try {
-      commits = gitDiffManager.getCommitHistory(session.worktreePath, limit, comparisonBranch, ctx.commandRunner);
+      commits = await gitDiffManager.getCommitHistory(session.worktreePath, limit, comparisonBranch, ctx.commandRunner);
     } catch (error) {
       // Only isMainRepo sessions have a fallback path (raw last-N commits);
       // worktree sessions should propagate the error.
@@ -279,7 +279,7 @@ export function registerGitHandlers(
       const ctx = sessionManager.getProjectContext(sessionId);
       if (!ctx) throw new Error('Project context not found for session');
 
-      const hasUncommittedChanges = gitDiffManager.hasChanges(session.worktreePath, ctx.commandRunner);
+      const hasUncommittedChanges = await gitDiffManager.hasChanges(session.worktreePath, ctx.commandRunner);
       if (hasUncommittedChanges) {
         // Get stats for uncommitted changes
         const uncommittedDiff = await gitDiffManager.getDiffManifest(session.worktreePath, { kind: 'working-tree' }, ctx.commandRunner, {
@@ -331,7 +331,7 @@ export function registerGitHandlers(
       const ctx = sessionManager.getProjectContext(sessionId);
       if (!ctx) throw new Error('Project context not found for session');
 
-      const diff = gitDiffManager.getCommitDiff(session.worktreePath, commit.hash, ctx.commandRunner);
+      const diff = await gitDiffManager.getCommitDiff(session.worktreePath, commit.hash, ctx.commandRunner);
       return { success: true, data: diff };
     } catch (error) {
       console.error('Failed to get execution diff:', error);
@@ -358,7 +358,7 @@ export function registerGitHandlers(
       const comparisonBranch = await worktreeManager.getSessionComparisonBranch(session, ctx);
       let branch: string;
       try {
-        branch = ctx.commandRunner.exec('git rev-parse --abbrev-ref HEAD', session.worktreePath).trim() || session.baseBranch || 'unknown';
+        branch = (await ctx.commandRunner.execAsync('git rev-parse --abbrev-ref HEAD', session.worktreePath)).stdout.trim() || session.baseBranch || 'unknown';
       } catch {
         branch = session.baseBranch || 'unknown';
       }
@@ -367,7 +367,7 @@ export function registerGitHandlers(
       let useFallback = false;
 
       try {
-        entries = gitDiffManager.getGraphCommitHistory(session.worktreePath, branch, 50, comparisonBranch, ctx.commandRunner);
+        entries = await gitDiffManager.getGraphCommitHistory(session.worktreePath, branch, 50, comparisonBranch, ctx.commandRunner);
         if (entries.length === 0 && session.isMainRepo) {
           useFallback = true;
         }
@@ -392,14 +392,14 @@ export function registerGitHandlers(
       }
 
       // Prepend uncommitted changes if any
-      const hasUncommittedChanges = gitDiffManager.hasChanges(session.worktreePath, ctx.commandRunner);
+      const hasUncommittedChanges = await gitDiffManager.hasChanges(session.worktreePath, ctx.commandRunner);
       if (hasUncommittedChanges) {
         // Get diff stats for uncommitted changes
         let filesChanged = 0;
         let additions = 0;
         let deletions = 0;
         try {
-          const combinedStat = ctx.commandRunner.exec('git diff HEAD --shortstat', session.worktreePath).trim();
+          const combinedStat = (await ctx.commandRunner.execAsync('git diff HEAD --shortstat', session.worktreePath)).stdout.trim();
           if (combinedStat) {
             const fileMatch = combinedStat.match(/(\d+) files? changed/);
             const addMatch = combinedStat.match(/(\d+) insertions?\(\+\)/);
@@ -444,20 +444,20 @@ export function registerGitHandlers(
       if (!ctx) throw new Error('Project context not found for session');
 
       // Check if there are any changes to commit
-      const status = ctx.commandRunner.exec('git status --porcelain', session.worktreePath).trim();
+      const status = (await ctx.commandRunner.execAsync('git status --porcelain', session.worktreePath)).stdout.trim();
 
       if (!status) {
         return { success: false, error: 'No changes to commit' };
       }
 
       // Stage all changes
-      ctx.commandRunner.exec('git add -A', session.worktreePath);
+      await ctx.commandRunner.execAsync('git add -A', session.worktreePath);
 
       // Create the commit with Pane's signature using safe escaping
       const commitCommand = buildGitCommitCommand(message);
 
       try {
-        ctx.commandRunner.exec(commitCommand, session.worktreePath);
+        await ctx.commandRunner.execAsync(commitCommand, session.worktreePath);
 
         // Refresh git status for this session after commit
         await refreshGitStatusForSession(sessionId);
@@ -497,16 +497,16 @@ export function registerGitHandlers(
       if (!ctx) return { success: false, error: 'No project context' };
 
       // Check working tree + staged changes for this specific file
-      const modified = ctx.commandRunner.exec(
+      const modified = (await ctx.commandRunner.execAsync(
         `git diff --name-only HEAD -- "${filePath}"`,
         session.worktreePath
-      ).trim();
+      )).stdout.trim();
 
       // Check if file is untracked
-      const untracked = ctx.commandRunner.exec(
+      const untracked = (await ctx.commandRunner.execAsync(
         `git ls-files --others --exclude-standard -- "${filePath}"`,
         session.worktreePath
-      ).trim();
+      )).stdout.trim();
 
       const status = untracked.length > 0 ? 'untracked' : modified.length > 0 ? 'modified' : 'clean';
       return { success: true, data: { status } };
@@ -752,7 +752,7 @@ export function registerGitHandlers(
       // Check if we're actually in a rebase state (could have been pre-detected conflicts)
       // Try to abort any existing rebase, but don't fail if there isn't one
       try {
-        const statusOutput = ctx.commandRunner.exec('git status --porcelain=v1', session.worktreePath);
+        const statusOutput = (await ctx.commandRunner.execAsync('git status --porcelain=v1', session.worktreePath)).stdout;
         if (statusOutput.includes('rebase')) {
           await worktreeManager.abortRebase(session.worktreePath, ctx.commandRunner);
 
@@ -1662,7 +1662,7 @@ export function registerGitHandlers(
       const comparisonBranch = await worktreeManager.getSessionComparisonBranch(session, ctx);
 
       // Get current branch name
-      const currentBranch = ctx.commandRunner.exec('git branch --show-current', session.worktreePath).trim();
+      const currentBranch = (await ctx.commandRunner.execAsync('git branch --show-current', session.worktreePath)).stdout.trim();
 
       // Only call getOriginBranch for legacy isMainRepo sessions where baseBranch is not set.
       // When baseBranch is set it already includes the origin/ prefix if applicable — calling
@@ -1772,7 +1772,7 @@ export function registerGitHandlers(
       const ctx = sessionManager.getProjectContext(sessionId);
       if (!ctx) return { success: true, data: null };
 
-      const stdout = ctx.commandRunner.exec('git remote -v', session.worktreePath);
+      const stdout = (await ctx.commandRunner.execAsync('git remote -v', session.worktreePath)).stdout;
 
       // Parse remote output for github.com
       const lines = stdout.split('\n');

--- a/main/src/ipc/project.ts
+++ b/main/src/ipc/project.ts
@@ -147,7 +147,7 @@ export function registerProjectHandlers(
 
       // Check if it's a git repository
       try {
-        commandRunner.exec('git rev-parse --is-inside-work-tree', actualPath, { silent: true });
+        await commandRunner.execAsync('git rev-parse --is-inside-work-tree', actualPath, { silent: true });
         isGitRepo = true;
         console.log('[Main] Directory is already a git repository');
       } catch {
@@ -158,13 +158,13 @@ export function registerProjectHandlers(
       if (!isGitRepo) {
         try {
           const branchName = 'main';
-          commandRunner.exec('git init', actualPath);
+          await commandRunner.execAsync('git init', actualPath);
           console.log('[Main] Git repository initialized successfully');
 
-          commandRunner.exec(`git checkout -b ${branchName}`, actualPath);
+          await commandRunner.execAsync(`git checkout -b ${branchName}`, actualPath);
           console.log(`[Main] Created and checked out branch: ${branchName}`);
 
-          commandRunner.exec('git commit -m "Initial commit" --allow-empty', actualPath, { env: getGitAttributionEnv(configManager.getConfig()) });
+          await commandRunner.execAsync('git commit -m "Initial commit" --allow-empty', actualPath, { env: getGitAttributionEnv(configManager.getConfig()) });
           console.log('[Main] Created initial empty commit');
         } catch (error) {
           console.error('[Main] Failed to initialize git repository:', error);

--- a/main/src/ipc/runpane.ts
+++ b/main/src/ipc/runpane.ts
@@ -2655,7 +2655,7 @@ async function computeArchiveSafety(services: AppServices, pane: Session): Promi
     // Deliberately bypass gitStatusManager's cache (up to CACHE_TTL_MS stale)
     // and read git plumbing directly — a safety gate must see the current
     // state, not a snapshot from moments-ago that predates a recent commit.
-    const workingDirectory = fastCheckWorkingDirectory(pane.worktreePath, ctx.commandRunner.wslContext);
+    const workingDirectory = await fastCheckWorkingDirectory(pane.worktreePath, ctx.commandRunner.wslContext);
     const hasUncommittedChanges = workingDirectory.hasModified || workingDirectory.hasStaged || workingDirectory.hasConflicts;
     const hasUntrackedFiles = workingDirectory.hasUntracked;
 
@@ -2667,7 +2667,7 @@ async function computeArchiveSafety(services: AppServices, pane: Session): Promi
         pane.worktreePath,
         { timeout: 30000 },
       );
-      const unpushedCommitDetails = listCommitsAhead(
+      const unpushedCommitDetails = await listCommitsAhead(
         pane.worktreePath,
         upstream,
         ctx.commandRunner.wslContext,
@@ -2688,7 +2688,7 @@ async function computeArchiveSafety(services: AppServices, pane: Session): Promi
     // commits ahead of its base/comparison branch are the closest proxy for
     // "unpushed work".
     const comparisonBranch = await services.worktreeManager.getSessionComparisonBranch(pane, ctx);
-    const unpushedCommitDetails = listCommitsAhead(
+    const unpushedCommitDetails = await listCommitsAhead(
       pane.worktreePath,
       comparisonBranch,
       ctx.commandRunner.wslContext,

--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -362,7 +362,7 @@ export function registerSessionHandlers(
       // Disable spotlight if this session is spotlighted
       try {
         if (spotlightManager.isSpotlightActive(sessionId)) {
-          spotlightManager.disable(sessionId);
+          await spotlightManager.disable(sessionId);
           console.log(`[Session IPC] Disabled spotlight for archived session ${sessionId}`);
         }
       } catch (spotlightError) {

--- a/main/src/ipc/spotlight.ts
+++ b/main/src/ipc/spotlight.ts
@@ -4,7 +4,7 @@ import type { AppServices } from './types';
 export function registerSpotlightHandlers(ipcMain: IpcMain, services: AppServices) {
   ipcMain.handle('spotlight:enable', async (_event, sessionId: string) => {
     try {
-      services.spotlightManager.enable(sessionId);
+      await services.spotlightManager.enable(sessionId);
       return { success: true };
     } catch (error) {
       console.error('[Spotlight IPC] Enable failed:', error);
@@ -14,7 +14,7 @@ export function registerSpotlightHandlers(ipcMain: IpcMain, services: AppService
 
   ipcMain.handle('spotlight:disable', async (_event, sessionId: string) => {
     try {
-      services.spotlightManager.disable(sessionId);
+      await services.spotlightManager.disable(sessionId);
       return { success: true };
     } catch (error) {
       console.error('[Spotlight IPC] Disable failed:', error);

--- a/main/src/ipc/updater.ts
+++ b/main/src/ipc/updater.ts
@@ -32,7 +32,7 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
     }
   });
 
-  ipcMain.handle('version:get-info', () => {
+  ipcMain.handle('version:get-info', async () => {
     try {
       console.log('🚀 [WORKTREE DEBUG] version:get-info called - NEW BUILD!');
       console.log('🚀 [WORKTREE DEBUG] app.isPackaged:', app.isPackaged);
@@ -68,15 +68,13 @@ export function registerUpdaterHandlers(ipcMain: IpcMain, { app, versionChecker 
       if (!app.isPackaged) {
         console.log('[Version Debug] Development mode detected, getting git info...');
         try {
-          const gitHash = commandExecutor.execSync('git rev-parse --short HEAD', { 
-            encoding: 'utf8',
+          const gitHash = (await commandExecutor.execAsync('git rev-parse --short HEAD', {
             cwd: process.cwd()
-          }).trim();
+          })).stdout.trim();
           
           // Check if the working directory is clean (no uncommitted changes)
           try {
-            commandExecutor.execSync('git diff-index --quiet HEAD --', { 
-              encoding: 'utf8',
+            await commandExecutor.execAsync('git diff-index --quiet HEAD --', {
               cwd: process.cwd(),
               silent: true
             });

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import { isDaemonOwnedChannel } from '../../shared/types/daemon';
 import {
   WINDOW_CONTROLS_OVERLAY_ARG,
   type WindowControlsOverlayColors,
@@ -123,75 +124,6 @@ interface UpdaterInfo {
   path?: string;
   sha512?: string;
   size?: number;
-}
-
-const DAEMON_OWNED_CHANNEL_PREFIXES = [
-  'agent-usage:',
-  'folders:',
-  'logs:',
-  'mobile:',
-  'pane-chat:',
-  'panels:',
-  'projects:',
-  'prompts:',
-  'resource-monitor:',
-  'runpane:',
-  'sessions:',
-  'terminal:',
-  'usage:',
-  'voice:',
-] as const;
-
-const DAEMON_OWNED_EXACT_CHANNELS = [
-  'git:cancel-status-for-project',
-  'git:clone-repo',
-  'git:commit',
-  'git:execute-project',
-  'git:file-status',
-  'git:get-github-remote',
-  'remote:pwa-affordances',
-  'git:restore',
-  'git:revert',
-  'permission:getPending',
-  'permission:respond',
-  'file:copy',
-  'file:delete',
-  'file:duplicate',
-  'file:exists',
-  'file:getPath',
-  'file:list',
-  'file:move',
-  'file:read',
-  'file:read-binary',
-  'file:read-project',
-  'file:readAtRevision',
-  'file:rename',
-  'file:resolveAbsolutePath',
-  'file:search',
-  'file:write',
-  'file:write-binary',
-  'file:write-project',
-] as const;
-const DAEMON_OWNED_EXACT_CHANNEL_SET = new Set<string>(DAEMON_OWNED_EXACT_CHANNELS);
-
-const ELECTRON_ADAPTER_ONLY_CHANNELS = new Set<string>([
-  'file:showInFolder',
-  'sessions:open-ide',
-  'sessions:set-active-session',
-  'terminal:clipboard-paste-image',
-]);
-
-// Keep the security-sensitive channel classifier visible at the bridge boundary.
-function isDaemonOwnedChannel(channel: string): boolean {
-  if (ELECTRON_ADAPTER_ONLY_CHANNELS.has(channel)) {
-    return false;
-  }
-
-  if (DAEMON_OWNED_EXACT_CHANNEL_SET.has(channel)) {
-    return true;
-  }
-
-  return DAEMON_OWNED_CHANNEL_PREFIXES.some((prefix) => channel.startsWith(prefix));
 }
 
 // Increase max listeners for ipcRenderer to prevent warnings when many components listen to events

--- a/main/src/services/__tests__/gitDiffManager.test.ts
+++ b/main/src/services/__tests__/gitDiffManager.test.ts
@@ -58,6 +58,34 @@ afterEach(() => {
   for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
 });
 
+describe('GitDiffManager asynchronous history and execution capture', () => {
+  it('keeps history, graph, commit diffs, and working changes usable through the async runner', async () => {
+    const cwd = repository();
+    const before = head(cwd);
+    write(cwd, 'tracked.txt', 'after\n');
+    const after = commitPaths(cwd, 'feature change', ['tracked.txt']);
+    const { manager, runner } = harness(cwd);
+
+    expect(await manager.getCurrentCommitHash(cwd, runner)).toBe(after);
+    const commits = await manager.getCommitHistory(cwd, 50, 'main', runner);
+    expect(commits.map(commit => commit.hash)).toEqual([after]);
+    expect(commits[0].stats).toEqual({ additions: 1, deletions: 1, filesChanged: 1 });
+    expect((await manager.getGraphCommitHistory(cwd, 'feature', 50, 'main', runner))[0].message).toBe('feature change');
+    expect((await manager.getCommitDiff(cwd, after, runner)).diff).toContain('+after');
+    const range = await manager.captureCommitDiff(cwd, before, after, runner);
+    expect(range.changedFiles).toEqual(['tracked.txt']);
+    expect(range.afterHash).toBe(after);
+    expect(await manager.hasChanges(cwd, runner)).toBe(false);
+
+    write(cwd, 'tracked.txt', 'working\n');
+    expect(await manager.hasChanges(cwd, runner)).toBe(true);
+    const working = await manager.captureWorkingDirectoryDiff(cwd, runner);
+    expect(working.diff).toContain('+working');
+    expect(working.stats).toEqual({ additions: 1, deletions: 1, filesChanged: 1 });
+    expect(working.beforeHash).toBe(after);
+  });
+});
+
 describe('GitDiffManager manifests', () => {
   it('lists the complete net session diff across 60 commits plus staged, unstaged, and untracked work', async () => {
     const cwd = repository();

--- a/main/src/services/__tests__/gitFileWatcher.test.ts
+++ b/main/src/services/__tests__/gitFileWatcher.test.ts
@@ -7,9 +7,9 @@ import type { Logger } from '../../utils/logger';
 // Typed access to the private pure logic under test (no-any policy).
 interface GitFileWatcherInternals {
   isIgnoredEventPath(relPath: string, gitignoredDirs: Set<string>, isLeafDirectory?: boolean): boolean;
-  getGitignoredDirs(watchPath: string): Set<string>;
-  transitionToPolling(sessionId: string, worktreePath: string, err: Error): void;
-  pollStatusSnapshot(sessionId: string): void;
+  getGitignoredDirs(watchPath: string): Promise<Set<string>>;
+  transitionToPolling(sessionId: string, worktreePath: string, err: Error): Promise<void>;
+  pollStatusSnapshot(sessionId: string): Promise<void>;
   handleWatcherFailure(sessionId: string, err: Error): void;
   watchedSessions: Map<string, { mode: string; watcherErrorLogged: boolean; lastStatusSnapshot?: string }>;
 }
@@ -38,8 +38,8 @@ function makeLogger(): Logger & { warns: string[]; errors: string[] } {
   });
 }
 
-function makeCommandRunner(exec: (command: string, cwd: string) => string): CommandRunner {
-  return partialMock<CommandRunner>({ exec, wslContext: undefined });
+function makeCommandRunner(exec: (command: string, cwd: string) => string | Promise<string>): CommandRunner {
+  return partialMock<CommandRunner>({ execAsync: async (command, cwd) => ({ stdout: await exec(command, cwd), stderr: '' }), wslContext: null });
 }
 
 describe('GitFileWatcher pure logic', () => {
@@ -57,12 +57,12 @@ describe('GitFileWatcher pure logic', () => {
     vi.useRealTimers();
   });
 
-  function build(exec: (command: string, cwd: string) => string = () => ''): void {
+  function build(exec: (command: string, cwd: string) => string | Promise<string> = () => ''): void {
     watcher = new GitFileWatcher(logger, makeCommandRunner(exec));
     internals = watcherInternals(watcher);
   }
 
-  it('does not start a watcher or invoke Git for the home directory', () => {
+  it('does not start a watcher or invoke Git for the home directory', async () => {
     const exec = vi.fn(() => '');
     build(exec);
     watcher.startWatching('home', os.homedir());
@@ -74,20 +74,20 @@ describe('GitFileWatcher pure logic', () => {
   describe('isIgnoredEventPath', () => {
     const none = new Set<string>();
 
-    it('drops anything under .git (narrow watcher owns those signals)', () => {
+    it('drops anything under .git (narrow watcher owns those signals)', async () => {
       build();
       expect(internals.isIgnoredEventPath('.git/index.lock', none)).toBe(true);
       expect(internals.isIgnoredEventPath('.git', none)).toBe(true);
     });
 
-    it('drops IGNORED_DIRS at any depth, including the leaf segment', () => {
+    it('drops IGNORED_DIRS at any depth, including the leaf segment', async () => {
       build();
       expect(internals.isIgnoredEventPath('node_modules/pkg/index.js', none)).toBe(true);
       expect(internals.isIgnoredEventPath('apps/web/node_modules/x', none)).toBe(true);
       expect(internals.isIgnoredEventPath('node_modules', none)).toBe(true);
     });
 
-    it('drops gitignore-derived relative prefixes, including nested ones', () => {
+    it('drops gitignore-derived relative prefixes, including nested ones', async () => {
       build();
       const gitignored = new Set(['worktrees', 'main/dist']);
       expect(internals.isIgnoredEventPath('worktrees/wt1/src/a.ts', gitignored)).toBe(true);
@@ -97,13 +97,13 @@ describe('GitFileWatcher pure logic', () => {
       expect(internals.isIgnoredEventPath('worktrees-notes.md', gitignored)).toBe(false);
     });
 
-    it('handles win32 backslash separators', () => {
+    it('handles win32 backslash separators', async () => {
       build();
       expect(internals.isIgnoredEventPath('node_modules\\pkg\\x.js', none)).toBe(true);
       expect(internals.isIgnoredEventPath('src\\a.ts', none)).toBe(false);
     });
 
-    it('applies IGNORED_FILE_PATTERNS to the leaf only when it may be a file', () => {
+    it('applies IGNORED_FILE_PATTERNS to the leaf only when it may be a file', async () => {
       build();
       expect(internals.isIgnoredEventPath('src/.DS_Store', none)).toBe(true);
       expect(internals.isIgnoredEventPath('src/backup~', none)).toBe(true);
@@ -113,83 +113,117 @@ describe('GitFileWatcher pure logic', () => {
       expect(internals.isIgnoredEventPath('src/regular.ts', none)).toBe(false);
     });
 
-    it('never ignores an empty path', () => {
+    it('never ignores an empty path', async () => {
       build();
       expect(internals.isIgnoredEventPath('', none)).toBe(false);
     });
   });
 
   describe('getGitignoredDirs', () => {
-    it('keeps only trailing-slash directory lines, stripped of the slash', () => {
+    it('keeps only trailing-slash directory lines, stripped of the slash', async () => {
       build(() => 'node_modules/\nmain/dist/\nsome-ignored-file.log\nworktrees/\n');
-      const dirs = internals.getGitignoredDirs('/repo');
+      const dirs = await internals.getGitignoredDirs('/repo');
       expect(dirs).toEqual(new Set(['node_modules', 'main/dist', 'worktrees']));
     });
 
-    it('returns an empty set (hardcoded list still applies) when git fails', () => {
+    it('returns an empty set (hardcoded list still applies) when git fails', async () => {
       build(() => {
         throw new Error('not a git repository');
       });
-      expect(internals.getGitignoredDirs('/not-a-repo').size).toBe(0);
+      expect((await internals.getGitignoredDirs('/not-a-repo')).size).toBe(0);
     });
 
-    it('caches per watchPath and refreshes only after the TTL', () => {
+    it('caches per watchPath and refreshes only after the TTL', async () => {
       const exec = vi.fn(() => 'worktrees/\n');
       build(exec);
-      internals.getGitignoredDirs('/repo');
-      internals.getGitignoredDirs('/repo');
+      await internals.getGitignoredDirs('/repo');
+      await internals.getGitignoredDirs('/repo');
       expect(exec).toHaveBeenCalledTimes(1);
-      vi.advanceTimersByTime(5 * 60_000 + 1);
-      internals.getGitignoredDirs('/repo');
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
+      await internals.getGitignoredDirs('/repo');
       expect(exec).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('transitionToPolling / handleWatcherFailure', () => {
-    it('builds a complete record with no prior session, warns once, seeds the baseline, emits once', () => {
+    it('discards an in-flight poll after stop and does not emit its old snapshot', async () => {
+      let finish = (_snapshot: string): void => { throw new Error('Poll not started'); };
+      const pending = new Promise<string>(resolve => { finish = resolve; });
+      const exec = vi.fn(() => pending);
+      build(exec);
+      const refresh = vi.fn();
+      watcher.on('needs-refresh', refresh);
+
+      const transition = internals.transitionToPolling('s1', '/repo', new Error('EMFILE'));
+      await internals.pollStatusSnapshot('s1');
+      expect(exec).toHaveBeenCalledTimes(1);
+      watcher.stopWatching('s1');
+      finish('M old-file.txt\n');
+      await transition;
+
+      expect(refresh).not.toHaveBeenCalled();
+      expect(internals.watchedSessions.size).toBe(0);
+    });
+
+    it('does not resurrect a watcher stopped during asynchronous startup', async () => {
+      let finish = (_snapshot: string): void => { throw new Error('Scan not started'); };
+      const pending = new Promise<string>(resolve => { finish = resolve; });
+      const exec = vi.fn(() => pending);
+      build(exec);
+
+      const start = watcher.startWatching('s1', '/repo');
+      watcher.stopAll();
+      finish('node_modules/\n');
+      await start;
+
+      expect(exec).toHaveBeenCalledTimes(1);
+      expect(internals.watchedSessions.size).toBe(0);
+    });
+
+    it('builds a complete record with no prior session, warns once, seeds the baseline, emits once', async () => {
       const exec = vi.fn((cmd: string) => (cmd.startsWith('git status') ? 'M file.txt\n' : ''));
       build(exec);
       const emits: string[] = [];
       watcher.on('needs-refresh', (sid: string) => emits.push(sid));
 
-      internals.transitionToPolling('s1', '/repo', new Error('EMFILE: too many open files'));
+      await internals.transitionToPolling('s1', '/repo', new Error('EMFILE: too many open files'));
 
       const record = internals.watchedSessions.get('s1');
       expect(record?.mode).toBe('polling');
       expect(record?.watcherErrorLogged).toBe(true);
-      // baseline seeded SYNCHRONOUSLY — a change in the 0-5s window diffs against it
+      // baseline seeded before the initial reconcile event — a change in the 0-5s window diffs against it
       expect(record?.lastStatusSnapshot).toBe('M file.txt\n');
       expect(logger.warns).toHaveLength(1);
       expect(emits).toEqual(['s1']); // immediate reconcile emit, no seed emit
     });
 
-    it('polling emits only on snapshot CHANGE, never while dirty-but-unchanged', () => {
+    it('polling emits only on snapshot CHANGE, never while dirty-but-unchanged', async () => {
       let status = 'M file.txt\n';
       build((cmd: string) => (cmd.startsWith('git status') ? status : ''));
       const emits: string[] = [];
       watcher.on('needs-refresh', (sid: string) => emits.push(sid));
 
-      internals.transitionToPolling('s1', '/repo', new Error('EMFILE'));
+      await internals.transitionToPolling('s1', '/repo', new Error('EMFILE'));
       expect(emits).toHaveLength(1); // the immediate degrade emit
 
-      vi.advanceTimersByTime(5_000); // tick with unchanged dirty status
-      vi.advanceTimersByTime(5_000);
+      await vi.advanceTimersByTimeAsync(5_000); // tick with unchanged dirty status
+      await vi.advanceTimersByTimeAsync(5_000);
       expect(emits).toHaveLength(1); // no spam
 
       status = 'M file.txt\nM other.ts\n';
-      vi.advanceTimersByTime(5_000);
+      await vi.advanceTimersByTimeAsync(5_000);
       expect(emits).toHaveLength(2); // change detected
     });
 
-    it('handleWatcherFailure swallows repeat failures once degraded', () => {
+    it('handleWatcherFailure swallows repeat failures once degraded', async () => {
       build((cmd: string) => (cmd.startsWith('git status') ? '' : ''));
-      internals.transitionToPolling('s1', '/repo', new Error('EMFILE'));
+      await internals.transitionToPolling('s1', '/repo', new Error('EMFILE'));
       internals.handleWatcherFailure('s1', new Error('EMFILE'));
       internals.handleWatcherFailure('s1', new Error('EMFILE'));
       expect(logger.warns).toHaveLength(1);
     });
 
-    it('handleWatcherFailure no-ops for unknown sessions', () => {
+    it('handleWatcherFailure no-ops for unknown sessions', async () => {
       build();
       internals.handleWatcherFailure('ghost', new Error('EMFILE'));
       expect(logger.warns).toHaveLength(0);

--- a/main/src/services/__tests__/gitStatusManager.test.ts
+++ b/main/src/services/__tests__/gitStatusManager.test.ts
@@ -64,10 +64,13 @@ const mockProject = {
   path: '/test/project',
 };
 
+const projectGitOutput = vi.fn<(command: string, cwd: string) => string>();
+const projectGithubCommand = vi.fn<CommandRunner['execAsync']>();
+
 const mockProjectContext = {
   project: mockProject,
   pathResolver: {},
-  commandRunner: { execAsync: vi.fn(), exec: vi.fn(), wslContext: null },
+  commandRunner: { execAsync: vi.fn<CommandRunner['execAsync']>(), wslContext: null },
 };
 
 const cleanIndexStatus: GitIndexStatus = {
@@ -138,15 +141,31 @@ describe('GitStatusManager', () => {
     );
 
     // Default: no uncommitted changes, no ahead/behind
-    vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
-    vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
-    vi.mocked(fastGetDiffStats).mockReturnValue({ additions: 0, deletions: 0, filesChanged: 0 });
+    vi.mocked(fastCheckWorkingDirectory).mockResolvedValue(cleanIndexStatus);
+    vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 0, behind: 0 });
+    vi.mocked(fastGetDiffStats).mockResolvedValue({ additions: 0, deletions: 0, filesChanged: 0 });
 
-    // Default commandRunner.exec returns empty string
-    vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('');
+    mockProjectContext.commandRunner.execAsync.mockImplementation(async (command, cwd, options) => {
+      if (command.startsWith('git ')) return { stdout: projectGitOutput(command, cwd), stderr: '' };
+      return projectGithubCommand(command, cwd, options);
+    });
+    // Git and GitHub CLI outputs have independent fixtures.
+    vi.mocked(projectGitOutput).mockReturnValue('');
   });
 
   describe('fetchGitStatus via getGitStatus (cache miss scenarios)', () => {
+    it('discards a status read cancelled while Git is running', async () => {
+      let finish = (_status: GitIndexStatus): void => { throw new Error('Git not started'); };
+      fastCheckWorkingDirectory.mockImplementationOnce(() => new Promise(resolve => { finish = resolve; }));
+      const pending = managerPrivates(gitStatusManager).fetchGitStatus('test-session');
+      await new Promise(resolve => setImmediate(resolve));
+      gitStatusManager.cancelSessionGitStatus('test-session');
+      finish(cleanIndexStatus);
+
+      expect(await pending).toBeNull();
+      expect(mockDatabaseService.saveSessionGitStatusCache).not.toHaveBeenCalled();
+    });
+
     it('skips home-directory scans on initial load and focus refresh', async () => {
       vi.mocked(mockSessionManager.getSession).mockResolvedValue(partialMock<Session>({
         ...mockSession, worktreePath: os.homedir(),
@@ -157,13 +176,13 @@ describe('GitStatusManager', () => {
       const refreshed = await gitStatusManager.refreshSessionGitStatus('test-session');
       expect(refreshed?.state).toBe('unknown');
       expect(fastCheckWorkingDirectory).not.toHaveBeenCalled();
-      expect(mockProjectContext.commandRunner.exec).not.toHaveBeenCalled();
+      expect(projectGitOutput).not.toHaveBeenCalled();
       gitStatusManager.stopPolling();
     });
 
     it('returns clean state when no changes, no ahead/behind, no untracked', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 0, behind: 0 });
 
       const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
@@ -176,14 +195,14 @@ describe('GitStatusManager', () => {
     });
 
     it('returns modified state when uncommitted changes exist', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue({
         hasModified: true,
         hasStaged: false,
         hasUntracked: false,
         hasConflicts: false,
       });
-      vi.mocked(fastGetDiffStats).mockReturnValue({ additions: 15, deletions: 5, filesChanged: 3 });
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastGetDiffStats).mockResolvedValue({ additions: 15, deletions: 5, filesChanged: 3 });
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 0, behind: 0 });
 
       const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
@@ -195,9 +214,9 @@ describe('GitStatusManager', () => {
     });
 
     it('returns ahead state when commits ahead of main', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 3, behind: 0 });
-      vi.mocked(mockProjectContext.commandRunner.exec).mockImplementation((cmd: string) => {
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 3, behind: 0 });
+      vi.mocked(projectGitOutput).mockImplementation((cmd: string) => {
         if (cmd.includes('diff --shortstat')) {
           return ' 5 files changed, 20 insertions(+), 10 deletions(-)';
         }
@@ -219,8 +238,8 @@ describe('GitStatusManager', () => {
     });
 
     it('returns behind state when commits behind main', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 5 });
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 0, behind: 5 });
 
       const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
@@ -230,9 +249,9 @@ describe('GitStatusManager', () => {
     });
 
     it('returns diverged state when both ahead and behind', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue(cleanIndexStatus);
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 2, behind: 3 });
-      vi.mocked(mockProjectContext.commandRunner.exec).mockImplementation((cmd: string) => {
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue(cleanIndexStatus);
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 2, behind: 3 });
+      vi.mocked(projectGitOutput).mockImplementation((cmd: string) => {
         if (cmd.includes('diff --shortstat')) {
           return ' 4 files changed, 15 insertions(+), 8 deletions(-)';
         }
@@ -250,13 +269,13 @@ describe('GitStatusManager', () => {
     });
 
     it('returns conflict state when merge conflicts exist', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue({
         hasModified: false,
         hasStaged: false,
         hasUntracked: false,
         hasConflicts: true,
       });
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 0, behind: 0 });
 
       const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
@@ -264,13 +283,13 @@ describe('GitStatusManager', () => {
     });
 
     it('returns untracked state when only untracked files exist', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue({
         hasModified: false,
         hasStaged: false,
         hasUntracked: true,
         hasConflicts: false,
       });
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 0, behind: 0 });
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 0, behind: 0 });
 
       const status = await managerPrivates(gitStatusManager).fetchGitStatus('test-session');
 
@@ -287,15 +306,15 @@ describe('GitStatusManager', () => {
     });
 
     it('sets modified as primary state and ahead as secondary when uncommitted changes and ahead', async () => {
-      vi.mocked(fastCheckWorkingDirectory).mockReturnValue({
+      vi.mocked(fastCheckWorkingDirectory).mockResolvedValue({
         hasModified: true,
         hasStaged: false,
         hasUntracked: false,
         hasConflicts: false,
       });
-      vi.mocked(fastGetDiffStats).mockReturnValue({ additions: 5, deletions: 2, filesChanged: 2 });
-      vi.mocked(fastGetAheadBehind).mockReturnValue({ ahead: 2, behind: 0 });
-      vi.mocked(mockProjectContext.commandRunner.exec).mockImplementation((cmd: string) => {
+      vi.mocked(fastGetDiffStats).mockResolvedValue({ additions: 5, deletions: 2, filesChanged: 2 });
+      vi.mocked(fastGetAheadBehind).mockResolvedValue({ ahead: 2, behind: 0 });
+      vi.mocked(projectGitOutput).mockImplementation((cmd: string) => {
         if (cmd.includes('diff --shortstat')) {
           return ' 3 files changed, 10 insertions(+), 5 deletions(-)';
         }
@@ -475,7 +494,7 @@ describe('GitStatusManager', () => {
       const privates = managerPrivates(gitStatusManager);
       privates.activeSessionId = 'test-session';
       privates.prCache.set(`${mockProject.path}:feature-branch`, { fetchedAt: Date.now() });
-      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('feature-branch\n');
+      vi.mocked(projectGitOutput).mockReturnValue('feature-branch\n');
       const refreshSpy = vi
         .spyOn(gitStatusManager, 'refreshSessionGitStatus')
         .mockResolvedValue({ state: 'clean', lastChecked: new Date().toISOString() });
@@ -497,8 +516,9 @@ describe('GitStatusManager', () => {
         ...mockSession,
         worktreePath: '/test/worktrees/not-the-branch',
       });
-      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('real-feature-branch\n');
-      vi.mocked(mockProjectContext.commandRunner.execAsync).mockResolvedValue({
+      vi.mocked(projectGitOutput).mockReturnValue('real-feature-branch\n');
+      projectGithubCommand.mockResolvedValue({
+        stderr: '',
         stdout: JSON.stringify([{
           number: 12,
           url: 'https://github.com/example/repo/pull/12',
@@ -514,17 +534,16 @@ describe('GitStatusManager', () => {
       void privates.enrichWithPrData('test-session');
       const status = await updated;
 
-      expect(mockProjectContext.commandRunner.exec).toHaveBeenCalledWith(
+      expect(projectGitOutput).toHaveBeenCalledWith(
         'git branch --show-current',
-        '/test/worktrees/not-the-branch',
-        { silent: true }
+        '/test/worktrees/not-the-branch'
       );
       expect(mockProjectContext.commandRunner.execAsync).toHaveBeenCalledWith(
         expect.stringContaining('real-feature-branch'),
         mockProject.path,
         { timeout: 5000 }
       );
-      expect(vi.mocked(mockProjectContext.commandRunner.execAsync).mock.calls[0][0]).not.toContain('not-the-branch');
+      expect(projectGithubCommand.mock.calls[0][0]).not.toContain('not-the-branch');
       expect(status.prNumber).toBe(12);
       expect(status.prUrl).toBe('https://github.com/example/repo/pull/12');
     });
@@ -543,8 +562,8 @@ describe('GitStatusManager', () => {
         },
         lastChecked: Date.now(),
       };
-      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('feature-branch\n');
-      vi.mocked(mockProjectContext.commandRunner.execAsync).mockResolvedValue({ stdout: '[]' });
+      vi.mocked(projectGitOutput).mockReturnValue('feature-branch\n');
+      projectGithubCommand.mockResolvedValue({ stdout: '[]', stderr: '' });
 
       const updated = new Promise<GitStatus>((resolve) => {
         gitStatusManager.once('git-status-updated', (_sessionId, status) => resolve(status));
@@ -580,8 +599,8 @@ describe('GitStatusManager', () => {
         status: cachedStatus,
         lastChecked: Date.now(),
       };
-      vi.mocked(mockProjectContext.commandRunner.exec).mockReturnValue('feature-branch\n');
-      vi.mocked(mockProjectContext.commandRunner.execAsync).mockRejectedValue(new Error('gh unavailable'));
+      vi.mocked(projectGitOutput).mockReturnValue('feature-branch\n');
+      projectGithubCommand.mockRejectedValue(new Error('gh unavailable'));
 
       await privates.enrichWithPrData('test-session');
 

--- a/main/src/services/__tests__/spotlightManager.test.ts
+++ b/main/src/services/__tests__/spotlightManager.test.ts
@@ -1,0 +1,134 @@
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CommandRunner } from '../../utils/commandRunner';
+import { PathResolver } from '../../utils/pathResolver';
+import type { SessionManager } from '../sessionManager';
+import { GitFileWatcher } from '../gitFileWatcher';
+import { SpotlightManager } from '../spotlightManager';
+
+const directories: string[] = [];
+const managers: SpotlightManager[] = [];
+const git = (cwd: string, ...args: string[]): string => execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+function harness() {
+  const root = mkdtempSync(join(tmpdir(), 'pane-spotlight-'));
+  directories.push(root);
+  vi.stubEnv('PANE_DIR', join(root, 'data'));
+  git(root, 'init', '-b', 'main');
+  git(root, 'config', 'user.name', 'Pane Test');
+  git(root, 'config', 'user.email', 'pane@example.test');
+  writeFileSync(join(root, 'tracked.txt'), 'original\n');
+  git(root, 'add', 'tracked.txt');
+  git(root, 'commit', '-m', 'initial');
+  const worktree = join(root, 'worktree');
+  git(root, 'worktree', 'add', '-b', 'feature', worktree);
+  writeFileSync(join(worktree, 'tracked.txt'), 'spotlight\n');
+  const project = { id: 1, path: root };
+  const runner = new CommandRunner(project);
+  const collaborators = {
+    getDbSession: () => ({ id: 's1', project_id: 1, worktree_path: worktree }),
+    getProjectForSession: () => project,
+    getProjectContextByProjectId: () => ({ commandRunner: runner, pathResolver: new PathResolver(project) }),
+  };
+  // SAFETY: Spotlight uses only these three SessionManager lookups; real Git
+  // supplies the state transitions under test, without a database fixture.
+  const sessionManager = collaborators as SessionManager;
+  const manager = new SpotlightManager(sessionManager, undefined, () => null);
+  managers.push(manager);
+  // Watcher startup/cancellation has its own coverage; no file events should
+  // race the explicit lifecycle operations in these real-repository tests.
+  vi.spyOn(GitFileWatcher.prototype, 'startWatching').mockResolvedValue();
+  return { root, worktree, runner, manager };
+}
+
+afterEach(async () => {
+  for (const manager of managers.splice(0)) await manager.disableAll();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  for (const directory of directories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe('Spotlight asynchronous lifecycle', () => {
+  it('syncs initial contents and uses the same restore path for disable and shutdown', async () => {
+    const { root, manager } = harness();
+    await manager.enable('s1');
+    expect(git(root, 'branch', '--show-current')).toBe('');
+    expect(git(root, 'show', 'HEAD:tracked.txt')).toBe('spotlight');
+    expect(manager.isSpotlightActive('s1')).toBe(true);
+
+    await manager.disable('s1');
+    expect(git(root, 'branch', '--show-current')).toBe('main');
+    expect(git(root, 'show', 'HEAD:tracked.txt')).toBe('original');
+    await manager.enable('s1');
+    await manager.disableAll();
+    expect(git(root, 'branch', '--show-current')).toBe('main');
+    expect(manager.getActiveSpotlight(1)).toBeNull();
+  });
+
+  it('serializes disable behind an in-flight initial sync so late Git cannot undo restoration', async () => {
+    const { root, runner, manager } = harness();
+    const execute = runner.execFile.bind(runner);
+    let release = (): void => { throw new Error('Sync not started'); };
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let notifyStarted = (): void => { throw new Error('Listener not installed'); };
+    const started = new Promise<void>(resolve => { notifyStarted = resolve; });
+    vi.spyOn(runner, 'execFile').mockImplementation(async (file, args, cwd, options) => {
+      if (args[0] === 'stash') {
+        notifyStarted();
+        await gate;
+      }
+      return execute(file, args, cwd, options);
+    });
+
+    const enabling = manager.enable('s1');
+    await started;
+    const disabling = manager.disable('s1');
+    release();
+    await Promise.all([enabling, disabling]);
+
+    expect(git(root, 'branch', '--show-current')).toBe('main');
+    expect(manager.isSpotlightActive('s1')).toBe(false);
+  });
+
+  it('keeps one spotlight per project when enables arrive concurrently', async () => {
+    const { manager } = harness();
+    const outcomes = await Promise.allSettled([manager.enable('s1'), manager.enable('s1')]);
+    expect(outcomes.map(outcome => outcome.status)).toEqual(['fulfilled', 'rejected']);
+    expect(manager.getActiveSpotlight(1)).toEqual({ sessionId: 's1', active: true });
+  });
+
+  it('reconciles another file event received while a sync is in flight', async () => {
+    const { root, worktree, runner, manager } = harness();
+    await manager.enable('s1');
+    const watcher = vi.mocked(GitFileWatcher.prototype.startWatching).mock.instances[0];
+    const execute = runner.execFile.bind(runner);
+    let release = (): void => { throw new Error('Sync not started'); };
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let notifyStarted = (): void => { throw new Error('Listener not installed'); };
+    const started = new Promise<void>(resolve => { notifyStarted = resolve; });
+    let delayed = false;
+    vi.spyOn(runner, 'execFile').mockImplementation(async (file, args, cwd, options) => {
+      const result = await execute(file, args, cwd, options);
+      if (args[0] === 'stash' && !delayed) {
+        delayed = true;
+        notifyStarted();
+        await gate;
+      }
+      return result;
+    });
+
+    writeFileSync(join(worktree, 'tracked.txt'), 'first update\n');
+    watcher.emit('needs-refresh', 's1');
+    await started;
+    writeFileSync(join(worktree, 'tracked.txt'), 'latest update\n');
+    watcher.emit('needs-refresh', 's1');
+    release();
+
+    await vi.waitFor(() => {
+      expect(git(root, 'show', 'HEAD:tracked.txt')).toBe('latest update');
+    }, { timeout: 5000 });
+  });
+});

--- a/main/src/services/executionTracker.ts
+++ b/main/src/services/executionTracker.ts
@@ -39,7 +39,7 @@ export class ExecutionTracker extends EventEmitter {
       if (!ctx) {
         throw new Error(`No project context found for session ${sessionId}`);
       }
-      const beforeCommitHash = this.gitDiffManager.getCurrentCommitHash(worktreePath, ctx.commandRunner);
+      const beforeCommitHash = await this.gitDiffManager.getCurrentCommitHash(worktreePath, ctx.commandRunner);
       console.log(`[ExecutionTracker] Starting from commit: ${beforeCommitHash}, sequence: ${executionSequence}`);
       this.logger?.verbose(`Starting from commit: ${beforeCommitHash}`);
       
@@ -81,7 +81,7 @@ export class ExecutionTracker extends EventEmitter {
       if (!ctx) {
         throw new Error(`No project context found for session ${sessionId}`);
       }
-      const afterCommitHash = this.gitDiffManager.getCurrentCommitHash(context.worktreePath, ctx.commandRunner);
+      const afterCommitHash = await this.gitDiffManager.getCurrentCommitHash(context.worktreePath, ctx.commandRunner);
 
       let executionDiff: GitDiffResult;
 
@@ -103,7 +103,7 @@ export class ExecutionTracker extends EventEmitter {
       let commitMessage = '';
       if (afterCommitHash !== context.beforeCommitHash && afterCommitHash !== 'UNCOMMITTED') {
         try {
-          commitMessage = ctx.commandRunner.exec(`git log -1 --format=%s ${afterCommitHash}`, context.worktreePath).trim();
+          commitMessage = (await ctx.commandRunner.execAsync(`git log -1 --format=%s ${afterCommitHash}`, context.worktreePath)).stdout.trim();
           this.logger?.verbose(`Retrieved commit message: ${commitMessage}`);
         } catch (error) {
           this.logger?.warn(`Failed to get commit message: ${error}`);

--- a/main/src/services/gitDiffManager.ts
+++ b/main/src/services/gitDiffManager.ts
@@ -278,17 +278,17 @@ export class GitDiffManager {
       this.logger?.verbose(`Capturing git diff in ${worktreePath}`);
 
       // Get current commit hash
-      const beforeHash = this.getCurrentCommitHash(worktreePath, commandRunner);
+      const beforeHash = await this.getCurrentCommitHash(worktreePath, commandRunner);
 
       // Get diff of working directory vs HEAD
-      const diff = this.getGitDiffString(worktreePath, commandRunner);
+      const diff = await this.getGitDiffString(worktreePath, commandRunner);
       console.log(`Captured diff length: ${diff.length}`);
 
       // Get changed files
-      const changedFiles = this.getChangedFiles(worktreePath, commandRunner);
+      const changedFiles = await this.getChangedFiles(worktreePath, commandRunner);
 
       // Get diff stats
-      const stats = this.getDiffStats(worktreePath, commandRunner);
+      const stats = await this.getDiffStats(worktreePath, commandRunner);
 
       this.logger?.verbose(`Captured diff: ${stats.filesChanged} files, +${stats.additions} -${stats.deletions}`);
       console.log(`Diff stats:`, stats);
@@ -315,20 +315,20 @@ export class GitDiffManager {
       this.logger?.verbose(`Capturing git diff in ${worktreePath} from ${fromCommit} to ${to}`);
 
       // Get diff between commits
-      const diff = this.getGitCommitDiff(worktreePath, fromCommit, to, commandRunner);
+      const diff = await this.getGitCommitDiff(worktreePath, fromCommit, to, commandRunner);
 
       // Get changed files between commits
-      const changedFiles = this.getChangedFilesBetweenCommits(worktreePath, fromCommit, to, commandRunner);
+      const changedFiles = await this.getChangedFilesBetweenCommits(worktreePath, fromCommit, to, commandRunner);
 
       // Get diff stats between commits
-      const stats = this.getCommitDiffStats(worktreePath, fromCommit, to, commandRunner);
+      const stats = await this.getCommitDiffStats(worktreePath, fromCommit, to, commandRunner);
 
       return {
         diff,
         stats,
         changedFiles,
         beforeHash: fromCommit,
-        afterHash: to === 'HEAD' ? this.getCurrentCommitHash(worktreePath, commandRunner) : to
+        afterHash: to === 'HEAD' ? await this.getCurrentCommitHash(worktreePath, commandRunner) : to
       };
     } catch (error) {
       this.logger?.error(`Failed to capture commit diff in ${worktreePath}:`, error instanceof Error ? error : undefined);
@@ -339,7 +339,7 @@ export class GitDiffManager {
   /**
    * Get git commit history for a worktree (only commits unique to this branch)
    */
-  getCommitHistory(worktreePath: string, limit: number, comparisonBranch: string, commandRunner: CommandRunner): GitCommit[] {
+  async getCommitHistory(worktreePath: string, limit: number, comparisonBranch: string, commandRunner: CommandRunner): Promise<GitCommit[]> {
     try {
       // Get commit log with stats for commits in HEAD not in the comparison branch.
       // Two-dot range: commits reachable from HEAD but not from comparisonBranch.
@@ -350,7 +350,7 @@ export class GitDiffManager {
       console.log(`[GitDiffManager] Comparison branch: ${comparisonBranch}`);
       console.log(`[GitDiffManager] Git command: ${gitCommand}`);
 
-      const logOutput = commandRunner.exec(gitCommand, worktreePath);
+      const logOutput = (await commandRunner.execAsync(gitCommand, worktreePath)).stdout;
       console.log(`[GitDiffManager] Git log output length: ${logOutput.length} characters`);
 
       const commits: GitCommit[] = [];
@@ -435,20 +435,20 @@ export class GitDiffManager {
   /**
    * Get git commit history for the graph visualization (lightweight, no stats)
    */
-  getGraphCommitHistory(
+  async getGraphCommitHistory(
     worktreePath: string,
     branch: string,
     limit: number = 50,
     comparisonBranch: string = 'main',
     commandRunner: CommandRunner
-  ): GitGraphCommit[] {
+  ): Promise<GitGraphCommit[]> {
     try {
       // Use %x00 (NUL) as field delimiter since commit messages can contain pipes
       // Use %x01 as record delimiter to separate commits (--shortstat adds extra lines)
       const logFormat = '%x01%h%x00%p%x00%s%x00%ai%x00%an%x00%ae';
       const gitCommand = `git log --format="${logFormat}" --shortstat -n ${limit} ${comparisonBranch}..HEAD --`;
 
-      const logOutput = commandRunner.exec(gitCommand, worktreePath);
+      const logOutput = (await commandRunner.execAsync(gitCommand, worktreePath)).stdout;
 
       if (!logOutput.trim()) {
         return [];
@@ -523,12 +523,12 @@ export class GitDiffManager {
   /**
    * Get diff for a specific commit
    */
-  getCommitDiff(worktreePath: string, commitHash: string, commandRunner: CommandRunner): GitDiffResult {
+  async getCommitDiff(worktreePath: string, commitHash: string, commandRunner: CommandRunner): Promise<GitDiffResult> {
     try {
-      const diff = commandRunner.exec(`git show --format= ${commitHash}`, worktreePath);
+      const diff = (await commandRunner.execAsync(`git show --format= ${commitHash}`, worktreePath)).stdout;
 
-      const stats = this.getCommitStats(worktreePath, commitHash, commandRunner);
-      const changedFiles = this.getCommitChangedFiles(worktreePath, commitHash, commandRunner);
+      const stats = await this.getCommitStats(worktreePath, commitHash, commandRunner);
+      const changedFiles = await this.getCommitChangedFiles(worktreePath, commitHash, commandRunner);
 
       return {
         diff,
@@ -550,9 +550,9 @@ export class GitDiffManager {
   /**
    * Get stats for a specific commit
    */
-  private getCommitStats(worktreePath: string, commitHash: string, commandRunner: CommandRunner): GitDiffStats {
+  private async getCommitStats(worktreePath: string, commitHash: string, commandRunner: CommandRunner): Promise<GitDiffStats> {
     try {
-      const fullOutput = commandRunner.exec(`git show --stat --format= ${commitHash}`, worktreePath);
+      const fullOutput = (await commandRunner.execAsync(`git show --stat --format= ${commitHash}`, worktreePath)).stdout;
       // Get the last line manually instead of using tail
       const lines = fullOutput.trim().split('\n');
       const statsOutput = lines[lines.length - 1];
@@ -565,17 +565,17 @@ export class GitDiffManager {
   /**
    * Get changed files for a specific commit
    */
-  private getCommitChangedFiles(worktreePath: string, commitHash: string, commandRunner: CommandRunner): string[] {
+  private async getCommitChangedFiles(worktreePath: string, commitHash: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
-      const output = commandRunner.exec(`git show --name-only --format= ${commitHash}`, worktreePath);
+      const output = (await commandRunner.execAsync(`git show --name-only --format= ${commitHash}`, worktreePath)).stdout;
       return output.trim().split('\n').filter(Boolean);
     } catch {
       return [];
     }
   }
-  getCurrentCommitHash(worktreePath: string, commandRunner: CommandRunner): string {
+  async getCurrentCommitHash(worktreePath: string, commandRunner: CommandRunner): Promise<string> {
     try {
-      return commandRunner.exec('git rev-parse HEAD', worktreePath).trim();
+      return (await commandRunner.execAsync('git rev-parse HEAD', worktreePath)).stdout.trim();
     } catch {
       this.logger?.warn(`Could not get current commit hash in ${worktreePath}`);
       return '';
@@ -588,7 +588,7 @@ export class GitDiffManager {
     // Track git diff viewed
     if (this.analyticsManager) {
       const fileCountCategory = this.analyticsManager.categorizeNumber(result.stats.filesChanged, [1, 5, 10, 25, 50]);
-      const hasUncommitted = this.hasChanges(worktreePath, commandRunner);
+      const hasUncommitted = await this.hasChanges(worktreePath, commandRunner);
 
       this.analyticsManager.track('git_diff_viewed', {
         file_count_category: fileCountCategory,
@@ -599,30 +599,30 @@ export class GitDiffManager {
     return result;
   }
 
-  private getGitDiffString(worktreePath: string, commandRunner: CommandRunner): string {
+  private async getGitDiffString(worktreePath: string, commandRunner: CommandRunner): Promise<string> {
     try {
       // First check if we're in a valid git repository
       try {
-        commandRunner.exec('git rev-parse --git-dir', worktreePath);
+        await commandRunner.execAsync('git rev-parse --git-dir', worktreePath);
       } catch {
         console.error(`Not a git repository: ${worktreePath}`);
         return '';
       }
 
       // Check git status to see what files have changes
-      const status = commandRunner.exec('git status --porcelain', worktreePath);
+      const status = (await commandRunner.execAsync('git status --porcelain', worktreePath)).stdout;
       console.log(`Git status in ${worktreePath}:`, status || '(no changes)');
 
       // Get diff of both staged and unstaged changes against HEAD
       // Using 'git diff HEAD' to include both staged and unstaged changes
-      let diff = commandRunner.exec('git diff HEAD', worktreePath);
+      let diff = (await commandRunner.execAsync('git diff HEAD', worktreePath)).stdout;
       console.log(`Git diff in ${worktreePath}: ${diff.length} characters`);
 
       // Get untracked files and create diff-like output for them
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
+      const untrackedFiles = await this.getUntrackedFiles(worktreePath, commandRunner);
       if (untrackedFiles.length > 0) {
         console.log(`Found ${untrackedFiles.length} untracked files`);
-        const untrackedDiff = this.createDiffForUntrackedFiles(worktreePath, untrackedFiles, commandRunner);
+        const untrackedDiff = await this.createDiffForUntrackedFiles(worktreePath, untrackedFiles, commandRunner);
         if (untrackedDiff) {
           diff = diff ? diff + '\n' + untrackedDiff : untrackedDiff;
         }
@@ -636,23 +636,23 @@ export class GitDiffManager {
     }
   }
 
-  private getGitCommitDiff(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): string {
+  private async getGitCommitDiff(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): Promise<string> {
     try {
-      return commandRunner.exec(`git diff ${fromCommit}..${toCommit}`, worktreePath);
+      return (await commandRunner.execAsync(`git diff ${fromCommit}..${toCommit}`, worktreePath)).stdout;
     } catch {
       this.logger?.warn(`Could not get git commit diff in ${worktreePath}`);
       return '';
     }
   }
 
-  private getChangedFiles(worktreePath: string, commandRunner: CommandRunner): string[] {
+  private async getChangedFiles(worktreePath: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
       // Get tracked changed files
-      const trackedOutput = commandRunner.exec('git diff --name-only HEAD', worktreePath);
+      const trackedOutput = (await commandRunner.execAsync('git diff --name-only HEAD', worktreePath)).stdout;
       const trackedFiles = trackedOutput.trim().split('\n').filter((f: string) => f.length > 0);
 
       // Get untracked files
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
+      const untrackedFiles = await this.getUntrackedFiles(worktreePath, commandRunner);
       
       // Combine both lists
       return [...trackedFiles, ...untrackedFiles];
@@ -662,9 +662,9 @@ export class GitDiffManager {
     }
   }
 
-  private getChangedFilesBetweenCommits(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): string[] {
+  private async getChangedFilesBetweenCommits(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
-      const output = commandRunner.exec(`git diff --name-only ${fromCommit}..${toCommit}`, worktreePath);
+      const output = (await commandRunner.execAsync(`git diff --name-only ${fromCommit}..${toCommit}`, worktreePath)).stdout;
       return output.trim().split('\n').filter((f: string) => f.length > 0);
     } catch {
       this.logger?.warn(`Could not get changed files between commits in ${worktreePath}`);
@@ -672,14 +672,14 @@ export class GitDiffManager {
     }
   }
 
-  private getDiffStats(worktreePath: string, commandRunner: CommandRunner): GitDiffStats {
+  private async getDiffStats(worktreePath: string, commandRunner: CommandRunner): Promise<GitDiffStats> {
     try {
-      const output = commandRunner.exec('git diff --stat HEAD', worktreePath);
+      const output = (await commandRunner.execAsync('git diff --stat HEAD', worktreePath)).stdout;
 
       const trackedStats = this.parseDiffStats(output);
 
       // Add stats for untracked files
-      const untrackedFiles = this.getUntrackedFiles(worktreePath, commandRunner);
+      const untrackedFiles = await this.getUntrackedFiles(worktreePath, commandRunner);
       if (untrackedFiles.length > 0) {
         let untrackedAdditions = 0;
         for (const file of untrackedFiles) {
@@ -691,7 +691,7 @@ export class GitDiffManager {
           try {
             const cleanFile = file.trim();
             const filePath = `${worktreePath}/${cleanFile}`;
-            const lines = commandRunner.exec(`wc -l < "${filePath}"`, worktreePath);
+            const lines = (await commandRunner.execAsync(`wc -l < "${filePath}"`, worktreePath)).stdout;
             untrackedAdditions += parseInt(lines.trim()) || 0;
           } catch {
             // Skip files that can't be counted
@@ -712,9 +712,9 @@ export class GitDiffManager {
     }
   }
 
-  private getCommitDiffStats(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): GitDiffStats {
+  private async getCommitDiffStats(worktreePath: string, fromCommit: string, toCommit: string, commandRunner: CommandRunner): Promise<GitDiffStats> {
     try {
-      const output = commandRunner.exec(`git diff --stat ${fromCommit}..${toCommit}`, worktreePath);
+      const output = (await commandRunner.execAsync(`git diff --stat ${fromCommit}..${toCommit}`, worktreePath)).stdout;
       
       return this.parseDiffStats(output);
     } catch {
@@ -742,9 +742,9 @@ export class GitDiffManager {
   /**
    * Check if there are any changes in the working directory
    */
-  hasChanges(worktreePath: string, commandRunner: CommandRunner): boolean {
+  async hasChanges(worktreePath: string, commandRunner: CommandRunner): Promise<boolean> {
     try {
-      const output = commandRunner.exec('git status --porcelain', worktreePath);
+      const output = (await commandRunner.execAsync('git status --porcelain', worktreePath)).stdout;
       return output.trim().length > 0;
     } catch {
       this.logger?.warn(`Could not check git status in ${worktreePath}`);
@@ -755,9 +755,9 @@ export class GitDiffManager {
   /**
    * Get list of untracked files
    */
-  private getUntrackedFiles(worktreePath: string, commandRunner: CommandRunner): string[] {
+  private async getUntrackedFiles(worktreePath: string, commandRunner: CommandRunner): Promise<string[]> {
     try {
-      const output = commandRunner.exec('git ls-files --others --exclude-standard', worktreePath);
+      const output = (await commandRunner.execAsync('git ls-files --others --exclude-standard', worktreePath)).stdout;
       
       // Handle empty output case
       if (!output || output.trim().length === 0) {
@@ -774,7 +774,7 @@ export class GitDiffManager {
   /**
    * Create diff-like output for untracked files
    */
-  private createDiffForUntrackedFiles(worktreePath: string, untrackedFiles: string[], commandRunner: CommandRunner): string {
+  private async createDiffForUntrackedFiles(worktreePath: string, untrackedFiles: string[], commandRunner: CommandRunner): Promise<string> {
     let diffOutput = '';
     
     for (const file of untrackedFiles) {
@@ -786,7 +786,7 @@ export class GitDiffManager {
       try {
         const cleanFile = file.trim();
         const filePath = `${worktreePath}/${cleanFile}`;
-        const fileContent = commandRunner.exec(`cat "${filePath}"`, worktreePath, { maxBuffer: 1024 * 1024 });
+        const fileContent = (await commandRunner.execAsync(`cat "${filePath}"`, worktreePath, { maxBuffer: 1024 * 1024 })).stdout;
         
         // Create a diff-like format for the new file
         diffOutput += `diff --git a/${cleanFile} b/${cleanFile}\n`;

--- a/main/src/services/gitFileWatcher.ts
+++ b/main/src/services/gitFileWatcher.ts
@@ -8,7 +8,7 @@ import type { Stats } from 'fs';
 import { watch as fsWatch, type FSWatcher as NodeFsWatcher, type WatchEventType } from 'node:fs';
 import { boundary, decodeBoundary } from '../../../shared/validation/boundaryDecoder';
 import { spawn, type ChildProcess } from 'child_process';
-import { execSync } from '../utils/commandExecutor';
+import { commandExecutor } from '../utils/commandExecutor';
 import type { CommandRunner } from '../utils/commandRunner';
 import type { PathResolver } from '../utils/pathResolver';
 import type { Logger } from '../utils/logger';
@@ -63,6 +63,8 @@ interface WatchedSession {
   nonFatalErrorLogged?: boolean; // rate-limits log-only watcher errors (separate from the degrade warn)
   lastModified: number;
   pendingRefresh: boolean;
+  refreshInFlight?: boolean;
+  pollInFlight?: boolean;
 }
 
 interface GitFileWatcherStats {
@@ -81,6 +83,8 @@ interface GitFileWatcherStats {
  */
 export class GitFileWatcher extends EventEmitter {
   private watchedSessions: Map<string, WatchedSession> = new Map();
+  private pendingStarts = new Map<string, symbol>();
+  private gitignoreRequests = new Map<string, Promise<Set<string>>>();
   private refreshDebounceTimers: Map<string, NodeJS.Timeout> = new Map();
   private readonly DEBOUNCE_MS = 1500; // 1.5 second debounce for file changes
 
@@ -109,7 +113,7 @@ export class GitFileWatcher extends EventEmitter {
   /**
    * Start watching a session's worktree for changes
    */
-  startWatching(sessionId: string, worktreePath: string): void {
+  async startWatching(sessionId: string, worktreePath: string): Promise<void> {
     // Stop existing watcher if any
     this.stopWatching(sessionId);
 
@@ -118,6 +122,9 @@ export class GitFileWatcher extends EventEmitter {
       return;
     }
 
+    let metadataWatcher: FSWatcher | undefined;
+    const start = Symbol(sessionId);
+    this.pendingStarts.set(sessionId, start);
     try {
       if (this.commandRunner?.wslContext) {
         if (this.startWSLNativeWatcher(sessionId, worktreePath)) {
@@ -136,8 +143,14 @@ export class GitFileWatcher extends EventEmitter {
       const useNative =
         (process.platform === 'darwin' || process.platform === 'win32') &&
         !this.commandRunner?.wslContext;
+      const gitignoredDirs = await this.getGitignoredDirs(watchPath);
+      if (this.pendingStarts.get(sessionId) !== start) return;
+      const gitWatcher = await this.createGitMetadataWatcher(sessionId, watchPath);
+      metadataWatcher = gitWatcher;
+      if (this.pendingStarts.get(sessionId) !== start) {
+        return;
+      }
       if (useNative) {
-        this.getGitignoredDirs(watchPath); // warm the cache before events flow
         let nativeWatcher: NodeFsWatcher;
         try {
           // default (utf8) encoding → Node types filename as string | null (never Buffer)
@@ -145,12 +158,13 @@ export class GitFileWatcher extends EventEmitter {
             watchPath,
             { recursive: true, persistent: true },
             (_eventType: WatchEventType, filename: string | null) => {
+              void this.getGitignoredDirs(watchPath);
               // null filename → conservative: cannot filter, treat as a change.
               // Re-read the (cache-hit) gitignore set each event so the TTL
               // refresh takes effect on long-lived spotlight watchers.
               if (
                 filename !== null &&
-                this.isIgnoredEventPath(filename, this.getGitignoredDirs(watchPath))
+                this.isIgnoredEventPath(filename, gitignoredDirs)
               ) {
                 return;
               }
@@ -171,11 +185,10 @@ export class GitFileWatcher extends EventEmitter {
             );
             return;
           }
-          this.transitionToPolling(sessionId, worktreePath, normalizedError);
+          await this.transitionToPolling(sessionId, worktreePath, normalizedError);
           return;
         }
         nativeWatcher.on('error', (err) => this.handleWatcherFailure(sessionId, err));
-        const gitWatcher = this.createGitMetadataWatcher(sessionId, watchPath);
         this.watchedSessions.set(sessionId, {
           sessionId,
           worktreePath,
@@ -193,7 +206,7 @@ export class GitFileWatcher extends EventEmitter {
         // record the already-dirty snapshot without emitting, leaving status
         // stale until the next real change. (pollStatusSnapshot no-ops if the
         // session was torn down before this runs.)
-        setImmediate(() => this.pollStatusSnapshot(sessionId));
+        setImmediate(() => { void this.pollStatusSnapshot(sessionId); });
 
         // Validation signal — keep in production: confirms watcher count is bounded
         this.logger?.info(
@@ -206,7 +219,6 @@ export class GitFileWatcher extends EventEmitter {
       // gitignore-derived) is threaded into the registration-time `ignored` fn
       // so it both prunes descent (handle budget) AND matches the native
       // event-time filter, keeping behavior uniform across platforms.
-      const gitignoredDirs = this.getGitignoredDirs(watchPath);
       // Function-form ignored: short-circuits descent into heavy directories.
       // stats may be undefined on initial calls — return false (don't ignore)
       // if unknown. Unlike event-time callers, stats IS available here, so
@@ -259,8 +271,6 @@ export class GitFileWatcher extends EventEmitter {
         }
       });
 
-      const gitWatcher = this.createGitMetadataWatcher(sessionId, watchPath);
-
       this.watchedSessions.set(sessionId, {
         sessionId,
         worktreePath,
@@ -275,7 +285,7 @@ export class GitFileWatcher extends EventEmitter {
 
       // Seed the self-heal snapshot baseline off the activation critical path
       // (same rationale as the native branch above).
-      setImmediate(() => this.pollStatusSnapshot(sessionId));
+      setImmediate(() => { void this.pollStatusSnapshot(sessionId); });
 
       // Validation signal — keep in production: confirms watcher count is bounded
       this.logger?.info(
@@ -286,6 +296,11 @@ export class GitFileWatcher extends EventEmitter {
         `[GitFileWatcher] Failed to start watching session ${sessionId}:`,
         error instanceof Error ? error : new Error(String(error))
       );
+    } finally {
+      if (metadataWatcher && this.watchedSessions.get(sessionId)?.gitWatcher !== metadataWatcher) {
+        await metadataWatcher.close().catch(() => {});
+      }
+      if (this.pendingStarts.get(sessionId) === start) this.pendingStarts.delete(sessionId);
     }
   }
 
@@ -390,6 +405,7 @@ export class GitFileWatcher extends EventEmitter {
    * Stop watching a session's worktree
    */
   stopWatching(sessionId: string): void {
+    this.pendingStarts.delete(sessionId);
     const session = this.watchedSessions.get(sessionId);
     if (!session) return;
 
@@ -416,6 +432,7 @@ export class GitFileWatcher extends EventEmitter {
    * Stop all watchers
    */
   stopAll(): void {
+    this.pendingStarts.clear();
     for (const sessionId of this.watchedSessions.keys()) {
       this.stopWatching(sessionId);
     }
@@ -453,7 +470,7 @@ export class GitFileWatcher extends EventEmitter {
     // Set new timer
     const timer = setTimeout(() => {
       this.refreshDebounceTimers.delete(sessionId);
-      this.performRefreshCheck(sessionId);
+      void this.performRefreshCheck(sessionId);
     }, this.DEBOUNCE_MS);
 
     this.refreshDebounceTimers.set(sessionId, timer);
@@ -462,18 +479,20 @@ export class GitFileWatcher extends EventEmitter {
   /**
    * Perform the actual refresh check using git plumbing commands
    */
-  private performRefreshCheck(sessionId: string): void {
+  private async performRefreshCheck(sessionId: string): Promise<void> {
     const session = this.watchedSessions.get(sessionId);
-    if (!session || !session.pendingRefresh) {
+    if (!session || !session.pendingRefresh || session.refreshInFlight) {
       return;
     }
 
     session.pendingRefresh = false;
+    session.refreshInFlight = true;
 
     try {
       // Quick check if the index is dirty using git update-index
       // This is much faster than running full git status
-      const needsRefresh = this.checkIfRefreshNeeded(session.worktreePath);
+      const needsRefresh = await this.checkIfRefreshNeeded(session.worktreePath);
+      if (this.watchedSessions.get(sessionId) !== session) return;
 
       if (needsRefresh) {
         this.logger?.info(`[GitFileWatcher] Session ${sessionId} needs refresh`);
@@ -484,16 +503,21 @@ export class GitFileWatcher extends EventEmitter {
     } catch (error) {
       this.logger?.error(`[GitFileWatcher] Error checking session ${sessionId}:`, error instanceof Error ? error : new Error(String(error)));
       // On error, emit refresh to be safe
-      this.emit('needs-refresh', sessionId);
+      if (this.watchedSessions.get(sessionId) === session) this.emit('needs-refresh', sessionId);
+    } finally {
+      session.refreshInFlight = false;
+      if (this.watchedSessions.get(sessionId) === session && session.pendingRefresh) {
+        this.scheduleRefreshCheck(sessionId);
+      }
     }
   }
 
   /** Run a git command, using CommandRunner when available for WSL support */
-  private execGit(command: string, cwd: string): string {
+  private async execGit(command: string, cwd: string): Promise<string> {
     if (this.commandRunner) {
-      return this.commandRunner.exec(command, cwd, { silent: true });
+      return (await this.commandRunner.execAsync(command, cwd, { silent: true })).stdout;
     }
-    return execSync(command, { cwd, encoding: 'utf8', silent: true });
+    return (await commandExecutor.execAsync(command, { cwd, silent: true })).stdout;
   }
 
   /**
@@ -505,23 +529,33 @@ export class GitFileWatcher extends EventEmitter {
    * only those lines, stripped of the slash. If the path is not yet a repo the
    * scan fails and we cache an empty set (the hardcoded list still applies).
    */
-  private getGitignoredDirs(watchPath: string): Set<string> {
+  private async getGitignoredDirs(watchPath: string): Promise<Set<string>> {
     const cached = this.gitignoreDirCache.get(watchPath);
     if (cached && Date.now() - cached.fetchedAt < GitFileWatcher.GITIGNORE_CACHE_TTL_MS) {
       return cached.dirs;
     }
-    const dirs = new Set<string>();
+    const pending = this.gitignoreRequests.get(watchPath);
+    if (pending) return pending;
+    const request = this.refreshGitignoredDirs(watchPath, cached?.dirs ?? new Set<string>());
+    this.gitignoreRequests.set(watchPath, request);
     try {
-      const out = this.execGit('git ls-files -o -i --directory --exclude-standard', watchPath);
+      return await request;
+    } finally {
+      this.gitignoreRequests.delete(watchPath);
+    }
+  }
+
+  private async refreshGitignoredDirs(watchPath: string, dirs: Set<string>): Promise<Set<string>> {
+    try {
+      const out = await this.execGit('git ls-files -o -i --directory --exclude-standard', watchPath);
+      // Keep the same set so existing native and chokidar callbacks see TTL refreshes.
+      dirs.clear();
       for (const line of out.split('\n')) {
         const trimmed = line.trim();
-        // dirs only — git marks ignored directories with a trailing slash
-        if (trimmed.endsWith('/')) {
-          dirs.add(trimmed.slice(0, -1));
-        }
+        if (trimmed.endsWith('/')) dirs.add(trimmed.slice(0, -1));
       }
     } catch {
-      /* not a repo yet → hardcoded list only */
+      // Not a repo yet: hardcoded ignores still apply.
     }
     this.gitignoreDirCache.set(watchPath, { dirs, fetchedAt: Date.now() });
     return dirs;
@@ -572,30 +606,34 @@ export class GitFileWatcher extends EventEmitter {
    * emits one extra needs-refresh. That single bounded refresh doubles as the
    * safety net for coalesced/dropped events, and refresh is idempotent.
    */
-  private pollStatusSnapshot(sessionId: string): void {
+  private async pollStatusSnapshot(sessionId: string): Promise<void> {
     const session = this.watchedSessions.get(sessionId);
-    if (!session) return;
+    if (!session || session.pollInFlight) return;
+    session.pollInFlight = true;
     try {
       // session.worktreePath (unconverted), matching performRefreshCheck →
       // checkIfRefreshNeeded(session.worktreePath) — execGit/commandRunner
       // expect the runner-domain path, not the toFileSystem-converted one.
-      const snapshot = this.execGit(
+      const snapshot = await this.execGit(
         'git status --porcelain=v1 --branch --untracked-files=normal',
         session.worktreePath,
       );
+      if (this.watchedSessions.get(sessionId) !== session) return;
       if (session.lastStatusSnapshot !== undefined && snapshot !== session.lastStatusSnapshot) {
         this.emit('needs-refresh', sessionId);
       }
       session.lastStatusSnapshot = snapshot;
     } catch {
       /* transient git failure — try again next tick */
+    } finally {
+      session.pollInFlight = false;
     }
   }
 
   /** 60s self-heal tick covering FSEvents coalescing / trailing-debounce starvation */
   private startSelfHeal(sessionId: string): NodeJS.Timeout {
     return setInterval(
-      () => this.pollStatusSnapshot(sessionId),
+      () => { void this.pollStatusSnapshot(sessionId); },
       GitFileWatcher.SELF_HEAL_INTERVAL_MS,
     );
   }
@@ -609,7 +647,7 @@ export class GitFileWatcher extends EventEmitter {
   private handleWatcherFailure(sessionId: string, err: Error): void {
     const session = this.watchedSessions.get(sessionId);
     if (!session || session.mode === 'polling') return; // already degraded (or torn down); swallow the storm
-    this.transitionToPolling(
+    void this.transitionToPolling(
       sessionId,
       session.worktreePath,
       err,
@@ -621,13 +659,13 @@ export class GitFileWatcher extends EventEmitter {
    * session record exists (the native creation-throw path throws before
    * watchedSessions.set), so it builds a COMPLETE WatchedSession record from
    * its own parameters instead of assuming a prior one. Emits exactly one warn
-   * per session lifetime (guarded by watcherErrorLogged), seeds the snapshot
-   * baseline SYNCHRONOUSLY (a change landing in the 0-5s window before the
+   * per session lifetime (guarded by watcherErrorLogged), starts the snapshot
+   * baseline immediately (a change landing in the 0-5s window before the
    * first tick must not be absorbed into a late-seeded baseline and go
    * un-emitted), then emits one immediate needs-refresh so consumers reconcile
    * promptly with the exact state the baseline captured.
    */
-  private transitionToPolling(sessionId: string, worktreePath: string, err: Error): void {
+  private async transitionToPolling(sessionId: string, worktreePath: string, err: Error): Promise<void> {
     const session = this.watchedSessions.get(sessionId);
     // close everything watcher-shaped; keep the debounce map intact
     session?.nativeWatcher?.close(); // sync
@@ -642,7 +680,7 @@ export class GitFileWatcher extends EventEmitter {
       );
     }
     const pollTimer = setInterval(
-      () => this.pollStatusSnapshot(sessionId),
+      () => { void this.pollStatusSnapshot(sessionId); },
       GitFileWatcher.POLL_INTERVAL_MS,
     );
     this.watchedSessions.set(sessionId, {
@@ -659,8 +697,9 @@ export class GitFileWatcher extends EventEmitter {
     // the baseline is undefined) — deferring it to the first 5s tick would
     // silently absorb any change made in that window. Then emit one immediate
     // refresh so consumers reconcile with the state the baseline captured.
-    this.pollStatusSnapshot(sessionId);
-    this.emit('needs-refresh', sessionId);
+    const polling = this.watchedSessions.get(sessionId);
+    await this.pollStatusSnapshot(sessionId);
+    if (this.watchedSessions.get(sessionId) === polling) this.emit('needs-refresh', sessionId);
   }
 
   /**
@@ -679,10 +718,10 @@ export class GitFileWatcher extends EventEmitter {
    * resolution fails (not yet a valid repo) we skip the narrow watcher and rely
    * on the worktree/native watcher alone, exactly as before.
    */
-  private createGitMetadataWatcher(sessionId: string, watchPath: string): FSWatcher | undefined {
+  private async createGitMetadataWatcher(sessionId: string, watchPath: string): Promise<FSWatcher | undefined> {
     try {
       // rev-parse emits one line per flag, in flag order — but guard the shape
-      const lines = this.execGit('git rev-parse --absolute-git-dir --git-common-dir', watchPath)
+      const lines = (await this.execGit('git rev-parse --absolute-git-dir --git-common-dir', watchPath))
         .split('\n')
         .map((l) => l.trim())
         .filter(Boolean);
@@ -735,12 +774,12 @@ export class GitFileWatcher extends EventEmitter {
    * Quick check if git status needs refreshing
    * Returns true if there are changes, false if working tree is clean
    */
-  private checkIfRefreshNeeded(worktreePath: string): boolean {
+  private async checkIfRefreshNeeded(worktreePath: string): Promise<boolean> {
     try {
       // First, refresh the index to ensure it's up to date
       // This is very fast and updates git's internal cache
       try {
-        this.execGit('git update-index --refresh --ignore-submodules', worktreePath);
+        await this.execGit('git update-index --refresh --ignore-submodules', worktreePath);
       } catch (error) {
         // `git update-index --refresh` exits non-zero for dirty/racy paths.
         // That is a refresh signal, not an application error.
@@ -750,7 +789,7 @@ export class GitFileWatcher extends EventEmitter {
 
       // Check for unstaged changes (modified files)
       try {
-        this.execGit('git diff-files --quiet --ignore-submodules', worktreePath);
+        await this.execGit('git diff-files --quiet --ignore-submodules', worktreePath);
       } catch {
         // Non-zero exit means there are unstaged changes
         return true;
@@ -758,14 +797,14 @@ export class GitFileWatcher extends EventEmitter {
 
       // Check for staged changes
       try {
-        this.execGit('git diff-index --cached --quiet HEAD --ignore-submodules', worktreePath);
+        await this.execGit('git diff-index --cached --quiet HEAD --ignore-submodules', worktreePath);
       } catch {
         // Non-zero exit means there are staged changes
         return true;
       }
 
       // Check for untracked files
-      const untrackedOutput = this.execGit('git ls-files --others --exclude-standard', worktreePath).trim();
+      const untrackedOutput = (await this.execGit('git ls-files --others --exclude-standard', worktreePath)).trim();
 
       if (untrackedOutput) {
         return true;

--- a/main/src/services/gitPlumbingCommands.ts
+++ b/main/src/services/gitPlumbingCommands.ts
@@ -1,4 +1,4 @@
-import { execSync } from '../utils/commandExecutor';
+import { commandExecutor } from '../utils/commandExecutor';
 import * as fs from 'fs';
 import { WSLContext, linuxToUNCPath } from '../utils/wslUtils';
 import { escapeShellArg } from '../utils/shellEscape';
@@ -36,10 +36,10 @@ export interface GitDiffStats {
  * This prevents ENOENT errors when worktrees have been deleted (e.g., /tmp cleanup).
  * WSL paths are not visible to Windows fs APIs directly, so check via the UNC mount.
  */
-function directoryExists(cwd: string, wslContext?: WSLContext | null): boolean {
+async function directoryExists(cwd: string, wslContext?: WSLContext | null): Promise<boolean> {
   const fsPath = wslContext ? linuxToUNCPath(cwd, wslContext.distribution) : cwd;
   try {
-    fs.accessSync(fsPath, fs.constants.F_OK);
+    await fs.promises.access(fsPath, fs.constants.F_OK);
     return true;
   } catch {
     return false;
@@ -50,7 +50,7 @@ function directoryExists(cwd: string, wslContext?: WSLContext | null): boolean {
  * Fast check if working directory has any changes using git plumbing commands
  * Much faster than running full `git status --porcelain`
  */
-export function fastCheckWorkingDirectory(cwd: string, wslContext?: WSLContext | null): GitIndexStatus {
+export async function fastCheckWorkingDirectory(cwd: string, wslContext?: WSLContext | null): Promise<GitIndexStatus> {
   const result: GitIndexStatus = {
     hasModified: false,
     hasStaged: false,
@@ -58,7 +58,7 @@ export function fastCheckWorkingDirectory(cwd: string, wslContext?: WSLContext |
     hasConflicts: false
   };
 
-  if (!directoryExists(cwd, wslContext)) {
+  if (!await directoryExists(cwd, wslContext)) {
     // Directory doesn't exist - return safe defaults
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return {
@@ -72,39 +72,38 @@ export function fastCheckWorkingDirectory(cwd: string, wslContext?: WSLContext |
   try {
     // 1. Refresh the index first (very fast, updates git's cache)
     try {
-      execSync('git update-index --refresh --ignore-submodules', { cwd, encoding: 'utf8', silent: true }, wslContext);
+      await commandExecutor.execAsync('git update-index --refresh --ignore-submodules', { cwd, silent: true }, wslContext);
     } catch {
       // Some files may have been modified, that's ok
     }
 
     // 2. Check for unstaged changes (modified files in working directory)
     try {
-      execSync('git diff-files --quiet --ignore-submodules', { cwd, encoding: 'utf8', silent: true }, wslContext);
+      await commandExecutor.execAsync('git diff-files --quiet --ignore-submodules', { cwd, silent: true }, wslContext);
     } catch {
       result.hasModified = true;
     }
 
     // 3. Check for staged changes (in index)
     try {
-      execSync('git diff-index --cached --quiet HEAD --ignore-submodules', { cwd, encoding: 'utf8', silent: true }, wslContext);
+      await commandExecutor.execAsync('git diff-index --cached --quiet HEAD --ignore-submodules', { cwd, silent: true }, wslContext);
     } catch {
       result.hasStaged = true;
     }
 
     // 4. Check for untracked files (more efficient than ls-files for just checking existence)
-    const untrackedCheck = execSync(
+    const untrackedCheck = (await commandExecutor.execAsync(
       'git ls-files --others --exclude-standard --directory --no-empty-directory',
       { cwd },
       wslContext
-    ).toString().trim();
+    )).stdout.trim();
 
     if (untrackedCheck) {
       result.hasUntracked = true;
     }
 
     // 5. Check for merge conflicts
-    const conflictCheck = execSync('git diff --name-only --diff-filter=U', { cwd }, wslContext)
-      .toString().trim();
+    const conflictCheck = (await commandExecutor.execAsync('git diff --name-only --diff-filter=U', { cwd }, wslContext)).stdout.trim();
 
     if (conflictCheck) {
       result.hasConflicts = true;
@@ -125,15 +124,14 @@ export function fastCheckWorkingDirectory(cwd: string, wslContext?: WSLContext |
 /**
  * Get count of commits ahead/behind using rev-list (faster than rev-parse)
  */
-export function fastGetAheadBehind(cwd: string, baseBranch: string, wslContext?: WSLContext | null): GitAheadBehind {
-  if (!directoryExists(cwd, wslContext)) {
+export async function fastGetAheadBehind(cwd: string, baseBranch: string, wslContext?: WSLContext | null): Promise<GitAheadBehind> {
+  if (!await directoryExists(cwd, wslContext)) {
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return { ahead: 0, behind: 0 };
   }
 
   try {
-    const result = execSync(`git rev-list --left-right --count ${baseBranch}...HEAD`, { cwd }, wslContext)
-      .toString().trim();
+    const result = (await commandExecutor.execAsync(`git rev-list --left-right --count ${baseBranch}...HEAD`, { cwd }, wslContext)).stdout.trim();
 
     const [behind, ahead] = result.split('\t').map(n => parseInt(n, 10));
     return {
@@ -145,22 +143,22 @@ export function fastGetAheadBehind(cwd: string, baseBranch: string, wslContext?:
   }
 }
 
-export function listCommitsAhead(
+export async function listCommitsAhead(
   cwd: string,
   baseBranch: string,
   wslContext?: WSLContext | null,
-): GitCommitSummary[] {
-  if (!directoryExists(cwd, wslContext)) {
+): Promise<GitCommitSummary[]> {
+  if (!await directoryExists(cwd, wslContext)) {
     throw new Error(`Directory does not exist: ${cwd}`);
   }
 
   const range = escapeShellArg(`${baseBranch}..HEAD`);
   const format = escapeShellArg('%H%x00%s');
-  const output = execSync(
+  const output = (await commandExecutor.execAsync(
     `git log --format=${format} -z ${range}`,
     { cwd, silent: true },
     wslContext,
-  ).toString();
+  )).stdout;
   const fields = output.split('\0');
   if (fields.at(-1) === '') fields.pop();
   const commits: GitCommitSummary[] = [];
@@ -178,15 +176,15 @@ export function listCommitsAhead(
 /**
  * Get statistics about changes (additions/deletions) efficiently
  */
-export function fastGetDiffStats(cwd: string, wslContext?: WSLContext | null): GitDiffStats {
-  if (!directoryExists(cwd, wslContext)) {
+export async function fastGetDiffStats(cwd: string, wslContext?: WSLContext | null): Promise<GitDiffStats> {
+  if (!await directoryExists(cwd, wslContext)) {
     console.warn(`[GitPlumbing] Directory does not exist: ${cwd}`);
     return { additions: 0, deletions: 0, filesChanged: 0 };
   }
 
   try {
     // Use numstat for machine-readable output (faster to parse)
-    const result = execSync('git diff --numstat', { cwd }, wslContext).toString().trim();
+    const result = (await commandExecutor.execAsync('git diff --numstat', { cwd }, wslContext)).stdout.trim();
 
     if (!result) {
       return { additions: 0, deletions: 0, filesChanged: 0 };

--- a/main/src/services/gitStatusManager.ts
+++ b/main/src/services/gitStatusManager.ts
@@ -187,7 +187,7 @@ export class GitStatusManager extends EventEmitter {
       if (session?.worktreePath) {
         const ctx = this.sessionManager.getProjectContext(sessionId);
         this.fileWatcher.setExecutionContext(ctx?.commandRunner, ctx?.pathResolver);
-        this.fileWatcher.startWatching(sessionId, session.worktreePath);
+        await this.fileWatcher.startWatching(sessionId, session.worktreePath);
         this.logger?.info(`[GitStatus] Started file watching for session ${sessionId}`);
       }
     } catch (error) {
@@ -339,7 +339,7 @@ export class GitStatusManager extends EventEmitter {
               const ctx = this.sessionManager.getProjectContext(session.id);
               if (ctx) {
                 const comparisonBranch = await this.worktreeManager.getSessionComparisonBranch(session, ctx);
-                const { ahead, behind } = this.dependencies.fastGetAheadBehind(session.worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
+                const { ahead, behind } = await this.dependencies.fastGetAheadBehind(session.worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
                 
                 const updatedStatus = { ...cached.status };
                 updatedStatus.ahead = ahead;
@@ -402,7 +402,7 @@ export class GitStatusManager extends EventEmitter {
         // hasUncommittedChanges might be true if there were conflicts
         // We'll do a quick check for uncommitted changes
         try {
-          const quickStatus = this.dependencies.fastCheckWorkingDirectory(session.worktreePath, ctx.commandRunner.wslContext);
+          const quickStatus = await this.dependencies.fastCheckWorkingDirectory(session.worktreePath, ctx.commandRunner.wslContext);
           updatedStatus.hasUncommittedChanges = quickStatus.hasModified || quickStatus.hasStaged;
           updatedStatus.hasUntrackedFiles = quickStatus.hasUntracked;
           // Update state based on conflicts
@@ -412,7 +412,7 @@ export class GitStatusManager extends EventEmitter {
 
           if (updatedStatus.hasUncommittedChanges) {
             // Get updated diff stats
-            const quickStats = this.dependencies.fastGetDiffStats(session.worktreePath, ctx.commandRunner.wslContext);
+            const quickStats = await this.dependencies.fastGetDiffStats(session.worktreePath, ctx.commandRunner.wslContext);
             updatedStatus.additions = quickStats.additions;
             updatedStatus.deletions = quickStats.deletions;
             updatedStatus.filesChanged = quickStats.filesChanged;
@@ -667,7 +667,7 @@ export class GitStatusManager extends EventEmitter {
     const ctx = this.sessionManager.getProjectContext(sessionId);
     if (!ctx) return;
 
-    const branchName = this.getCurrentBranchName(session.worktreePath, ctx.commandRunner);
+    const branchName = await this.getCurrentBranchName(session.worktreePath, ctx.commandRunner);
     if (!branchName) return;
 
     const cacheKey = `${project.path}:${branchName}`;
@@ -677,9 +677,9 @@ export class GitStatusManager extends EventEmitter {
     }
   }
 
-  private getCurrentBranchName(worktreePath: string, commandRunner: CommandRunner): string | null {
+  private async getCurrentBranchName(worktreePath: string, commandRunner: CommandRunner): Promise<string | null> {
     try {
-      const branchName = commandRunner.exec('git branch --show-current', worktreePath, { silent: true }).trim();
+      const branchName = (await commandRunner.execAsync('git branch --show-current', worktreePath, { silent: true })).stdout.trim();
       if (branchName) return branchName;
     } catch {
       // Fall back to the worktree folder name below.
@@ -715,7 +715,7 @@ export class GitStatusManager extends EventEmitter {
     const ctx = this.sessionManager.getProjectContext(sessionId);
     if (!ctx) return;
 
-    const branchName = this.getCurrentBranchName(session.worktreePath, ctx.commandRunner);
+    const branchName = await this.getCurrentBranchName(session.worktreePath, ctx.commandRunner);
     if (!branchName) return;
 
     const prResult = await this.fetchPrForSessionResult(branchName, project.path, ctx.commandRunner);
@@ -856,7 +856,7 @@ export class GitStatusManager extends EventEmitter {
       const ctx = this.sessionManager.getProjectContext(sessionId);
 
       // Quick check using plumbing commands
-      const quickStatus = this.dependencies.fastCheckWorkingDirectory(worktreePath, ctx?.commandRunner.wslContext);
+      const quickStatus = await this.dependencies.fastCheckWorkingDirectory(worktreePath, ctx?.commandRunner.wslContext);
 
       // Compare with cached status
       const cachedHasChanges = cached.status.hasUncommittedChanges || cached.status.hasUntrackedFiles;
@@ -874,7 +874,7 @@ export class GitStatusManager extends EventEmitter {
           const comparisonBranch = session
             ? await this.worktreeManager.getSessionComparisonBranch(session, ctx)
             : await this.worktreeManager.getProjectMainBranch(ctx.project.path, ctx.commandRunner);
-          const { ahead, behind } = this.dependencies.fastGetAheadBehind(worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
+          const { ahead, behind } = await this.dependencies.fastGetAheadBehind(worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
 
           if ((cached.status.ahead || 0) !== ahead || (cached.status.behind || 0) !== behind) {
             return true;
@@ -895,24 +895,22 @@ export class GitStatusManager extends EventEmitter {
   private async fetchGitStatus(sessionId: string): Promise<GitStatus | null> {
     // Create abort controller for this operation
     const abortController = new AbortController();
+    this.abortControllers.get(sessionId)?.abort();
     this.abortControllers.set(sessionId, abortController);
     
     try {
       const session = await this.sessionManager.getSession(sessionId);
       if (!session || !session.worktreePath) {
-        this.abortControllers.delete(sessionId);
         return null;
       }
       
       if (isHomeDirectory(session.worktreePath)) {
         this.logger?.warn(`[GitStatus] ${HOME_GIT_SCAN_WARNING}`);
-        this.abortControllers.delete(sessionId);
         return { state: 'unknown', lastChecked: new Date().toISOString() };
       }
 
       // Check if operation was cancelled
       if (abortController.signal.aborted) {
-        this.abortControllers.delete(sessionId);
         return null;
       }
       
@@ -924,7 +922,7 @@ export class GitStatusManager extends EventEmitter {
       }
 
       // Use fast plumbing commands for initial checks
-      const quickStatus = this.dependencies.fastCheckWorkingDirectory(session.worktreePath, ctx.commandRunner.wslContext);
+      const quickStatus = await this.dependencies.fastCheckWorkingDirectory(session.worktreePath, ctx.commandRunner.wslContext);
       const hasUncommittedChanges = quickStatus.hasModified || quickStatus.hasStaged;
       const hasUntrackedFiles = quickStatus.hasUntracked;
       const hasMergeConflicts = quickStatus.hasConflicts;
@@ -933,7 +931,7 @@ export class GitStatusManager extends EventEmitter {
       let uncommittedDiff = { stats: { filesChanged: 0, additions: 0, deletions: 0 } };
       if (hasUncommittedChanges) {
         // Use fast diff stats instead of full diff capture when possible
-        const quickStats = this.dependencies.fastGetDiffStats(session.worktreePath, ctx.commandRunner.wslContext);
+        const quickStats = await this.dependencies.fastGetDiffStats(session.worktreePath, ctx.commandRunner.wslContext);
         uncommittedDiff = {
           stats: {
             filesChanged: quickStats.filesChanged,
@@ -945,7 +943,7 @@ export class GitStatusManager extends EventEmitter {
 
       // Get ahead/behind status using fast plumbing command
       const comparisonBranch = await this.worktreeManager.getSessionComparisonBranch(session, ctx);
-      const { ahead, behind } = this.dependencies.fastGetAheadBehind(session.worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
+      const { ahead, behind } = await this.dependencies.fastGetAheadBehind(session.worktreePath, comparisonBranch, ctx.commandRunner.wslContext);
 
       // Get total additions/deletions for all commits in the branch (compared to comparison branch)
       let totalCommitAdditions = 0;
@@ -954,7 +952,7 @@ export class GitStatusManager extends EventEmitter {
       if (ahead > 0) {
         // Use git diff --shortstat for commit statistics
         try {
-          const statLine = ctx.commandRunner.exec(`git diff --shortstat ${comparisonBranch}...HEAD`, session.worktreePath, { silent: true }).trim();
+          const statLine = (await ctx.commandRunner.execAsync(`git diff --shortstat ${comparisonBranch}...HEAD`, session.worktreePath, { silent: true })).stdout.trim();
           if (statLine) {
             const filesMatch = statLine.match(/(\d+) files? changed/);
             const additionsMatch = statLine.match(/(\d+) insertions?\(\+\)/);
@@ -1002,7 +1000,7 @@ export class GitStatusManager extends EventEmitter {
       // Get total number of commits in the branch
       let totalCommits = ahead;
       try {
-        const countStr = ctx.commandRunner.exec(`git rev-list --count ${comparisonBranch}..HEAD`, session.worktreePath, { silent: true }).trim();
+        const countStr = (await ctx.commandRunner.execAsync(`git rev-list --count ${comparisonBranch}..HEAD`, session.worktreePath, { silent: true })).stdout.trim();
         totalCommits = parseInt(countStr, 10) || ahead;
       } catch {
         // Keep default of ahead if command fails
@@ -1028,14 +1026,13 @@ export class GitStatusManager extends EventEmitter {
         totalCommits: totalCommits > 0 ? totalCommits : undefined
       };
       
+      if (abortController.signal.aborted) return null;
       this.gitLogger.logSessionSuccess(sessionId);
-      this.abortControllers.delete(sessionId);
       return result;
     } catch (error) {
-      this.abortControllers.delete(sessionId);
       
       // Check if this was a cancellation
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (abortController.signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
         this.gitLogger.logSessionFetch(sessionId, true); // cancelled
         return null;
       }
@@ -1045,6 +1042,10 @@ export class GitStatusManager extends EventEmitter {
         state: 'unknown',
         lastChecked: new Date().toISOString()
       };
+    } finally {
+      if (this.abortControllers.get(sessionId) === abortController) {
+        this.abortControllers.delete(sessionId);
+      }
     }
   }
 

--- a/main/src/services/skillCacheManager.ts
+++ b/main/src/services/skillCacheManager.ts
@@ -348,10 +348,7 @@ export class SkillCacheManager {
   private buildPaneChatGuide(): string {
     const runtimeContext = this.paneChatRuntimeContextPath;
     const paneOrchestratorSkill = this.paneChatOrchestratorSkillPath;
-    const codexOrchestrator = path.join(this.cacheRoot, 'parsa', '.codex', 'skills', 'runpane-orchestrator', 'SKILL.md');
     const claudeOrchestrator = path.join(this.cacheRoot, 'parsa', '.claude', 'skills', 'runpane-orchestrator', 'SKILL.md');
-    const workflowMap = path.join(this.cacheRoot, 'docs', 'readme-workflow-map.png');
-    const skillLegend = path.join(this.cacheRoot, 'docs', 'readme-skill-legend.png');
     const managedBlock = RUNPANE_CONTRACT.agentContext.managedBlock.join('\n');
 
     return `# Pane Chat Orchestrator
@@ -417,8 +414,6 @@ ${managedBlock}
     const claudeOrchestrator = path.join(this.cacheRoot, 'parsa', '.claude', 'skills', 'runpane-orchestrator', 'SKILL.md');
     const workflowMap = path.join(this.cacheRoot, 'docs', 'readme-workflow-map.png');
     const workflowMapSource = path.join(this.cacheRoot, 'docs', 'readme-workflow-map.excalidraw');
-    const skillLegend = path.join(this.cacheRoot, 'docs', 'readme-skill-legend.png');
-    const skillLegendSource = path.join(this.cacheRoot, 'docs', 'readme-skill-legend.excalidraw');
     const codexProjectSkillsRoot = this.codexProjectSkillsRoot;
     const claudeProjectSkillsRoot = this.claudeProjectSkillsRoot;
 

--- a/main/src/services/spotlightManager.ts
+++ b/main/src/services/spotlightManager.ts
@@ -1,13 +1,12 @@
-import { EventEmitter } from 'events';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { dirname } from 'path';
 import { getAppSubdirectory } from '../utils/appDirectory';
 import { GitFileWatcher } from './gitFileWatcher';
 import type { CommandRunner } from '../utils/commandRunner';
-import type { PathResolver } from '../utils/pathResolver';
 import type { SessionManager } from './sessionManager';
 import type { Logger } from '../utils/logger';
 import type { BrowserWindow } from 'electron';
+import { withLock } from '../utils/mutex';
 
 interface SpotlightState {
   sessionId: string;
@@ -18,9 +17,11 @@ interface SpotlightState {
   originalCommit: string;
   watcher: GitFileWatcher;
   commandRunner: CommandRunner;
-  pathResolver: PathResolver;
   lastSyncCommit?: string;
-  syncInProgress: boolean;
+  syncPending?: Promise<void>;
+  syncRequested?: boolean;
+  stopping?: boolean;
+  retryTimer?: NodeJS.Timeout;
 }
 
 interface PersistedSpotlightEntry {
@@ -33,22 +34,25 @@ interface PersistedSpotlightState {
   [projectId: string]: PersistedSpotlightEntry;
 }
 
-export class SpotlightManager extends EventEmitter {
+export class SpotlightManager {
   private activeSpotlights: Map<number, SpotlightState> = new Map();
   private readonly SPOTLIGHT_STATE_FILE: string;
-  private readonly SPOTLIGHT_DEBOUNCE_MS = 2500;
 
   constructor(
     private sessionManager: SessionManager,
     private logger: Logger | undefined,
     private getMainWindow: () => BrowserWindow | null
   ) {
-    super();
     this.SPOTLIGHT_STATE_FILE = getAppSubdirectory('spotlight-state.json');
-    this.setMaxListeners(100);
   }
 
-  enable(sessionId: string): void {
+  // Commands have their own deadlines. Lifecycle operations must wait for
+  // checkout completion so a lock timeout cannot skip branch restoration.
+  enable(sessionId: string): Promise<void> {
+    return withLock(this.SPOTLIGHT_STATE_FILE, () => this.enableSpotlight(sessionId), Infinity);
+  }
+
+  private async enableSpotlight(sessionId: string): Promise<void> {
     const session = this.sessionManager.getDbSession(sessionId);
     if (!session) {
       throw new Error(`Session ${sessionId} not found`);
@@ -84,29 +88,20 @@ export class SpotlightManager extends EventEmitter {
     }
 
     // Check repo clean
-    if (!this.isRepoClean(project.path, commandRunner)) {
+    if (!await this.isRepoClean(project.path, commandRunner)) {
       throw new Error(
         'Project repository has uncommitted changes. Please commit or stash changes before enabling spotlight.'
       );
     }
 
     // Save original state
-    const originalBranch = commandRunner.exec('git rev-parse --abbrev-ref HEAD', project.path, { silent: true }).trim();
-    const originalCommit = commandRunner.exec('git rev-parse HEAD', project.path, { silent: true }).trim();
+    const originalBranch = (await commandRunner.execFile('git', ['rev-parse', '--abbrev-ref', 'HEAD'], project.path, { silent: true })).stdout.trim();
+    const originalCommit = (await commandRunner.execFile('git', ['rev-parse', 'HEAD'], project.path, { silent: true })).stdout.trim();
 
     this.logger?.info(`[SpotlightManager] Enabling spotlight for session ${sessionId} on project ${project.id}`);
     this.logger?.info(`[SpotlightManager] Original branch: ${originalBranch}, commit: ${originalCommit}`);
 
-    // Do initial sync
-    this.syncWorktreeToRoot(session.worktree_path, project.path, project.id);
-
-    // Create watcher with WSL-aware command execution
     const watcher = new GitFileWatcher(this.logger, commandRunner, pathResolver);
-    watcher.startWatching(sessionId, session.worktree_path);
-    watcher.on('needs-refresh', () => {
-      this.logger?.info(`[SpotlightManager] File change detected in session ${sessionId}, syncing...`);
-      this.syncWorktreeToRoot(session.worktree_path, project.path, project.id);
-    });
 
     // Store in activeSpotlights
     const state: SpotlightState = {
@@ -118,14 +113,16 @@ export class SpotlightManager extends EventEmitter {
       originalCommit,
       watcher,
       commandRunner,
-      pathResolver,
-      syncInProgress: false
     };
 
     this.activeSpotlights.set(project.id, state);
-
-    // Persist state
+    // Record the original branch before the first checkout so disable/shutdown
+    // always use the same restore path, including during initial activation.
     this.persistState();
+    await this.syncWorktreeToRoot(state);
+    if (this.activeSpotlights.get(project.id) !== state) return;
+    watcher.on('needs-refresh', () => { void this.requestSync(state); });
+    await watcher.startWatching(sessionId, session.worktree_path);
 
     // Notify frontend
     const mainWindow = this.getMainWindow();
@@ -140,133 +137,75 @@ export class SpotlightManager extends EventEmitter {
     this.logger?.info(`[SpotlightManager] Spotlight enabled for session ${sessionId}`);
   }
 
-  disable(sessionId: string): void {
-    // Find the active spotlight entry where state.sessionId === sessionId
-    let state: SpotlightState | undefined;
-    let projectId: number | undefined;
+  disable(sessionId: string): Promise<void> {
+    const active = [...this.activeSpotlights.values()].find(entry => entry.sessionId === sessionId);
+    if (active) active.stopping = true;
+    return withLock(this.SPOTLIGHT_STATE_FILE, async () => {
+      const state = [...this.activeSpotlights.values()].find(entry => entry.sessionId === sessionId);
+      if (state) await this.disableSpotlight(state);
+    }, Infinity);
+  }
 
-    for (const [pid, s] of this.activeSpotlights.entries()) {
-      if (s.sessionId === sessionId) {
-        state = s;
-        projectId = pid;
-        break;
-      }
-    }
-
-    if (!state || projectId === undefined) {
-      this.logger?.warn(`[SpotlightManager] No active spotlight found for session ${sessionId}`);
-      return;
-    }
-
-    this.logger?.info(`[SpotlightManager] Disabling spotlight for session ${sessionId}`);
-
-    // Stop watcher
-    state.watcher.stopWatching(sessionId);
+  private async disableSpotlight(state: SpotlightState): Promise<void> {
+    const { sessionId, projectId } = state;
     state.watcher.stopAll();
+    if (state.retryTimer) clearTimeout(state.retryTimer);
+    this.activeSpotlights.delete(projectId);
 
-    // Restore original state
     try {
-      if (state.originalBranch === 'HEAD') {
-        // Was detached
-        this.logger?.info(`[SpotlightManager] Restoring detached HEAD state to ${state.originalCommit}`);
-        state.commandRunner.exec(`git checkout ${state.originalCommit}`, state.projectPath, { silent: true });
-      } else {
-        // Was on a branch
-        this.logger?.info(`[SpotlightManager] Restoring branch ${state.originalBranch}`);
-        state.commandRunner.exec(`git checkout ${state.originalBranch}`, state.projectPath, { silent: true });
-      }
+      const target = state.originalBranch === 'HEAD' ? state.originalCommit : state.originalBranch;
+      await state.commandRunner.execFile('git', ['checkout', target], state.projectPath, { silent: true });
     } catch (error) {
       this.logger?.error(
         `[SpotlightManager] Failed to restore original state for session ${sessionId}:`,
-        new Error(String(error))
+        new Error(String(error)),
       );
-      // Don't throw - we still want to clean up the spotlight state
     }
 
-    // Remove from activeSpotlights
-    this.activeSpotlights.delete(projectId);
-
-    // Persist state
     this.persistState();
-
-    // Notify frontend
     const mainWindow = this.getMainWindow();
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('spotlight:status-changed', {
-        sessionId,
-        projectId,
-        active: false
-      });
+      mainWindow.webContents.send('spotlight:status-changed', { sessionId, projectId, active: false });
     }
-
-    this.logger?.info(`[SpotlightManager] Spotlight disabled for session ${sessionId}`);
   }
 
-  disableAll(): void {
-    this.logger?.info('[SpotlightManager] Disabling all spotlights...');
-
-    for (const [projectId, state] of this.activeSpotlights.entries()) {
-      // Stop watcher
-      state.watcher.stopWatching(state.sessionId);
-      state.watcher.stopAll();
-
-      // Restore original state
+  disableAll(): Promise<void> {
+    for (const state of this.activeSpotlights.values()) state.stopping = true;
+    return withLock(this.SPOTLIGHT_STATE_FILE, async () => {
+      for (const state of this.activeSpotlights.values()) await this.disableSpotlight(state);
       try {
-        if (state.originalBranch === 'HEAD') {
-          // Was detached
-          this.logger?.info(
-            `[SpotlightManager] Restoring detached HEAD state to ${state.originalCommit} for project ${projectId}`
-          );
-          state.commandRunner.exec(`git checkout ${state.originalCommit}`, state.projectPath, { silent: true });
-        } else {
-          // Was on a branch
-          this.logger?.info(
-            `[SpotlightManager] Restoring branch ${state.originalBranch} for project ${projectId}`
-          );
-          state.commandRunner.exec(`git checkout ${state.originalBranch}`, state.projectPath, { silent: true });
-        }
+        if (existsSync(this.SPOTLIGHT_STATE_FILE)) unlinkSync(this.SPOTLIGHT_STATE_FILE);
       } catch (error) {
-        this.logger?.error(
-          `[SpotlightManager] Failed to restore original state for project ${projectId}:`,
-          new Error(String(error))
-        );
-        // Continue with other spotlights
+        this.logger?.error('[SpotlightManager] Failed to delete state file:', new Error(String(error)));
       }
-    }
-
-    // Clear the map
-    this.activeSpotlights.clear();
-
-    // Delete persisted state file
-    try {
-      if (existsSync(this.SPOTLIGHT_STATE_FILE)) {
-        unlinkSync(this.SPOTLIGHT_STATE_FILE);
-      }
-    } catch (error) {
-      this.logger?.error('[SpotlightManager] Failed to delete state file:', new Error(String(error)));
-    }
-
-    this.logger?.info('[SpotlightManager] All spotlights disabled');
+    }, Infinity);
   }
 
-  private syncWorktreeToRoot(worktreePath: string, projectPath: string, projectId: number): void {
-    const state = this.activeSpotlights.get(projectId);
-    if (!state) {
-      return;
-    }
+  private requestSync(state: SpotlightState, retry = false): Promise<void> {
+    if (state.stopping) return Promise.resolve();
+    state.syncRequested = true;
+    if (state.syncPending) return state.syncPending;
+    const pending = withLock(this.SPOTLIGHT_STATE_FILE, async () => {
+      // A queued sync must never checkout after disable or after replacement.
+      while (state.syncRequested && !state.stopping && this.activeSpotlights.get(state.projectId) === state) {
+        state.syncRequested = false;
+        await this.syncWorktreeToRoot(state, retry);
+      }
+    }, Infinity).catch(error => {
+      this.logger?.error('[SpotlightManager] Failed to schedule sync:', new Error(String(error)));
+    }).finally(() => {
+      if (state.syncPending === pending) state.syncPending = undefined;
+    });
+    state.syncPending = pending;
+    return pending;
+  }
 
-    // Guard: if syncInProgress, return
-    if (state.syncInProgress) {
-      this.logger?.info(`[SpotlightManager] Sync already in progress for project ${projectId}, skipping`);
-      return;
-    }
-
-    state.syncInProgress = true;
-
+  private async syncWorktreeToRoot(state: SpotlightState, retry = false): Promise<void> {
+    const { projectId, projectPath, worktreePath } = state;
     try {
       // Tamper detection
       if (state.lastSyncCommit) {
-        const currentCommit = state.commandRunner.exec('git rev-parse HEAD', projectPath, { silent: true }).trim();
+        const currentCommit = (await state.commandRunner.execFile('git', ['rev-parse', 'HEAD'], projectPath, { silent: true })).stdout.trim();
 
         if (currentCommit !== state.lastSyncCommit) {
           this.logger?.warn(
@@ -284,13 +223,13 @@ export class SpotlightManager extends EventEmitter {
           }
 
           // Auto-disable
-          this.disable(state.sessionId);
+          await this.disableSpotlight(state);
           return;
         }
       }
 
       // Run git stash create
-      const stashHash = state.commandRunner.exec('git stash create', worktreePath, { silent: true }).trim();
+      const stashHash = (await state.commandRunner.execFile('git', ['stash', 'create'], worktreePath, { silent: true })).stdout.trim();
 
       // If empty string, no changes
       if (!stashHash) {
@@ -301,7 +240,7 @@ export class SpotlightManager extends EventEmitter {
       this.logger?.info(`[SpotlightManager] Created stash ${stashHash} for project ${projectId}`);
 
       // Checkout the stash at project root
-      state.commandRunner.exec(`git checkout ${stashHash}`, projectPath, { silent: true });
+      await state.commandRunner.execFile('git', ['checkout', stashHash], projectPath, { silent: true });
 
       // Update lastSyncCommit
       state.lastSyncCommit = stashHash;
@@ -309,16 +248,16 @@ export class SpotlightManager extends EventEmitter {
       this.logger?.info(`[SpotlightManager] Successfully synced worktree to root for project ${projectId}`);
     } catch (error) {
       // Check for lock error
-      if (String(error).includes('.lock')) {
+      if (!retry && !state.retryTimer && String(error).includes('.lock')) {
         this.logger?.warn(`[SpotlightManager] Git lock detected for project ${projectId}, retrying in 1s...`);
 
         // Retry once after 1s delay
-        setTimeout(() => {
+        state.retryTimer = setTimeout(() => {
           this.logger?.info(`[SpotlightManager] Retrying sync for project ${projectId}...`);
-          state.syncInProgress = false;
-          this.syncWorktreeToRoot(worktreePath, projectPath, projectId);
+          state.retryTimer = undefined;
+          void this.requestSync(state, true);
         }, 1000);
-        return; // Don't set syncInProgress to false yet
+        return;
       }
 
       this.logger?.error(`[SpotlightManager] Sync error for project ${projectId}:`, new Error(String(error)));
@@ -332,29 +271,16 @@ export class SpotlightManager extends EventEmitter {
           error: String(error)
         });
       }
-    } finally {
-      state.syncInProgress = false;
     }
   }
 
-  private isRepoClean(repoPath: string, commandRunner: CommandRunner): boolean {
+  private async isRepoClean(repoPath: string, commandRunner: CommandRunner): Promise<boolean> {
     try {
-      commandRunner.exec('git diff-files --quiet', repoPath, { silent: true });
-      commandRunner.exec('git diff-index --cached --quiet HEAD', repoPath, { silent: true });
+      await commandRunner.execFile('git', ['diff-files', '--quiet'], repoPath, { silent: true });
+      await commandRunner.execFile('git', ['diff-index', '--cached', '--quiet', 'HEAD'], repoPath, { silent: true });
       return true;
     } catch {
       return false;
-    }
-  }
-
-  handleSessionDeleted(sessionId: string): void {
-    // Check if this session is spotlighted
-    for (const state of this.activeSpotlights.values()) {
-      if (state.sessionId === sessionId) {
-        this.logger?.info(`[SpotlightManager] Session ${sessionId} deleted, disabling spotlight`);
-        this.disable(sessionId);
-        break;
-      }
     }
   }
 
@@ -399,20 +325,7 @@ export class SpotlightManager extends EventEmitter {
     }
   }
 
-  loadState(): void {
-    try {
-      if (existsSync(this.SPOTLIGHT_STATE_FILE)) {
-        const contents = readFileSync(this.SPOTLIGHT_STATE_FILE, 'utf8');
-        // We just read it for validation, actual restore happens in restoreAll
-        JSON.parse(contents);
-        this.logger?.info('[SpotlightManager] State file loaded successfully');
-      }
-    } catch (error) {
-      this.logger?.error('[SpotlightManager] Failed to load state file:', new Error(String(error)));
-    }
-  }
-
-  restoreAll(): void {
+  async restoreAll(): Promise<void> {
     try {
       if (!existsSync(this.SPOTLIGHT_STATE_FILE)) {
         this.logger?.info('[SpotlightManager] No state file to restore');
@@ -447,7 +360,7 @@ export class SpotlightManager extends EventEmitter {
 
           // Re-enable spotlight
           this.logger?.info(`[SpotlightManager] Restoring spotlight for session ${entry.sessionId}`);
-          this.enable(entry.sessionId);
+          await this.enable(entry.sessionId);
         } catch (error) {
           this.logger?.error(
             `[SpotlightManager] Failed to restore spotlight for project ${projectIdStr}:`,

--- a/main/src/utils/commandExecutor.ts
+++ b/main/src/utils/commandExecutor.ts
@@ -1,4 +1,4 @@
-import { execSync as nodeExecSync, execFileSync as nodeExecFileSync, ExecSyncOptions, ExecSyncOptionsWithStringEncoding, ExecSyncOptionsWithBufferEncoding, exec, execFile, ExecOptions, ExecFileOptions } from 'child_process';
+import { exec, execFile, ExecOptions, ExecFileOptions } from 'child_process';
 import { promisify } from 'util';
 import { getShellPath } from './shellPath';
 import { WSLContext, escapeForBash, getWSLExecArgs } from './wslUtils';
@@ -32,14 +32,6 @@ function getExtraEnvVars(mergedEnv?: Record<string, string | undefined>): Record
   return Object.keys(extra).length > 0 ? extra : undefined;
 }
 
-/**
- * Extended ExecSyncOptions that includes a custom 'silent' flag
- * to suppress command execution logging
- */
-interface ExtendedExecSyncOptions extends ExecSyncOptions {
-  silent?: boolean;
-}
-
 interface ExtendedExecAsyncOptions extends ExecOptions {
   timeout?: number;
   silent?: boolean;
@@ -64,100 +56,6 @@ interface ExecFileFailure extends Error {
 
 export class CommandExecutor {
   constructor(private readonly fileExecutor: typeof nodeExecFileAsync = nodeExecFileAsync) {}
-
-  execSync(command: string, options: ExecSyncOptionsWithStringEncoding & { silent?: boolean }, wslContext?: WSLContext | null): string;
-  execSync(command: string, options?: ExecSyncOptionsWithBufferEncoding & { silent?: boolean }, wslContext?: WSLContext | null): Buffer;
-  execSync(command: string, options?: ExtendedExecSyncOptions, wslContext?: WSLContext | null): string | Buffer {
-    // Log the command being executed (unless silent mode requested)
-    const cwd = options?.cwd || process.cwd();
-
-    const extendedOptions = options;
-    const silentMode = extendedOptions?.silent === true;
-
-    // Get enhanced shell PATH
-    const shellPath = getShellPath();
-
-    if (wslContext) {
-      // Invoke wsl.exe directly via execFileSync — bypasses cmd.exe entirely,
-      // avoiding all cmd.exe escaping issues (%, ^, &, etc.)
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { cwd: _cwd, silent: _silent, ...cleanOptions } = extendedOptions || {};
-      const wslCwd = decodeStringCwd(cwd);
-      const extraEnv = getExtraEnvVars(cleanOptions?.env);
-      const { file, args } = getWSLExecArgs(command, wslContext.distribution, wslCwd, extraEnv);
-
-      if (!silentMode) {
-        console.log(`[CommandExecutor] Executing (WSL): ${file} ${args.join(' ')} in ${cwd}`);
-      }
-
-      const wslOptions = {
-        ...cleanOptions,
-        maxBuffer: cleanOptions?.maxBuffer || 10 * 1024 * 1024,
-        encoding: cleanOptions?.encoding || 'utf-8',
-        env: { ...process.env, ...cleanOptions?.env, PATH: shellPath },
-      };
-
-      try {
-        const result = nodeExecFileSync(file, args, wslOptions);
-
-        if (result && !silentMode) {
-          const resultStr = result.toString();
-          const lines = resultStr.split('\n');
-          const preview = lines[0].substring(0, 100) +
-                          (lines.length > 1 ? ` ... (${lines.length} lines)` : '');
-          console.log(`[CommandExecutor] Success: ${preview}`);
-        }
-
-        return result;
-      } catch (error: unknown) {
-        if (!silentMode) {
-          console.error(`[CommandExecutor] Failed (WSL): ${command}`);
-          console.error(`[CommandExecutor] Error: ${error instanceof Error ? error.message : String(error)}`);
-        }
-        throw error;
-      }
-    }
-
-    if (!silentMode) {
-      console.log(`[CommandExecutor] Executing: ${command} in ${cwd}`);
-    }
-
-    // Merge enhanced PATH into options (but remove our custom silent flag)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { silent: _silent, ...cleanOptions } = extendedOptions || {};
-    const enhancedOptions = {
-      ...cleanOptions,
-      maxBuffer: cleanOptions?.maxBuffer || 10 * 1024 * 1024,
-      env: {
-        ...process.env,
-        ...cleanOptions?.env,
-        PATH: shellPath
-      }
-    };
-
-    try {
-      const result = nodeExecSync(command, enhancedOptions);
-
-      // Log success with a preview of the result (unless silent mode)
-      if (result && !silentMode) {
-        const resultStr = result.toString();
-        const lines = resultStr.split('\n');
-        const preview = lines[0].substring(0, 100) +
-                        (lines.length > 1 ? ` ... (${lines.length} lines)` : '');
-        console.log(`[CommandExecutor] Success: ${preview}`);
-      }
-
-      return result;
-    } catch (error: unknown) {
-      // Log error (unless silent mode)
-      if (!silentMode) {
-        console.error(`[CommandExecutor] Failed: ${command}`);
-        console.error(`[CommandExecutor] Error: ${error instanceof Error ? error.message : String(error)}`);
-      }
-
-      throw error;
-    }
-  }
 
   async execAsync(command: string, options?: ExtendedExecAsyncOptions, wslContext?: WSLContext | null): Promise<{ stdout: string; stderr: string }> {
     const cwd = options?.cwd || process.cwd();
@@ -298,6 +196,3 @@ export class CommandExecutor {
 
 // Export a singleton instance
 export const commandExecutor = new CommandExecutor();
-
-// Export the execSync function as a drop-in replacement
-export const execSync = commandExecutor.execSync.bind(commandExecutor);

--- a/main/src/utils/commandRunner.ts
+++ b/main/src/utils/commandRunner.ts
@@ -9,17 +9,6 @@ export class CommandRunner {
     this.wslContext = getWSLContextFromProject(project);
   }
 
-  /** Execute command synchronously, wrapping for WSL if needed */
-  exec(command: string, cwd: string, options?: { encoding?: BufferEncoding; maxBuffer?: number; silent?: boolean; env?: Record<string, string> }): string {
-    return commandExecutor.execSync(command, {
-      cwd,
-      encoding: options?.encoding || 'utf-8',
-      maxBuffer: options?.maxBuffer,
-      silent: options?.silent,
-      env: options?.env ? { ...process.env, ...options.env } : undefined,
-    }, this.wslContext);
-  }
-
   /** Execute command asynchronously, wrapping for WSL if needed */
   async execAsync(command: string, cwd: string, options?: { timeout?: number; maxBuffer?: number; env?: Record<string, string>; silent?: boolean }): Promise<{ stdout: string; stderr: string }> {
     return commandExecutor.execAsync(command, {

--- a/scripts/smoke-sandboxed-preload.cjs
+++ b/scripts/smoke-sandboxed-preload.cjs
@@ -1,6 +1,13 @@
 const path = require('path');
 process.env.NODE_ENV = 'production';
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain } = require('electron');
+// This smoke test runs after build:main and compares both compiled artifacts.
+const daemonContractPath = path.resolve(__dirname, '..', 'main', 'dist', 'shared', 'types', 'daemon.js');
+const {
+  DAEMON_OWNED_CHANNEL_PREFIXES,
+  DAEMON_OWNED_EXACT_CHANNELS,
+  ELECTRON_ADAPTER_ONLY_CHANNELS,
+} = require(daemonContractPath);
 
 const preloadPath = path.resolve(__dirname, '..', 'main', 'dist', 'main', 'src', 'preload.js');
 const defaultAppearance = {
@@ -16,6 +23,16 @@ const timeout = setTimeout(() => {
 }, 15_000);
 
 async function run() {
+  const daemonChannels = [
+    ...DAEMON_OWNED_CHANNEL_PREFIXES.map(prefix => `${prefix}routing-probe`),
+    ...DAEMON_OWNED_EXACT_CHANNELS,
+    'sessions:set-active-session',
+  ];
+  const electronChannels = [...ELECTRON_ADAPTER_ONLY_CHANNELS, 'routing-probe:local'];
+  ipcMain.handle('daemon:invoke', (_event, channel, ...args) => ({ route: 'daemon', channel, args }));
+  for (const channel of electronChannels) {
+    ipcMain.handle(channel, (_event, ...args) => ({ route: 'electron', channel, args }));
+  }
   const window = new BrowserWindow({
     show: false,
     webPreferences: {
@@ -49,7 +66,18 @@ async function run() {
     throw new Error('Sandboxed preload did not decode the appearance snapshot');
   }
 
-  console.log('Sandboxed preload smoke test passed');
+  const cases = [
+    ...daemonChannels.map(channel => ({ route: 'daemon', channel, args: ['probe', null] })),
+    ...electronChannels.map(channel => ({ route: 'electron', channel, args: ['probe', null] })),
+  ];
+  const routed = await window.webContents.executeJavaScript(
+    `Promise.all(${JSON.stringify(cases)}.map(({ channel, args }) => window.electronAPI.invoke(channel, ...args)))`,
+  );
+  if (JSON.stringify(routed) !== JSON.stringify(cases)) {
+    throw new Error('Sandboxed preload changed channel ownership or invoke arguments');
+  }
+
+  console.log(`Sandboxed preload smoke test passed (${cases.length} routing cases)`);
   window.destroy();
 }
 


### PR DESCRIPTION
Pane maintained duplicated IPC ownership rules, two command-execution APIs, and separate copies of session-summary and Spotlight restoration logic. Slow project commands could block the main process, and the duplicate preload classifier obscured the fact that active-session hints also belong to remote daemons.

This consolidates those paths in one PR against current main, including the performance work in #592. The change removes 950 lines and adds 696 across 28 files, including regression coverage.

Closes #123.
Closes #485.
Related to #469 and the audit requested in #235.

## Changes

- Import the shared daemon channel classifier into the bundled preload. Active-session hints use the daemon bridge; actual Electron-only actions retain local routing. Extend the existing sandboxed Electron smoke test to exercise 47 ownership/argument-forwarding cases.
- Migrate every `CommandRunner.exec()` caller to asynchronous execution, including history/diffs, git IPC, project initialization, file command execution, execution tracking, watchers, and Spotlight. Migrate the underlying Git plumbing helpers and the updater's development Git lookup too.
- Delete the synchronous `CommandRunner` and `CommandExecutor` APIs and their duplicate local/WSL execution implementations. Existing async environment forwarding, output limits, and command deadlines now govern these operations.
- Make watcher startup cancellable, prevent overlapping polls, discard results for stopped/replaced watchers, and discard cancelled/superseded Git status results.
- Serialize Spotlight activation, synchronization, disable, and shutdown. Reuse one restoration implementation, cancel retries on disable, and reconcile edits arriving during an in-flight sync. Initial synchronization now runs after its state is registered, fixing the previous no-op.
- Consolidate successful/error session summaries. Remove fallback commands whose output was discarded, 150 lines of commented-out dashboard implementations, unused Spotlight members/inheritance, and five unused skill-cache locals.
- Document the shared routing and asynchronous command rules in AGENTS.md.

## Validation

- `pnpm lint`: passed with zero findings, including Oxlint, residual ESLint, anti-slop, boundary conformance, and Knip. The initial baseline had five ESLint warnings; those are removed.
- `pnpm typecheck`: passed across all workspace packages.
- Backend suite on Node 22.18: **915 passed, 2 existing skips** after updating onto current main. Two Unix-socket test files were excluded from this final local run because the full run demonstrated `listen EPERM` in this environment: `src/daemon/server.test.ts` and `src/services/permissionIpcServer.test.ts`. The committed suite/configuration is unchanged; CI still runs them.
- Frontend Vitest: **331 passed** before the unrelated #592 base update.
- Maintained Playwright smoke, health, and accessibility specs: **27 passed**.
- `pnpm build:main` and `pnpm build:frontend`: passed. Preload verification reports one Electron require; frontend verification excludes React Scan from production.
- Executed the bundled preload with a sandbox-style Electron stub: **47 routing cases passed**. The extended real Electron sandbox smoke remains a CI gate.
- Real Git regression tests cover history, graph, commit/range/working-tree diffs, Spotlight restoration, concurrent activation/disable, and edits during sync. Delayed-command fixtures cover watcher teardown and Git-status cancellation.
- No `commandRunner.exec(` or `commandExecutor.execSync` calls remain in `main/src`.

## Review notes

This does not claim the entire broader #469 campaign is finished. #235's remaining CLI manager is still used by task-queue execution and legacy session start/continue/stop handlers; deleting it without migrating those live consumers would break functionality, so it is retained.

Desktop interaction on macOS/Windows/WSL and the real sandboxed Electron run were not available locally. The existing cross-platform CI and sandbox smoke should be reviewed before merge. No release or merge is included.