### PR TITLE
fix: replace usage watchers with four-hour scans and manual refresh

### DIFF
--- a/frontend/src/components/settings/categories/UsageSettings.tsx
+++ b/frontend/src/components/settings/categories/UsageSettings.tsx
@@ -7,14 +7,22 @@ import type { UsageRateLimitSample } from '../../../../../shared/types/usage';
 export function UsageSettings() {
   const [limits, setLimits] = useState<UsageRateLimitSample[]>([]);
   const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (rescan = false) => {
     setRefreshing(true);
     try {
-      const response = await API.usage.getReport({ providers: ['codex'] });
-      if (response.success && response.data) {
-        setLimits(response.data.rateLimits);
+      if (rescan) {
+        const scanned = await API.usage.rescan();
+        if (!scanned.success) throw new Error(scanned.error || 'Failed to refresh usage');
+        if (scanned.data?.lastError) throw new Error(scanned.data.lastError);
       }
+      const response = await API.usage.getReport({ providers: ['codex'] });
+      if (!response.success || !response.data) throw new Error(response.error || 'Failed to load usage');
+      setLimits(response.data.rateLimits);
+      setError(null);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : 'Failed to refresh usage');
     } finally {
       setRefreshing(false);
     }
@@ -28,7 +36,9 @@ export function UsageSettings() {
       description="Plan and rate limits from Codex transcripts indexed by Pane."
     >
       <div className="px-3 py-2">
-        <ProviderLimitsPanel limits={limits} refreshing={refreshing} onRefresh={() => { void load(); }} />
+        <p className="mb-2 text-xs text-text-muted">Checked at startup and every 4 hours. Refresh to scan transcripts now.</p>
+        <ProviderLimitsPanel limits={limits} refreshing={refreshing} onRefresh={() => { void load(true); }} />
+        {error && <p role="alert" className="mt-2 text-xs text-status-warning">{error}</p>}
       </div>
     </SettingsPage>
   );

--- a/frontend/src/components/usage/UsageView.tsx
+++ b/frontend/src/components/usage/UsageView.tsx
@@ -775,6 +775,12 @@ export function UsageView() {
 
             <footer className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-text-muted">
               <span>{report.index.eventsIndexed.toLocaleString()} messages indexed from {report.index.filesTracked.toLocaleString()} transcripts.</span>
+              <span>Usage is checked every 5 minutes; large scans may take longer. Refresh to check now.</span>
+              <span>
+                {report.index.lastScanFinishedMs === null
+                  ? 'No completed scan yet.'
+                  : `Last successful scan: ${new Date(report.index.lastScanFinishedMs).toLocaleString()}.`}
+              </span>
               <span>Agents running inside WSL write their transcripts in the distro's home and are not counted.</span>
               {report.index.missingRoots.length > 0 && (
                 <span>Not found: {report.index.missingRoots.join(', ')}</span>

--- a/frontend/src/components/usage/UsageView.tsx
+++ b/frontend/src/components/usage/UsageView.tsx
@@ -775,7 +775,7 @@ export function UsageView() {
 
             <footer className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-text-muted">
               <span>{report.index.eventsIndexed.toLocaleString()} messages indexed from {report.index.filesTracked.toLocaleString()} transcripts.</span>
-              <span>Usage is checked every 5 minutes; large scans may take longer. Refresh to check now.</span>
+              <span>Usage is checked every 4 hours; large scans may take longer. Refresh to check now.</span>
               <span>
                 {report.index.lastScanFinishedMs === null
                   ? 'No completed scan yet.'

--- a/main/src/services/usage/README.md
+++ b/main/src/services/usage/README.md
@@ -5,10 +5,10 @@ and `~/.codex/sessions`. This includes Claude subagent transcripts and Codex
 `year/month/day` directories. Roots are rediscovered on every pass, including
 when their parent directories did not exist at startup.
 
-Indexing runs at startup, every five minutes, and on manual Refresh. There are
+Indexing runs at startup, every four hours, and on manual Refresh from the usage dashboard or Settings → Usage. There are
 no native usage watchers or per-transcript watch handles. Unchanged files are
 checked by metadata and skipped; changed files resume from their stored cursor.
-The five-minute interval is a scheduling cadence, not a maximum freshness
+The four-hour interval is a scheduling cadence, not a maximum freshness
 bound: large scans can take longer. The usage page shows the last successful
 scan and keeps errors visible until a subsequent successful pass.
 

--- a/main/src/services/usage/README.md
+++ b/main/src/services/usage/README.md
@@ -1,0 +1,31 @@
+# Transcript usage indexing
+
+UsageManager scans all JSONL files recursively beneath `~/.claude/projects`
+and `~/.codex/sessions`. This includes Claude subagent transcripts and Codex
+`year/month/day` directories. Roots are rediscovered on every pass, including
+when their parent directories did not exist at startup.
+
+Indexing runs at startup, every five minutes, and on manual Refresh. There are
+no native usage watchers or per-transcript watch handles. Unchanged files are
+checked by metadata and skipped; changed files resume from their stored cursor.
+The five-minute interval is a scheduling cadence, not a maximum freshness
+bound: large scans can take longer. The usage page shows the last successful
+scan and keeps errors visible until a subsequent successful pass.
+
+All indexing uses a single queue. Requests made while a scan is running coalesce
+into one follow-up discovery pass. A manual refresh waits for its requested pass,
+including when an earlier pass is still running. Stop clears the polling timer
+and invalidates queued and in-flight work. A lifecycle generation check after
+asynchronous operations prevents stopped work from updating events, cursors,
+quota samples or status. Restart queues fresh discovery after old reads drain.
+
+Tests use generated transcripts in temporary directories and in-memory SQLite.
+Run them with Node 22:
+
+```sh
+pnpm --filter main exec vitest run src/services/usage
+```
+
+Do not reproduce descriptor exhaustion against a user's real transcript trees.
+For resource measurements, generate a disposable tree, constrain only child
+processes, and delete only fixtures created by that run.

--- a/main/src/services/usage/usageManager.coverage.test.ts
+++ b/main/src/services/usage/usageManager.coverage.test.ts
@@ -105,7 +105,7 @@ describe('UsageManager transcript coverage without native watchers', () => {
     expect(manager.getStatus().missingRoots).toHaveLength(2);
     await addTranscript('.codex/sessions/2026/09/10/rollout-new.jsonl', codexLine());
     await addTranscript('.claude/projects/project/session/subagents/agent-new.jsonl', claudeLine('new-child'));
-    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(4 * 60 * 60 * 1000);
     await vi.waitFor(() => expect(repository.countEvents()).toBe(2));
     await vi.waitFor(() => expect(manager.getStatus().scanning).toBe(false));
     expect(manager.getStatus().missingRoots).toEqual([]);

--- a/main/src/services/usage/usageManager.coverage.test.ts
+++ b/main/src/services/usage/usageManager.coverage.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { DatabaseService } from '../../database/database';
+import { UsageManager } from './usageManager';
+import { UsageRepository } from './usageRepository';
+import { scanJsonlFile } from './jsonlScanner';
+import { databaseService } from '../database';
+
+// usageManager imports the app database singleton; isolate its migrations from
+// other test workers before that module loads, even though tests inject a repo.
+const appDirectory = vi.hoisted(() => {
+  const previous = process.env.PANE_DIR;
+  const temporaryRoot = previous ?? process.env.TMPDIR ?? process.env.TEMP ?? '/tmp';
+  const directory = `${temporaryRoot}/pane-usage-coverage-${process.pid}-${process.env.VITEST_POOL_ID}`;
+  process.env.PANE_DIR = directory;
+  return { directory, previous };
+});
+
+afterAll(async () => {
+  databaseService.getDb().close();
+  await rm(appDirectory.directory, { recursive: true, force: true });
+  if (appDirectory.previous === undefined) delete process.env.PANE_DIR;
+  else process.env.PANE_DIR = appDirectory.previous;
+});
+
+function claudeLine(id: string): string {
+  return `${JSON.stringify({
+    type: 'assistant', timestamp: new Date().toISOString(),
+    message: { id, model: 'claude-sonnet-4', usage: { input_tokens: 10, output_tokens: 1 } },
+  })}\n`;
+}
+
+function codexLine(): string {
+  return `${JSON.stringify({
+    type: 'event_msg', timestamp: new Date().toISOString(),
+    payload: { type: 'token_count', info: { last_token_usage: { input_tokens: 10, output_tokens: 1 } } },
+  })}\n`;
+}
+
+describe('UsageManager transcript coverage without native watchers', () => {
+  let directory: string;
+  let database: DatabaseService;
+  let repository: UsageRepository;
+  let manager: UsageManager;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'pane-usage-coverage-'));
+    database = new DatabaseService(':memory:');
+    database.initialize();
+    repository = new UsageRepository(database.getDb());
+    manager = new UsageManager({
+      roots: () => [
+        { provider: 'claude', path: join(directory, '.claude/projects') },
+        { provider: 'codex', path: join(directory, '.codex/sessions') },
+      ],
+      repository,
+      createPriceProvider: () => ({ start() {}, stop() {} }),
+    });
+  });
+
+  afterEach(async () => {
+    manager.stop();
+    vi.useRealTimers();
+    database.getDb().close();
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  async function addTranscript(relative: string, line: string): Promise<string> {
+    const file = join(directory, relative);
+    await mkdir(dirname(file), { recursive: true });
+    await writeFile(file, line);
+    return file;
+  }
+
+  it('indexes additions and appended usage in Claude, subagent, and dated Codex layouts', async () => {
+    await manager.start();
+    await manager.rescan();
+    const files = await Promise.all([
+      addTranscript('.claude/projects/project/session.jsonl', claudeLine('parent-1')),
+      addTranscript('.claude/projects/project/session/subagents/agent-child.jsonl', claudeLine('child-1')),
+      addTranscript('.codex/sessions/2026/09/09/rollout-session.jsonl', codexLine()),
+    ]);
+    await manager.rescan();
+    expect(repository.countFiles()).toBe(3);
+    expect(repository.countEvents()).toBe(3);
+    expect(files.map(file => repository.getFileCursor(file)?.provider)).toEqual(['claude', 'claude', 'codex']);
+
+    await Promise.all([
+      appendFile(files[0], claudeLine('parent-2')),
+      appendFile(files[1], claudeLine('child-2')),
+      appendFile(files[2], codexLine()),
+    ]);
+    await manager.rescan();
+    expect(repository.countEvents()).toBe(6);
+    await manager.rescan();
+    expect(repository.countEvents()).toBe(6);
+  });
+
+  it('discovers newly created deep roots on the polling tick without an exhaustion error', async () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    await manager.start();
+    await manager.rescan();
+    expect(manager.getStatus().missingRoots).toHaveLength(2);
+    await addTranscript('.codex/sessions/2026/09/10/rollout-new.jsonl', codexLine());
+    await addTranscript('.claude/projects/project/session/subagents/agent-new.jsonl', claudeLine('new-child'));
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.waitFor(() => expect(repository.countEvents()).toBe(2));
+    await vi.waitFor(() => expect(manager.getStatus().scanning).toBe(false));
+    expect(manager.getStatus().missingRoots).toEqual([]);
+    manager.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each(['EMFILE', 'ENFILE', 'ENOSPC'])('recovers from a transient %s scan failure on refresh', async code => {
+    let fail = true;
+    manager = new UsageManager({
+      roots: () => [{ provider: 'claude', path: directory }],
+      repository,
+      scanFile: async (...args) => {
+        if (fail) throw Object.assign(new Error(`synthetic ${code}`), { code });
+        return scanJsonlFile(...args);
+      },
+    });
+    await addTranscript('project/session/subagents/agent-test.jsonl', claudeLine(code));
+    await manager.rescan();
+    expect(manager.getStatus().lastError).toContain(code);
+    expect(repository.countEvents()).toBe(0);
+    fail = false;
+    await manager.rescan();
+    expect(manager.getStatus().lastError).toBeNull();
+    expect(repository.countEvents()).toBe(1);
+  });
+});

--- a/main/src/services/usage/usageManager.test.ts
+++ b/main/src/services/usage/usageManager.test.ts
@@ -1,116 +1,313 @@
-import { describe, expect, it, vi } from 'vitest';
-import { EventEmitter } from 'events';
-import { createTranscriptWatchers } from './usageManager';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3-multiple-ciphers';
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { UsageManager } from './usageManager';
+import { databaseService } from '../database';
+import { UsageRepository } from './usageRepository';
+import { scanJsonlFile } from './jsonlScanner';
+import type { UsageProvider } from '../../../../shared/types/usage';
 
-class TestWatcher extends EventEmitter {
-  closeCount = 0;
-  async close(): Promise<void> {
-    this.closeCount += 1;
-  }
-}
-
-function errno(code: string): Error {
-  return Object.assign(new Error(`${code}: too many open files, watch`), { code });
-}
-
-describe('createTranscriptWatchers', () => {
-  it('watches roots before they exist and queues only JSONL files', () => {
-    const createdPaths: string[] = [];
-    const watchers: TestWatcher[] = [];
-    const queueFile = vi.fn();
-
-    createTranscriptWatchers(
-      [
-        { provider: 'claude', path: '/missing/.claude/projects' },
-        { provider: 'codex', path: '/missing/.codex/sessions' },
-      ],
-      path => {
-        createdPaths.push(path);
-        const watcher = new TestWatcher();
-        watchers.push(watcher);
-        return watcher;
-      },
-      queueFile,
-    );
-
-    expect(createdPaths).toEqual([
-      '/missing/.claude/projects',
-      '/missing/.codex/sessions',
-    ]);
-
-    watchers[0].emit('add', '/missing/.claude/projects/session.jsonl');
-    watchers[1].emit('change', '/missing/.codex/sessions/readme.txt');
-
-    expect(queueFile).toHaveBeenCalledOnce();
-    expect(queueFile).toHaveBeenCalledWith('/missing/.claude/projects/session.jsonl', 'claude');
-  });
+// The manager imports the application database singleton before test setup.
+// Isolate that initialization as well as the injected in-memory repositories.
+const appDirectory = vi.hoisted(() => {
+  const previous = process.env.PANE_DIR;
+  const root = process.env.TMPDIR ?? process.env.TEMP ?? '/tmp';
+  const directory = `${root}/pane-usage-manager-${process.pid}-${process.env.VITEST_POOL_ID}-${Date.now()}`;
+  process.env.PANE_DIR = directory;
+  return { previous, directory };
 });
 
-describe('createTranscriptWatchers handle budget', () => {
-  it('watches one level deep so nested session scratch costs no handles', () => {
-    let watchedDepth: number | undefined;
+afterAll(async () => {
+  databaseService.getDb().close();
+  await rm(appDirectory.directory, { recursive: true, force: true });
+  if (appDirectory.previous === undefined) delete process.env.PANE_DIR;
+  else process.env.PANE_DIR = appDirectory.previous;
+});
 
-    createTranscriptWatchers(
-      [{ provider: 'claude', path: '/home/.claude/projects' }],
-      (_path, options) => {
-        watchedDepth = options.depth;
-        return new TestWatcher();
-      },
-      vi.fn(),
+const POLL_MS = 300_000;
+let home: string;
+let db: InstanceType<typeof Database>;
+let repository: UsageRepository;
+let manager: UsageManager;
+let message = 0;
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+function usage(provider: UsageProvider): string {
+  const id = ++message;
+  return JSON.stringify(provider === 'claude' ? {
+    type: 'assistant', timestamp: new Date().toISOString(), sessionId: 'synthetic',
+    message: { id: `message-${id}`, model: 'claude-sonnet-4', usage: { input_tokens: 10, output_tokens: 2 } },
+  } : {
+    type: 'event_msg', timestamp: new Date().toISOString(),
+    payload: { type: 'token_count', rate_limits: { limit_id: 'codex', primary: { used_percent: 42, window_minutes: 300 } }, info: {
+      last_token_usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+      total_token_usage: { input_tokens: id * 10, output_tokens: id * 2, total_tokens: id * 12 },
+    } },
+  }) + '\n';
+}
+
+async function transcript(relative: string, provider: UsageProvider): Promise<string> {
+  const path = join(home, relative);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, usage(provider));
+  return path;
+}
+
+function createManager(
+  scanFile: typeof scanJsonlFile = scanJsonlFile,
+  roots: () => Array<{ provider: UsageProvider; path: string }> = () => [
+    { provider: 'claude', path: join(home, '.claude/projects') },
+    { provider: 'codex', path: join(home, '.codex/sessions') },
+  ],
+) {
+  return new UsageManager({
+    roots,
+    repository, scanFile,
+    createPriceProvider: () => ({ start() {}, stop() {} }),
+  });
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'Date'] });
+  home = await mkdtemp(join(tmpdir(), 'pane-usage-poll-test-'));
+  db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS usage_rate_limits (
+      provider TEXT NOT NULL,
+      limit_id TEXT NOT NULL,
+      scope TEXT NOT NULL,
+      used_percent REAL NOT NULL,
+      window_minutes INTEGER,
+      resets_at_ms INTEGER,
+      plan_type TEXT,
+      captured_at_ms INTEGER NOT NULL,
+      credits_has INTEGER,
+      credits_balance TEXT,
+      credits_unlimited INTEGER,
+      rate_limit_reached_type TEXT,
+      spend_control_reached INTEGER,
+      limit_name TEXT,
+      PRIMARY KEY (provider, limit_id, scope)
     );
+    CREATE TABLE IF NOT EXISTS usage_files (
+      path TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      mtime_ms INTEGER NOT NULL,
+      offset_bytes INTEGER NOT NULL DEFAULT 0,
+      last_scanned_ms INTEGER NOT NULL,
+      parser_version INTEGER,
+      parse_context TEXT
+    );
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      timestamp_ms INTEGER NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      agent_session_id TEXT,
+      cwd TEXT,
+      source_path TEXT NOT NULL
+    );
+  `);
+  repository = new UsageRepository(db);
+  manager = createManager();
+});
 
-    // depth 6 registered an fs.watch handle for every <project>/<uuid>/ and
-    // <project>/<uuid>/tool-results/ directory, none of which hold transcripts.
-    expect(watchedDepth).toBe(1);
+afterEach(async () => {
+  manager.stop();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  db.close();
+  await rm(home, { recursive: true, force: true });
+});
+
+describe('usage polling', () => {
+  it('indexes every layout at startup and discovers appends, new directories and files on the five-minute tick', async () => {
+    const layouts: Array<[string, UsageProvider]> = [
+      ['.claude/projects/project/session.jsonl', 'claude'],
+      ['.claude/projects/project/session/subagents/agent.jsonl', 'claude'],
+      ['.codex/sessions/2026/09/09/rollout.jsonl', 'codex'],
+    ];
+    const files = await Promise.all(layouts.map(([path, provider]) => transcript(path, provider)));
+    await manager.start();
+    await vi.waitFor(() => expect(repository.countEvents()).toBe(3));
+    for (const [i, path] of files.entries()) await appendFile(path, usage(layouts[i][1]));
+    await transcript('.claude/projects/new/session/subagents/new.jsonl', 'claude');
+    await transcript('.codex/sessions/2027/01/01/new.jsonl', 'codex');
+    await vi.advanceTimersByTimeAsync(POLL_MS - 1);
+    expect(repository.countEvents()).toBe(3);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.waitFor(() => expect(repository.countEvents()).toBe(8));
+    await manager.rescan();
+    expect(repository.countEvents()).toBe(8);
   });
 
-  it('degrades once on handle exhaustion and stays silent afterwards', async () => {
-    const watchers: TestWatcher[] = [];
-    const onHandleExhaustion = vi.fn();
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    createTranscriptWatchers(
-      [{ provider: 'claude', path: '/home/.claude/projects' }],
-      () => {
-        const watcher = new TestWatcher();
-        watchers.push(watcher);
-        return watcher;
-      },
-      vi.fn(),
-      onHandleExhaustion,
-    );
-
-    // chokidar emits one error per failed directory registration and keeps
-    // emitting until close() lands — the guard must collapse the storm.
-    for (let i = 0; i < 500; i += 1) watchers[0].emit('error', errno('EMFILE'));
-
-    expect(onHandleExhaustion).toHaveBeenCalledOnce();
-    expect(watchers[0].closeCount).toBe(1);
-    expect(warn).not.toHaveBeenCalled();
-    warn.mockRestore();
+  it('discovers provider parents and transcript roots created after startup', async () => {
+    await manager.start();
+    await manager.rescan();
+    expect(manager.getStatus().missingRoots).toHaveLength(2);
+    await transcript('.claude/projects/project/session/subagents/new.jsonl', 'claude');
+    await transcript('.codex/sessions/2026/09/09/new.jsonl', 'codex');
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    await vi.waitFor(() => expect(repository.countEvents()).toBe(2));
+    expect(manager.getStatus().missingRoots).toEqual([]);
   });
 
-  it('logs other watcher errors without giving up native watching', () => {
-    const watchers: TestWatcher[] = [];
-    const onHandleExhaustion = vi.fn();
+  it('queues one follow-up discovery for overlapping refreshes and never overlaps file reads', async () => {
+    const entered = deferred(), release = deferred();
+    let active = 0, maxActive = 0, reads = 0;
+    const discover = vi.fn((): Array<{ provider: UsageProvider; path: string }> => [
+      { provider: 'claude', path: join(home, '.claude/projects') },
+      { provider: 'codex', path: join(home, '.codex/sessions') },
+    ]);
+    manager = createManager(async (...args) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      const result = await scanJsonlFile(...args);
+      if (++reads === 1) { entered.resolve(); await release.promise; }
+      active -= 1;
+      return result;
+    }, discover);
+    await transcript('.claude/projects/p/first.jsonl', 'claude');
+    await manager.start();
+    await entered.promise;
+    await transcript('.codex/sessions/2026/10/01/new.jsonl', 'codex');
+    let finished = false;
+    const refresh = manager.rescan().then(() => { finished = true; });
+    const other = manager.rescan();
+    await vi.advanceTimersByTimeAsync(POLL_MS * 5);
+    expect(finished).toBe(false);
+    release.resolve();
+    await Promise.all([refresh, other]);
+    expect(discover).toHaveBeenCalledTimes(2);
+    expect(maxActive).toBe(1);
+    expect(reads).toBe(2);
+    expect(repository.countEvents()).toBe(2);
+  });
+
+  it('discards an in-flight read after stop and cancels queued refreshes and timers', async () => {
+    const entered = deferred(), release = deferred();
+    manager = createManager(async (...args) => {
+      const result = await scanJsonlFile(...args);
+      entered.resolve(); await release.promise;
+      return result;
+    });
+    await transcript('.codex/sessions/2026/09/09/a.jsonl', 'codex');
+    const running = manager.rescan();
+    await entered.promise;
+    const queued = manager.rescan();
+    manager.stop();
+    release.resolve();
+    await Promise.all([running, queued]);
+    expect(repository.countEvents()).toBe(0);
+    expect(repository.countFiles()).toBe(0);
+    expect(repository.getRateLimits(Date.now())).toEqual([]);
+    expect(manager.getStatus().lastScanFinishedMs).toBeNull();
+    expect(manager.getStatus().scanning).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('restarts with fresh discovery after old reads drain, without committing their stale snapshots', async () => {
+    const entered = deferred(), release = deferred();
+    let reads = 0;
+    manager = createManager(async (...args) => {
+      const result = await scanJsonlFile(...args);
+      if (++reads === 1) { entered.resolve(); await release.promise; }
+      return result;
+    });
+    const file = await transcript('.claude/projects/p/a.jsonl', 'claude');
+    await manager.start();
+    await entered.promise;
+    manager.stop();
+    await appendFile(file, usage('claude'));
+    const later = await transcript('.codex/sessions/2026/11/01/later.jsonl', 'codex');
+    await manager.start();
+    const refresh = manager.rescan();
+    release.resolve();
+    await refresh;
+    expect(repository.countEvents()).toBe(3);
+    expect(repository.getFileCursor(later)).not.toBeNull();
+    const offset = repository.getFileCursor(file)?.offsetBytes;
+    await manager.rescan();
+    expect(repository.getFileCursor(file)?.offsetBytes).toBe(offset);
+    expect(repository.countEvents()).toBe(3);
+  });
+
+  it.each(['ENOENT', 'EMFILE'])('ignores a late %s after stop without deleting cursors or changing status', async code => {
+    const entered = deferred(), release = deferred();
+    let fail = false;
+    manager = createManager(async (...args) => {
+      if (fail) {
+        entered.resolve(); await release.promise;
+        throw Object.assign(new Error(`synthetic ${code}`), { code });
+      }
+      return scanJsonlFile(...args);
+    });
+    const file = await transcript('.claude/projects/p/a.jsonl', 'claude');
+    await manager.rescan();
+    const cursor = repository.getFileCursor(file);
+    const finished = manager.getStatus().lastScanFinishedMs;
+    await appendFile(file, usage('claude'));
+    fail = true;
+    const running = manager.rescan();
+    await entered.promise;
+    manager.stop();
+    release.resolve();
+    await running;
+    expect(repository.getFileCursor(file)).toEqual(cursor);
+    expect(repository.countEvents()).toBe(1);
+    expect(manager.getStatus().lastError).toBeNull();
+    expect(manager.getStatus().lastScanFinishedMs).toBe(finished);
+  });
+
+  it('starts only one timer and does no scheduled indexing after stop', async () => {
+    await manager.start();
+    await manager.start();
+    await manager.rescan();
+    expect(vi.getTimerCount()).toBe(1);
+    manager.stop();
+    expect(vi.getTimerCount()).toBe(0);
+    await transcript('.claude/projects/p/a.jsonl', 'claude');
+    await vi.advanceTimersByTimeAsync(POLL_MS * 2);
+    expect(repository.countEvents()).toBe(0);
+    await manager.start();
+    await manager.rescan();
+    expect(repository.countEvents()).toBe(1);
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it.each(['EMFILE', 'ENFILE', 'ENOSPC'])('retains the last successful scan and error until recovery from %s', async code => {
+    let fail = false;
+    manager = createManager(async (...args) => {
+      if (fail) throw Object.assign(new Error(`synthetic ${code}`), { code });
+      return scanJsonlFile(...args);
+    });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    createTranscriptWatchers(
-      [{ provider: 'claude', path: '/home/.claude/projects' }],
-      () => {
-        const watcher = new TestWatcher();
-        watchers.push(watcher);
-        return watcher;
-      },
-      vi.fn(),
-      onHandleExhaustion,
-    );
-
-    watchers[0].emit('error', errno('EPERM'));
-
-    expect(onHandleExhaustion).not.toHaveBeenCalled();
-    expect(watchers[0].closeCount).toBe(0);
+    await transcript('.claude/projects/p/a.jsonl', 'claude');
+    await manager.rescan();
+    const finished = manager.getStatus().lastScanFinishedMs;
+    fail = true;
+    await transcript('.codex/sessions/2026/09/09/b.jsonl', 'codex');
+    vi.setSystemTime(Date.now() + 10_000);
+    await manager.rescan();
+    expect(manager.getStatus().lastError).toContain(code);
+    expect(manager.getStatus().lastScanFinishedMs).toBe(finished);
     expect(warn).toHaveBeenCalledOnce();
-    warn.mockRestore();
+    fail = false;
+    await manager.rescan();
+    expect(manager.getStatus().lastError).toBeNull();
+    expect(manager.getStatus().lastScanFinishedMs).toBeGreaterThan(finished!);
+    expect(repository.countEvents()).toBe(2);
   });
 });

--- a/main/src/services/usage/usageManager.test.ts
+++ b/main/src/services/usage/usageManager.test.ts
@@ -3,7 +3,14 @@ import { EventEmitter } from 'events';
 import { createTranscriptWatchers } from './usageManager';
 
 class TestWatcher extends EventEmitter {
-  async close(): Promise<void> {}
+  closeCount = 0;
+  async close(): Promise<void> {
+    this.closeCount += 1;
+  }
+}
+
+function errno(code: string): Error {
+  return Object.assign(new Error(`${code}: too many open files, watch`), { code });
 }
 
 describe('createTranscriptWatchers', () => {
@@ -36,5 +43,74 @@ describe('createTranscriptWatchers', () => {
 
     expect(queueFile).toHaveBeenCalledOnce();
     expect(queueFile).toHaveBeenCalledWith('/missing/.claude/projects/session.jsonl', 'claude');
+  });
+});
+
+describe('createTranscriptWatchers handle budget', () => {
+  it('watches one level deep so nested session scratch costs no handles', () => {
+    let watchedDepth: number | undefined;
+
+    createTranscriptWatchers(
+      [{ provider: 'claude', path: '/home/.claude/projects' }],
+      (_path, options) => {
+        watchedDepth = options.depth;
+        return new TestWatcher();
+      },
+      vi.fn(),
+    );
+
+    // depth 6 registered an fs.watch handle for every <project>/<uuid>/ and
+    // <project>/<uuid>/tool-results/ directory, none of which hold transcripts.
+    expect(watchedDepth).toBe(1);
+  });
+
+  it('degrades once on handle exhaustion and stays silent afterwards', async () => {
+    const watchers: TestWatcher[] = [];
+    const onHandleExhaustion = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    createTranscriptWatchers(
+      [{ provider: 'claude', path: '/home/.claude/projects' }],
+      () => {
+        const watcher = new TestWatcher();
+        watchers.push(watcher);
+        return watcher;
+      },
+      vi.fn(),
+      onHandleExhaustion,
+    );
+
+    // chokidar emits one error per failed directory registration and keeps
+    // emitting until close() lands — the guard must collapse the storm.
+    for (let i = 0; i < 500; i += 1) watchers[0].emit('error', errno('EMFILE'));
+
+    expect(onHandleExhaustion).toHaveBeenCalledOnce();
+    expect(watchers[0].closeCount).toBe(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('logs other watcher errors without giving up native watching', () => {
+    const watchers: TestWatcher[] = [];
+    const onHandleExhaustion = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    createTranscriptWatchers(
+      [{ provider: 'claude', path: '/home/.claude/projects' }],
+      () => {
+        const watcher = new TestWatcher();
+        watchers.push(watcher);
+        return watcher;
+      },
+      vi.fn(),
+      onHandleExhaustion,
+    );
+
+    watchers[0].emit('error', errno('EPERM'));
+
+    expect(onHandleExhaustion).not.toHaveBeenCalled();
+    expect(watchers[0].closeCount).toBe(0);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 });

--- a/main/src/services/usage/usageManager.test.ts
+++ b/main/src/services/usage/usageManager.test.ts
@@ -26,7 +26,7 @@ afterAll(async () => {
   else process.env.PANE_DIR = appDirectory.previous;
 });
 
-const POLL_MS = 300_000;
+const POLL_MS = 4 * 60 * 60 * 1000;
 let home: string;
 let db: InstanceType<typeof Database>;
 let repository: UsageRepository;
@@ -133,7 +133,7 @@ afterEach(async () => {
 });
 
 describe('usage polling', () => {
-  it('indexes every layout at startup and discovers appends, new directories and files on the five-minute tick', async () => {
+  it('indexes every layout at startup and discovers appends, new directories and files on the four-hour tick', async () => {
     const layouts: Array<[string, UsageProvider]> = [
       ['.claude/projects/project/session.jsonl', 'claude'],
       ['.claude/projects/project/session/subagents/agent.jsonl', 'claude'],

--- a/main/src/services/usage/usageManager.ts
+++ b/main/src/services/usage/usageManager.ts
@@ -39,7 +39,7 @@ interface PaneCostsReport {
 /** Yield to the event loop every N files so a first scan never blocks the UI. */
 const YIELD_EVERY_FILES = 25;
 /** Complete discovery runs even when CLI transcript roots do not exist yet. */
-const USAGE_POLL_INTERVAL_MS = 5 * 60 * 1000;
+const USAGE_POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function transcriptRoots(): TranscriptRoot[] {

--- a/main/src/services/usage/usageManager.ts
+++ b/main/src/services/usage/usageManager.ts
@@ -48,17 +48,48 @@ type UsageWatchFactory = (
   options: NonNullable<Parameters<typeof chokidar.watch>[1]>,
 ) => UsageWatcher;
 
+/**
+ * Transcript roots are watched one level deep, not six.
+ *
+ * chokidar 5 carries no fsevents dependency (`readdirp` is its only one), so on
+ * every platform it registers one `fs.watch` handle per directory. The
+ * transcripts this indexer needs are the `.jsonl` files sitting directly inside
+ * each project directory — `~/.claude/projects/<project>/<session>.jsonl`.
+ * Everything nested below that is per-session scratch (`<uuid>/`, and
+ * `<uuid>/tool-results/`) that holds no transcript.
+ *
+ * At depth 6 the walk registers a handle for all of that scratch too. On the
+ * machine that motivated this fix, 63 project directories expanded to 5,194
+ * handles and exhausted the process handle table roughly ten seconds after
+ * launch. The resulting EMFILE is not contained to this watcher: it starves
+ * every descriptor the app opens afterwards (SQLite, node-pty, the daemon
+ * socket), so the visible failure is a crash on the next interaction rather
+ * than a fault reported here.
+ *
+ * Depth 1 reaches the same transcripts for the cost of the project directories
+ * plus the transcript files themselves — measured on that machine at 2,437
+ * handles against 4,632-and-climbing at depth 6, and it reaches `ready` where
+ * depth 6 never does. That is a reduction, not a constant: a large enough
+ * transcript corpus can still reach the ceiling, which is why the exhaustion
+ * path below degrades instead of assuming this bound always holds.
+ */
+const TRANSCRIPT_WATCH_DEPTH = 1;
+
+/** Handle-exhaustion codes that make native watching unrecoverable. */
+const HANDLE_EXHAUSTION_CODES = new Set(['EMFILE', 'ENFILE', 'ENOSPC']);
+
 export function createTranscriptWatchers(
   roots: readonly TranscriptRoot[],
   createWatcher: UsageWatchFactory,
   queueFile: (path: string, provider: UsageProvider) => void,
+  onHandleExhaustion: (root: TranscriptRoot, error: Error) => void = () => {},
 ): UsageWatcher[] {
   return roots.map(root => {
     // Missing paths are intentional. Chokidar watches the nearest existing
     // parent and begins reporting once a CLI creates its transcript root.
     const watcher = createWatcher(root.path, {
       ignoreInitial: true,
-      depth: 6,
+      depth: TRANSCRIPT_WATCH_DEPTH,
       awaitWriteFinish: { stabilityThreshold: 1500, pollInterval: 300 },
     });
 
@@ -67,7 +98,23 @@ export function createTranscriptWatchers(
     };
     watcher.on('add', queue);
     watcher.on('change', queue);
+
+    // Storm guard FIRST, mirroring the gitFileWatcher fix for #309: while the
+    // handle table is exhausted chokidar emits one error per failed directory
+    // registration and keeps emitting until the fire-and-forget close() lands.
+    // Unguarded, this handler wrote ~17,000 EMFILE lines in a single session
+    // and kept the table pinned. Degrade once, then stay silent.
+    let degraded = false;
     watcher.on('error', error => {
+      // SAFETY: Node filesystem failures may carry the optional errno code.
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== undefined && HANDLE_EXHAUSTION_CODES.has(code)) {
+        if (degraded) return;
+        degraded = true;
+        void watcher.close();
+        onHandleExhaustion(root, error);
+        return;
+      }
       console.warn('[Usage] Watcher error:', error);
     });
     return watcher;
@@ -78,6 +125,8 @@ export function createTranscriptWatchers(
 const YIELD_EVERY_FILES = 25;
 /** Coalesce watcher events — an active agent appends constantly. */
 const WATCH_DEBOUNCE_MS = 3000;
+/** Re-scan cadence once native watching has been given up. */
+const USAGE_POLL_INTERVAL_MS = 5 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function transcriptRoots(): TranscriptRoot[] {
@@ -108,6 +157,8 @@ class UsageManager {
   private watchers: UsageWatcher[] = [];
   private pendingFiles = new Map<string, UsageProvider>();
   private debounceTimer: NodeJS.Timeout | undefined;
+  private pollingTimer: NodeJS.Timeout | undefined;
+  private watchMode: 'native' | 'polling' = 'native';
   private scanning = false;
   private started = false;
 
@@ -156,6 +207,9 @@ class UsageManager {
     this.priceProvider?.stop();
     this.priceProvider = null;
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    if (this.pollingTimer) clearInterval(this.pollingTimer);
+    this.pollingTimer = undefined;
+    this.watchMode = 'native';
     for (const watcher of this.watchers) void watcher.close();
     this.watchers = [];
   }
@@ -320,7 +374,37 @@ class UsageManager {
         this.pendingFiles.set(path, provider);
         this.scheduleFlush();
       },
+      (root, error) => this.degradeToPolling(root, error),
     );
+  }
+
+  /**
+   * Last-resort fallback when a transcript root cannot be watched natively.
+   *
+   * Depth 1 lowers the handle cost but does not bound it — it still scales with
+   * the number of transcripts — so a large enough corpus, or pressure from
+   * elsewhere in the process, can exhaust the table anyway. Usage indexing is a
+   * reporting feature, not a critical path: it gives up its handles and re-reads
+   * on a timer rather than compete for descriptors that terminals, the database
+   * and the daemon socket need in order to keep the app alive.
+   *
+   * Degradation is process-lifetime: nothing here reclaims native watching,
+   * because retrying is what produced the original storm. `stop()` resets it.
+   */
+  private degradeToPolling(root: TranscriptRoot, error: Error): void {
+    console.warn(
+      `[Usage] Handle exhaustion watching ${root.path} — falling back to a ` +
+        `${USAGE_POLL_INTERVAL_MS / 60000}min polling scan:`,
+      error.message,
+    );
+    this.status.lastError = `Live usage updates unavailable (${error.message}). Refreshing every ${USAGE_POLL_INTERVAL_MS / 60000}min.`;
+    if (this.watchMode === 'polling') return;
+    this.watchMode = 'polling';
+
+    this.pollingTimer = setInterval(() => {
+      void this.runFullScan();
+    }, USAGE_POLL_INTERVAL_MS);
+    this.pollingTimer.unref?.();
   }
 
   private scheduleFlush(): void {

--- a/main/src/services/usage/usageManager.ts
+++ b/main/src/services/usage/usageManager.ts
@@ -3,7 +3,6 @@ import { stat } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
 import { glob } from 'glob';
-import chokidar from 'chokidar';
 import { databaseService } from '../database';
 import { UsageRepository } from './usageRepository';
 import { UsageAggregator, resolveReportRange } from './usageAggregator';
@@ -29,12 +28,6 @@ interface TranscriptRoot {
   path: string;
 }
 
-interface UsageWatcher {
-  on(event: 'add' | 'change', listener: (path: string) => void): this;
-  on(event: 'error', listener: (error: Error) => void): this;
-  close(): Promise<void>;
-}
-
 interface PaneCostsReport {
   fromMs: number;
   toMs: number;
@@ -43,89 +36,9 @@ interface PaneCostsReport {
   totals: UsageTotals;
 }
 
-type UsageWatchFactory = (
-  path: string,
-  options: NonNullable<Parameters<typeof chokidar.watch>[1]>,
-) => UsageWatcher;
-
-/**
- * Transcript roots are watched one level deep, not six.
- *
- * chokidar 5 carries no fsevents dependency (`readdirp` is its only one), so on
- * every platform it registers one `fs.watch` handle per directory. The
- * transcripts this indexer needs are the `.jsonl` files sitting directly inside
- * each project directory — `~/.claude/projects/<project>/<session>.jsonl`.
- * Everything nested below that is per-session scratch (`<uuid>/`, and
- * `<uuid>/tool-results/`) that holds no transcript.
- *
- * At depth 6 the walk registers a handle for all of that scratch too. On the
- * machine that motivated this fix, 63 project directories expanded to 5,194
- * handles and exhausted the process handle table roughly ten seconds after
- * launch. The resulting EMFILE is not contained to this watcher: it starves
- * every descriptor the app opens afterwards (SQLite, node-pty, the daemon
- * socket), so the visible failure is a crash on the next interaction rather
- * than a fault reported here.
- *
- * Depth 1 reaches the same transcripts for the cost of the project directories
- * plus the transcript files themselves — measured on that machine at 2,437
- * handles against 4,632-and-climbing at depth 6, and it reaches `ready` where
- * depth 6 never does. That is a reduction, not a constant: a large enough
- * transcript corpus can still reach the ceiling, which is why the exhaustion
- * path below degrades instead of assuming this bound always holds.
- */
-const TRANSCRIPT_WATCH_DEPTH = 1;
-
-/** Handle-exhaustion codes that make native watching unrecoverable. */
-const HANDLE_EXHAUSTION_CODES = new Set(['EMFILE', 'ENFILE', 'ENOSPC']);
-
-export function createTranscriptWatchers(
-  roots: readonly TranscriptRoot[],
-  createWatcher: UsageWatchFactory,
-  queueFile: (path: string, provider: UsageProvider) => void,
-  onHandleExhaustion: (root: TranscriptRoot, error: Error) => void = () => {},
-): UsageWatcher[] {
-  return roots.map(root => {
-    // Missing paths are intentional. Chokidar watches the nearest existing
-    // parent and begins reporting once a CLI creates its transcript root.
-    const watcher = createWatcher(root.path, {
-      ignoreInitial: true,
-      depth: TRANSCRIPT_WATCH_DEPTH,
-      awaitWriteFinish: { stabilityThreshold: 1500, pollInterval: 300 },
-    });
-
-    const queue = (path: string) => {
-      if (path.endsWith('.jsonl')) queueFile(path, root.provider);
-    };
-    watcher.on('add', queue);
-    watcher.on('change', queue);
-
-    // Storm guard FIRST, mirroring the gitFileWatcher fix for #309: while the
-    // handle table is exhausted chokidar emits one error per failed directory
-    // registration and keeps emitting until the fire-and-forget close() lands.
-    // Unguarded, this handler wrote ~17,000 EMFILE lines in a single session
-    // and kept the table pinned. Degrade once, then stay silent.
-    let degraded = false;
-    watcher.on('error', error => {
-      // SAFETY: Node filesystem failures may carry the optional errno code.
-      const code = (error as NodeJS.ErrnoException)?.code;
-      if (code !== undefined && HANDLE_EXHAUSTION_CODES.has(code)) {
-        if (degraded) return;
-        degraded = true;
-        void watcher.close();
-        onHandleExhaustion(root, error);
-        return;
-      }
-      console.warn('[Usage] Watcher error:', error);
-    });
-    return watcher;
-  });
-}
-
 /** Yield to the event loop every N files so a first scan never blocks the UI. */
 const YIELD_EVERY_FILES = 25;
-/** Coalesce watcher events — an active agent appends constantly. */
-const WATCH_DEBOUNCE_MS = 3000;
-/** Re-scan cadence once native watching has been given up. */
+/** Complete discovery runs even when CLI transcript roots do not exist yet. */
 const USAGE_POLL_INTERVAL_MS = 5 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -148,19 +61,24 @@ function transcriptRoots(): TranscriptRoot[] {
  * Windows with WSL-based projects the agents write inside the distro's home,
  * which this does not reach.
  */
-class UsageManager {
+export class UsageManager {
+  constructor(private readonly dependencies: {
+    roots?: () => TranscriptRoot[];
+    repository?: UsageRepository;
+    scanFile?: typeof scanJsonlFile;
+    createPriceProvider?: () => Pick<OpenRouterPriceProvider, 'start' | 'stop'>;
+  } = {}) {}
+
   // Resolved on first use, not in the constructor: this module is imported at
   // load time and the database handle is only guaranteed after initialisation.
   private repositoryRef: UsageRepository | null = null;
   private aggregatorRef: UsageAggregator | null = null;
-  private priceProvider: OpenRouterPriceProvider | null = null;
-  private watchers: UsageWatcher[] = [];
-  private pendingFiles = new Map<string, UsageProvider>();
-  private debounceTimer: NodeJS.Timeout | undefined;
+  private priceProvider: Pick<OpenRouterPriceProvider, 'start' | 'stop'> | null = null;
   private pollingTimer: NodeJS.Timeout | undefined;
-  private watchMode: 'native' | 'polling' = 'native';
-  private scanning = false;
   private started = false;
+  private generation = 0;
+  private scanQueue: Promise<void> = Promise.resolve();
+  private pendingScan: Promise<void> | null = null;
 
   private status: UsageIndexStatus = {
     lastScanStartedMs: null,
@@ -175,7 +93,7 @@ class UsageManager {
   };
 
   private get repository(): UsageRepository {
-    if (!this.repositoryRef) this.repositoryRef = new UsageRepository(databaseService.getDb());
+    if (!this.repositoryRef) this.repositoryRef = this.dependencies.repository ?? new UsageRepository(databaseService.getDb());
     return this.repositoryRef;
   }
 
@@ -189,7 +107,7 @@ class UsageManager {
     if (this.started) return;
     this.started = true;
 
-    this.priceProvider = new OpenRouterPriceProvider(getAppDirectory());
+    this.priceProvider = this.dependencies.createPriceProvider?.() ?? new OpenRouterPriceProvider(getAppDirectory());
     this.priceProvider.start();
 
     try {
@@ -198,20 +116,22 @@ class UsageManager {
       console.error('[Usage] Retention sweep failed:', error);
     }
 
-    void this.runFullScan();
-    this.startWatching();
+    void this.requestScan();
+    this.pollingTimer = setInterval(() => {
+      void this.requestScan();
+    }, USAGE_POLL_INTERVAL_MS);
+    this.pollingTimer.unref();
   }
 
   stop(): void {
     this.started = false;
     this.priceProvider?.stop();
     this.priceProvider = null;
-    if (this.debounceTimer) clearTimeout(this.debounceTimer);
     if (this.pollingTimer) clearInterval(this.pollingTimer);
     this.pollingTimer = undefined;
-    this.watchMode = 'native';
-    for (const watcher of this.watchers) void watcher.close();
-    this.watchers = [];
+    this.generation += 1;
+    this.pendingScan = null;
+    this.status = { ...this.status, scanning: false };
   }
 
   getStatus(): UsageIndexStatus {
@@ -224,7 +144,7 @@ class UsageManager {
 
   /** Force a full re-scan; used by the page's refresh action. */
   async rescan(): Promise<UsageIndexStatus> {
-    await this.runFullScan();
+    await this.requestScan();
     return this.getStatus();
   }
 
@@ -276,39 +196,69 @@ class UsageManager {
     }
   }
 
-  private async runFullScan(): Promise<void> {
-    if (this.scanning) return;
-    this.scanning = true;
-    this.status = { ...this.status, scanning: true, lastScanStartedMs: Date.now(), lastError: null, filesScanned: 0 };
+  /** Coalesce queued refreshes, but always follow an active scan with a fresh pass. */
+  private requestScan(): Promise<void> {
+    if (this.pendingScan) return this.pendingScan;
+    const generation = this.generation;
+    const scan = this.scanQueue.then(async () => {
+      if (generation !== this.generation) return;
+      this.pendingScan = null;
+      await this.runFullScan(generation);
+    });
+    this.pendingScan = scan;
+    this.scanQueue = scan;
+    return scan;
+  }
+
+  private async runFullScan(generation: number): Promise<void> {
+    this.status = { ...this.status, scanning: true, lastScanStartedMs: Date.now(), filesScanned: 0, filesTotal: 0 };
+    let scanError: string | null = null;
 
     try {
-      const roots = transcriptRoots();
+      const roots = this.dependencies.roots?.() ?? transcriptRoots();
       this.status.missingRoots = roots.filter(root => !existsSync(root.path)).map(root => root.path);
 
       const files: Array<{ path: string; provider: UsageProvider }> = [];
       for (const root of roots) {
         if (!existsSync(root.path)) continue;
         const matches = await glob('**/*.jsonl', { cwd: root.path, absolute: true, nodir: true });
+        if (generation !== this.generation) return;
         for (const path of matches) files.push({ path, provider: root.provider });
       }
 
       this.status.filesTotal = files.length;
-
-      let processed = 0;
       for (const file of files) {
-        await this.scanOne(file.path, file.provider);
-        processed += 1;
-        this.status.filesScanned = processed;
-        if (processed % YIELD_EVERY_FILES === 0) {
+        if (generation !== this.generation) return;
+        try {
+          await this.scanOne(file.path, file.provider, generation);
+        } catch (error) {
+          if (generation !== this.generation) return;
+          // Keep indexing readable files, but report the pass as incomplete.
+          if (scanError === null) {
+            scanError = error instanceof Error ? error.message : String(error);
+            console.warn(`[Usage] Skipped ${file.path}:`, scanError);
+          }
+        }
+        if (generation !== this.generation) return;
+        this.status.filesScanned += 1;
+        if (this.status.filesScanned % YIELD_EVERY_FILES === 0) {
           await new Promise<void>(resolve => setImmediate(resolve));
         }
       }
     } catch (error) {
-      this.status.lastError = error instanceof Error ? error.message : String(error);
+      if (generation !== this.generation) return;
+      scanError = error instanceof Error ? error.message : String(error);
       console.error('[Usage] Scan failed:', error);
     } finally {
-      this.scanning = false;
-      this.status = { ...this.status, scanning: false, lastScanFinishedMs: Date.now() };
+      if (generation === this.generation) {
+        this.status = {
+          ...this.status,
+          scanning: false,
+          lastError: scanError,
+          // Preserve the last successful reconciliation across errors and stop.
+          lastScanFinishedMs: scanError === null ? Date.now() : this.status.lastScanFinishedMs,
+        };
+      }
     }
   }
 
@@ -317,9 +267,10 @@ class UsageManager {
    * and mtime are unchanged are skipped without being opened, which is what
    * makes subsequent launches fast.
    */
-  private async scanOne(path: string, provider: UsageProvider): Promise<void> {
+  private async scanOne(path: string, provider: UsageProvider, generation: number): Promise<void> {
     try {
       const stats = await stat(path);
+      if (generation !== this.generation) return;
       let recorded = this.repository.getFileCursor(path);
 
       // A parser fix must reach transcripts that were already indexed, so a
@@ -336,7 +287,8 @@ class UsageManager {
       // a stored context would describe bytes that are no longer there — this is
       // the rotation and truncation case.
       const seedContext = startOffset > 0 ? recorded?.parseContext ?? null : null;
-      const scanned = await scanJsonlFile(path, provider, startOffset, stats.mtimeMs, seedContext);
+      const scanned = await (this.dependencies.scanFile ?? scanJsonlFile)(path, provider, startOffset, stats.mtimeMs, seedContext);
+      if (generation !== this.generation) return;
 
       this.repository.commitFile(
         {
@@ -355,70 +307,16 @@ class UsageManager {
 
       this.repository.recordRateLimits(scanned.rateLimits);
     } catch (error) {
-      // A single unreadable transcript must not abort the pass.
+      if (generation !== this.generation) return;
+      // A disappeared transcript must not abort the pass.
       // SAFETY: Node filesystem failures may carry the optional errno code.
       const code = (error as NodeJS.ErrnoException)?.code;
       if (code === 'ENOENT') {
         this.repository.forgetFile(path);
         return;
       }
-      console.warn(`[Usage] Skipped ${path}:`, error instanceof Error ? error.message : error);
+      throw error;
     }
-  }
-
-  private startWatching(): void {
-    this.watchers = createTranscriptWatchers(
-      transcriptRoots(),
-      (path, options) => chokidar.watch(path, options),
-      (path, provider) => {
-        this.pendingFiles.set(path, provider);
-        this.scheduleFlush();
-      },
-      (root, error) => this.degradeToPolling(root, error),
-    );
-  }
-
-  /**
-   * Last-resort fallback when a transcript root cannot be watched natively.
-   *
-   * Depth 1 lowers the handle cost but does not bound it — it still scales with
-   * the number of transcripts — so a large enough corpus, or pressure from
-   * elsewhere in the process, can exhaust the table anyway. Usage indexing is a
-   * reporting feature, not a critical path: it gives up its handles and re-reads
-   * on a timer rather than compete for descriptors that terminals, the database
-   * and the daemon socket need in order to keep the app alive.
-   *
-   * Degradation is process-lifetime: nothing here reclaims native watching,
-   * because retrying is what produced the original storm. `stop()` resets it.
-   */
-  private degradeToPolling(root: TranscriptRoot, error: Error): void {
-    console.warn(
-      `[Usage] Handle exhaustion watching ${root.path} — falling back to a ` +
-        `${USAGE_POLL_INTERVAL_MS / 60000}min polling scan:`,
-      error.message,
-    );
-    this.status.lastError = `Live usage updates unavailable (${error.message}). Refreshing every ${USAGE_POLL_INTERVAL_MS / 60000}min.`;
-    if (this.watchMode === 'polling') return;
-    this.watchMode = 'polling';
-
-    this.pollingTimer = setInterval(() => {
-      void this.runFullScan();
-    }, USAGE_POLL_INTERVAL_MS);
-    this.pollingTimer.unref?.();
-  }
-
-  private scheduleFlush(): void {
-    if (this.debounceTimer) clearTimeout(this.debounceTimer);
-    this.debounceTimer = setTimeout(() => {
-      const batch = [...this.pendingFiles.entries()];
-      this.pendingFiles.clear();
-      void (async () => {
-        for (const [path, provider] of batch) {
-          await this.scanOne(path, provider);
-        }
-      })();
-    }, WATCH_DEBOUNCE_MS);
-    this.debounceTimer.unref?.();
   }
 }
 

--- a/shared/types/usage.ts
+++ b/shared/types/usage.ts
@@ -115,6 +115,7 @@ export interface UsageReportRequest {
 /** Health of the background transcript index, surfaced in the page header. */
 export interface UsageIndexStatus {
   lastScanStartedMs: number | null;
+  /** Last successful full scan; failed or canceled passes do not advance it. */
   lastScanFinishedMs: number | null;
   filesTracked: number;
   eventsIndexed: number;

--- a/tests/agent-usage.spec.ts
+++ b/tests/agent-usage.spec.ts
@@ -191,7 +191,7 @@ test('Settings shows the Usage tab when Codex limits exist in transcripts', asyn
   await expect(page.getByRole('heading', { name: 'Usage', exact: true })).toBeVisible();
   const widget = page.getByRole('region', { name: 'Codex usage' });
   await expect(widget).toBeVisible();
-  await expect(widget.getByText('pro_lite', { exact: true })).toBeVisible();
+  await expect(widget.getByText('· pro_lite', { exact: true })).toBeVisible();
   await expect(widget.getByText('58% left', { exact: true })).toBeVisible();
   await capture(page, testInfo, 'codex-usage-settings.png');
 
@@ -241,6 +241,40 @@ test('Settings Usage tab shows limits from transcript-parsed data', async ({ pag
   const widget = page.getByRole('region', { name: 'Codex usage' });
   await expect(widget.getByText('58% left', { exact: true })).toBeVisible();
   await expect(widget.getByRole('button', { name: 'Refresh usage', exact: true })).toBeVisible();
+});
+
+test('Settings manual refresh waits for transcript indexing before reloading quota', async ({ page }) => {
+  await openSettings(page, {
+    initialProjects: [project], initialSessions: [session], initialPanels: panels,
+    initialUsageReport: usageReport, activeProjectId: project.id,
+  });
+  await page.getByRole('navigation', { name: 'Settings categories' })
+    .getByRole('button', { name: 'Usage', exact: true }).click();
+  const widget = page.getByRole('region', { name: 'Codex usage' });
+  await expect(widget.getByText('58% left', { exact: true })).toBeVisible();
+  await page.evaluate(() => {
+    const usage = window.electronAPI.usage;
+    const rescan = usage.rescan;
+    const getReport = usage.getReport;
+    let indexed = false;
+    usage.rescan = async () => {
+      await new Promise(resolve => setTimeout(resolve, 300));
+      indexed = true;
+      return rescan();
+    };
+    usage.getReport = async (...args) => {
+      if (!indexed) throw new Error('Report requested before indexing completed');
+      const response = await getReport(...args);
+      if (response.data) response.data.rateLimits[0].usedPercent = 80;
+      return response;
+    };
+  });
+  const refresh = widget.getByRole('button', { name: 'Refresh usage', exact: true });
+  await refresh.click();
+  await expect(refresh).toBeDisabled();
+  await expect(widget.getByText('20% left', { exact: true })).toBeVisible();
+  await expect(refresh).toBeEnabled();
+  await expect(page.getByRole('alert')).toHaveCount(0);
 });
 
 test('main-repository branch detection never renders the previous repository branch', async ({ page }) => {

--- a/tests/usage-and-limits.spec.ts
+++ b/tests/usage-and-limits.spec.ts
@@ -243,6 +243,11 @@ test('opens Usage & Limits from expanded and compact navigation', async ({ page 
   await expect(page.getByRole('button', { name: 'Share usage image' })).toBeVisible();
 
   await capture(page, testInfo, '01-usage-dashboard-expanded.png');
+  const cadence = page.getByText('Usage is checked every 4 hours; large scans may take longer. Refresh to check now.', { exact: true });
+  await cadence.scrollIntoViewIfNeeded();
+  await expect(cadence).toBeVisible();
+  await expect(page.getByText(/^Last successful scan:/)).toBeVisible();
+  await capture(page, testInfo, '04-usage-freshness-footer.png');
 
   await page.getByRole('button', { name: 'Collapse sidebar' }).click();
   await expect(page.getByTestId('compact-usage')).toBeVisible();


### PR DESCRIPTION
## Summary

Usage transcript watchers can retain enough native handles to exhaust the process descriptor table, affecting terminals and the database. Replace them with serialized recursive scans at startup, **every four hours**, and on manual refresh. Related to #309.

Discovery covers Claude project transcripts, nested Claude subagents, and Codex year/month/day transcripts, including roots and parent directories created after startup. There are no native usage watchers or watcher-close error paths.

## Behavior and UX

- Startup, scheduled scans and manual refresh share one queue. Requests during a running scan coalesce into one follow-up pass; manual refresh waits for the requested pass.
- Stop clears scheduling and invalidates pending/in-flight results. Generation checks prevent stale events, cursors, quota samples and status writes; restart queues fresh discovery after old reads drain.
- Both the Usage dashboard and Settings → Usage refresh buttons trigger indexing. Settings previously only reloaded its cached report.
- The UI explains the cadence and shows the last successful scan. Scan errors remain visible until a successful pass.
- **Intentional tradeoff:** background usage and Codex quota data can be nearly four hours old, plus scan time. Refresh requests a scan immediately, waiting behind any active pass. Existing idle dashboard behavior remains: a page that is not already displaying an active scan does not continuously reload reports; refresh/reopen it to fetch the latest saved index.

## Scan cost

The steady schedule is **six full discovery passes/day**, plus startup and manual requests. The previously proposed five-minute schedule would run 288/day: this reduces scheduled passes by about 98%.

For D directories, F transcript files, and ΔB newly read bytes, filesystem discovery/metadata/parsing work is roughly **O(D + F + ΔB)** per pass, excluding database indexing/query costs. Unchanged transcripts are checked by size/mtime and are not reopened. Scratch directories are still traversed. Native watching previously targeted changed files after registration; polling deliberately trades that event-driven efficiency for eliminating persistent usage-watch handles. A longer interval lowers frequency, not the peak cost of a single deep scan.

Synthetic macOS / Node 22 measurement: 2,640 transcripts (62.5 MB), 4,800 scratch directories:

| Pass | Elapsed | Transcript opens |
| --- | ---: | ---: |
| Initial indexing | 4.107 s | 2,640 |
| Unchanged tree | 178 ms | 0 |
| Deep append + new Codex year directory | 172 ms | 2 |

Peak concurrent transcript streams: **1**. This is a synthetic measurement, not a bound for larger/slower filesystems.

<!-- pr-test-automation-summary:start -->
## Verification

Tested implementation: **5363fbfa9d1e5270855a014c9990465e0cf8bed8**.

- `pnpm lint` and `pnpm typecheck`: pass.
- `pnpm build:main` and `pnpm build:frontend`: pass, including sandboxed preload verification.
- Main Vitest suite: **947 passed, 2 skipped**; usage coverage includes **128 tests**.
- Chromium automated journeys against the production frontend build with synthetic Electron API fixtures: **9 passed**. Includes expanded/narrow navigation, quota display, per-pane cost sorting, freshness copy, and Settings refresh waiting for indexing before loading the new quota.
- Real temporary-directory / SQLite tests cover initial and later-created roots, deep creates/appends, four-hour timing, coalescing, manual refresh completion, stop/restart, stale-write rejection, and EMFILE/ENFILE/ENOSPC scan recovery.
- Real scanner cost probe validates complete discovery, unchanged-file skipping, incremental updates and one open transcript stream.

The earlier blockers reported on a6357c1b are addressed by the replacement implementation; earlier review and QA comments refer to that old head. New-head CI and renewed review remain separate from these local passes. Native watcher fault injection is no longer applicable to the removed path. Four-hour scheduling is tested with a controlled clock; no four-hour physical wait or full Electron end-to-end run is claimed.

All transcript fixtures are synthetic and were deleted. No private transcript corpus was used. Reproducible local evidence, scripts, screenshots and videos are retained under `tmp/pr-596-review/fix/final-qa/`; scan-cost script: `tmp/pr-596-review/fix/synthetic-cost.cjs`. An inherited browser selector expected `pro_lite` while the UI rendered `· pro_lite`; the selector was corrected without changing plan-label rendering.

<details>
<summary>Usage and Settings screenshots (synthetic data)</summary>

| Usage freshness and last successful scan | Settings on-demand refresh |
| --- | --- |
| <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-596-5363fbfa-d503e685d2c2-usage-freshness.png" width="480" alt="Usage page with four-hour cadence and last successful scan" /> | <img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-596-5363fbfa-92834672075b-settings-refresh.png" width="480" alt="Usage Settings with four-hour cadence and refresh button" /> |

Narrow navigation and layout:

<img src="https://github.com/dcouple/Pane/releases/download/pr-assets/pr-596-5363fbfa-dccd3ff947c6-usage-narrow.png" width="360" alt="Usage page with compact navigation at narrow viewport" />

</details>
<!-- pr-test-automation-summary:end -->
