### PR TITLE
fix: generalize review criteria from Doozy-specific to two-layer structure

### DIFF
--- a/.claude/agents/implementation-reviewer.md
+++ b/.claude/agents/implementation-reviewer.md
@@ -32,11 +32,11 @@ surface after all review lanes complete.
 Run these checks and record exact output for failures:
 
 ```bash
-npm run typecheck
+pnpm typecheck
 ```
 
 ```bash
-npm run lint
+pnpm lint
 ```
 
 ## Step 2: Plan Completeness
@@ -69,8 +69,9 @@ Also check for:
 Review all changed files against the criteria in `.claude/skills/review/CRITERIA.md`. Focus on:
 
 - **Sections 1-2 (Must-Fix):** Bugs, correctness, and security issues. These block completion.
-- **Sections 3-5 (Should-Fix):** Architecture, React patterns, and TypeScript quality. Flag these but they don't block.
-- **Sections 6-7 (Suggestion):** Tailwind/shadcn and conventions. Note briefly, low priority.
+- **Sections 3-4 (Should-Fix):** React patterns and TypeScript quality. Flag these but they don't block.
+- **Section 5 (Suggestion):** Conventions. Note briefly, low priority.
+- **Per-repo section:** Apply project-specific criteria at their stated severity.
 
 Only review files that were changed by the implementation — don't review the entire codebase.
 
@@ -98,17 +99,12 @@ PASS/FAIL
 - [DEVIATED] Task description — deviation: [explanation]
 
 ### Integration Check
-- [ ] All new routes registered
+- [ ] All new routes or IPC channels registered
 - [ ] All new exports added to barrel files
-- [ ] All new types exported from @doozy/shared (if cross-app)
-- [ ] Frontend components wired to API endpoints
-- [ ] Database schema changes reflected in types
+- [ ] All new shared types exported from the shared package
+- [ ] Frontend components wired to their data sources
+- [ ] Schema or type changes reflected across package boundaries
 [Check or uncheck each as appropriate]
-
-### Schema Changes
-[Run: git diff origin/main --name-only | grep schema.ts]
-- If schema.ts was modified: "⚠️ Schema changes detected — migration SQL will be generated after this review."
-- If not modified: omit this section entirely.
 
 ### Code Quality Issues
 

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-pr
-description: Commits changes grouped by done-plans, rebases main, builds API and webapp, then creates or updates a PR. Replaces the commit command. Use when you're ready to open or update a pull request.
+description: Commits changes grouped by done-plans, rebases main, runs build and quality gates, then creates or updates a PR. Replaces the commit command. Use when you're ready to open or update a pull request.
 argument-hint: "[optional: PR title or description]"
 disable-model-invocation: true
 ---
@@ -49,42 +49,28 @@ For each group:
    - If the resolution is **ambiguous** (e.g., both sides changed the same logic, semantic conflicts), show the user the conflict with context and ask them how to resolve it. Wait for their response before continuing.
 4. After rebase completes, verify with `git log --oneline -10` that history looks correct.
 
-## Step 2.5: Generate Production Migration SQL (If Schema Changed)
+## Step 3: Build and Quality Gates
 
-Check if `apps/api/src/shared/db/schema.ts` was modified in any commit on this branch (vs origin/main):
+Run the build and quality gates, fixing any errors:
 
 ```bash
-git diff origin/main...HEAD --name-only | grep schema.ts
+pnpm build
 ```
 
-If schema.ts was changed:
-1. Run `npm run db:diff:prod` and capture the actual output SQL.
-2. Wrap it in a transaction block (`BEGIN; ... COMMIT;`).
-3. Include the **actual SQL** in the PR description under the **Schema Changes** section — not instructions to run a command.
-4. Only include additive SQL (CREATE, ADD). If destructive SQL (DROP, ALTER type) appears, flag it for the user to review and confirm.
-
-If schema.ts was NOT changed, omit the **Schema Changes** section from the PR template entirely.
-
-## Step 3: Build and Fix Errors
-
-Run both builds and fix any errors:
-
-### Build webapp
 ```bash
-npx nx build @doozy/webapp
+pnpm lint
 ```
 
-### Build API
 ```bash
-npx nx build @doozy/api
+pnpm typecheck
 ```
 
-For each build:
+For each command:
 1. If it **passes**, move on.
 2. If it **fails**, read the error output carefully:
-   - Fix type errors, missing imports, and build issues.
-   - After fixing, re-run the failing build to confirm the fix.
-   - Repeat until both builds pass.
+   - Fix type errors, missing imports, lint violations, and build issues.
+   - After fixing, re-run the failing command to confirm the fix.
+   - Repeat until all gates pass.
 3. If a fix requires non-trivial changes (architectural issues, missing dependencies), tell the user and ask how to proceed.
 
 **Commit build fixes** as a separate commit: `fix: resolve build errors`
@@ -134,23 +120,10 @@ Build the PR description from the done-plans. List work in **chronological order
 - [ ] [Another key behavior to verify]
 - [ ] [Edge case or integration point worth checking]
 
-## Schema Changes
-<!-- Only include this section if schema.ts was modified -->
-- [ ] Migration SQL reviewed
-- [ ] Migration applied to staging
-- [ ] Migration applied to production
-
-### Production Migration SQL
-⚠️ Run this SQL against the production database BEFORE deploying:
-```sql
-BEGIN;
--- actual generated SQL from npm run db:diff:prod goes here
-COMMIT;
-```
-
 ## Build Verification
-- [x] `npx nx build @doozy/webapp` passes
-- [x] `npx nx build @doozy/api` passes
+- [x] `pnpm build` passes
+- [x] `pnpm lint` passes
+- [x] `pnpm typecheck` passes
 ```
 
 Use `$ARGUMENTS` as the PR title if provided, otherwise derive one from the done-plans.
@@ -171,9 +144,9 @@ PR ready.
 Commits:
 - <commit summaries>
 
-Build:
-  webapp: PASS
-  api: PASS
+Build: PASS
+Lint: PASS
+Typecheck: PASS
 
 PR: <url>
 Branch: <branch name> (rebased on main)

--- a/.claude/skills/review/CRITERIA.md
+++ b/.claude/skills/review/CRITERIA.md
@@ -1,6 +1,19 @@
 # Code Review Criteria
 
-Shared review criteria used by both the PR review skill and the implementation-reviewer agent. This is the single source of truth for what "good code" looks like in Doozy.
+Shared review criteria used by the PR review skill and the implementation-reviewer agent. This file has two layers: a project-agnostic core that transfers to any TypeScript/React codebase, and a per-repo section for Pane.
+
+---
+
+## 0. Discovery (Required First Step)
+
+Before applying any criterion below, derive the project's actual floor from the repo itself. Read these sources in priority order and let them override anything generic in this file:
+
+1. **AGENTS.md** (or CLAUDE.md) -- project conventions, forbidden patterns, tooling
+2. **Lint configuration and blocking custom rules** -- the CI-enforced floor for new code
+3. **tsconfig** -- path aliases, strictness flags, module resolution
+4. **Package manifests** -- what frameworks, libraries, and toolchains actually exist
+
+Where the derived floor conflicts with a generic criterion below, the repo's own rules win. State the override explicitly in the review rather than silently ignoring either source.
 
 ---
 
@@ -9,49 +22,21 @@ Shared review criteria used by both the PR review skill and the implementation-r
 - Logic errors: incorrect conditionals, off-by-one, wrong comparison operators
 - Null/undefined risks: missing optional chaining, unhandled nullable paths
 - Async bugs: missing `await`, unhandled promise rejections, race conditions
-- Error handling: missing `try/catch` on API calls, unhandled error states
+- Error handling: missing `try/catch` on calls that can throw, unhandled error states
 - State bugs: stale closures in hooks, missing dependency array entries
-- Data flow: mutations that don't invalidate the right query keys, optimistic updates without rollback
 
 ## 2. Security (Must-Fix)
 
 - `dangerouslySetInnerHTML` without DOMPurify sanitization
 - API keys, tokens, or credentials in frontend code
 - User input rendered without sanitization
-- `NEXT_PUBLIC_` prefix on server-only secrets
-- SQL injection, command injection, or XSS vectors in API code
-- Auth/permission checks missing on new API endpoints
+- Command injection or XSS vectors
+- Auth/permission checks missing on new endpoints or IPC channels
 
-## 3. Architecture and Patterns (Should-Fix)
-
-**API (Express backend):**
-- Three-layer architecture: Repository → Service → Controller
-- Business logic must not live in controllers or route handlers
-- New routes registered in `apps/api/src/routes/`
-- Shared types exported from `@doozy/shared`
-
-**Webapp (Next.js frontend):**
-- Server Components by default; `"use client"` only when genuinely needed (hooks, event handlers, browser APIs)
-- `"use client"` placed at the smallest viable boundary — not on layouts or large parent containers
-- Thin pages — heavy logic lives in `_hooks/`, complex UI in `_components/`
-- No Server Actions — all data flows through the Express API
-- No direct database access from the webapp
-
-**State management:**
-- Server data managed exclusively via TanStack Query — never duplicated into Zustand
-- Zustand used only for client/UI state (modals, theme, preferences)
-- Mutations use `useMutation` with `onSuccess` invalidation, not manual store updates
-- Components subscribe to Zustand via selectors, not full store objects
-
-**Data fetching:**
-- Independent requests use `Promise.all` / `Promise.allSettled`, not sequential `await`
-- `React.cache()` used for deduplicating ORM/database calls in Server Components
-- `<Suspense>` placed close to data-dependent components with meaningful skeleton fallbacks
-
-## 4. React and Component Design (Should-Fix)
+## 3. React and Component Design (Should-Fix)
 
 - Components under 200-300 lines; JSX under ~50 lines per component
-- Single responsibility — business logic separated from presentational rendering
+- Single responsibility -- business logic separated from presentational rendering
 - Props destructured at the function signature, explicitly typed
 - Prop drilling through 3+ levels replaced with Context or state management
 - Hooks never called inside loops, conditionals, or nested functions
@@ -64,32 +49,38 @@ Shared review criteria used by both the PR review skill and the implementation-r
 - List rendering uses stable unique keys (never array index for dynamic lists)
 - `React.lazy` + `Suspense` for code-split routes and heavy components
 
-## 5. TypeScript (Should-Fix)
+## 4. TypeScript (Should-Fix)
 
-- No `any` without a justifying comment; prefer `unknown` for genuinely unknown types
-- No `{}` as a type — use `Record<string, unknown>` or a named interface
+- No explicit `any` -- use a specific type or `unknown` with narrowing
+- No `{}` as a type -- use `Record<string, unknown>` or a named interface
 - Type assertions (`as X`) include a comment explaining why
-- Double assertions (`as unknown as X`) are a strong code smell — flag these
+- Double assertions (`as unknown as X`) are a blocking error, not just a smell
 - `import type` used for type-only imports
 - Interfaces preferred over type aliases for object shapes
 - No `I` prefix on interface names
 
-## 6. Tailwind CSS and shadcn/ui (Suggestion)
+## 5. Conventions (Suggestion)
 
-- Semantic token classes (`text-primary`, `bg-background`) — no hardcoded hex/rgb values
-- Design tokens centralized in `globals.css` via `@theme` — not scattered in component files
-- shadcn/ui base components in `components/ui/` not modified directly — use wrapper pattern
-- `cn()` argument ordering deliberate: `cn("base-classes", className)` for overridable, `cn(className, "forced")` for enforced
-- CVA used for component variants — not ad-hoc conditional class string concatenation
-- Radix UI accessibility props (`role`, `aria-*`, `data-state`) preserved — not stripped
-- `{...props}` spread present on wrapper components for prop forwarding
-
-## 7. Conventions (Suggestion)
-
-- All imports use `@/` aliases for local files, `@doozy/shared` for shared — no `../` relative imports
-- Underscore-prefix locality: `_components/`, `_hooks/` for route-scoped files
 - File names match their default export
 - `const` by default, `let` only when reassignment required, never `var`
 - No `console.log` in committed code (except intentional server-side logging)
 - No commented-out code blocks or dead code
 - No unused imports or variables
+
+---
+
+## Pane
+
+Project-specific criteria for this repo. These supplement the generic sections above.
+
+**Quality gate:** `pnpm lint` and `pnpm typecheck` must pass. These are the CI-enforced commands.
+
+**Anti-slop floor:** The 15 blocking Oxlint rules in `references/anti-slop.md` are the new-code floor. A review finding that recommends code violating any of these rules (e.g., chained type assertions, unsafe dictionary types, unguarded `unknown` parameters) is itself a defect.
+
+**`any` is forbidden:** Per AGENTS.md, do not introduce explicit `any`. There is no comment-justification escape. ESLint enforces `@typescript-eslint/no-explicit-any` at error level.
+
+**Knip:** Every Knip category is blocking. Unused exports, types, dependencies, and files are not advisory.
+
+**Process boundaries:** Pane is Electron: main process, preload bridge, React renderer. Review IPC contract wiring -- new channels need registration in the preload bridge (`main/src/preload.ts`) and the daemon-owned channel classifier. Code that crosses a process boundary without going through the declared IPC surface is a must-fix.
+
+**Boundary decoders:** I/O from IPC, daemon, filesystem, process, or browser input must be parsed at the boundary into a named domain type using `shared/validation/boundaryDecoder`. Late `unknown` aliases, representation ladders, or assertions that treat the symptom instead of parsing the input are a should-fix.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -39,24 +39,25 @@ Before reviewing any code, write down (internally):
 Run these checks and record results:
 
 ```bash
-npm run typecheck
+pnpm typecheck
 ```
 
 ```bash
-npm run lint
+pnpm lint
 ```
 
 If either fails, include the specific errors in the review as **must-fix** items.
 
 ## Step 3: Review the Diff
 
-Read the shared review criteria at `.claude/skills/review/CRITERIA.md`. This is the single source of truth for what to check.
+Read the shared review criteria at `.claude/skills/review/CRITERIA.md`. This is the single source of truth for what to check. Start with section 0 (Discovery) to derive the project's actual floor before applying the generic sections.
 
-For each changed file, evaluate against **all 7 sections** of the criteria. Organize findings by severity:
+For each changed file, evaluate against the criteria. Organize findings by severity:
 
 - **Sections 1-2 (Must-Fix):** Bugs, correctness, security. The PR should not merge without addressing these.
-- **Sections 3-5 (Should-Fix):** Architecture, React patterns, TypeScript. Strong recommendation to fix.
-- **Sections 6-7 (Suggestion):** Tailwind/shadcn, conventions. Nice-to-have, not blocking.
+- **Sections 3-4 (Should-Fix):** React patterns, TypeScript. Strong recommendation to fix.
+- **Section 5 (Suggestion):** Conventions. Nice-to-have, not blocking.
+- **Per-repo section:** Apply the project-specific criteria (e.g. Pane) at their stated severity.
 
 ## Step 4: Check Completeness Against Issue
 


### PR DESCRIPTION
## Summary

`.claude/skills/review/CRITERIA.md` was synced verbatim from Doozy (an Express/Next.js/TanStack/shadcn project) via bcc041b (#154). Reviews were grading Pane against the wrong standard. This restructures the file into a project-agnostic core plus a thin Pane-specific section, and fixes the other foreign files from the same bulk sync.

Fixes #490

## What was foreign

Four files from bcc041b (#154) carried Doozy-specific content:

| File | Foreign content removed |
|---|---|
| `CRITERIA.md` | S3 Express/Next.js architecture, S6 Tailwind/shadcn, `@doozy/shared`, `NEXT_PUBLIC_`, `@/` alias requirement, comment-justified `any` |
| `prepare-pr/SKILL.md` | `npx nx build @doozy/webapp`, `npx nx build @doozy/api`, `npm run db:diff:prod`, schema migration SQL step |
| `implementation-reviewer.md` | `@doozy/shared (if cross-app)`, "Tailwind/shadcn", `npm run` commands, `schema.ts` migration section |
| `review/SKILL.md` | "all 7 sections", "Sections 6-7: Tailwind/shadcn" |

The remaining bcc041b files (agents: codebase-explorer, implementer, plan-reviewer, research-dossier-writer, researcher; skills: commit, create-plan, discussion, implement, simple-plan) were checked and contain no foreign references. The `.claude/commands/parsa/` files with Doozy/TanStack content predate bcc041b and are out of scope.

## What generalizes (Layer 1)

- **Section 0 -- Discovery:** mandatory step to derive the project floor from AGENTS.md/CLAUDE.md, lint config, tsconfig, and package manifests before applying generic criteria. Where the derived floor conflicts with anything generic, the repo's own rules win.
- **Section 1 -- Bugs and Correctness:** unchanged except removing TanStack-specific "query key invalidation" item
- **Section 2 -- Security:** kept framework-agnostic (dropped `NEXT_PUBLIC_`, "SQL injection in API code")
- **Section 3 -- React and Component Design:** former S4, fully generic
- **Section 4 -- TypeScript:** former S5, corrected: `any` forbidden (not comment-justified), double assertions are blocking errors (not just "code smell")
- **Section 5 -- Conventions:** generic subset (file naming, const/let/var, no dead code)

## What is Pane-specific (Layer 2)

- 15 blocking anti-slop Oxlint rules (`references/anti-slop.md`) as the new-code floor
- `pnpm lint` and `pnpm typecheck` as the quality gate
- main/preload/renderer process boundaries, IPC contract wiring
- Boundary decoders (`shared/validation/boundaryDecoder`)
- Knip all-categories-blocking
- `any` forbidden per AGENTS.md with no comment-justification escape

https://claude.ai/code/session_01Av92YasMpgFiLXZbQrNn1c